### PR TITLE
remove cub include for CUDA>=11

### DIFF
--- a/source/lib/src/cuda/CMakeLists.txt
+++ b/source/lib/src/cuda/CMakeLists.txt
@@ -15,7 +15,12 @@ SET(CMAKE_CUDA_STANDARD 11)
 # nvcc -o libdeepmd_op_cuda.so -I/usr/local/cub-1.8.0 -rdc=true -DHIGH_PREC=true -gencode arch=compute_61,code=sm_61 -shared -Xcompiler -fPIC deepmd_op.cu -L/usr/local/cuda/lib64 -lcudadevrt
 # very important here! Include path to cub.
 # for searching device compute capability, https://developer.nvidia.com/cuda-gpus
+
+# cub has been included in CUDA Toolkit 11, we do not need to include it any more
+# see https://github.com/NVIDIA/cub
+if (${CUDA_VERSION_MAJOR} LESS_EQUAL "10")
 include_directories(cub)
+endif ()
 
 message(STATUS "CUDA major version is " ${CUDA_VERSION_MAJOR})
 


### PR DESCRIPTION
CUDA 11 has included cub, so we don't need to include it any more.
cub can be upgraded along with the CUDA Toolkit to obtain bugfixes.
See https://github.com/NVIDIA/cub#releases.
See also https://github.com/NVIDIA/cub/blob/main/CHANGELOG.md.

P.S. It's still unclear to me that which version of C++ it supports.  (#755)