### PR TITLE
append to out_file when LAMMPS restarts

### DIFF
--- a/source/lmp/pair_nnp.cpp
+++ b/source/lmp/pair_nnp.cpp
@@ -206,7 +206,7 @@ PairNNP::PairNNP(LAMMPS *lmp)
   if (strcmp(update->unit_style,"metal") != 0) {
     error->all(FLERR,"Pair deepmd requires metal unit, please set it by \"units metal\"");
   }
-  restartinfo = 0;
+  restartinfo = 1;
   pppmflag = 1;
   respa_enable = 0;
   writedata = 0;
@@ -222,6 +222,7 @@ PairNNP::PairNNP(LAMMPS *lmp)
   single_model = false;
   multi_models_mod_devi = false;
   multi_models_no_mod_devi = false;
+  is_restart = false;
   // set comm size needed by this Pair
   comm_reverse = 1;
 
@@ -754,6 +755,7 @@ void PairNNP::settings(int narg, char **arg)
   
   if (comm->me == 0){
     if (numb_models > 1 && out_freq > 0){
+      if (!is_restart) {
       fp.open (out_file);
       fp << scientific;
       fp << "#"
@@ -765,6 +767,10 @@ void PairNNP::settings(int narg, char **arg)
 	 << setw(18+1) << "min_devi_f"
 	 << setw(18+1) << "avg_devi_f"
 	 << endl;
+      } else {
+        fp.open (out_file, std::ofstream::out | std::ofstream::app);
+        fp << scientific;
+      }
     }
     string pre = "  ";
     cout << pre << ">>> Info of model(s):" << endl
@@ -798,6 +804,16 @@ void PairNNP::settings(int narg, char **arg)
   
   comm_reverse = numb_models * 3;
   all_force.resize(numb_models);
+}
+
+void PairDeepMD::read_restart(FILE *)
+{
+  is_restart = true;
+}
+
+void PairDeepMD::write_restart(FILE *)
+{
+  // pass
 }
 
 /* ----------------------------------------------------------------------

--- a/source/lmp/pair_nnp.h.in
+++ b/source/lmp/pair_nnp.h.in
@@ -59,6 +59,8 @@ class PairNNP : public Pair {
   void settings(int, char **);
   virtual void coeff(int, char **);
   void init_style();
+  virtual void write_restart(FILE *);
+  virtual void read_restart(FILE *);
   double init_one(int i, int j);
   int pack_reverse_comm(int, int, double *);
   void unpack_reverse_comm(int, int *, double *);
@@ -85,6 +87,7 @@ private:
   bool single_model;
   bool multi_models_mod_devi;
   bool multi_models_no_mod_devi;
+  bool is_restart;
 #ifdef HIGH_PREC
   vector<double > fparam;
   vector<double > aparam;


### PR DESCRIPTION
This ensures the out file will not be override when LAMMPS restarts.
This commit may be conflicted with #392. Commit
@5597ea2b49f96e99a52a9779b04b6c12e5a79a04 should be dropped.
