### PR TITLE
remove unused tqdm 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ venv*
 _build
 _templates
 API_CC
+dp/
+build_lammps/

--- a/deepmd/utils/neighbor_stat.py
+++ b/deepmd/utils/neighbor_stat.py
@@ -1,7 +1,6 @@
 import math
 import logging
 import numpy as np
-from tqdm import tqdm
 from deepmd.env import tf
 from typing import Tuple, List
 from deepmd.env import op_module

--- a/deepmd/utils/tabulate.py
+++ b/deepmd/utils/tabulate.py
@@ -2,7 +2,6 @@ import re
 import math
 import logging
 import numpy as np
-from tqdm import tqdm
 from typing import Tuple, List
 from deepmd.env import tf
 from deepmd.env import op_module

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy
 scipy
 pyyaml
 dargs >= 0.2.2
-tqdm
 typing_extensions


### PR DESCRIPTION
tqdm is not used at present. It may be imported in #350 for tests, but since it is not really used for production, it is safe to remove this requirement.