### PR TITLE
append to out_file when LAMMPS restarts

### DIFF
--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -237,6 +237,7 @@ PairDeepMD::PairDeepMD(LAMMPS *lmp)
   if (strcmp(update->unit_style,"metal") != 0) {
     error->all(FLERR,"Pair deepmd requires metal unit, please set it by \"units metal\"");
   }
+  restartinfo = 1;
   pppmflag = 1;
   respa_enable = 0;
   writedata = 0;
@@ -254,6 +255,7 @@ PairDeepMD::PairDeepMD(LAMMPS *lmp)
   single_model = false;
   multi_models_mod_devi = false;
   multi_models_no_mod_devi = false;
+  is_restart = false;
   // set comm size needed by this Pair
   comm_reverse = 1;
 
@@ -855,6 +857,7 @@ void PairDeepMD::settings(int narg, char **arg)
   
   if (comm->me == 0){
     if (numb_models > 1 && out_freq > 0){
+      if (!is_restart) {
       fp.open (out_file);
       fp << scientific;
       fp << "#"
@@ -866,6 +869,10 @@ void PairDeepMD::settings(int narg, char **arg)
 	 << setw(18+1) << "min_devi_f"
 	 << setw(18+1) << "avg_devi_f"
 	 << endl;
+      } else {
+        fp.open (out_file, std::ofstream::out | std::ofstream::app);
+        fp << scientific;
+      }
     }
     string pre = "  ";
     cout << pre << ">>> Info of model(s):" << endl
@@ -899,6 +906,16 @@ void PairDeepMD::settings(int narg, char **arg)
   
   comm_reverse = numb_models * 3;
   all_force.resize(numb_models);
+}
+
+void PairDeepMD::read_restart(FILE *)
+{
+  is_restart = true;
+}
+
+void PairDeepMD::write_restart(FILE *)
+{
+  // pass
 }
 
 /* ----------------------------------------------------------------------

--- a/source/lmp/pair_deepmd.h.in
+++ b/source/lmp/pair_deepmd.h.in
@@ -46,6 +46,8 @@ class PairDeepMD : public Pair {
   void settings(int, char **);
   virtual void coeff(int, char **);
   void init_style();
+  virtual void write_restart(FILE *);
+  virtual void read_restart(FILE *);
   double init_one(int i, int j);
   int pack_reverse_comm(int, int, double *);
   void unpack_reverse_comm(int, int *, double *);
@@ -75,6 +77,7 @@ private:
   bool single_model;
   bool multi_models_mod_devi;
   bool multi_models_no_mod_devi;
+  bool is_restart;
 #ifdef HIGH_PREC
   std::vector<double > fparam;
   std::vector<double > aparam;


### PR DESCRIPTION
This ensures the out file will not be override when LAMMPS restarts.
This commit may be conflicted with #392. Commit
https://github.com/deepmodeling/deepmd-kit/commit/5597ea2b49f96e99a52a9779b04b6c12e5a79a04 should be dropped.

Resolves #623.