### PR TITLE
Fix member declartion of `deepmd` and `deepmd.entrypoints`.

### DIFF
--- a/deepmd/__init__.py
+++ b/deepmd/__init__.py
@@ -4,7 +4,7 @@ import deepmd.utils.network as network
 
 from . import cluster, descriptor, fit, loss, utils
 from .env import set_mkl
-from .infer import DeepPotential
+from .infer import DeepEval, DeepPotential
 from .infer.data_modifier import DipoleChargeModifier
 
 set_mkl()

--- a/deepmd/entrypoints/__init__.py
+++ b/deepmd/entrypoints/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
     "doc_train_input",
     "freeze",
     "test",
-    "train",
+    "train_dp",
     "transfer",
     "compress",
     "doc_train_input",


### PR DESCRIPTION
Symbol `DeepEval` is not imported while declared in field `__all__` of `deepmd/__init__.py`.
```
>>> from deepmd import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'deepmd' has no attribute 'DeepEval'
```

Module `train` should not be declared as public in `deepmd/entrypoints/__init__.py`. Actually, `train_dp` is the correct one.
```
>>> from deepmd.entrypoints import *
>>> test
<function test at 0x7f7c2bc53d08>
>>> train
<module 'deepmd.entrypoints.train' from '/usr/local/lib/python3.7/dist-packages/deepmd_kit-2.0.0b3.dev37+g4d08f7e-py3.7-linux-x86_64.egg/deepmd/entrypoints/train.py'>
```