### PR TITLE
Fix the empty neighbor distance array in neighbor_stat.py 

### DIFF
--- a/deepmd/utils/neighbor_stat.py
+++ b/deepmd/utils/neighbor_stat.py
@@ -86,7 +86,7 @@ class NeighborStat():
                         dt = np.min(dt)              
                     else:
                         dt = self.rcut
-                        log.warn("Atoms with no neighbors found in %s. Please make sure it's what you expected."%jj)
+                        log.warning("Atoms with no neighbors found in %s. Please make sure it's what you expected."%jj)
                         
                     if dt < self.min_nbor_dist:
                         self.min_nbor_dist = dt

--- a/deepmd/utils/neighbor_stat.py
+++ b/deepmd/utils/neighbor_stat.py
@@ -82,7 +82,12 @@ class NeighborStat():
                                                 self.place_holders['box']: np.array(data_set['box'])[kk].reshape([-1, 9]),
                                                 self.place_holders['default_mesh']: np.array(data.default_mesh[ii]),
                                             })
-                    dt = np.min(dt)
+                    if dt.size != 0:
+                        dt = np.min(dt)              
+                    else:
+                        dt = self.rcut
+                        log.warn("Atoms with no neighbors found in %s. Please make sure it's what you expected."%jj)
+                        
                     if dt < self.min_nbor_dist:
                         self.min_nbor_dist = dt
                     for ww in range(self.ntypes):


### PR DESCRIPTION
atoms with no neighbors generate empty neighbor distance array causing np.min to crush.
add safe check and warning for atoms with no neighbors
