### PR TITLE
cherry pick #536: only enable link what you use on GNU compilers

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.7)
 project(DeePMD)
-set(CMAKE_LINK_WHAT_YOU_USE TRUE)
+if (CMAKE_COMPILER_IS_GNU)
+  set(CMAKE_LINK_WHAT_YOU_USE TRUE)
+endif ()
 
 # build cpp or python interfaces
 if (NOT DEFINED BUILD_CPP_IF) 


### PR DESCRIPTION
cherry pick #536.

----

Clang doesn't support this flag, cause an error on osx:

> ld: unknown option: --no-as-needed

This commit should be cherry-picked to `r1.2` branch.

(cherry picked from commit ee8c419517fad9d7bcbf9fa13321a024889e5440)