### PR TITLE
speedup ROCm kernel which uses atomicAdd

### DIFF
--- a/source/lib/src/rocm/prod_force.hip.cu
+++ b/source/lib/src/rocm/prod_force.hip.cu
@@ -51,12 +51,11 @@ __global__ void force_deriv_wrt_neighbors_a(
     const int nnei)
 {  
     // idy -> nnei
-    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const unsigned int idy = blockIdx.y;
+    const unsigned int idx = blockIdx.x;
+    const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
     const unsigned int idz = threadIdx.y;
-    const unsigned int idw = threadIdx.z;
     const int ndescrpt = nnei * 4;
-    if (idx >= nloc) {
+    if (idy >= nnei) {
         return;
     }
     // deriv wrt neighbors
@@ -64,9 +63,11 @@ __global__ void force_deriv_wrt_neighbors_a(
     if (j_idx < 0) {
         return;
     }
-    atomicAdd(
-        force + j_idx * 3 + idz, 
-        net_deriv[idx * ndescrpt + idy * 4 + idw] * in_deriv[idx * ndescrpt * 3 + (idy * 4 + idw) * 3 + idz]);
+    FPTYPE force_tmp = 0.f;
+    for (int idw = 0; idw < 4; ++idw) {
+        force_tmp += net_deriv[idx * ndescrpt + idy * 4 + idw] * in_deriv[idx * ndescrpt * 3 + (idy * 4 + idw) * 3 + idz];
+    }
+    atomicAdd(force + j_idx * 3 + idz, force_tmp);
 }
 
 template<typename FPTYPE>
@@ -117,9 +118,9 @@ namespace deepmd {
         net_deriv, in_deriv, ndescrpt);
   
     const int LEN = 64;
-    const int nblock = (nloc + LEN -1) / LEN;
-    dim3 block_grid(nblock, nnei);
-    dim3 thread_grid(LEN, 3, 4);
+    const int nblock = (nnei + LEN - 1) / LEN;
+    dim3 block_grid(nloc, nblock);
+    dim3 thread_grid(LEN, 3);
     hipLaunchKernelGGL(force_deriv_wrt_neighbors_a, block_grid, thread_grid, 0, 0, 
         force, 
         net_deriv, in_deriv, nlist, nloc, nnei);

--- a/source/lib/src/rocm/prod_virial.hip.cu
+++ b/source/lib/src/rocm/prod_virial.hip.cu
@@ -46,24 +46,22 @@ __global__ void virial_deriv_wrt_neighbors_a(
   // idz = dd0 * 3 + dd1
   // dd0 = idz / 3
   // dd1 = idz % 3
-  const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  const unsigned int idy = blockIdx.y;
+  const unsigned int idx = blockIdx.x;
+  const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
   const unsigned int idz = threadIdx.y;
-  const unsigned int idw = threadIdx.z;
   const int ndescrpt = nnei * 4;
-  if (idx >= nloc) {
+  if (idy >= nnei) {
       return;
   }
   int j_idx = nlist[idx * nnei + idy];
   if (j_idx < 0) {
       return;
   }
-  // atomicAdd(
-  //    virial + idz, 
-  //    net_deriv[idx * ndescrpt + idy * 4 + idw] * rij[idx * nnei * 3 + idy * 3 + idz / 3] * in_deriv[idx * ndescrpt * 3 + (idy * 4 + idw) * 3 + idz % 3]);
-  atomicAdd(
-      atom_virial + j_idx * 9 + idz, 
-      net_deriv[idx * ndescrpt + idy * 4 + idw] * rij[idx * nnei * 3 + idy * 3 + idz % 3] * in_deriv[idx * ndescrpt * 3 + (idy * 4 + idw) * 3 + idz / 3]);
+  FPTYPE virial_tmp = 0.f;
+  for (int idw = 0; idw < 4; ++idw) {
+      virial_tmp += net_deriv[idx * ndescrpt + idy * 4 + idw] * rij[idx * nnei * 3 + idy * 3 + idz % 3] * in_deriv[idx * ndescrpt * 3 + (idy * 4 + idw) * 3 + idz / 3];
+  }
+  atomicAdd(atom_virial + j_idx * 9 + idz, virial_tmp);
 }
 
 template<typename FPTYPE>
@@ -123,9 +121,9 @@ void prod_virial_a_gpu_rocm(
       0.0, sizeof(FPTYPE) * 9 * nall));
     
   const int LEN = 16;
-  int nblock = (nloc + LEN -1) / LEN;
-  dim3 block_grid(nblock, nnei);
-  dim3 thread_grid(LEN, 9, 4);
+  int nblock = (nnei + LEN -1) / LEN;
+  dim3 block_grid(nloc, nblock);
+  dim3 thread_grid(LEN, 9);
   // compute virial of a frame
   hipLaunchKernelGGL(virial_deriv_wrt_neighbors_a, block_grid, thread_grid, 0, 0, 
       virial, atom_virial, 


### PR DESCRIPTION
This PR works on optimizing ROCm kernel which uses atomicAdd. 

By the experiments before, we already knew that atomicAdd on CUDA is much more efficient than on ROCm. A straightforward idea is to reduce the calling number of atomicAdd instruction.  By pre-summing the four values before doing atomicAdd, we gains nearly **4 times** speedup on `force_deriv_wrt_neighbors_a` and `virial_deriv_wrt_neighbors_a` ROCm kernels. 

Moreover, by switching the computing order inside and cross a block, we aim to reduce the crashing of writing same global memory address. In our benchmark, this switching gets **1.4 ~ 2.2 times** speedup.

We also benchmark the E2E performance on LAMMPS inference. On compressed copper model, this work gets **1.45x** speedup on pairs computing.

Baseline:
[2_compress.json.gz](https://github.com/deepmodeling/deepmd-kit/files/6730613/2_compress.json.gz)
![screenshot-20210629-034744](https://user-images.githubusercontent.com/15198390/123736251-5de63880-d8d3-11eb-980b-387a13f10b70.png)


After speedup:
[2_compress_optimized.json.gz](https://github.com/deepmodeling/deepmd-kit/files/6730617/2_compress_optimized.json.gz)
![screenshot-20210629-034352](https://user-images.githubusercontent.com/15198390/123736199-4d35c280-d8d3-11eb-97fb-4296830362ac.png)

