### PR TITLE
update conda install documents

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -21,7 +21,7 @@ Both CPU and GPU version offline packages are avaiable in [the Releases page](ht
 
 Some packages are splited into two files due to size limit of GitHub. One may merge them into one after downloading:
 ```bash
-cat deepmd-kit-2.0.0-cuda11.1_gpu-Linux-x86_64.sh.0 deepmd-kit-2.0.0-cuda11.1_gpu-Linux-x86_64.sh.1 > deepmd-kit-2.0.0-cuda11.1_gpu-Linux-x86_64.sh
+cat deepmd-kit-2.0.0-cuda11.3_gpu-Linux-x86_64.sh.0 deepmd-kit-2.0.0-cuda11.3_gpu-Linux-x86_64.sh.1 > deepmd-kit-2.0.0-cuda11.3_gpu-Linux-x86_64.sh
 ```
 
 ### Install with conda
@@ -29,18 +29,18 @@ DeePMD-kit is avaiable with [conda](https://github.com/conda/conda). Install [An
 
 One may create an environment that contains the CPU version of DeePMD-kit and LAMMPS:
 ```bash
-conda create -n deepmd deepmd-kit=*=*cpu lammps-dp=*=*cpu -c https://conda.deepmodeling.org
+conda create -n deepmd deepmd-kit=*=*cpu libdeepmd=*=*cpu lammps-dp -c https://conda.deepmodeling.org
 ```
 
 Or one may want to create a GPU environment containing [CUDA Toolkit](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver):
 ```bash
-conda create -n deepmd deepmd-kit=*=*gpu lammps-dp=*=*gpu cudatoolkit=11.1 -c https://conda.deepmodeling.org -c nvidia
+conda create -n deepmd deepmd-kit=*=*gpu libdeepmd=*=*gpu lammps-dp cudatoolkit=11.3 -c https://conda.deepmodeling.org
 ```
-One could change the CUDA Toolkit version from `11.1` to `10.1` or `10.0`.
+One could change the CUDA Toolkit version from `10.1` or `11.3`.
 
 One may speficy the DeePMD-kit version such as `2.0.0` using
 ```bash
-conda create -n deepmd deepmd-kit=2.0.0=*cpu lammps-dp=2.0.0=*cpu -c https://conda.deepmodeling.org
+conda create -n deepmd deepmd-kit=2.0.0=*cpu libdeepmd=2.0.0=*cpu lammps-dp=2.0.0 -c https://conda.deepmodeling.org
 ```
 
 One may enable the environment using


### PR DESCRIPTION
Starting from v2.0.0.b4, `libdeepmd` and `lammps-dp` will decouple.
The idea is that both C++ API and LAMMPS are usually stable, so we do not need to build LAMMPS in every release. Also, CPU version and GPU version share the same API and LAMMPS itself does not need CUDA, so we do not need to build LAMMPS twice.