### PR TITLE
unpin tensorflow version

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -38,16 +38,16 @@ jobs:
             tf: 1.14
           - python: 3.7
             gcc: 5
-            tf: 2.3
+            tf:
           - python: 3.7
             gcc: 8
-            tf: 2.3
+            tf:
           - python: 3.8
             gcc: 5
-            tf: 2.3
+            tf:
           - python: 3.8
             gcc: 8
-            tf: 2.3
+            tf:
 
     steps:
     - uses: actions/checkout@master

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -27,7 +27,7 @@ We follow the virtual environment approach to install the tensorflow's Python in
 virtualenv -p python3 $tensorflow_venv
 source $tensorflow_venv/bin/activate
 pip install --upgrade pip
-pip install --upgrade tensorflow==2.3.0
+pip install --upgrade tensorflow
 ```
 It is notice that everytime a new shell is started and one wants to use `DeePMD-kit`, the virtual environment should be activated by 
 ```bash
@@ -43,7 +43,7 @@ virtualenv -p python3.7 $tensorflow_venv
 ```
 If one does not need the GPU support of deepmd-kit and is concerned about package size, the CPU-only version of tensorflow should be installed by	
 ```bash	
-pip install --upgrade tensorflow-cpu==2.3.0	
+pip install --upgrade tensorflow-cpu
 ```
 To verify the installation, run
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ tf_version = os.environ.get("TENSORFLOW_VERSION", "")
 
 if tf_version == "":
     extras_require = {
-        "cpu": ["tensorflow"],
-        "gpu": ["tensorflow-gpu"],
+        "cpu": ["tensorflow-cpu"],
+        "gpu": ["tensorflow"],
     }
 elif tf_version in SpecifierSet("<1.15") or tf_version in SpecifierSet(">=2.0,<2.1"):
     extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,14 @@ setup_requires = ["setuptools_scm", "scikit-build"]
 readme_file = Path(__file__).parent / "README.md"
 readme = readme_file.read_text()
 
-tf_version = os.environ.get("TENSORFLOW_VERSION", "2.3")
+tf_version = os.environ.get("TENSORFLOW_VERSION", "")
 
-if tf_version in SpecifierSet("<1.15") or tf_version in SpecifierSet(">=2.0,<2.1"):
+if tf_version == "":
+    extras_require = {
+        "cpu": ["tensorflow"],
+        "gpu": ["tensorflow-gpu"],
+    }
+elif tf_version in SpecifierSet("<1.15") or tf_version in SpecifierSet(">=2.0,<2.1"):
     extras_require = {
         "cpu": [f"tensorflow=={tf_version}"],
         "gpu": [f"tensorflow-gpu=={tf_version}"],


### PR DESCRIPTION
As tensorflow API v1 has been stable, it's safe not to pin the tensorflow version.
