### PR TITLE
add model compression support for models without training script

### DIFF
--- a/deepmd/entrypoints/compress.py
+++ b/deepmd/entrypoints/compress.py
@@ -70,12 +70,16 @@ def compress(
         t_min_nbor_dist = get_tensor_by_name(input, 'train_attr/min_nbor_dist')
         jdata = json.loads(t_jdata)
     except GraphWithoutTensorError as e:
-        if os.path.exists(training_script) == False:
+        if training_script == None:
             raise RuntimeError(
                 "The input frozen model: %s has no training script or min_nbor_dist information, "
                 "which is not supported by the model compression interface. "
                 "Please consider using the --training-script command within the model compression interface to provide the training script of the input frozen model. "
                 "Note that the input training script must contain the correct path to the training data." % input
+            ) from e
+        elif os.path.exists(training_script) == False:
+            raise RuntimeError(
+                "The input training script %s does not exist! Please check the path of the training script. " % (input + "(" + os.path.abspath(input) + ")")
             ) from e
         else:
             log.info("stage 0: compute the min_nbor_dist")

--- a/deepmd/entrypoints/compress.py
+++ b/deepmd/entrypoints/compress.py
@@ -1,5 +1,6 @@
 """Compress a model, which including tabulating the embedding-net."""
 
+import os
 import json
 import logging
 from typing import Optional
@@ -11,7 +12,7 @@ from deepmd.utils.compat import updata_deepmd_input
 from deepmd.utils.errors import GraphTooLargeError, GraphWithoutTensorError
 
 from .freeze import freeze
-from .train import train
+from .train import train, get_rcut, get_min_nbor_dist
 from .transfer import transfer
 
 __all__ = ["compress"]
@@ -27,6 +28,7 @@ def compress(
     step: float,
     frequency: str,
     checkpoint_folder: str,
+    training_script: str,
     mpi_log: str,
     log_path: Optional[str],
     log_level: int,
@@ -54,6 +56,8 @@ def compress(
         frequency of tabulation overflow check
     checkpoint_folder : str
         trining checkpoint folder for freezing
+    training_script : str
+        training script of the input frozen model
     mpi_log : str
         mpi logging mode for training
     log_path : Optional[str]
@@ -64,16 +68,23 @@ def compress(
     try:
         t_jdata = get_tensor_by_name(input, 'train_attr/training_script')
         t_min_nbor_dist = get_tensor_by_name(input, 'train_attr/min_nbor_dist')
+        jdata = json.loads(t_jdata)
     except GraphWithoutTensorError as e:
-        raise RuntimeError(
-            "The input frozen model: %s has no training script or min_nbor_dist information,"
-            "which is not supported by the model compression program."
-            "Please consider using the dp convert-from interface to upgrade the model" % input
-        ) from e
+        if os.path.exists(training_script) == False:
+            raise RuntimeError(
+                "The input frozen model: %s has no training script or min_nbor_dist information, "
+                "which is not supported by the model compression interface. "
+                "Please consider using the --training-script command within the model compression interface to provide the training script of the input frozen model. "
+                "Note that the input training script must contain the correct path to the training data." % input
+            ) from e
+        else:
+            log.info("stage 0: compute the min_nbor_dist")
+            jdata = j_loader(training_script)
+            t_min_nbor_dist = get_min_nbor_dist(jdata, get_rcut(jdata))
+
     tf.constant(t_min_nbor_dist,
         name = 'train_attr/min_nbor_dist',
         dtype = GLOBAL_TF_FLOAT_PRECISION)
-    jdata = json.loads(t_jdata)
     jdata["model"]["compress"] = {}
     jdata["model"]["compress"]["type"] = 'se_e2_a'
     jdata["model"]["compress"]["compress"] = True

--- a/deepmd/entrypoints/main.py
+++ b/deepmd/entrypoints/main.py
@@ -310,7 +310,7 @@ def parse_args(args: Optional[List[str]] = None):
         "-t",
         "--training-script",
         type=str,
-        default="input.json",
+        default=None,
         help="The training script of the input frozen model",
     )
 

--- a/deepmd/entrypoints/main.py
+++ b/deepmd/entrypoints/main.py
@@ -306,6 +306,13 @@ def parse_args(args: Optional[List[str]] = None):
         default=".",
         help="path to checkpoint folder",
     )
+    parser_compress.add_argument(
+        "-t",
+        "--training-script",
+        type=str,
+        default="input.json",
+        help="The training script of the input frozen model",
+    )
 
     # * print docs script **************************************************************
     parsers_doc = subparsers.add_parser(

--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -239,8 +239,7 @@ def get_rcut(jdata):
 def get_type_map(jdata):
     return jdata['model'].get('type_map', None)
 
-
-def get_sel(jdata, rcut):
+def get_nbor_stat(jdata, rcut):
     max_rcut = get_rcut(jdata)
     type_map = get_type_map(jdata)
 
@@ -258,8 +257,15 @@ def get_sel(jdata, rcut):
     neistat = NeighborStat(ntypes, rcut)
 
     min_nbor_dist, max_nbor_size = neistat.get_stat(train_data)
+    return min_nbor_dist, max_nbor_size
 
+def get_sel(jdata, rcut):
+    _, max_nbor_size = get_nbor_stat(jdata, rcut)
     return max_nbor_size
+
+def get_min_nbor_dist(jdata, rcut):
+    min_nbor_dist, _ = get_nbor_stat(jdata, rcut)
+    return min_nbor_dist
 
 
 def parse_auto_sel(sel):

--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -239,6 +239,7 @@ def get_rcut(jdata):
 def get_type_map(jdata):
     return jdata['model'].get('type_map', None)
 
+
 def get_nbor_stat(jdata, rcut):
     max_rcut = get_rcut(jdata)
     type_map = get_type_map(jdata)
@@ -266,7 +267,6 @@ def get_sel(jdata, rcut):
 def get_min_nbor_dist(jdata, rcut):
     min_nbor_dist, _ = get_nbor_stat(jdata, rcut)
     return min_nbor_dist
-
 
 def parse_auto_sel(sel):
     if type(sel) is not str:

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -338,7 +338,7 @@ optional arguments:
                         path to checkpoint folder (default: .)
   -t TRAINING_SCRIPT, --training-script TRAINING_SCRIPT
                         The training script of the input frozen model
-                        (default: input.json)
+                        (default: None)
 ```
 **Parameter explanation**
 


### PR DESCRIPTION
Add model compression support for models without training script. The main changes are:

- Allow users to provide the training script if there's no training script within the input frozen model.
- Note if there's a training script within the frozen model and the users provide one at the same time, the training script within the model will be used by default.