### PR TITLE
cherry pick #535: Do not find protobuf for python

### DIFF
--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -53,6 +53,7 @@ find_path(TensorFlow_INCLUDE_DIRS
   PATH_SUFFIXES "/include"
   NO_DEFAULT_PATH
   )
+if (BUILD_CPP_IF)
 find_path(TensorFlow_INCLUDE_DIRS_GOOGLE
   NAMES 
   google/protobuf/type.pb.h
@@ -61,6 +62,7 @@ find_path(TensorFlow_INCLUDE_DIRS_GOOGLE
   NO_DEFAULT_PATH
   )
 list(APPEND TensorFlow_INCLUDE_DIRS ${TensorFlow_INCLUDE_DIRS_GOOGLE})
+endif ()
   
 if (NOT TensorFlow_INCLUDE_DIRS AND tensorflow_FIND_REQUIRED)
   message(FATAL_ERROR 


### PR DESCRIPTION
cherry pick #535

----

In conda-forge's recent released tensorflow, protobuf is external
from tensorflow and not inside the tensorflow directory.

(cherry picked from commit f66c78ec3ac21248d2a0dc0427f8d87d503e9636)