### PR TITLE
add get_type_map for c++ api

### DIFF
--- a/source/lib/include/NNPInter.h
+++ b/source/lib/include/NNPInter.h
@@ -59,6 +59,7 @@ public:
   int numb_types () const {assert(inited); return ntypes;};
   int dim_fparam () const {assert(inited); return dfparam;};
   int dim_aparam () const {assert(inited); return daparam;};
+  void get_type_map (std::string & type_map);
 private:
   Session* session;
   int num_intra_nthreads, num_inter_nthreads;

--- a/source/lib/src/NNPInter.cc
+++ b/source/lib/src/NNPInter.cc
@@ -677,6 +677,11 @@ compute (ENERGYTYPE &			dener,
     run_model (dener, dforce_, dvirial, datom_energy_, datom_virial_, session, input_tensors, nnpmap, nghost);
 }
 
+void
+NNPInter::
+get_type_map(std::string & type_map){
+    type_map = get_scalar<std::string>("model_attr/tmap");
+}
 
 
 


### PR DESCRIPTION
```cpp
  std::string type_map;
  nnp_inter.get_type_map(type_map);
  std::cout << "type_map:" << type_map << "\n";
```

output:
```
type_map:O H
```