### PR TITLE
disable native md and i-pi automaticaly if gcc<4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,22 +542,7 @@ export CC=/path/to/gcc-7.2.0/bin/gcc
 export CXX=/path/to/gcc-7.2.0/bin/g++
 ```
 
-If, for any reason, for example, you only have a gcc/g++ of version 4.8.5, you can still compile all the parts of TensorFlow and most of the parts of DeePMD-kit. In this case, follow the following steps.
-
-First, goto the source code directory, open the file `CMakeLists.txt`
-```bash
-cd $deepmd_source_dir/source
-vi CMakeLists.txt
-```
-Next, comment the following 4 lines out:
-```
-# set (LIB_DEEPMD_NATIVE  "deepmd_native_md")
-# set (LIB_DEEPMD_IPI     "deepmd_ipi")
-# add_subdirectory (md/)
-# add_subdirectory (ipi/)
-```
-
-Then you may continue with the installation procedure.
+If, for any reason, for example, you only have a gcc/g++ of version 4.8.5, you can still compile all the parts of TensorFlow and most of the parts of DeePMD-kit. Native MD and i-Pi will be disabled automatically.
 
 ## Installation: build files left in DeePMD-kit
 When you try to build a second time when installing DeePMD-kit, files produced before may contribute to failure. Thus, you may clear them by

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -39,7 +39,7 @@ endif(GIT_FOUND)
 
 # global defines
 list (APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/)
-list (APPEND CMAKE_CXX_FLAGS "-std=c++11 -Wno-ignored-attributes")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-ignored-attributes")
 
 # define the abi
 if (NOT DEFINED TF_GOOGLE_BIN) 
@@ -93,8 +93,12 @@ include_directories(${TensorFlow_INCLUDE_DIRS})
 if (BUILD_CPP_IF)
   set (LIB_DEEPMD		"deepmd")
   set (LIB_DEEPMD_OP		"deepmd_op")
-  set (LIB_DEEPMD_NATIVE	"deepmd_native_md")
-  set (LIB_DEEPMD_IPI		"deepmd_ipi")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+    set (LIB_DEEPMD_NATIVE	"deepmd_native_md")
+    set (LIB_DEEPMD_IPI		"deepmd_ipi")
+  else ()
+    message (STATUS "Your gcc/g++ version is ${CMAKE_CXX_COMPILER_VERSION}, so native MD and ipi are disabled. To enable them, use gcc/g++ >= 4.9.")
+  endif ()
 endif (BUILD_CPP_IF)
 
 include_directories(${CMAKE_BINARY_DIR}/lib/)
@@ -107,8 +111,10 @@ endif (BUILD_PY_IF)
 if (BUILD_CPP_IF) 
   add_subdirectory (lib/)
   add_subdirectory (lmp/)
-# add_subdirectory (md/)
-  add_subdirectory (ipi/)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+#   add_subdirectory (md/)
+    add_subdirectory (ipi/)
+  endif ()
 endif (BUILD_CPP_IF)
 
 # uninstall target


### PR DESCRIPTION
also fix a bug and update README

Currently, if a user uses gcc 4.8.5, he/she needs to modify `CMakeLists.txt` to disable native MD and i-Pi on his/her own. Why not detect gcc version and do it automatically?