### PR TITLE
fix 'NoneType' has no len() in `auto_sel`

### DIFF
--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -229,7 +229,7 @@ def get_sel(jdata, rcut):
     max_rcut = get_rcut(jdata)
     type_map = get_type_map(jdata)
 
-    if len(type_map) == 0:
+    if type_map and len(type_map) == 0:
         type_map = None
     train_data = get_data(jdata["training"]["training_data"], max_rcut, type_map, None)
     train_data.get_batch()


### PR DESCRIPTION
The default value of `type_map` is `None`, so when you don't set `type_map`, you'll get this error.

https://github.com/deepmodeling/deepmd-kit/blob/043ac869bfcdc7f3a20aa24d04bb7c7b88abcc0b/deepmd/entrypoints/train.py#L225