### PR TITLE
Find available GPUs in an elegant way.

### DIFF
--- a/deepmd/cluster/local.py
+++ b/deepmd/cluster/local.py
@@ -1,4 +1,5 @@
 """Get local GPU resources."""
+
 import logging
 import os
 import socket
@@ -35,8 +36,8 @@ def get_gpus():
 
     # Ensure TensorFlow is compatible
     if num_gpus > 0 and not tf.test.is_built_with_gpu_support():
-        log.warning("GPU devices are found while your installed TensorFlow has no GPU support!"
-            + " Switch to CPU device for calculation.")
+        log.warning("GPU devices are found while your installed TensorFlow has no GPU "
+                    "support! Switch to CPU device for calculation.")
         return None
 
     # All GPUs are avaiable
@@ -51,7 +52,8 @@ def get_gpus():
             gpu_id = len(valid_ids)
             valid_ids.append(gpu_id)
         else:
-            log.warning("GPU ID %d in `` is out of range and thus ignored!")
+            log.warning("GPU ID %d in `CUDA_VISIBLE_DEVICES` is out of range and thus "
+                        "ignored!", idx)
     return valid_ids if len(valid_ids) > 0 else None  # Always None if no GPU available
 
 

--- a/deepmd/cluster/local.py
+++ b/deepmd/cluster/local.py
@@ -39,12 +39,8 @@ def get_gpus():
             + " Switch to CPU device for calculation.")
         return None
 
-    # Warn for better GPU visibility
+    # All GPUs are avaiable
     if "CUDA_VISIBLE_DEVICES" not in os.environ:
-        if num_gpus > 1:
-            log.warning("Multiple GPU devices are found while only the first one will be used!"
-            + " It is recommended to limit GPU visibility by the environment variable"
-            + " `CUDA_VISIBLE_DEVICES`.")
         return list(range(num_gpus))
 
     # In case where user set "CUDA_VISIBLE_DEVICES=-1" to disable GPU usage
@@ -54,6 +50,8 @@ def get_gpus():
         if idx >= 0 and idx < num_gpus:
             gpu_id = len(valid_ids)
             valid_ids.append(gpu_id)
+        else:
+            log.warning("GPU ID %d in `` is out of range and thus ignored!")
     return valid_ids if len(valid_ids) > 0 else None  # Always None if no GPU available
 
 

--- a/deepmd/cluster/local.py
+++ b/deepmd/cluster/local.py
@@ -1,10 +1,60 @@
-"""Get local GPU resources from `CUDA_VISIBLE_DEVICES` enviroment variable."""
-
+"""Get local GPU resources."""
+import logging
 import os
 import socket
+
+import GPUtil
+
+from deepmd.env import tf
 from typing import List, Tuple, Optional
 
-__all__ = ["get_resource"]
+__all__ = ["get_gpus", "get_resource"]
+
+log = logging.getLogger(__name__)
+
+
+def get_gpus():
+    """Get available IDs of GPU cards at local.
+    These IDs are valid when used as the TensorFlow device ID.
+
+    Returns:
+    -------
+    Optional[List[int]]
+        List of available GPU IDs. Otherwise, None.
+    """
+    # TODO: Create a pull request of `GPUtil` to cover ROCM devices.
+    # Currently, even if None is returned, a ROCM device is still visible in TensorFlow.
+    available = GPUtil.getGPUs()
+    num_gpus = len(available)
+    if num_gpus == 0:
+        return None
+
+    # Print help messages
+    gpu_str_list = ["- %d#%s" % (item.id, item.name) for item in available]
+    log.info("Availalbe GPUs are:\n%s", "\n".join(gpu_str_list))
+
+    # Ensure TensorFlow is compatible
+    if num_gpus > 0 and not tf.test.is_built_with_gpu_support():
+        log.warning("GPU devices are found while your installed TensorFlow has no GPU support!"
+            + " Switch to CPU device for calculation.")
+        return None
+
+    # Warn for better GPU visibility
+    if "CUDA_VISIBLE_DEVICES" not in os.environ:
+        if num_gpus > 1:
+            log.warning("Multiple GPU devices are found while only the first one will be used!"
+            + " It is recommended to limit GPU visibility by the environment variable"
+            + " `CUDA_VISIBLE_DEVICES`.")
+        return list(range(num_gpus))
+
+    # In case where user set "CUDA_VISIBLE_DEVICES=-1" to disable GPU usage
+    valid_ids = []
+    for item in os.environ["CUDA_VISIBLE_DEVICES"].split(","):
+        idx = int(item)
+        if idx >= 0 and idx < num_gpus:
+            gpu_id = len(valid_ids)
+            valid_ids.append(gpu_id)
+    return valid_ids if len(valid_ids) > 0 else None  # Always None if no GPU available
 
 
 def get_resource() -> Tuple[str, List[str], Optional[List[int]]]:
@@ -17,10 +67,5 @@ def get_resource() -> Tuple[str, List[str], Optional[List[int]]]:
     """
     nodename = socket.gethostname()
     nodelist = [nodename]
-    gpus_env = os.getenv("CUDA_VISIBLE_DEVICES", None)
-    if not gpus_env:
-        gpus = None
-    else:
-        gpus = [gpu for gpu in gpus_env.split(",")]
-
+    gpus = get_gpus()
     return nodename, nodelist, gpus

--- a/deepmd/cluster/local.py
+++ b/deepmd/cluster/local.py
@@ -25,14 +25,14 @@ def get_gpus():
                'devices = device_lib.list_local_devices(); ' \
                'gpus = [d.name for d in devices if d.device_type == "GPU"]; ' \
                'print(len(gpus))'
-    p = sp.Popen([sys.executable, "-c", test_cmd], stderr=sp.PIPE, stdout=sp.PIPE)
-    stdout, stderr = p.communicate()
-    if p.returncode != 0:
-        decoded = stderr.decode('UTF-8')
-        raise RuntimeError('Failed to detect availbe GPUs due to:\n%s' % decoded)
-    decoded = stdout.decode('UTF-8').strip()
-    num_gpus = int(decoded)
-    return list(range(num_gpus)) if num_gpus > 0 else None
+    with sp.Popen([sys.executable, "-c", test_cmd], stderr=sp.PIPE, stdout=sp.PIPE) as p:
+        stdout, stderr = p.communicate()
+        if p.returncode != 0:
+            decoded = stderr.decode('UTF-8')
+            raise RuntimeError('Failed to detect availbe GPUs due to:\n%s' % decoded)
+        decoded = stdout.decode('UTF-8').strip()
+        num_gpus = int(decoded)
+        return list(range(num_gpus)) if num_gpus > 0 else None
 
 
 def get_resource() -> Tuple[str, List[str], Optional[List[int]]]:

--- a/deepmd/cluster/slurm.py
+++ b/deepmd/cluster/slurm.py
@@ -7,6 +7,8 @@ https://github.com/deepsense-ai/tensorflow_on_slurm ####
 
 import re
 import os
+
+from deepmd.cluster import local
 from typing import List, Tuple, Optional, Iterable
 
 __all__ = ["get_resource"]
@@ -45,11 +47,7 @@ def get_resource() -> Tuple[str, List[str], Optional[List[int]]]:
         raise ValueError(
             f"Nodename({nodename}) not in nodelist({nodelist}). This should not happen!"
         )
-    gpus_env = os.getenv("CUDA_VISIBLE_DEVICES")
-    if not gpus_env:
-        gpus = None
-    else:
-        gpus = [int(gpu) for gpu in gpus_env.split(",")]
+    gpus = local.get_gpus()
     return nodename, nodelist, gpus
 
 

--- a/deepmd/train/run_options.py
+++ b/deepmd/train/run_options.py
@@ -123,14 +123,15 @@ class RunOptions:
         log.info("---Summary of the training---------------------------------------")
         if self.is_distrib:
             log.info("distributed")
-            log.info(f"world size:              {self.world_size}")
+            log.info(f"world size:           {self.world_size}")
             log.info(f"my rank:              {self.my_rank}")
-            log.info(f"node list:          {self.nodelist}")
+            log.info(f"node list:            {self.nodelist}")
         log.info(f"running on:           {self.nodename}")
-        if self.gpus is None:
-            log.info(f"CUDA_VISIBLE_DEVICES: unset")
-        else:
-            log.info(f"CUDA_VISIBLE_DEVICES: {self.gpus}")
+        log.info(f"computing device:     {self.my_device}")
+        if tf.test.is_built_with_gpu_support():
+            env_value = os.environ.get('CUDA_VISIBLE_DEVICES', 'unset')
+            log.info(f"CUDA_VISIBLE_DEVICES: {env_value}")
+            log.info(f"Count of visible GPU: {len(self.gpus)}")
         intra, inter = get_tf_default_nthreads()
         log.info(f"num_intra_threads:    {intra:d}")
         log.info(f"num_inter_threads:    {inter:d}")

--- a/deepmd/train/run_options.py
+++ b/deepmd/train/run_options.py
@@ -128,10 +128,9 @@ class RunOptions:
             log.info(f"node list:            {self.nodelist}")
         log.info(f"running on:           {self.nodename}")
         log.info(f"computing device:     {self.my_device}")
-        if tf.test.is_built_with_gpu_support():
-            env_value = os.environ.get('CUDA_VISIBLE_DEVICES', 'unset')
-            log.info(f"CUDA_VISIBLE_DEVICES: {env_value}")
-            log.info(f"Count of visible GPU: {len(self.gpus)}")
+        env_value = os.environ.get('CUDA_VISIBLE_DEVICES', 'unset')
+        log.info(f"CUDA_VISIBLE_DEVICES: {env_value}")
+        log.info(f"Count of visible GPU: {len(self.gpus or [])}")
         intra, inter = get_tf_default_nthreads()
         log.info(f"num_intra_threads:    {intra:d}")
         log.info(f"num_inter_threads:    {inter:d}")

--- a/deepmd/train/run_options.py
+++ b/deepmd/train/run_options.py
@@ -206,7 +206,7 @@ class RunOptions:
             gpu_idx = HVD.local_rank()
             if gpu_idx >= len(gpus):
                 raise RuntimeError('Count of local processes is larger than that of available GPUs!')
-            my_device = f"gpu:{gpu_idx:d}"
+            self.my_device = f"gpu:{gpu_idx:d}"
         else:
             self.my_device = "cpu:0"
 

--- a/deepmd/train/run_options.py
+++ b/deepmd/train/run_options.py
@@ -52,57 +52,6 @@ BUILD = (
 )
 
 
-def _is_distributed(HVD: "HVD") -> bool:
-    """Check if there are more than one MPI processes.
-
-    Parameters
-    ----------
-    HVD : HVD
-        Horovod object
-
-    Returns
-    -------
-    bool
-        True if we have more than 1 MPI process
-    """
-    return HVD.size() > 1
-
-
-def _distributed_task_config(
-    HVD: "HVD",
-    gpu_list: Optional[List[int]] = None
-) -> Tuple[int, int, str]:
-    """Create configuration for distributed tensorflow session.
-
-    Parameters
-    ----------
-    HVD : horovod.tensorflow
-        Horovod TensorFlow module
-    gpu_list : Optional[List[int]], optional
-        the list of GPUs on each node, by default None
-
-    Returns
-    -------
-    Tuple[int, int, str]
-        task count, index of this task, the device for this task
-    """
-    my_rank = HVD.rank()
-    world_size = HVD.size()
-
-    # setup gpu/cpu devices
-    if gpu_list is not None:
-        numb_gpu = len(gpu_list)
-        gpu_idx = HVD.local_rank()
-        if gpu_idx >= numb_gpu:
-            my_device = "cpu:0"  # "cpu:%d" % node_task_idx
-        else:
-            my_device = f"gpu:{gpu_idx:d}"
-    else:
-        my_device = "cpu:0"  # "cpu:%d" % node_task_idx
-
-    return world_size, my_rank, my_device
-
-
 class RunOptions:
     """Class with inf oon how to run training (cluster, MPI and GPU config).
 
@@ -225,7 +174,7 @@ class RunOptions:
         try:
             import horovod.tensorflow as HVD
             HVD.init()
-            self.is_distrib = _is_distributed(HVD)
+            self.is_distrib = HVD.size() > 1
         except ImportError:
             log.warning("Switch to serial execution due to lack of horovod module.")
             self.is_distrib = False
@@ -250,11 +199,16 @@ class RunOptions:
         self.nodename = nodename
         self.nodelist = nodelist
         self.gpus = gpus
-        (
-            self.world_size,
-            self.my_rank,
-            self.my_device,
-        ) = _distributed_task_config(HVD, gpus)
+        self.my_rank = HVD.rank()
+        self.world_size = HVD.size()
+
+        if gpus is not None:
+            gpu_idx = HVD.local_rank()
+            if gpu_idx >= len(gpus):
+                raise RuntimeError('Count of local processes is larger than that of available GPUs!')
+            my_device = f"gpu:{gpu_idx:d}"
+        else:
+            self.my_device = "cpu:0"
 
     def _init_serial(self):
         """Initialize setting for serial training."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy
 scipy
 pyyaml
 dargs >= 0.2.6
-GPUtil >= 0.14.0
 typing_extensions; python_version < "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ numpy
 scipy
 pyyaml
 dargs >= 0.2.2
+GPUtil >= 0.14.0
 typing_extensions; python_version < "3.7"


### PR DESCRIPTION
Before this pull request, the implementation of GPU discovery at `deepmd.cluster.local` and `deepmd.cluster.slurm` is based on the environment variable `CUDA_VISIBLE_DEVICE`.

This is not safe because the value of `CUDA_VISIBLE_DEVICE` may be illegal. What's more, IDs returned should obey the naming rule of platform GPU ID at [gpu_id.h](https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/core/common_runtime/gpu/gpu_id.h).