### PR TITLE
Fix lammps related bugs

### DIFF
--- a/source/lib/src/NNPInter.cc
+++ b/source/lib/src/NNPInter.cc
@@ -190,7 +190,10 @@ void
 NNPInter::
 init (const string & model, const int & gpu_rank)
 {
-  assert (!inited);
+  if (inited){
+    std::cerr << "WARNING: deepmd-kit should not be initialized twice, do nothing at the second call of initializer" << std::endl;
+    return ;
+  }
   SessionOptions options;
   options.config.set_inter_op_parallelism_threads(num_inter_nthreads);
   options.config.set_intra_op_parallelism_threads(num_intra_nthreads);
@@ -497,7 +500,10 @@ void
 NNPInterModelDevi::
 init (const vector<string> & models, const int & gpu_rank)
 {
-  assert (!inited);
+  if (inited){
+    std::cerr << "WARNING: deepmd-kit should not be initialized twice, do nothing at the second call of initializer" << std::endl;
+    return ;
+  }
   numb_models = models.size();
   sessions.resize(numb_models);
   graph_defs.resize(numb_models);

--- a/source/lmp/pair_nnp.cpp
+++ b/source/lmp/pair_nnp.cpp
@@ -206,6 +206,7 @@ PairNNP::PairNNP(LAMMPS *lmp)
   if (strcmp(update->unit_style,"metal") != 0) {
     error->all(FLERR,"Pair deepmd requires metal unit, please set it by \"units metal\"");
   }
+  restartinfo = 0;
   pppmflag = 1;
   respa_enable = 0;
   writedata = 0;


### PR DESCRIPTION
1. Do nothing if the C++ interface is initialized more than once. Solves issue #370 
2. set the `restartinfo` to `0` because the pair_style `deepmd` does not support restarting from lammps restart file. Solve the issue #329