### PR TITLE
make native MD compatible with v2.0

### DIFF
--- a/source/md/CMakeLists.txt
+++ b/source/md/CMakeLists.txt
@@ -8,8 +8,6 @@ list (APPEND MD_INCLUDE_PATH "include")
 list (APPEND MD_INCLUDE_PATH ${XDRFILE_INCLUDE_DIRS})
 
 file(GLOB MD_SRC src/*.cc src/*.cpp)
-add_library(${LIB_DEEPMD_NATIVE} SHARED ${MD_SRC})
-target_include_directories(${LIB_DEEPMD_NATIVE} PUBLIC ${MD_INCLUDE_PATH})
 
 set(MDNN_SOURCE_FILES mdnn.cc)
 if (MAKE_FF_AD)
@@ -18,9 +16,20 @@ if (MAKE_FF_AD)
 endif()
 
 function(_add_md_variant variant_name prec_def)
+set (libname "${LIB_DEEPMD_NATIVE}${variant_name}")
 set (dp_mdnn_name "dp_mdnn${variant_name}")
 set (dp_mdff_name "dp_mdff${variant_name}")
 set (dp_mdad_name "dp_mdad${variant_name}")
+
+add_library(${libname} SHARED ${MD_SRC})
+target_link_libraries(${libname} PRIVATE ${LIB_DEEPMD})
+target_include_directories(${libname} PUBLIC ${MD_INCLUDE_PATH})
+set_target_properties(
+  ${libname}
+  PROPERTIES
+  COMPILE_DEFINITIONS ${prec_def}
+  INSTALL_RPATH "$ORIGIN"
+)
 
 add_executable(${dp_mdnn_name} ${MDNN_SOURCE_FILES})
 if (MAKE_FF_AD)
@@ -29,15 +38,19 @@ if (MAKE_FF_AD)
 endif()
 
 # link: libdeepmd_native libdeepmd_cc libxdr
-target_link_libraries(${dp_mdnn_name} PRIVATE ${LIB_DEEPMD_NATIVE} ${LIB_DEEPMD_CC} ${XDRFILE_LIBRARIES})
+target_link_libraries(${dp_mdnn_name} PRIVATE ${libname} ${LIB_DEEPMD_CC}${variant_name} ${XDRFILE_LIBRARIES})
+target_include_directories(${dp_mdnn_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/)
 if (MAKE_FF_AD)
-  target_link_libraries(${dp_mdad_name} PRIVATE ${LIB_DEEPMD_NATIVE} ${LIB_DEEPMD_CC} ${XDRFILE_LIBRARIES})
-  target_link_libraries(${dp_mdff_name} PRIVATE ${LIB_DEEPMD_NATIVE} ${LIB_DEEPMD_CC} ${XDRFILE_LIBRARIES})
+  target_link_libraries(${dp_mdad_name} PRIVATE ${libname} ${LIB_DEEPMD_CC}${variant_name} ${XDRFILE_LIBRARIES})
+  target_include_directories(${dp_mdad_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/)
+  target_link_libraries(${dp_mdff_name} PRIVATE ${libname} ${LIB_DEEPMD_CC}${variant_name} ${XDRFILE_LIBRARIES})
+  target_include_directories(${dp_mdff_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/)
 endif()
 
 set_target_properties(
   ${dp_mdnn_name}
   PROPERTIES
+  COMPILE_DEFINITIONS ${prec_def}
   LINK_FLAGS "-Wl,-rpath,'$ORIGIN'/../lib -Wl,-z,defs"
   INSTALL_RPATH "$ORIGIN/../lib:${TensorFlow_LIBRARY_PATH}"
 )
@@ -45,12 +58,14 @@ if (MAKE_FF_AD)
   set_target_properties(
     ${dp_mdad_name}
     PROPERTIES
+    COMPILE_DEFINITIONS ${prec_def}
     LINK_FLAGS "-Wl,-rpath,'$ORIGIN'/../lib -Wl,-z,defs"
     INSTALL_RPATH "$ORIGIN/../lib:${TensorFlow_LIBRARY_PATH}"
     )
   set_target_properties(
     ${dp_mdff_name}
     PROPERTIES
+    COMPILE_DEFINITIONS ${prec_def}
     LINK_FLAGS "-Wl,-rpath,'$ORIGIN'/../lib -Wl,-z,defs"
     INSTALL_RPATH "$ORIGIN/../lib:${TensorFlow_LIBRARY_PATH}"
     )
@@ -76,4 +91,5 @@ if (MAKE_FF_AD)
 endif()
 endfunction()
 _add_md_variant("${HIGH_PREC_VARIANT}" "${HIGH_PREC_DEF}")
-_add_md_variant("${LOW_PREC_VARIANT}" "${LOW_PREC_DEF}")
+# TODO: there is hard-code `DOUBLE` in the code
+#_add_md_variant("${LOW_PREC_VARIANT}" "${LOW_PREC_DEF}")

--- a/source/md/mdnn.cc
+++ b/source/md/mdnn.cc
@@ -1,6 +1,6 @@
 #include "common.h"
 #include "Integrator.h"
-#include "NNPInter.h"
+#include "DeepPot.h"
 #include "Statistics.h"
 
 #include "Trajectory.h"
@@ -148,7 +148,7 @@ int main(int argc, char * argv[])
 
   Integrator<VALUETYPE> inte;
   ThermostatLangevin<VALUETYPE> thm (temperature, tau_t, seed);
-  NNPInter nnp (graph_file);
+  deepmd::DeepPot nnp (graph_file);
   
   Statistics<VALUETYPE> st;
   XtcSaver sxtc (xtc_file.c_str(), nloc);


### PR DESCRIPTION
Although no one really enables and uses it, I still make it compatible with v2.0.
Also fix compilation errors.
Seems there is hard-code `DOUBLE` in the code, and I have no time to fix it, so I comment the build for float precision.