### PR TITLE
use setuptools_scm instead of setuptools-git-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
 python: "3.6"
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
 env:
   matrix:
   - TENSORFLOW_VERSION=1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ addons:
     - gcc-4.8
     - g++-4.8
 env:
+  global:
+  - CC=gcc-4.8
+  - CXX=g++-4.8
   matrix:
   - TENSORFLOW_VERSION=1.8
   - TENSORFLOW_VERSION=1.12

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 # install_requires = ['xml']
 install_requires=['numpy', 'scipy']
-setup_requires=['setuptools-git-version']
+setup_requires=['setuptools_scm']
 
 # add cmake as a build requirement if cmake>3.0 is not installed
 try:
@@ -38,7 +38,7 @@ except OSError:
 setup(
     name="deepmd-kit",
     setup_requires=setup_requires,
-    version_format='{tag}.dev{commitcount}_{gitsha}',
+    use_scm_version={'write_to': 'source/train/_version.py'},
     author="Han Wang",
     author_email="wang_han@iapcm.ac.cn",
     description="A deep learning package for many-body potential energy representation and molecular dynamics",


### PR DESCRIPTION
Then, we can use `python setup.py sdist` to package the source, and use `twine upload dist/*` to upload it to [pypi.org](https://pypi.org/simple). Users can use `pip install deepmd-kit` to install the python interface directly.