### PR TITLE
add sphinx plugins `viewcode` and `intersphinx`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -156,6 +156,8 @@ extensions = [
     "sphinx_rtd_theme",
     'myst_parser',
     'sphinx.ext.autosummary',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
     'breathe',
     'exhale'
 ]
@@ -198,6 +200,14 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+intersphinx_mapping = {
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "python": ("https://docs.python.org/", None),
+    "tensorflow": (
+        "https://www.tensorflow.org/api_docs/python",
+        "https://github.com/mr-ubik/tensorflow-intersphinx/raw/master/tf2_py_objects.inv",
+    ),
+}
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
See [here](https://explore-deepmd.njzjz.win/en/latest/development/api.html) for preview.
`viewcode` add a link in each class to the source code.
`intersphinx` add a link in each type hint to the documentation of Python, NumPy, and TensorFlow.

PS: some type hints are wrong, hence the link is not generated. For example,
```py
eval(coords: numpy.array, cells: numpy.array, atom_types: List[int], atomic: bool = False, fparam: Optional[numpy.array] = None, aparam: Optional[numpy.array] = None, efield: Optional[numpy.array] = None) → Tuple[numpy.ndarray, ...]
```
`numpy.array` should be `numpy.ndarray`.
