### PR TITLE
Passing error to TF instead of exit

### DIFF
--- a/source/api_cc/tests/CMakeLists.txt
+++ b/source/api_cc/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ configure_file(
 set(opname "deepmd_op")
 set(OP_BASE_DIR ${CMAKE_SOURCE_DIR}/../../op)
 # file(GLOB OP_SRC ${OP_BASE_DIR}/*.cc)
-file(GLOB OP_SRC ${OP_BASE_DIR}/prod_force.cc ${OP_BASE_DIR}/prod_virial.cc ${OP_BASE_DIR}/descrpt.cc ${OP_BASE_DIR}/descrpt_se_a_ef.cc ${OP_BASE_DIR}/descrpt_se_a_ef.cc ${OP_BASE_DIR}/descrpt_se_a_ef_para.cc ${OP_BASE_DIR}/descrpt_se_a_ef_vert.cc ${OP_BASE_DIR}/pair_tab.cc ${OP_BASE_DIR}/prod_force_multi_device.cc ${OP_BASE_DIR}/prod_virial_multi_device.cc ${OP_BASE_DIR}/soft_min.cc ${OP_BASE_DIR}/soft_min_force.cc ${OP_BASE_DIR}/soft_min_virial.cc ${OP_BASE_DIR}/ewald_recp.cc ${OP_BASE_DIR}/gelu_multi_device.cc ${OP_BASE_DIR}/map_aparam.cc ${OP_BASE_DIR}/neighbor_stat.cc ${OP_BASE_DIR}/unaggregated_grad.cc ${OP_BASE_DIR}/tabulate_multi_device.cc ${OP_BASE_DIR}/prod_env_mat_multi_device.cc)
+file(GLOB OP_SRC ${OP_BASE_DIR}/custom_op.cc ${OP_BASE_DIR}/prod_force.cc ${OP_BASE_DIR}/prod_virial.cc ${OP_BASE_DIR}/descrpt.cc ${OP_BASE_DIR}/descrpt_se_a_ef.cc ${OP_BASE_DIR}/descrpt_se_a_ef.cc ${OP_BASE_DIR}/descrpt_se_a_ef_para.cc ${OP_BASE_DIR}/descrpt_se_a_ef_vert.cc ${OP_BASE_DIR}/pair_tab.cc ${OP_BASE_DIR}/prod_force_multi_device.cc ${OP_BASE_DIR}/prod_virial_multi_device.cc ${OP_BASE_DIR}/soft_min.cc ${OP_BASE_DIR}/soft_min_force.cc ${OP_BASE_DIR}/soft_min_virial.cc ${OP_BASE_DIR}/ewald_recp.cc ${OP_BASE_DIR}/gelu_multi_device.cc ${OP_BASE_DIR}/map_aparam.cc ${OP_BASE_DIR}/neighbor_stat.cc ${OP_BASE_DIR}/unaggregated_grad.cc ${OP_BASE_DIR}/tabulate_multi_device.cc ${OP_BASE_DIR}/prod_env_mat_multi_device.cc)
 add_library(${opname} SHARED ${OP_SRC})
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake/)

--- a/source/lib/include/SimulationRegion_Impl.h
+++ b/source/lib/include/SimulationRegion_Impl.h
@@ -6,6 +6,7 @@
 #include <limits>
 #include <typeinfo>
 #include <stdexcept>
+#include "errors.h"
 
 // using namespace std;
 
@@ -502,7 +503,7 @@ computeVolume()
       boxt[0*3+2] * (boxt[1*3+0]*boxt[2*3+1] - boxt[2*3+0]*boxt[1*3+1]);
   volumei = static_cast<double>(1.)/volume;
   if (volume < 0) {
-    throw std::runtime_error("Negative volume detected. Please make sure the simulation cell obeys the right-hand rule.");
+    throw deepmd::deepmd_exception("Negative volume detected. Please make sure the simulation cell obeys the right-hand rule.");
   }
 }
 

--- a/source/lib/include/errors.h
+++ b/source/lib/include/errors.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace deepmd{
+    struct
+    deepmd_exception: public std::runtime_error {
+    public:
+        deepmd_exception(): runtime_error("DeePMD-kit Error!") {};
+        deepmd_exception(const std::string& msg): runtime_error(std::string("DeePMD-kit Error: ") + msg) {};
+    };
+
+    struct
+    deepmd_exception_oom: public std::runtime_error{
+    public:
+        deepmd_exception_oom(): runtime_error("DeePMD-kit OOM!") {};
+        deepmd_exception_oom(const std::string& msg): runtime_error(std::string("DeePMD-kit OOM: ") + msg) {};
+    };
+};

--- a/source/lib/include/gpu_cuda.h
+++ b/source/lib/include/gpu_cuda.h
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <cuda_runtime.h>
+#include "errors.h"
 
 #define GPU_MAX_NBOR_SIZE 4096
 #define DPErrcheck(res) {DPAssert((res), __FILE__, __LINE__);}
@@ -12,7 +13,6 @@ inline void DPAssert(cudaError_t code, const char *file, int line, bool abort=tr
     fprintf(stderr,"cuda assert: %s %s %d\n", cudaGetErrorString(code), file, line);
     if (code == 2) {
       // out of memory
-      // TODO: I have no idea how to thorw errors back to Python interface
       fprintf(stderr, "Your memory is not enough, thus an error has been raised " \
         "above. You need to take the following actions:\n" \
         "1. Check if the network size of the model is too large.\n" \
@@ -22,8 +22,9 @@ inline void DPAssert(cudaError_t code, const char *file, int line, bool abort=tr
         "4. Check if another program is using the same GPU by execuating `nvidia-smi`. " \
         "The usage of GPUs is controlled by `CUDA_VISIBLE_DEVICES` " \
         "environment variable.\n");
+      if (abort) throw deepmd::deepmd_exception_oom("CUDA Assert");
     }
-    if (abort) exit(code);
+    if (abort) throw deepmd::deepmd_exception("CUDA Assert");
   }
 }
 
@@ -34,7 +35,6 @@ inline void nborAssert(cudaError_t code, const char *file, int line, bool abort=
         fprintf(stderr,"cuda assert: %s %s %d\n", "DeePMD-kit:\tillegal nbor list sorting", file, line);
         if (code == 2) {
           // out of memory
-          // TODO: I have no idea how to thorw errors back to Python interface
           fprintf(stderr, "Your memory is not enough, thus an error has been raised " \
             "above. You need to take the following actions:\n" \
             "1. Check if the network size of the model is too large.\n" \
@@ -44,8 +44,9 @@ inline void nborAssert(cudaError_t code, const char *file, int line, bool abort=
             "4. Check if another program is using the same GPU by execuating `nvidia-smi`. " \
             "The usage of GPUs is controlled by `CUDA_VISIBLE_DEVICES` " \
             "environment variable.\n");
+            if (abort) throw deepmd::deepmd_exception_oom("CUDA Assert");
         }
-        if (abort) exit(code);
+        if (abort) throw deepmd::deepmd_exception("CUDA Assert");
     }
 }
 

--- a/source/lib/include/gpu_rocm.h
+++ b/source/lib/include/gpu_rocm.h
@@ -5,6 +5,7 @@
 #include<hip/hip_runtime.h>
 //#include<rocprim/rocprim.hpp>
 //#include <hipcub/hipcub.hpp>
+#include "errors.h"
 
 #define GPU_MAX_NBOR_SIZE 4096
 
@@ -12,7 +13,7 @@
 inline void DPAssert(hipError_t code, const char *file, int line, bool abort=true) {
     if (code != hipSuccess) {
         fprintf(stderr,"hip assert: %s %s %d\n", hipGetErrorString(code), file, line);
-        if (abort) exit(code);
+        if (abort) throw deepmd::deepmd_exception("CUDA Assert");
     }
 }
 
@@ -20,7 +21,7 @@ inline void DPAssert(hipError_t code, const char *file, int line, bool abort=tru
 inline void nborAssert(hipError_t code, const char *file, int line, bool abort=true) {
     if (code != hipSuccess) {
         fprintf(stderr,"hip assert: %s %s %d\n", "DeePMD-kit:\tillegal nbor list sorting", file, line);
-        if (abort) exit(code);
+        if (abort) throw deepmd::deepmd_exception("CUDA Assert");
     }
 }
 

--- a/source/lib/src/fmt_nlist.cc
+++ b/source/lib/src/fmt_nlist.cc
@@ -4,6 +4,7 @@
 #include "fmt_nlist.h"
 #include "SimulationRegion.h"
 #include <iostream>
+#include "errors.h"
 
 using namespace deepmd;
 
@@ -185,7 +186,7 @@ format_nlist_cpu (
 		<< fmt_ilist.size()
 		<< " which does not match " 
 		<< nnei	<< std::endl;
-      exit(1);
+      throw deepmd::deepmd_exception();
     }
     std::copy(fmt_ilist.begin(), fmt_ilist.end(), cur_nlist);
   }

--- a/source/lib/src/pair_tab.cc
+++ b/source/lib/src/pair_tab.cc
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <vector>
 #include "pair_tab.h"
+#include "errors.h"
 
 inline 
 void _pair_tabulated_inter (
@@ -25,7 +26,7 @@ void _pair_tabulated_inter (
   // std::cout << rr << " " << rmin << " " << hh << " " << uu << std::endl;
   if (uu < 0) {
     std::cerr << "coord go beyond table lower boundary" << std::endl;
-    exit(1);
+    throw deepmd::deepmd_exception();
   }
   int idx = uu;
   if (idx >= nspline) {

--- a/source/lib/src/prod_force.cc
+++ b/source/lib/src/prod_force.cc
@@ -1,6 +1,7 @@
 #include <stdexcept>
 #include <cstring>
 #include "prod_force.h"
+#include "errors.h"
 
 inline void
 make_index_range (
@@ -14,7 +15,7 @@ make_index_range (
     idx_end   = nei_idx * 4 + 4;
   }
   else {
-    throw std::runtime_error("should no reach here");
+    throw deepmd::deepmd_exception("should no reach here");
   }
 }
 

--- a/source/lib/src/prod_force_grad.cc
+++ b/source/lib/src/prod_force_grad.cc
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include <cstring>
 #include "prod_force_grad.h"
+#include "errors.h"
 
 inline void
 make_index_range (
@@ -15,7 +16,7 @@ make_index_range (
     idx_end   = nei_idx * 4 + 4;
   }
   else {
-    throw std::runtime_error("should no reach here");
+    throw deepmd::deepmd_exception("should no reach here");
   }
 }
 

--- a/source/lib/src/prod_virial.cc
+++ b/source/lib/src/prod_virial.cc
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include <cstring>
 #include "prod_virial.h"
+#include "errors.h"
 
 inline void 
 make_index_range (
@@ -15,7 +16,7 @@ make_index_range (
     idx_end   = nei_idx * 4 + 4;
   }
   else {
-    throw std::runtime_error("should no reach here");    
+    throw deepmd::deepmd_exception("should no reach here");    
   }
 }
 

--- a/source/lib/src/prod_virial_grad.cc
+++ b/source/lib/src/prod_virial_grad.cc
@@ -1,6 +1,7 @@
 #include <stdexcept>
 #include <cstring>
 #include "prod_virial_grad.h"
+#include "errors.h"
 
 inline void
 make_index_range (
@@ -14,7 +15,7 @@ make_index_range (
     idx_end   = nei_idx * 4 + 4;
   }
   else {
-    throw std::runtime_error("should no reach here");
+    throw deepmd::deepmd_exception("should no reach here");
   }
 }
 

--- a/source/lib/src/region.cc
+++ b/source/lib/src/region.cc
@@ -1,6 +1,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include "region.h"
+#include "errors.h"
 #define BOXT_DIM 9
 
 using namespace deepmd;
@@ -33,7 +34,7 @@ compute_volume(const FPTYPE * boxt)
       boxt[0*3+1] * (boxt[1*3+0]*boxt[2*3+2] - boxt[2*3+0]*boxt[1*3+2]) +
       boxt[0*3+2] * (boxt[1*3+0]*boxt[2*3+1] - boxt[2*3+0]*boxt[1*3+1]);
   if (volume < 0) {
-    throw std::runtime_error("Negative volume detected. Please make sure the simulation cell obeys the right-hand rule.");
+    throw deepmd::deepmd_exception("Negative volume detected. Please make sure the simulation cell obeys the right-hand rule.");
   }
   return volume;
 }

--- a/source/op/CMakeLists.txt
+++ b/source/op/CMakeLists.txt
@@ -3,10 +3,10 @@
 set(OP_LIB ${PROJECT_SOURCE_DIR}/lib/src/SimulationRegion.cpp ${PROJECT_SOURCE_DIR}/lib/src/neighbor_list.cc)
 
 set (OP_CXX_FLAG -D_GLIBCXX_USE_CXX11_ABI=${OP_CXX_ABI} )
-file(GLOB OP_SRC prod_force.cc prod_virial.cc descrpt.cc descrpt_se_a_ef.cc descrpt_se_a_ef.cc descrpt_se_a_ef_para.cc descrpt_se_a_ef_vert.cc pair_tab.cc prod_force_multi_device.cc prod_virial_multi_device.cc soft_min.cc soft_min_force.cc soft_min_virial.cc ewald_recp.cc gelu_multi_device.cc map_aparam.cc neighbor_stat.cc unaggregated_grad.cc tabulate_multi_device.cc prod_env_mat_multi_device.cc)
-file(GLOB OP_CUDA_SRC prod_force.cc prod_virial.cc descrpt.cc prod_env_mat_multi_device.cc pair_tab.cc prod_force_multi_device.cc prod_virial_multi_device.cc soft_min.cc soft_min_force.cc soft_min_virial.cc gelu_multi_device.cc tabulate_multi_device.cc)
-file(GLOB OP_ROCM_SRC prod_force.cc prod_virial.cc descrpt.cc prod_env_mat_multi_device.cc pair_tab.cc prod_force_multi_device.cc prod_virial_multi_device.cc soft_min.cc soft_min_force.cc soft_min_virial.cc gelu_multi_device.cc tabulate_multi_device.cc)
-file(GLOB OP_GRADS_SRC prod_force_grad.cc prod_force_grad_multi_device.cc prod_virial_grad.cc prod_virial_grad_multi_device.cc soft_min_force_grad.cc soft_min_virial_grad.cc )
+file(GLOB OP_SRC custom_op.cc prod_force.cc prod_virial.cc descrpt.cc descrpt_se_a_ef.cc descrpt_se_a_ef.cc descrpt_se_a_ef_para.cc descrpt_se_a_ef_vert.cc pair_tab.cc prod_force_multi_device.cc prod_virial_multi_device.cc soft_min.cc soft_min_force.cc soft_min_virial.cc ewald_recp.cc gelu_multi_device.cc map_aparam.cc neighbor_stat.cc unaggregated_grad.cc tabulate_multi_device.cc prod_env_mat_multi_device.cc)
+file(GLOB OP_CUDA_SRC custom_op.cc prod_force.cc prod_virial.cc descrpt.cc prod_env_mat_multi_device.cc pair_tab.cc prod_force_multi_device.cc prod_virial_multi_device.cc soft_min.cc soft_min_force.cc soft_min_virial.cc gelu_multi_device.cc tabulate_multi_device.cc)
+file(GLOB OP_ROCM_SRC custom_op.cc prod_force.cc prod_virial.cc descrpt.cc prod_env_mat_multi_device.cc pair_tab.cc prod_force_multi_device.cc prod_virial_multi_device.cc soft_min.cc soft_min_force.cc soft_min_virial.cc gelu_multi_device.cc tabulate_multi_device.cc)
+file(GLOB OP_GRADS_SRC custom_op.cc prod_force_grad.cc prod_force_grad_multi_device.cc prod_virial_grad.cc prod_virial_grad_multi_device.cc soft_min_force_grad.cc soft_min_virial_grad.cc )
 file(GLOB OP_PY *.py)
 
 if (BUILD_CPP_IF) 

--- a/source/op/custom_op.cc
+++ b/source/op/custom_op.cc
@@ -2,7 +2,7 @@
 #include "errors.h"
 
 namespace deepmd {
-  void save_compute(OpKernelContext* context, std::function<void(OpKernelContext*)> ff) {
+  void safe_compute(OpKernelContext* context, std::function<void(OpKernelContext*)> ff) {
     try{
       ff(context);
     } catch (deepmd::deepmd_exception_oom& e){

--- a/source/op/custom_op.cc
+++ b/source/op/custom_op.cc
@@ -1,0 +1,20 @@
+#include "custom_op.h"
+#include "errors.h"
+
+namespace deepmd {
+  void save_compute(OpKernelContext* context, std::function<void(OpKernelContext*)> ff) {
+    try{
+      ff(context);
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
+  }
+};

--- a/source/op/custom_op.h
+++ b/source/op/custom_op.h
@@ -27,3 +27,8 @@ struct DeviceFunctor {
   }
   #endif // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 };
+
+namespace deepmd {
+  typedef void ComputeFunction(OpKernelContext*);
+  void save_compute(OpKernelContext* context, std::function<void(OpKernelContext*)> ff);
+};

--- a/source/op/custom_op.h
+++ b/source/op/custom_op.h
@@ -29,5 +29,5 @@ struct DeviceFunctor {
 };
 
 namespace deepmd {
-  void save_compute(OpKernelContext* context, std::function<void(OpKernelContext*)> ff);
+  void safe_compute(OpKernelContext* context, std::function<void(OpKernelContext*)> ff);
 };

--- a/source/op/custom_op.h
+++ b/source/op/custom_op.h
@@ -29,6 +29,5 @@ struct DeviceFunctor {
 };
 
 namespace deepmd {
-  typedef void ComputeFunction(OpKernelContext*);
   void save_compute(OpKernelContext* context, std::function<void(OpKernelContext*)> ff);
 };

--- a/source/op/descrpt.cc
+++ b/source/op/descrpt.cc
@@ -2,6 +2,7 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;

--- a/source/op/descrpt.cc
+++ b/source/op/descrpt.cc
@@ -50,7 +50,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/descrpt.cc
+++ b/source/op/descrpt.cc
@@ -2,7 +2,6 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
-#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;
@@ -50,7 +49,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& coord_tensor	= context->input(0);
     const Tensor& type_tensor	= context->input(1);
@@ -107,7 +109,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw deepmd::deepmd_exception("invalid mesh tensor");
+      throw std::runtime_error("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -256,7 +258,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw deepmd::deepmd_exception("unknow neighbor mode");
+	throw std::runtime_error("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom
@@ -361,17 +363,6 @@ public:
 	  axis (kk, ii * 4 + jj * 2 + 1) = d_axis_idx [jj];
 	}
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/descrpt.cc
+++ b/source/op/descrpt.cc
@@ -109,7 +109,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -258,7 +258,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw std::runtime_error("unknow neighbor mode");
+	throw deepmd::deepmd_exception("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom

--- a/source/op/descrpt_se_a_ef.cc
+++ b/source/op/descrpt_se_a_ef.cc
@@ -3,6 +3,7 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;
@@ -49,6 +50,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& coord_tensor	= context->input(context_input_index++);
@@ -112,7 +114,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -267,7 +269,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw std::runtime_error("unknow neighbor mode");
+	throw deepmd::deepmd_exception("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom
@@ -330,6 +332,17 @@ public:
 	  nlist (kk, ii * nnei + jj) = record;
 	}
       }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/descrpt_se_a_ef.cc
+++ b/source/op/descrpt_se_a_ef.cc
@@ -116,7 +116,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -271,7 +271,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw std::runtime_error("unknow neighbor mode");
+	throw deepmd::deepmd_exception("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom

--- a/source/op/descrpt_se_a_ef.cc
+++ b/source/op/descrpt_se_a_ef.cc
@@ -50,7 +50,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/descrpt_se_a_ef.cc
+++ b/source/op/descrpt_se_a_ef.cc
@@ -3,6 +3,7 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;

--- a/source/op/descrpt_se_a_ef_para.cc
+++ b/source/op/descrpt_se_a_ef_para.cc
@@ -2,6 +2,7 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;

--- a/source/op/descrpt_se_a_ef_para.cc
+++ b/source/op/descrpt_se_a_ef_para.cc
@@ -49,7 +49,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/descrpt_se_a_ef_para.cc
+++ b/source/op/descrpt_se_a_ef_para.cc
@@ -2,7 +2,6 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
-#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;
@@ -49,7 +48,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& coord_tensor	= context->input(context_input_index++);
@@ -113,7 +115,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw deepmd::deepmd_exception("invalid mesh tensor");
+      throw std::runtime_error("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -268,7 +270,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw deepmd::deepmd_exception("unknow neighbor mode");
+	throw std::runtime_error("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom
@@ -331,17 +333,6 @@ public:
 	  nlist (kk, ii * nnei + jj) = record;
 	}
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/descrpt_se_a_ef_para.cc
+++ b/source/op/descrpt_se_a_ef_para.cc
@@ -115,7 +115,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -270,7 +270,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw std::runtime_error("unknow neighbor mode");
+	throw deepmd::deepmd_exception("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom

--- a/source/op/descrpt_se_a_ef_vert.cc
+++ b/source/op/descrpt_se_a_ef_vert.cc
@@ -2,6 +2,7 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;

--- a/source/op/descrpt_se_a_ef_vert.cc
+++ b/source/op/descrpt_se_a_ef_vert.cc
@@ -49,7 +49,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/descrpt_se_a_ef_vert.cc
+++ b/source/op/descrpt_se_a_ef_vert.cc
@@ -2,7 +2,6 @@
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
-#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;
@@ -49,7 +48,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& coord_tensor	= context->input(context_input_index++);
@@ -113,7 +115,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw deepmd::deepmd_exception("invalid mesh tensor");
+      throw std::runtime_error("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -268,7 +270,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw deepmd::deepmd_exception("unknow neighbor mode");
+	throw std::runtime_error("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom
@@ -331,17 +333,6 @@ public:
 	  nlist (kk, ii * nnei + jj) = record;
 	}
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/descrpt_se_a_ef_vert.cc
+++ b/source/op/descrpt_se_a_ef_vert.cc
@@ -115,7 +115,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -270,7 +270,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw std::runtime_error("unknow neighbor mode");
+	throw deepmd::deepmd_exception("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom

--- a/source/op/ewald_recp.cc
+++ b/source/op/ewald_recp.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "ewald.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;
@@ -28,6 +29,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int cc = 0;
     const Tensor& coord_tensor	= context->input(cc++);
@@ -114,6 +116,17 @@ public:
       for (int ii = 0; ii < 9; ++ii){
 	virial(kk, ii) = d_virial[ii];
       }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/ewald_recp.cc
+++ b/source/op/ewald_recp.cc
@@ -28,7 +28,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/ewald_recp.cc
+++ b/source/op/ewald_recp.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "ewald.h"
-#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;
@@ -29,7 +28,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int cc = 0;
     const Tensor& coord_tensor	= context->input(cc++);
@@ -116,17 +118,6 @@ public:
       for (int ii = 0; ii < 9; ++ii){
 	virial(kk, ii) = d_virial[ii];
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/gelu_multi_device.cc
+++ b/source/op/gelu_multi_device.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "gelu.h"
+#include "errors.h"
 
 REGISTER_OP("Gelu")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,6 +27,7 @@ class GeluOp : public OpKernel {
  public :
   explicit GeluOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     const Tensor& x_tensor = context->input(0);
     Tensor * output_tensor = NULL;
@@ -61,6 +63,17 @@ class GeluOp : public OpKernel {
           out, 
           x, size);
     }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
   }
  private :
   std::string device;
@@ -73,6 +86,7 @@ class GeluGradOp : public OpKernel {
  public :
   explicit GeluGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     const Tensor& dy_tensor = context->input(0);
     const Tensor& x_tensor  = context->input(1);
@@ -110,6 +124,17 @@ class GeluGradOp : public OpKernel {
           out, 
           x, dy, size);
     }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
   }
  private :
   std::string device;
@@ -122,6 +147,7 @@ class GeluGradGradOp : public OpKernel {
  public :
   explicit GeluGradGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     const Tensor& dy_tensor = context->input(0);
     const Tensor& dy_2_tensor = context->input(1);
@@ -156,6 +182,17 @@ class GeluGradGradOp : public OpKernel {
       deepmd::gelu_grad_grad_cpu(
           out, 
           x, dy, dy_2, size);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
  private :

--- a/source/op/gelu_multi_device.cc
+++ b/source/op/gelu_multi_device.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "gelu.h"
-#include "errors.h"
 
 REGISTER_OP("Gelu")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -27,7 +26,10 @@ class GeluOp : public OpKernel {
  public :
   explicit GeluOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& x_tensor = context->input(0);
     Tensor * output_tensor = NULL;
@@ -63,17 +65,6 @@ class GeluOp : public OpKernel {
           out, 
           x, size);
     }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    }
   }
  private :
   std::string device;
@@ -86,7 +77,10 @@ class GeluGradOp : public OpKernel {
  public :
   explicit GeluGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& dy_tensor = context->input(0);
     const Tensor& x_tensor  = context->input(1);
@@ -124,17 +118,6 @@ class GeluGradOp : public OpKernel {
           out, 
           x, dy, size);
     }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    }
   }
  private :
   std::string device;
@@ -147,7 +130,10 @@ class GeluGradGradOp : public OpKernel {
  public :
   explicit GeluGradGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& dy_tensor = context->input(0);
     const Tensor& dy_2_tensor = context->input(1);
@@ -182,17 +168,6 @@ class GeluGradGradOp : public OpKernel {
       deepmd::gelu_grad_grad_cpu(
           out, 
           x, dy, dy_2, size);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
  private :

--- a/source/op/gelu_multi_device.cc
+++ b/source/op/gelu_multi_device.cc
@@ -26,7 +26,7 @@ class GeluOp : public OpKernel {
  public :
   explicit GeluOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {
@@ -77,7 +77,7 @@ class GeluGradOp : public OpKernel {
  public :
   explicit GeluGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {
@@ -130,7 +130,7 @@ class GeluGradGradOp : public OpKernel {
  public :
   explicit GeluGradGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/legacy/descrpt_se_a.cc
+++ b/source/op/legacy/descrpt_se_a.cc
@@ -3,6 +3,7 @@
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
 #include "env_mat.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;

--- a/source/op/legacy/descrpt_se_a.cc
+++ b/source/op/legacy/descrpt_se_a.cc
@@ -107,7 +107,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -253,7 +253,7 @@ public:
 	::build_nlist (d_nlist_a, d_nlist_r, d_coord3, rcut_a, rcut_r, NULL);
       }
       else {
-	throw std::runtime_error("unknow neighbor mode");
+	throw deepmd::deepmd_exception("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom

--- a/source/op/legacy/descrpt_se_r.cc
+++ b/source/op/legacy/descrpt_se_r.cc
@@ -3,6 +3,7 @@
 #include "neighbor_list.h"
 #include "fmt_nlist.h"
 #include "env_mat.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;

--- a/source/op/legacy/descrpt_se_r.cc
+++ b/source/op/legacy/descrpt_se_r.cc
@@ -99,7 +99,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
     bool b_pbc = true;
     // if region is given extended, do not use pbc
@@ -238,7 +238,7 @@ public:
 	::build_nlist (d_nlist_null, d_nlist, d_coord3, -1, rcut, NULL);
       }
       else {
-	throw std::runtime_error("unknow neighbor mode");
+	throw deepmd::deepmd_exception("unknow neighbor mode");
       }
 
       // loop over atoms, compute descriptors for each atom

--- a/source/op/map_aparam.cc
+++ b/source/op/map_aparam.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "map_aparam.h"
+#include "errors.h"
 
 REGISTER_OP("MapAparam")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -20,6 +21,7 @@ class MapAparamOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& aparam_tensor		= context->input(context_input_index++);
@@ -69,6 +71,17 @@ class MapAparamOp : public OpKernel {
 	  nloc,
 	  nnei,
 	  numb_aparam);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/map_aparam.cc
+++ b/source/op/map_aparam.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "map_aparam.h"
-#include "errors.h"
 
 REGISTER_OP("MapAparam")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -21,7 +20,10 @@ class MapAparamOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& aparam_tensor		= context->input(context_input_index++);
@@ -71,17 +73,6 @@ class MapAparamOp : public OpKernel {
 	  nloc,
 	  nnei,
 	  numb_aparam);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/map_aparam.cc
+++ b/source/op/map_aparam.cc
@@ -20,7 +20,7 @@ class MapAparamOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/neighbor_stat.cc
+++ b/source/op/neighbor_stat.cc
@@ -64,7 +64,7 @@ public:
             nei_mode = -1;
         }
         else {
-            throw std::runtime_error("invalid mesh tensor");
+            throw deepmd::deepmd_exception("invalid mesh tensor");
         }
         // if region is given extended, do not use pbc
         bool b_pbc = (nei_mode >= 1 || nei_mode == -1) ? false : true;
@@ -143,7 +143,7 @@ public:
 	        ::build_nlist (d_nlist_a, d_nlist_r, d_coord3, -1, rcut, NULL);
         }
         else {
-	        throw std::runtime_error("unknow neighbor mode");
+	        throw deepmd::deepmd_exception("unknow neighbor mode");
         }
 
         int MAX_NNEI = 0;

--- a/source/op/neighbor_stat.cc
+++ b/source/op/neighbor_stat.cc
@@ -24,7 +24,7 @@ public:
     }
 
     void Compute(OpKernelContext* context) override {
-        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+        deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
     }
 
     void _Compute(OpKernelContext* context) {

--- a/source/op/neighbor_stat.cc
+++ b/source/op/neighbor_stat.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "neighbor_list.h"
-#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;
@@ -24,7 +23,10 @@ public:
     }
 
     void Compute(OpKernelContext* context) override {
-        try {
+        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    }
+
+    void _Compute(OpKernelContext* context) {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& coord_tensor	= context->input(context_input_index++);
@@ -62,7 +64,7 @@ public:
             nei_mode = -1;
         }
         else {
-            throw deepmd::deepmd_exception("invalid mesh tensor");
+            throw std::runtime_error("invalid mesh tensor");
         }
         // if region is given extended, do not use pbc
         bool b_pbc = (nei_mode >= 1 || nei_mode == -1) ? false : true;
@@ -141,7 +143,7 @@ public:
 	        ::build_nlist (d_nlist_a, d_nlist_r, d_coord3, -1, rcut, NULL);
         }
         else {
-	        throw deepmd::deepmd_exception("unknow neighbor mode");
+	        throw std::runtime_error("unknow neighbor mode");
         }
 
         int MAX_NNEI = 0;
@@ -168,17 +170,6 @@ public:
                 compute_t rij[3] = {d_coord3[d_nlist_r[ii][jj] * 3 + 0] - d_coord3[ii * 3 + 0], d_coord3[d_nlist_r[ii][jj] * 3 + 1] - d_coord3[ii * 3 + 1], d_coord3[d_nlist_r[ii][jj] * 3 + 2] - d_coord3[ii * 3 + 2]};
                 min_nbor_dist[ii * MAX_NNEI + jj] = sqrt(rij[0] * rij[0] + rij[1] * rij[1] + rij[2] * rij[2]);
             }
-        }
-        } catch (deepmd::deepmd_exception_oom& e){
-            OP_REQUIRES_OK(
-                context,
-                errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        } catch (deepmd::deepmd_exception& e) {
-            OP_REQUIRES_OK(
-                context,
-                errors::Internal("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
         }
     }
 

--- a/source/op/neighbor_stat.cc
+++ b/source/op/neighbor_stat.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "neighbor_list.h"
+#include "errors.h"
 
 typedef double boxtensor_t ;
 typedef double compute_t;

--- a/source/op/pair_tab.cc
+++ b/source/op/pair_tab.cc
@@ -34,6 +34,10 @@ class PairTabOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int tmp_idx = 0;
     const Tensor& table_info_tensor	= context->input(tmp_idx++);

--- a/source/op/pair_tab.cc
+++ b/source/op/pair_tab.cc
@@ -34,7 +34,7 @@ class PairTabOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_env_mat_multi_device.cc
+++ b/source/op/prod_env_mat_multi_device.cc
@@ -4,6 +4,7 @@
 #include "region.h"
 #include "neighbor_list.h"
 #include "prod_env_mat.h"
+#include "errors.h"
 
 REGISTER_OP("ProdEnvMatA")
     .Attr("T: {float, double} = DT_DOUBLE")

--- a/source/op/prod_env_mat_multi_device.cc
+++ b/source/op/prod_env_mat_multi_device.cc
@@ -4,7 +4,6 @@
 #include "region.h"
 #include "neighbor_list.h"
 #include "prod_env_mat.h"
-#include "errors.h"
 
 REGISTER_OP("ProdEnvMatA")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -322,7 +321,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& coord_tensor	= context->input(context_input_index++);
@@ -384,7 +386,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw deepmd::deepmd_exception("invalid mesh tensor");
+      throw std::runtime_error("invalid mesh tensor");
     }
 
     // Create output tensors
@@ -544,19 +546,6 @@ public:
       if(b_nlist_map) _map_nlist_cpu(nlist, &idx_mapping[0], nloc, nnei);
     }
     }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      // Ref:
-      // https://github.com/tensorflow/tensorflow/blob/5dcfc51118817f27fad5246812d83e5dccdc5f72/tensorflow/core/kernels/mkl/mkl_tfconv_op.h#L120-L126
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    }
   }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -599,7 +588,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& coord_tensor  = context->input(context_input_index++);
@@ -658,7 +650,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw deepmd::deepmd_exception("invalid mesh tensor");
+      throw std::runtime_error("invalid mesh tensor");
     }
 
     // Create an output tensor
@@ -817,17 +809,6 @@ public:
           coord, type, inlist, max_nbor_size, avg, std, nloc, frame_nall, rcut, rcut_smth, sec);
       if(b_nlist_map) _map_nlist_cpu(nlist, &idx_mapping[0], nloc, nnei);
     }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 

--- a/source/op/prod_env_mat_multi_device.cc
+++ b/source/op/prod_env_mat_multi_device.cc
@@ -322,7 +322,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {
@@ -589,7 +589,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_env_mat_multi_device.cc
+++ b/source/op/prod_env_mat_multi_device.cc
@@ -386,7 +386,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
 
     // Create output tensors
@@ -650,7 +650,7 @@ public:
       nei_mode = -1;
     }
     else {
-      throw std::runtime_error("invalid mesh tensor");
+      throw deepmd::deepmd_exception("invalid mesh tensor");
     }
 
     // Create an output tensor

--- a/source/op/prod_force.cc
+++ b/source/op/prod_force.cc
@@ -26,7 +26,7 @@ class ProdForceOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_force.cc
+++ b/source/op/prod_force.cc
@@ -1,4 +1,5 @@
 #include "custom_op.h"
+#include "errors.h"
 
 REGISTER_OP("ProdForce")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,6 +27,7 @@ class ProdForceOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     const Tensor& net_deriv_tensor	= context->input(0);
     const Tensor& in_deriv_tensor	= context->input(1);
@@ -138,6 +140,17 @@ class ProdForceOp : public OpKernel {
 	  }
 	}
       }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_force.cc
+++ b/source/op/prod_force.cc
@@ -1,5 +1,4 @@
 #include "custom_op.h"
-#include "errors.h"
 
 REGISTER_OP("ProdForce")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -27,7 +26,10 @@ class ProdForceOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& net_deriv_tensor	= context->input(0);
     const Tensor& in_deriv_tensor	= context->input(1);
@@ -140,17 +142,6 @@ class ProdForceOp : public OpKernel {
 	  }
 	}
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_force_grad.cc
+++ b/source/op/prod_force_grad.cc
@@ -1,5 +1,4 @@
 #include "custom_op.h"
-#include "errors.h"
 
 REGISTER_OP("ProdForceGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,7 +25,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& grad_tensor		= context->input(0);
     const Tensor& net_deriv_tensor	= context->input(1);
@@ -152,17 +154,6 @@ public:
 	  }
 	}
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_force_grad.cc
+++ b/source/op/prod_force_grad.cc
@@ -25,7 +25,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_force_grad.cc
+++ b/source/op/prod_force_grad.cc
@@ -1,4 +1,5 @@
 #include "custom_op.h"
+#include "errors.h"
 
 REGISTER_OP("ProdForceGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -25,6 +26,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     const Tensor& grad_tensor		= context->input(0);
     const Tensor& net_deriv_tensor	= context->input(1);
@@ -150,6 +152,17 @@ public:
 	  }
 	}
       }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_force_grad_multi_device.cc
+++ b/source/op/prod_force_grad_multi_device.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_force_grad.h"
-#include "errors.h"
 
 REGISTER_OP("ProdForceSeAGrad")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -32,7 +31,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -128,17 +130,6 @@ public:
             grad, in_deriv, nlist, nloc, nnei);
         }
     }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    }
   }
 private:
   std::string device;
@@ -152,7 +143,10 @@ public:
   explicit ProdForceSeRGradOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
-    try {
+      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -247,17 +241,6 @@ public:
               grad_net, 
               grad, in_deriv, nlist, nloc, nnei);
         }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
   private:

--- a/source/op/prod_force_grad_multi_device.cc
+++ b/source/op/prod_force_grad_multi_device.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_force_grad.h"
+#include "errors.h"
 
 REGISTER_OP("ProdForceSeAGrad")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -31,6 +32,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -126,6 +128,17 @@ public:
             grad, in_deriv, nlist, nloc, nnei);
         }
     }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
   }
 private:
   std::string device;
@@ -139,6 +152,7 @@ public:
   explicit ProdForceSeRGradOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -233,6 +247,17 @@ public:
               grad_net, 
               grad, in_deriv, nlist, nloc, nnei);
         }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
   private:

--- a/source/op/prod_force_grad_multi_device.cc
+++ b/source/op/prod_force_grad_multi_device.cc
@@ -31,7 +31,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {
@@ -143,7 +143,7 @@ public:
   explicit ProdForceSeRGradOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
-      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_force_multi_device.cc
+++ b/source/op/prod_force_multi_device.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_force.h"
+#include "errors.h"
 
 REGISTER_OP("ProdForceSeA")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -25,6 +26,7 @@ public:
   explicit ProdForceSeAOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -101,6 +103,17 @@ public:
           net_deriv, in_deriv, nlist, nloc, nall, nnei);
     }
     }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
   }
  private:
   std::string device;
@@ -111,6 +124,7 @@ class ProdForceSeROp : public OpKernel {
 public:
   explicit ProdForceSeROp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -185,6 +199,17 @@ public:
           force, 
           net_deriv, in_deriv, nlist, nloc, nall, nnei);
     }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
  private:

--- a/source/op/prod_force_multi_device.cc
+++ b/source/op/prod_force_multi_device.cc
@@ -25,7 +25,7 @@ public:
   explicit ProdForceSeAOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_force_multi_device.cc
+++ b/source/op/prod_force_multi_device.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_force.h"
-#include "errors.h"
 
 REGISTER_OP("ProdForceSeA")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,7 +25,10 @@ public:
   explicit ProdForceSeAOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -103,17 +105,6 @@ public:
           net_deriv, in_deriv, nlist, nloc, nall, nnei);
     }
     }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    }
   }
  private:
   std::string device;
@@ -124,7 +115,6 @@ class ProdForceSeROp : public OpKernel {
 public:
   explicit ProdForceSeROp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -199,17 +189,6 @@ public:
           force, 
           net_deriv, in_deriv, nlist, nloc, nall, nnei);
     }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
  private:

--- a/source/op/prod_force_se_a_grad.cc
+++ b/source/op/prod_force_se_a_grad.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_force_grad.h"
+#include "errors.h"
 
 REGISTER_OP("ProdForceSeAGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -25,6 +26,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -94,6 +96,17 @@ public:
 	  &nlist(nlist_iter),
 	  nloc, 
 	  nnei);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_force_se_a_grad.cc
+++ b/source/op/prod_force_se_a_grad.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_force_grad.h"
-#include "errors.h"
 
 REGISTER_OP("ProdForceSeAGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,7 +25,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -96,17 +98,6 @@ public:
 	  &nlist(nlist_iter),
 	  nloc, 
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_force_se_a_grad.cc
+++ b/source/op/prod_force_se_a_grad.cc
@@ -25,7 +25,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_force_se_r_grad.cc
+++ b/source/op/prod_force_se_r_grad.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_force_grad.h"
+#include "errors.h"
 
 REGISTER_OP("ProdForceSeRGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -20,6 +21,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -88,6 +90,17 @@ public:
 	  &nlist(nlist_iter),
 	  nloc,
 	  nnei);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 };

--- a/source/op/prod_force_se_r_grad.cc
+++ b/source/op/prod_force_se_r_grad.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_force_grad.h"
-#include "errors.h"
 
 REGISTER_OP("ProdForceSeRGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -21,7 +20,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -90,17 +92,6 @@ public:
 	  &nlist(nlist_iter),
 	  nloc,
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 };

--- a/source/op/prod_force_se_r_grad.cc
+++ b/source/op/prod_force_se_r_grad.cc
@@ -20,7 +20,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_virial.cc
+++ b/source/op/prod_virial.cc
@@ -1,5 +1,4 @@
 #include "custom_op.h"
-#include "errors.h"
 
 REGISTER_OP("ProdVirial")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -29,7 +28,10 @@ class ProdVirialOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& net_deriv_tensor	= context->input(0);
     const Tensor& in_deriv_tensor	= context->input(1);
@@ -161,17 +163,6 @@ class ProdVirialOp : public OpKernel {
 	  }
 	}
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial.cc
+++ b/source/op/prod_virial.cc
@@ -28,7 +28,7 @@ class ProdVirialOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_virial.cc
+++ b/source/op/prod_virial.cc
@@ -1,4 +1,5 @@
 #include "custom_op.h"
+#include "errors.h"
 
 REGISTER_OP("ProdVirial")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -28,6 +29,7 @@ class ProdVirialOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     const Tensor& net_deriv_tensor	= context->input(0);
     const Tensor& in_deriv_tensor	= context->input(1);
@@ -159,6 +161,17 @@ class ProdVirialOp : public OpKernel {
 	  }
 	}
       }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial_grad.cc
+++ b/source/op/prod_virial_grad.cc
@@ -1,4 +1,5 @@
 #include "custom_op.h"
+#include "errors.h"
 
 REGISTER_OP("ProdVirialGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,6 +27,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     const Tensor& grad_tensor		= context->input(0);
     const Tensor& net_deriv_tensor	= context->input(1);
@@ -159,6 +161,17 @@ public:
 	  }
 	}
       }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial_grad.cc
+++ b/source/op/prod_virial_grad.cc
@@ -26,7 +26,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_virial_grad.cc
+++ b/source/op/prod_virial_grad.cc
@@ -1,5 +1,4 @@
 #include "custom_op.h"
-#include "errors.h"
 
 REGISTER_OP("ProdVirialGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -27,7 +26,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& grad_tensor		= context->input(0);
     const Tensor& net_deriv_tensor	= context->input(1);
@@ -161,17 +163,6 @@ public:
 	  }
 	}
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial_grad_multi_device.cc
+++ b/source/op/prod_virial_grad_multi_device.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_virial_grad.h"
+#include "errors.h"
 
 REGISTER_OP("ProdVirialSeAGrad")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -34,6 +35,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -140,6 +142,17 @@ public:
           grad, in_deriv, rij, nlist, nloc, nnei);
       }
     }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
   }
 private:
   std::string device;
@@ -153,6 +166,7 @@ public:
   explicit ProdVirialSeRGradOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -257,6 +271,17 @@ public:
           grad_net, 
           grad, in_deriv, rij, nlist, nloc, nnei);
       }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial_grad_multi_device.cc
+++ b/source/op/prod_virial_grad_multi_device.cc
@@ -34,7 +34,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {
@@ -157,7 +157,7 @@ public:
   explicit ProdVirialSeRGradOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_virial_grad_multi_device.cc
+++ b/source/op/prod_virial_grad_multi_device.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_virial_grad.h"
-#include "errors.h"
 
 REGISTER_OP("ProdVirialSeAGrad")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -35,7 +34,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -142,17 +144,6 @@ public:
           grad, in_deriv, rij, nlist, nloc, nnei);
       }
     }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    }
   }
 private:
   std::string device;
@@ -166,7 +157,10 @@ public:
   explicit ProdVirialSeRGradOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -271,17 +265,6 @@ public:
           grad_net, 
           grad, in_deriv, rij, nlist, nloc, nnei);
       }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial_multi_device.cc
+++ b/source/op/prod_virial_multi_device.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_virial.h"
-#include "errors.h"
 
 REGISTER_OP("ProdVirialSeA")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -29,7 +28,10 @@ class ProdVirialSeAOp : public OpKernel {
  public:
   explicit ProdVirialSeAOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    try {
+      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -112,17 +114,6 @@ class ProdVirialSeAOp : public OpKernel {
           net_deriv, in_deriv, rij, nlist, nloc, nall, nnei);
     }
     }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    }
   }
  private:
   std::string device;
@@ -133,7 +124,10 @@ class ProdVirialSeROp : public OpKernel {
  public:
   explicit ProdVirialSeROp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-    try {
+      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -215,17 +209,6 @@ class ProdVirialSeROp : public OpKernel {
           virial, atom_virial,
           net_deriv, in_deriv, rij, nlist, nloc, nall, nnei);
     }
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
  private:

--- a/source/op/prod_virial_multi_device.cc
+++ b/source/op/prod_virial_multi_device.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_virial.h"
+#include "errors.h"
 
 REGISTER_OP("ProdVirialSeA")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -28,6 +29,7 @@ class ProdVirialSeAOp : public OpKernel {
  public:
   explicit ProdVirialSeAOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -110,6 +112,17 @@ class ProdVirialSeAOp : public OpKernel {
           net_deriv, in_deriv, rij, nlist, nloc, nall, nnei);
     }
     }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
   }
  private:
   std::string device;
@@ -120,6 +133,7 @@ class ProdVirialSeROp : public OpKernel {
  public:
   explicit ProdVirialSeROp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& net_deriv_tensor  = context->input(context_input_index++);
@@ -201,6 +215,17 @@ class ProdVirialSeROp : public OpKernel {
           virial, atom_virial,
           net_deriv, in_deriv, rij, nlist, nloc, nall, nnei);
     }
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
  private:

--- a/source/op/prod_virial_multi_device.cc
+++ b/source/op/prod_virial_multi_device.cc
@@ -28,7 +28,7 @@ class ProdVirialSeAOp : public OpKernel {
  public:
   explicit ProdVirialSeAOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {
@@ -124,7 +124,7 @@ class ProdVirialSeROp : public OpKernel {
  public:
   explicit ProdVirialSeROp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_virial_se_a_grad.cc
+++ b/source/op/prod_virial_se_a_grad.cc
@@ -26,7 +26,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/prod_virial_se_a_grad.cc
+++ b/source/op/prod_virial_se_a_grad.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_virial_grad.h"
-#include "errors.h"
 
 REGISTER_OP("ProdVirialSeAGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -27,7 +26,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -105,17 +107,6 @@ public:
 	  &nlist(nlist_iter),
 	  nloc,
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial_se_a_grad.cc
+++ b/source/op/prod_virial_se_a_grad.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_virial_grad.h"
+#include "errors.h"
 
 REGISTER_OP("ProdVirialSeAGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,6 +27,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -103,6 +105,17 @@ public:
 	  &nlist(nlist_iter),
 	  nloc,
 	  nnei);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/prod_virial_se_r_grad.cc
+++ b/source/op/prod_virial_se_r_grad.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "prod_virial_grad.h"
+#include "errors.h"
 
 REGISTER_OP("ProdVirialSeRGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -21,6 +22,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -97,6 +99,17 @@ public:
 	  &nlist(nlist_iter),
 	  nloc,
 	  nnei);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 };

--- a/source/op/prod_virial_se_r_grad.cc
+++ b/source/op/prod_virial_se_r_grad.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "prod_virial_grad.h"
-#include "errors.h"
 
 REGISTER_OP("ProdVirialSeRGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -22,7 +21,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -99,17 +101,6 @@ public:
 	  &nlist(nlist_iter),
 	  nloc,
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 };

--- a/source/op/prod_virial_se_r_grad.cc
+++ b/source/op/prod_virial_se_r_grad.cc
@@ -21,7 +21,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/soft_min.cc
+++ b/source/op/soft_min.cc
@@ -1,7 +1,6 @@
 #include "custom_op.h"
 #include "ComputeDescriptor.h"
 #include "soft_min_switch.h"
-#include "errors.h"
 
 REGISTER_OP("SoftMinSwitch")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -38,7 +37,10 @@ class SoftMinSwitchOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int tmp_idx = 0;
     const Tensor& type_tensor	= context->input(tmp_idx++);
@@ -103,17 +105,6 @@ class SoftMinSwitchOp : public OpKernel {
 	  alpha,
 	  rmin,
 	  rmax);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min.cc
+++ b/source/op/soft_min.cc
@@ -37,7 +37,7 @@ class SoftMinSwitchOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/soft_min.cc
+++ b/source/op/soft_min.cc
@@ -1,6 +1,7 @@
 #include "custom_op.h"
 #include "ComputeDescriptor.h"
 #include "soft_min_switch.h"
+#include "errors.h"
 
 REGISTER_OP("SoftMinSwitch")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -37,6 +38,7 @@ class SoftMinSwitchOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int tmp_idx = 0;
     const Tensor& type_tensor	= context->input(tmp_idx++);
@@ -101,6 +103,17 @@ class SoftMinSwitchOp : public OpKernel {
 	  alpha,
 	  rmin,
 	  rmax);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_force.cc
+++ b/source/op/soft_min_force.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "soft_min_switch_force.h"
-#include "errors.h"
 
 REGISTER_OP("SoftMinForce")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -25,7 +24,10 @@ class SoftMinForceOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     const Tensor& du_tensor		= context->input(0);
     const Tensor& sw_deriv_tensor	= context->input(1);
@@ -78,17 +80,6 @@ class SoftMinForceOp : public OpKernel {
 	  nloc,
 	  nall,
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_force.cc
+++ b/source/op/soft_min_force.cc
@@ -24,7 +24,7 @@ class SoftMinForceOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/soft_min_force_grad.cc
+++ b/source/op/soft_min_force_grad.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "soft_min_switch_force_grad.h"
-#include "errors.h"
 
 REGISTER_OP("SoftMinForceGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -25,7 +24,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -89,17 +91,6 @@ public:
 	  &nlist(kk,0),
 	  nloc,
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_force_grad.cc
+++ b/source/op/soft_min_force_grad.cc
@@ -24,7 +24,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/soft_min_force_grad.cc
+++ b/source/op/soft_min_force_grad.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "soft_min_switch_force_grad.h"
+#include "errors.h"
 
 REGISTER_OP("SoftMinForceGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -24,6 +25,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -87,6 +89,17 @@ public:
 	  &nlist(kk,0),
 	  nloc,
 	  nnei);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_virial.cc
+++ b/source/op/soft_min_virial.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "soft_min_switch_virial.h"
+#include "errors.h"
 
 REGISTER_OP("SoftMinVirial")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,6 +27,7 @@ class SoftMinVirialOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& du_tensor		= context->input(context_input_index++);
@@ -92,6 +94,17 @@ class SoftMinVirialOp : public OpKernel {
 	  nloc,
 	  nall,
 	  nnei);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_virial.cc
+++ b/source/op/soft_min_virial.cc
@@ -26,7 +26,7 @@ class SoftMinVirialOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/soft_min_virial.cc
+++ b/source/op/soft_min_virial.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "soft_min_switch_virial.h"
-#include "errors.h"
 
 REGISTER_OP("SoftMinVirial")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -27,7 +26,10 @@ class SoftMinVirialOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& du_tensor		= context->input(context_input_index++);
@@ -94,17 +96,6 @@ class SoftMinVirialOp : public OpKernel {
 	  nloc,
 	  nall,
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_virial_grad.cc
+++ b/source/op/soft_min_virial_grad.cc
@@ -1,6 +1,5 @@
 #include "custom_op.h"
 #include "soft_min_switch_virial_grad.h"
-#include "errors.h"
 
 REGISTER_OP("SoftMinVirialGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -26,7 +25,10 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    try {
+    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -97,17 +99,6 @@ public:
 	  &nlist(kk, 0),
 	  nloc,
 	  nnei);
-    }
-    } catch (deepmd::deepmd_exception_oom& e){
-      OP_REQUIRES_OK(
-          context,
-          errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
-    } catch (deepmd::deepmd_exception& e) {
-      OP_REQUIRES_OK(
-          context,
-          errors::Internal("Operation received an exception: ", e.what(),
-                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_virial_grad.cc
+++ b/source/op/soft_min_virial_grad.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "soft_min_switch_virial_grad.h"
+#include "errors.h"
 
 REGISTER_OP("SoftMinVirialGrad")
 .Attr("T: {float, double} = DT_DOUBLE")
@@ -25,6 +26,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& grad_tensor		= context->input(context_input_index++);
@@ -95,6 +97,17 @@ public:
 	  &nlist(kk, 0),
 	  nloc,
 	  nnei);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/soft_min_virial_grad.cc
+++ b/source/op/soft_min_virial_grad.cc
@@ -25,7 +25,7 @@ public:
   }
 
   void Compute(OpKernelContext* context) override {
-    deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/tabulate_multi_device.cc
+++ b/source/op/tabulate_multi_device.cc
@@ -1,5 +1,6 @@
 #include "custom_op.h"
 #include "tabulate.h"
+#include "errors.h"
 
 REGISTER_OP("TabulateFusion")
     .Attr("T: {float, double} = DT_DOUBLE")
@@ -28,6 +29,7 @@ class TabulateFusionOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("last_layer_size", &last_layer_size));
   }
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& table_tensor	= context->input(context_input_index++);
@@ -79,6 +81,17 @@ class TabulateFusionOp : public OpKernel {
           descriptor,
           table, table_info, em_x, em, nloc, nnei, last_layer_size);
     }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    }
   }
 private:
     int last_layer_size;
@@ -90,6 +103,7 @@ class TabulateFusionGradOp : public OpKernel {
  public:
   explicit TabulateFusionGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
+    try {
     // Grab the input tensor
     int context_input_index = 0;
     const Tensor& table_tensor	= context->input(context_input_index++);
@@ -146,6 +160,17 @@ class TabulateFusionGradOp : public OpKernel {
       deepmd::tabulate_fusion_grad_cpu(    
           dy_dem_x, dy_dem,
           table, table_info, em_x, em, dy, nloc, nnei, last_layer_size);
+    }
+    } catch (deepmd::deepmd_exception_oom& e){
+      OP_REQUIRES_OK(
+          context,
+          errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
+    } catch (deepmd::deepmd_exception& e) {
+      OP_REQUIRES_OK(
+          context,
+          errors::Internal("Operation received an exception: ", e.what(),
+                          ", in file ",__FILE__, ":", __LINE__));
     }
   }
 private:

--- a/source/op/tabulate_multi_device.cc
+++ b/source/op/tabulate_multi_device.cc
@@ -28,7 +28,7 @@ class TabulateFusionOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("last_layer_size", &last_layer_size));
   }
   void Compute(OpKernelContext* context) override {
-      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {
@@ -94,7 +94,7 @@ class TabulateFusionGradOp : public OpKernel {
  public:
   explicit TabulateFusionGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
-      deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
 
   void _Compute(OpKernelContext* context) {

--- a/source/op/unaggregated_grad.cc
+++ b/source/op/unaggregated_grad.cc
@@ -1,6 +1,7 @@
 #include "custom_op.h"
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
+#include "errors.h"
 
 REGISTER_OP("UnaggregatedDyDxS")
     .Attr("T: {float, double} = DT_DOUBLE") 
@@ -136,6 +137,7 @@ class UnaggregatedDyDxSOp : public OpKernel {
     explicit UnaggregatedDyDxSOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
+        try {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& y	= context->input(context_input_index++);
@@ -159,6 +161,17 @@ class UnaggregatedDyDxSOp : public OpKernel {
             y.shape().dim_size(1),
             dy_dx->flat<FPTYPE>().data()
         );
+        } catch (deepmd::deepmd_exception_oom& e){
+            OP_REQUIRES_OK(
+                context,
+                errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                                ", in file ",__FILE__, ":", __LINE__));
+        } catch (deepmd::deepmd_exception& e) {
+            OP_REQUIRES_OK(
+                context,
+                errors::Internal("Operation received an exception: ", e.what(),
+                                ", in file ",__FILE__, ":", __LINE__));
+        }
     }
 private:
 };
@@ -169,6 +182,7 @@ class UnaggregatedDy2DxSOp : public OpKernel {
     explicit UnaggregatedDy2DxSOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
+        try {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& y	    = context->input(context_input_index++);
@@ -195,6 +209,17 @@ class UnaggregatedDy2DxSOp : public OpKernel {
             y.shape().dim_size(1),
             dy2_dx->flat<FPTYPE>().data()
         );
+        } catch (deepmd::deepmd_exception_oom& e){
+            OP_REQUIRES_OK(
+                context,
+                errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                                ", in file ",__FILE__, ":", __LINE__));
+        } catch (deepmd::deepmd_exception& e) {
+            OP_REQUIRES_OK(
+                context,
+                errors::Internal("Operation received an exception: ", e.what(),
+                                ", in file ",__FILE__, ":", __LINE__));
+        }
     }
 private:
 };
@@ -205,6 +230,7 @@ class UnaggregatedDyDxOp : public OpKernel {
     explicit UnaggregatedDyDxOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
+        try {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& z	= context->input(context_input_index++);
@@ -232,6 +258,17 @@ class UnaggregatedDyDxOp : public OpKernel {
             w.shape().dim_size(0),
             dz_dx->flat<FPTYPE>().data()
         );
+        } catch (deepmd::deepmd_exception_oom& e){
+            OP_REQUIRES_OK(
+                context,
+                errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                                ", in file ",__FILE__, ":", __LINE__));
+        } catch (deepmd::deepmd_exception& e) {
+        OP_REQUIRES_OK(
+            context,
+            errors::Internal("Operation received an exception: ", e.what(),
+                            ", in file ",__FILE__, ":", __LINE__));
+        }
     }
 private:
 };
@@ -242,6 +279,7 @@ class UnaggregatedDy2DxOp : public OpKernel {
     explicit UnaggregatedDy2DxOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
+        try {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& z	= context->input(context_input_index++);
@@ -275,6 +313,17 @@ class UnaggregatedDy2DxOp : public OpKernel {
             w.shape().dim_size(0),
             dz2_dx->flat<FPTYPE>().data()
         );
+        } catch (deepmd::deepmd_exception_oom& e){
+            OP_REQUIRES_OK(
+                context,
+                errors::ResourceExhausted("Operation received an exception: ", e.what(),
+                                ", in file ",__FILE__, ":", __LINE__));
+        } catch (deepmd::deepmd_exception& e) {
+            OP_REQUIRES_OK(
+                context,
+                errors::Internal("Operation received an exception: ", e.what(),
+                                ", in file ",__FILE__, ":", __LINE__));
+        }
     }
 private:
 };

--- a/source/op/unaggregated_grad.cc
+++ b/source/op/unaggregated_grad.cc
@@ -136,7 +136,7 @@ class UnaggregatedDyDxSOp : public OpKernel {
     explicit UnaggregatedDyDxSOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+        deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
     }
 
     void _Compute(OpKernelContext* context) {
@@ -173,7 +173,7 @@ class UnaggregatedDy2DxSOp : public OpKernel {
     explicit UnaggregatedDy2DxSOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+        deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
     }
 
     void _Compute(OpKernelContext* context) {
@@ -213,7 +213,7 @@ class UnaggregatedDyDxOp : public OpKernel {
     explicit UnaggregatedDyDxOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+        deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
     }
 
     void _Compute(OpKernelContext* context) {
@@ -254,7 +254,7 @@ class UnaggregatedDy2DxOp : public OpKernel {
     explicit UnaggregatedDy2DxOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+        deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
     }
 
     void _Compute(OpKernelContext* context) {

--- a/source/op/unaggregated_grad.cc
+++ b/source/op/unaggregated_grad.cc
@@ -1,7 +1,6 @@
 #include "custom_op.h"
 #include "ComputeDescriptor.h"
 #include "neighbor_list.h"
-#include "errors.h"
 
 REGISTER_OP("UnaggregatedDyDxS")
     .Attr("T: {float, double} = DT_DOUBLE") 
@@ -137,7 +136,10 @@ class UnaggregatedDyDxSOp : public OpKernel {
     explicit UnaggregatedDyDxSOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        try {
+        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    }
+
+    void _Compute(OpKernelContext* context) {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& y	= context->input(context_input_index++);
@@ -161,17 +163,6 @@ class UnaggregatedDyDxSOp : public OpKernel {
             y.shape().dim_size(1),
             dy_dx->flat<FPTYPE>().data()
         );
-        } catch (deepmd::deepmd_exception_oom& e){
-            OP_REQUIRES_OK(
-                context,
-                errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        } catch (deepmd::deepmd_exception& e) {
-            OP_REQUIRES_OK(
-                context,
-                errors::Internal("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        }
     }
 private:
 };
@@ -182,7 +173,10 @@ class UnaggregatedDy2DxSOp : public OpKernel {
     explicit UnaggregatedDy2DxSOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        try {
+        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    }
+
+    void _Compute(OpKernelContext* context) {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& y	    = context->input(context_input_index++);
@@ -209,17 +203,6 @@ class UnaggregatedDy2DxSOp : public OpKernel {
             y.shape().dim_size(1),
             dy2_dx->flat<FPTYPE>().data()
         );
-        } catch (deepmd::deepmd_exception_oom& e){
-            OP_REQUIRES_OK(
-                context,
-                errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        } catch (deepmd::deepmd_exception& e) {
-            OP_REQUIRES_OK(
-                context,
-                errors::Internal("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        }
     }
 private:
 };
@@ -230,7 +213,10 @@ class UnaggregatedDyDxOp : public OpKernel {
     explicit UnaggregatedDyDxOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        try {
+        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    }
+
+    void _Compute(OpKernelContext* context) {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& z	= context->input(context_input_index++);
@@ -258,17 +244,6 @@ class UnaggregatedDyDxOp : public OpKernel {
             w.shape().dim_size(0),
             dz_dx->flat<FPTYPE>().data()
         );
-        } catch (deepmd::deepmd_exception_oom& e){
-            OP_REQUIRES_OK(
-                context,
-                errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        } catch (deepmd::deepmd_exception& e) {
-        OP_REQUIRES_OK(
-            context,
-            errors::Internal("Operation received an exception: ", e.what(),
-                            ", in file ",__FILE__, ":", __LINE__));
-        }
     }
 private:
 };
@@ -279,7 +254,10 @@ class UnaggregatedDy2DxOp : public OpKernel {
     explicit UnaggregatedDy2DxOp(OpKernelConstruction* context) : OpKernel(context) {}
 
     void Compute(OpKernelContext* context) override {
-        try {
+        deepmd::save_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+    }
+
+    void _Compute(OpKernelContext* context) {
         // Grab the input tensor
         int context_input_index = 0;
         const Tensor& z	= context->input(context_input_index++);
@@ -313,17 +291,6 @@ class UnaggregatedDy2DxOp : public OpKernel {
             w.shape().dim_size(0),
             dz2_dx->flat<FPTYPE>().data()
         );
-        } catch (deepmd::deepmd_exception_oom& e){
-            OP_REQUIRES_OK(
-                context,
-                errors::ResourceExhausted("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        } catch (deepmd::deepmd_exception& e) {
-            OP_REQUIRES_OK(
-                context,
-                errors::Internal("Operation received an exception: ", e.what(),
-                                ", in file ",__FILE__, ":", __LINE__));
-        }
     }
 private:
 };


### PR DESCRIPTION
This commit does three little things:
(1) create an exception called `deepmd::deepmd_exception` (based on `std::runtime_error`);
(2) throw this exception instead of `exit` or `std::runtime_error`;
(3) catch this exception in the op, and pass to TF using `OP_REQUIRES_OK`.
One more, the OOM error will raise ResourceExhausted, as the same as TF ops.

The benifit of doing so is that the TF side and Python side can processing other things, catch the error, and print the traceback.
This commit can also fix #802, where the Python didn't save the buffer to the file before exit.

The idea was inspired by TF: https://github.com/tensorflow/tensorflow/blob/5dcfc51118817f27fad5246812d83e5dccdc5f72/tensorflow/core/kernels/mkl/mkl_tfconv_op.h#L120-L126