### PR TITLE
remove typing_extensions for python>=3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 scipy
 pyyaml
 dargs >= 0.2.2
-typing_extensions
+typing_extensions; python_version < "3.7"


### PR DESCRIPTION
We don't need typing_extensions for python>=3.7.
See:
[1] https://pypi.org/project/typing-extensions/
[2] https://www.python.org/dev/peps/pep-0508/