### PR TITLE
raise warning before training if `sel` is not enough

### DIFF
--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -276,11 +276,22 @@ def wrap_up_4(xx):
 
 
 def update_one_sel(jdata, descriptor):
+    rcut = descriptor['rcut']
+    tmp_sel = get_sel(jdata, rcut)
     if parse_auto_sel(descriptor['sel']) :
         ratio = parse_auto_sel_ratio(descriptor['sel'])
-        rcut = descriptor['rcut']
-        tmp_sel = get_sel(jdata, rcut)
         descriptor['sel'] = [int(wrap_up_4(ii * ratio)) for ii in tmp_sel]
+    else:
+        # sel is set by user
+        for ii, (tt, dd) in enumerate(zip(tmp_sel, descriptor['sel'])):
+            if dd and tt > dd:
+                # we may skip warning for sel=0, where the user is likely
+                # to exclude such type in the descriptor
+                log.warning(
+                    "sel of type %d is not enough! The expected value is "
+                    "not less than %d, but you set it to %d. The accuracy"
+                    " of your model may get worse." %(ii, tt, dd)
+                )
     return descriptor
 
 

--- a/deepmd/utils/neighbor_stat.py
+++ b/deepmd/utils/neighbor_stat.py
@@ -89,6 +89,13 @@ class NeighborStat():
                         log.warning("Atoms with no neighbors found in %s. Please make sure it's what you expected."%jj)
                         
                     if dt < self.min_nbor_dist:
+                        if math.isclose(dt, 0., rel_tol=1e-6):
+                            # it's unexpected that the distance between two atoms is zero
+                            # zero distance will cause nan (#874) 
+                            raise RuntimeError(
+                                "Some atoms in %s are overlapping. Please check your"
+                                " training data to remove duplicated atoms." % jj
+                            )
                         self.min_nbor_dist = dt
                     for ww in range(self.ntypes):
                         var = np.max(mn[:, ww])


### PR DESCRIPTION
Currently I can't see any warning during the training if `sel` is not enough, so it's a good idea to check it before training, and tell the user what to do.

Also fix #874.