### PR TITLE
[Paddle] Fixed model save issues with Ener model

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -191,7 +191,7 @@ else:
     GLOBAL_TF_FLOAT_PRECISION = tf.float32
     GLOBAL_PD_FLOAT_PRECISION = "float32"
     GLOBAL_NP_FLOAT_PRECISION = np.float32
-    GLOBAL_ENER_FLOAT_PRECISION = np.float64
+    GLOBAL_ENER_FLOAT_PRECISION = np.float32
     global_float_prec = "float"
 
 

--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -108,14 +108,13 @@ class EnerModel(paddle.nn.Layer) :
     def _compute_output_stat (self, all_stat) :
         self.fitting.compute_output_stats(all_stat)
 
-    @paddle.jit.to_static
     def forward (self, 
                coord_, 
                atype_,
                natoms,
                box, 
                mesh,
-               input_dict,
+               input_dict = {},
                suffix = '', 
                reuse = None):
         coord = paddle.reshape(coord_, [-1, natoms[1] * 3])

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         f"-DTENSORFLOW_ROOT:STRING={tf_install_dir}",
         "-DBUILD_PY_IF:BOOL=TRUE",
         "-DBUILD_CPP_IF:BOOL=FALSE",
-        "-DFLOAT_PREC:STRING=high",
+        "-DFLOAT_PREC:STRING=low",
     ],
     cmake_source_dir="source",
     cmake_minimum_required_version="3.0",

--- a/source/op/paddle_ops/srcs/pd_prod_env_mat_multi_devices_cpu.cc
+++ b/source/op/paddle_ops/srcs/pd_prod_env_mat_multi_devices_cpu.cc
@@ -72,6 +72,7 @@ _prepare_coord_nlist_cpu(
     const int &max_cpy_trial,
     const int &max_nnei_trial);
 
+#ifdef PADDLE_WITH_CUDA
 std::vector<paddle::Tensor> PdProdEnvMatAOpCUDAForward(
     const paddle::Tensor &coord_tensor,
     const paddle::Tensor &type_tensor,
@@ -85,6 +86,7 @@ std::vector<paddle::Tensor> PdProdEnvMatAOpCUDAForward(
     float rcut_r_smth,
     std::vector<int> sel_a,
     std::vector<int> sel_r);
+#endif
 
 template <typename data_t>
 void PdProdEnvMatAOpCPUForwardKernel(
@@ -295,6 +297,7 @@ std::vector<paddle::Tensor> PdProdEnvMatAOpForward(
       sel_a,
       sel_r
     );
+#ifdef PADDLE_WITH_CUDA
   } else if (coord_tensor.place() == paddle::PlaceType::kGPU) {
     return PdProdEnvMatAOpCUDAForward(
       coord_tensor, 
@@ -310,6 +313,7 @@ std::vector<paddle::Tensor> PdProdEnvMatAOpForward(
       sel_a,
       sel_r
     );
+#endif
   } else {
     PD_THROW("Not implemented.");
   }

--- a/source/op/paddle_ops/srcs/pd_prod_force_se_a_multi_devices_cpu.cc
+++ b/source/op/paddle_ops/srcs/pd_prod_force_se_a_multi_devices_cpu.cc
@@ -10,6 +10,7 @@
 
 
 
+#ifdef PADDLE_WITH_CUDA
 std::vector<paddle::Tensor> PdProdForceSeAOpCUDAForward(
 const paddle::Tensor& net_deriv_tensor,
 const paddle::Tensor& in_deriv_tensor,
@@ -17,6 +18,7 @@ const paddle::Tensor& nlist_tensor,
 const paddle::Tensor& natoms_tensor,
 int n_a_sel, 
 int n_r_sel);
+#endif
 
 template <typename data_t>
 void PdProdForceSeAOpForwardCPUKernel(
@@ -199,8 +201,10 @@ int n_a_sel,
 int n_r_sel){
     if(net_deriv_tensor.place() == paddle::PlaceType::kCPU){
         return PdProdForceSeAOpCPUForward(net_deriv_tensor, in_deriv_tensor, nlist_tensor, natoms_tensor, n_a_sel, n_r_sel);
+#ifdef PADDLE_WITH_CUDA
     }else if(net_deriv_tensor.place() == paddle::PlaceType::kGPU){
         return PdProdForceSeAOpCUDAForward(net_deriv_tensor, in_deriv_tensor, nlist_tensor, natoms_tensor, n_a_sel, n_r_sel);
+#endif
     }else{
         PD_THROW("No Such kernel for PdFrodForceSeAForward!");
     }

--- a/source/op/paddle_ops/srcs/pd_prod_virial_se_a_multi_devices_cpu.cc
+++ b/source/op/paddle_ops/srcs/pd_prod_virial_se_a_multi_devices_cpu.cc
@@ -9,7 +9,7 @@
 #define CHECK_INPUT_DIM(x, value) PD_CHECK(x.shape().size() == value, #x "'s dim should be " #value ".")
 
 
-
+#ifdef PADDLE_WITH_CUDA
 std::vector<paddle::Tensor> PdProdVirialSeAOpCUDAForward(
 const paddle::Tensor& net_deriv_tensor,
 const paddle::Tensor& in_deriv_tensor,
@@ -18,6 +18,7 @@ const paddle::Tensor& nlist_tensor,
 const paddle::Tensor& natoms_tensor,
 int n_a_sel, 
 int n_r_sel);
+#endif
 
 template <typename data_t>
 void PdProdVirialSeAOpForwardCPUKernel(


### PR DESCRIPTION
Following issues fixed:
1. Removed @paddle.jit.to_static decorator. Model will be converted to
static graph at save time.

2. Manually set InputSpec for "Ener" model with "se_a" descriptor

3. Due to lack of support for "double" datatype at inference time,
default training precision was set to float (low precision)