### PR TITLE
send model file through mpi bcast

### DIFF
--- a/deepmd/utils/neighbor_stat.py
+++ b/deepmd/utils/neighbor_stat.py
@@ -62,7 +62,6 @@ class NeighborStat():
         max_nbor_size
                 A list with ntypes integers, denotes the actual achieved max sel
         """
-        print(type(data))
         self.min_nbor_dist = 100.0
         self.max_nbor_size = [0] * self.ntypes
 

--- a/source/lib/CMakeLists.txt
+++ b/source/lib/CMakeLists.txt
@@ -8,9 +8,6 @@ configure_file(
   @ONLY
 )
 
-find_package(MPI REQUIRED)
-include_directories(SYSTEM ${MPI_INCLUDE_PATH})
-
 if (USE_CUDA_TOOLKIT)
   include_directories("${CUDA_INCLUDE_DIRS}")
 endif()
@@ -23,8 +20,6 @@ add_library(${libname} SHARED ${LIB_SRC})
 if (USE_CUDA_TOOLKIT)
   target_link_libraries (${libname} ${CUDA_LIBRARIES})
 endif()
-
-target_link_libraries (${libname} ${MPI_C_LIBRARIES})
 
 install(TARGETS ${libname} DESTINATION lib/)
 

--- a/source/lib/CMakeLists.txt
+++ b/source/lib/CMakeLists.txt
@@ -8,6 +8,9 @@ configure_file(
   @ONLY
 )
 
+find_package(MPI REQUIRED)
+include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+
 if (USE_CUDA_TOOLKIT)
   include_directories("${CUDA_INCLUDE_DIRS}")
 endif()
@@ -20,6 +23,8 @@ add_library(${libname} SHARED ${LIB_SRC})
 if (USE_CUDA_TOOLKIT)
   target_link_libraries (${libname} ${CUDA_LIBRARIES})
 endif()
+
+target_link_libraries (${libname} ${MPI_C_LIBRARIES})
 
 install(TARGETS ${libname} DESTINATION lib/)
 

--- a/source/lib/include/DeviceFunctor.h
+++ b/source/lib/include/DeviceFunctor.h
@@ -8,6 +8,7 @@
 typedef unsigned long long int_64;
 #define SQRT_2_PI 0.7978845608028654 
 #define TPB 256
+#define GPU_MAX_NBOR_SIZE 4096
 
 #define cudaErrcheck(res) {cudaAssert((res), __FILE__, __LINE__);}
 inline void cudaAssert(cudaError_t code, const char *file, int line, bool abort=true) {

--- a/source/lib/include/NNPInter.h
+++ b/source/lib/include/NNPInter.h
@@ -8,8 +8,8 @@ class NNPInter
 public:
   NNPInter () ;
   ~NNPInter() ;
-  NNPInter  (const std::string & model, const int & gpu_rank = 0);
-  void init (const std::string & model, const int & gpu_rank = 0);
+  NNPInter  (const std::string & model, const int & gpu_rank = 0, const std::string & file_content = "");
+  void init (const std::string & model, const int & gpu_rank = 0, const std::string & file_content = "");
   void print_summary(const std::string &pre) const;
 public:
   void compute (ENERGYTYPE &			ener,
@@ -105,8 +105,8 @@ class NNPInterModelDevi
 public:
   NNPInterModelDevi () ;
   ~NNPInterModelDevi() ;
-  NNPInterModelDevi  (const std::vector<std::string> & models, const int & gpu_rank = 0);
-  void init (const std::vector<std::string> & models, const int & gpu_rank = 0);
+  NNPInterModelDevi  (const std::vector<std::string> & models, const int & gpu_rank = 0, const std::vector<std::string> & file_contents = std::vector<std::string>());
+  void init (const std::vector<std::string> & models, const int & gpu_rank = 0, const std::vector<std::string> & file_contents = std::vector<std::string>());
 public:
   void compute (ENERGYTYPE &			ener,
   		std::vector<VALUETYPE> &		force,

--- a/source/lmp/pair_nnp.cpp
+++ b/source/lmp/pair_nnp.cpp
@@ -129,26 +129,9 @@ std::string PairNNP::get_file_content(const std::string & model) {
 }
 
 std::vector<std::string> PairNNP::get_file_content(const std::vector<std::string> & models) {
-  int myrank = 0, root = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-  unsigned nchar = 0;
   std::vector<std::string> file_contents(models.size());
   for (unsigned ii = 0; ii < models.size(); ++ii) {
-    if (myrank == root) {
-      checkStatus (ReadFileToString(Env::Default(), models[ii], &file_contents[ii]));
-      nchar = file_contents[ii].size();
-    }
-    MPI_Bcast(&nchar, 1, MPI_UNSIGNED, root, MPI_COMM_WORLD);  
-    char * buff = (char *)malloc(sizeof(char) * nchar);  
-    if (myrank == root) {  
-      memcpy(buff, file_contents[ii].c_str(), sizeof(char) * nchar);
-    }
-    MPI_Bcast(buff, nchar, MPI_CHAR, root, MPI_COMM_WORLD);
-    file_contents[ii].resize(nchar);
-    for (unsigned jj = 0; jj < nchar; ++jj) {
-      file_contents[ii][jj] = buff[jj];
-    }
-    free(buff);
+    file_contents[ii] = get_file_content(models[ii]);
   }
   return file_contents;
 }

--- a/source/lmp/pair_nnp.cpp
+++ b/source/lmp/pair_nnp.cpp
@@ -108,13 +108,13 @@ int PairNNP::get_node_rank() {
 std::string PairNNP::get_file_content(const std::string & model) {
   int myrank = 0, root = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-  unsigned nchar = 0;
+  int nchar = 0;
   std::string file_content;
   if (myrank == root) {
     checkStatus (ReadFileToString(Env::Default(), model, &file_content));
     nchar = file_content.size();
   }
-  MPI_Bcast(&nchar, 1, MPI_UNSIGNED, root, MPI_COMM_WORLD);  
+  MPI_Bcast(&nchar, 1, MPI_INT, root, MPI_COMM_WORLD);  
   char * buff = (char *)malloc(sizeof(char) * nchar);  
   if (myrank == root) {  
     memcpy(buff, file_content.c_str(), sizeof(char) * nchar);

--- a/source/lmp/pair_nnp.cpp
+++ b/source/lmp/pair_nnp.cpp
@@ -124,8 +124,8 @@ std::string PairNNP::get_file_content(const std::string & model) {
   for (unsigned ii = 0; ii < nchar; ++ii) {
     file_content[ii] = buff[ii];
   }
-  return file_content;
   free(buff);
+  return file_content;
 }
 
 std::vector<std::string> PairNNP::get_file_content(const std::vector<std::string> & models) {

--- a/source/lmp/pair_nnp.h.in
+++ b/source/lmp/pair_nnp.h.in
@@ -64,6 +64,8 @@ class PairNNP : public Pair {
   void unpack_reverse_comm(int, int *, double *);
   void print_summary(const std::string pre) const;
   int get_node_rank();
+  std::string get_file_content(const std::string & model);
+  std::vector<std::string> get_file_content(const std::vector<std::string> & models);
  protected:  
   virtual void allocate();
   double **scale;

--- a/source/op/descrpt_se_a_multi_device.cc
+++ b/source/op/descrpt_se_a_multi_device.cc
@@ -158,14 +158,14 @@ public:
             OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
             Tensor uint64_temp;
             TensorShape uint64_shape;
-            uint64_shape.AddDim(nloc * max_nbor_size * 2);
+            uint64_shape.AddDim(nloc * GPU_MAX_NBOR_SIZE * 2);
             OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
 
             array_int = int_temp.flat<int>().data(); 
             array_longlong = uint64_temp.flat<unsigned long long>().data();
 
             nbor_update(mesh_tensor.flat<int>().data(), static_cast<int>(mesh_tensor.NumElements()));
-            OP_REQUIRES (context, (max_nbor_size <= 4096),	                errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_nbor_size) + " is larger than 4096, which currently is not supported by deepmd-kit."));
+            OP_REQUIRES (context, (max_nbor_size <= GPU_MAX_NBOR_SIZE), errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_nbor_size) + " is larger than " + std::to_string(GPU_MAX_NBOR_SIZE) + ", which currently is not supported by deepmd-kit."));
         }
         else if (device == "CPU") {
             memcpy (&ilist,  4  + mesh_tensor.flat<int>().data(), sizeof(int *));

--- a/source/op/descrpt_se_r_multi_device.cc
+++ b/source/op/descrpt_se_r_multi_device.cc
@@ -104,8 +104,6 @@ public:
         OP_REQUIRES (context, (9 == box_tensor.shape().dim_size(1)),		errors::InvalidArgument ("number of box should be 9"));
         OP_REQUIRES (context, (ndescrpt == avg_tensor.shape().dim_size(1)),		errors::InvalidArgument ("number of avg should be ndescrpt"));
         OP_REQUIRES (context, (ndescrpt == std_tensor.shape().dim_size(1)),		errors::InvalidArgument ("number of std should be ndescrpt")); 
-        
-        OP_REQUIRES (context, (nnei <= 4096),	                errors::InvalidArgument ("Assert failed, max neighbor size of atom(nnei) " + std::to_string(nnei) + " is larger than 4096, which currently is not supported by deepmd-kit."));
 
         // Create an output tensor
         TensorShape descrpt_shape ;
@@ -147,14 +145,14 @@ public:
             OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
             Tensor uint64_temp;
             TensorShape uint64_shape;
-            uint64_shape.AddDim(nloc * max_nbor_size * 2);
+            uint64_shape.AddDim(nloc * GPU_MAX_NBOR_SIZE * 2);
             OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
 
             array_int = int_temp.flat<int>().data(); 
             array_longlong = uint64_temp.flat<unsigned long long>().data();
 
             nbor_update(mesh_tensor.flat<int>().data(), static_cast<int>(mesh_tensor.NumElements()));
-            OP_REQUIRES (context, (max_nbor_size <= 4096),	                errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_nbor_size) + " is larger than 4096, which currently is not supported by deepmd-kit."));
+            OP_REQUIRES (context, (max_nbor_size <= GPU_MAX_NBOR_SIZE), errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_nbor_size) + " is larger than " + std::to_string(GPU_MAX_NBOR_SIZE) + ", which currently is not supported by deepmd-kit."));
         }
         else if (device == "CPU") {
             memcpy (&ilist,  4  + mesh_tensor.flat<int>().data(), sizeof(int *));


### PR DESCRIPTION
### changes

- bcast the modle files to all MPI processors.
- fix a bug, change the default memory size of temporary tensor(used in descrpt_se_a.cu)to nloc * GPU_MAX_NBOR_SIZE(4096) to avoid a potential GPU memory access error.
- fix a bug, rm print in class NeighborStat.