### PR TITLE
speedup tabulate cuda kernel by reducing shm using

### DIFF
--- a/source/lib/src/cuda/tabulate.cu
+++ b/source/lib/src/cuda/tabulate.cu
@@ -73,17 +73,13 @@ __global__ void tabulate_fusion_fifth_order_polynomial(
     const int nnei, 
     const int last_layer_size) 
 {
-  extern __shared__ int _data[];
   const int block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
   FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei + nnei - 1], 0);
   bool unloop = false;
   int breakpoint = nnei - 1;
-  FPTYPE * iteratorC = (FPTYPE*) &_data[0];
-  for (int kk = 0; kk < MTILE; kk++)
-    iteratorC[kk * last_layer_size + thread_idx] = 0.f;
-  __syncthreads();
 
+  FPTYPE sum[MTILE] = {0.f};
   for (int ii = 0; ii < nnei; ii++) {
     FPTYPE var[6]; 
     FPTYPE xx = em_x[block_idx * nnei + ii];
@@ -102,12 +98,12 @@ __global__ void tabulate_fusion_fifth_order_polynomial(
     FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
     
     for (int kk = 0; kk < MTILE; kk++) {
-      iteratorC[kk * last_layer_size + thread_idx] += (nnei - breakpoint) * em[block_idx * nnei * MTILE + ii * MTILE + kk] * res;
+      sum[kk] += (nnei - breakpoint) * em[block_idx * nnei * MTILE + ii * MTILE + kk] * res;
     }
     if (unloop) break;
   }
   for (int ii = 0; ii < MTILE; ii++) {
-    out[block_idx * MTILE * last_layer_size + ii * last_layer_size + thread_idx] = iteratorC[ii * last_layer_size + thread_idx];
+    out[block_idx * MTILE * last_layer_size + ii * last_layer_size + thread_idx] = sum[ii];
   }
 }
 
@@ -204,7 +200,7 @@ void tabulate_fusion_gpu_cuda(
     const int last_layer_size) 
 {
   if (nloc <= 0) {return;}
-  tabulate_fusion_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size>>>(
+  tabulate_fusion_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size>>>(
       out, 
       table, em_x, em, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei, last_layer_size);
 }


### PR DESCRIPTION
This PR works on tabulate fusion CUDA kernel, including:

* speedup `tabulate_fusion_fifth_order_polynomial` kernel 1.3 times by reducing shm using (and thread syncing). 
* fix misusage between `KTILE` and `MTILE` in `tabulate_fusion_grad_fifth_order_polynomial` kernel.
* format the `warp_idx` variable used in `tabulate_fusion_grad_fifth_order_polynomial` kernel.