### PR TITLE
fix incorrect type hints and docstrings

### DIFF
--- a/deepmd/cluster/local.py
+++ b/deepmd/cluster/local.py
@@ -16,7 +16,7 @@ def get_gpus():
     """Get available IDs of GPU cards at local.
     These IDs are valid when used as the TensorFlow device ID.
 
-    Returns:
+    Returns
     -------
     Optional[List[int]]
         List of available GPU IDs. Otherwise, None.

--- a/deepmd/descriptor/hybrid.py
+++ b/deepmd/descriptor/hybrid.py
@@ -77,6 +77,7 @@ class DescrptHybrid ():
         ----------
         ii : int
                 Get the neighbor information of the ii-th descriptor
+
         Returns
         -------
         nlist
@@ -194,8 +195,9 @@ class DescrptHybrid ():
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
-        Return
-        ------
+
+        Returns
+        -------
         force
                 The force on atoms
         virial

--- a/deepmd/descriptor/loc_frame.py
+++ b/deepmd/descriptor/loc_frame.py
@@ -286,7 +286,8 @@ class DescrptLocFrame () :
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
-        Return
+
+        Returns
         ------
         force
                 The force on atoms

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -409,7 +409,8 @@ class DescrptSeA ():
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
-        Return
+
+        Returns
         ------
         force
                 The force on atoms

--- a/deepmd/descriptor/se_a_ef.py
+++ b/deepmd/descriptor/se_a_ef.py
@@ -248,7 +248,8 @@ class DescrptSeAEf ():
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
-        Return
+
+        Returns
         ------
         force
                 The force on atoms

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -336,7 +336,8 @@ class DescrptSeR ():
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
-        Return
+
+        Returns
         ------
         force
                 The force on atoms

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -334,7 +334,8 @@ class DescrptSeT ():
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
-        Return
+
+        Returns
         ------
         force
                 The force on atoms

--- a/deepmd/fit/dipole.py
+++ b/deepmd/fit/dipole.py
@@ -113,8 +113,8 @@ class DipoleFittingSeA () :
         suffix
                 Name suffix to identify this descriptor
 
-        Return
-        ------
+        Returns
+        -------
         dipole
                 The atomic dipole.
         """

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -173,7 +173,8 @@ class EnerFitting ():
         """
         Compute the input statistics
 
-        Parameters:
+        Parameters
+        ----------
         all_stat
                 if numb_fparam > 0 must have all_stat['fparam']
                 if numb_aparam > 0 must have all_stat['aparam']
@@ -315,8 +316,8 @@ class EnerFitting ():
         suffix
                 Name suffix to identify this descriptor
 
-        Return
-        ------
+        Returns
+        -------
         ener
                 The system energy
         """

--- a/deepmd/fit/polar.py
+++ b/deepmd/fit/polar.py
@@ -208,7 +208,8 @@ class PolarFittingSeA () :
         """
         Compute the input statistics
 
-        Parameters:
+        Parameters
+        ----------
         all_stat
                 Dictionary of inputs. 
                 can be prepared by model.make_stat_input
@@ -292,8 +293,8 @@ class PolarFittingSeA () :
         suffix
                 Name suffix to identify this descriptor
 
-        Return
-        ------
+        Returns
+        -------
         atomic_polar
                 The atomic polarizability        
         """
@@ -464,8 +465,8 @@ class GlobalPolarFittingSeA () :
         suffix
                 Name suffix to identify this descriptor
 
-        Return
-        ------
+        Returns
+        -------
         polar
                 The system polarizability        
         """

--- a/deepmd/infer/data_modifier.py
+++ b/deepmd/infer/data_modifier.py
@@ -208,11 +208,11 @@ class DipoleChargeModifier(DeepDipole):
 
 
     def eval(self, 
-             coord : np.array, 
-             box : np.array, 
-             atype : np.array, 
+             coord : np.ndarray, 
+             box : np.ndarray, 
+             atype : np.ndarray, 
              eval_fv : bool = True
-    ) -> Tuple[np.array, np.array, np.array]:
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Evaluate the modification
         

--- a/deepmd/infer/deep_eval.py
+++ b/deepmd/infer/deep_eval.py
@@ -52,7 +52,10 @@ class DeepEval:
     def model_version(self) -> str:
         """Get type of model.
 
-        :type:str
+        Returns
+        -------
+        str
+            type of model
         """
         if not self._model_version:
             try:
@@ -71,7 +74,8 @@ class DeepEval:
     ) -> bool :
         """ Check the model compatability
         
-        Return
+        Returns
+        -------
         bool
             If the model stored in the graph file is compatable with the current code
         """
@@ -146,7 +150,7 @@ class DeepEval:
 
     @staticmethod
     def sort_input(
-        coord : np.array, atom_type : np.array, sel_atoms : List[int] = None
+        coord : np.ndarray, atom_type : np.ndarray, sel_atoms : List[int] = None
     ):
         """
         Sort atoms in the system according their types.

--- a/deepmd/infer/deep_polar.py
+++ b/deepmd/infer/deep_polar.py
@@ -92,7 +92,7 @@ class DeepGlobalPolar(DeepTensor):
     def eval(
         self,
         coords: np.ndarray,
-        cells: np.ndrray,
+        cells: np.ndarray,
         atom_types: List[int],
         atomic: bool = False,
         fparam: Optional[np.ndarray] = None,

--- a/deepmd/infer/deep_polar.py
+++ b/deepmd/infer/deep_polar.py
@@ -91,14 +91,14 @@ class DeepGlobalPolar(DeepTensor):
 
     def eval(
         self,
-        coords: np.array,
-        cells: np.array,
+        coords: np.ndarray,
+        cells: np.ndrray,
         atom_types: List[int],
         atomic: bool = False,
-        fparam: Optional[np.array] = None,
-        aparam: Optional[np.array] = None,
-        efield: Optional[np.array] = None,
-    ) -> np.array:
+        fparam: Optional[np.ndarray] = None,
+        aparam: Optional[np.ndarray] = None,
+        efield: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
         """Evaluate the model.
 
         Parameters

--- a/deepmd/infer/deep_pot.py
+++ b/deepmd/infer/deep_pot.py
@@ -159,13 +159,13 @@ class DeepPot(DeepEval):
 
     def eval(
         self,
-        coords: np.array,
-        cells: np.array,
+        coords: np.ndarray,
+        cells: np.ndarray,
         atom_types: List[int],
         atomic: bool = False,
-        fparam: Optional[np.array] = None,
-        aparam: Optional[np.array] = None,
-        efield: Optional[np.array] = None
+        fparam: Optional[np.ndarray] = None,
+        aparam: Optional[np.ndarray] = None,
+        efield: Optional[np.ndarray] = None
     ) -> Tuple[np.ndarray, ...]:
         """Evaluate the energy, force and virial by using this DP.
 

--- a/deepmd/infer/deep_tensor.py
+++ b/deepmd/infer/deep_tensor.py
@@ -119,14 +119,14 @@ class DeepTensor(DeepEval):
 
     def eval(
         self,
-        coords: np.array,
-        cells: np.array,
+        coords: np.ndarray,
+        cells: np.ndarray,
         atom_types: List[int],
         atomic: bool = True,
-        fparam: Optional[np.array] = None,
-        aparam: Optional[np.array] = None,
-        efield: Optional[np.array] = None
-    ) -> np.array:
+        fparam: Optional[np.ndarray] = None,
+        aparam: Optional[np.ndarray] = None,
+        efield: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """Evaluate the model.
 
         Parameters
@@ -211,8 +211,8 @@ class DeepTensor(DeepEval):
 
     def eval_full(
         self,
-        coords: np.array,
-        cells: np.array,
+        coords: np.ndarray,
+        cells: np.ndarray,
         atom_types: List[int],
         atomic: bool = False,
         fparam: Optional[np.array] = None,

--- a/deepmd/infer/ewald_recp.py
+++ b/deepmd/infer/ewald_recp.py
@@ -45,10 +45,10 @@ class EwaldRecp () :
         self.sess = tf.Session(graph=graph, config=default_tf_session_config)
 
     def eval(self, 
-             coord : np.array, 
-             charge : np.array, 
-             box : np.array
-    ) -> Tuple[np.array, np.array, np.array] :
+             coord : np.ndarray, 
+             charge : np.ndarray, 
+             box : np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray] :
         """
         Evaluate 
         

--- a/deepmd/infer/model_devi.py
+++ b/deepmd/infer/model_devi.py
@@ -3,9 +3,12 @@ from .deep_pot import DeepPot
 from ..utils.data import DeepmdData
         
 
-def calc_model_devi_f(fs):
+def calc_model_devi_f(fs: np.ndarray):
     '''
-    fs : numpy.ndarray, size of `n_models x n_frames x n_atoms x 3`
+    Parameters
+    ----------
+    fs : numpy.ndarray
+        size of `n_models x n_frames x n_atoms x 3`
     '''
     fs_devi = np.linalg.norm(np.std(fs, axis=0), axis=-1)
     max_devi_f = np.max(fs_devi, axis=-1)
@@ -13,9 +16,12 @@ def calc_model_devi_f(fs):
     avg_devi_f = np.mean(fs_devi, axis=-1)
     return max_devi_f, min_devi_f, avg_devi_f
 
-def calc_model_devi_e(es):
+def calc_model_devi_e(es: np.ndarray):
     '''
-    es : numpy.ndarray, size of `n_models x n_frames x n_atoms
+    Parameters
+    ----------
+    es : numpy.ndarray
+        size of `n_models x n_frames x n_atoms
     '''
     es_devi = np.std(es, axis=0)
     max_devi_e = np.max(es_devi, axis=1)
@@ -23,9 +29,12 @@ def calc_model_devi_e(es):
     avg_devi_e = np.mean(es_devi, axis=1)
     return max_devi_e, min_devi_e, avg_devi_e
 
-def calc_model_devi_v(vs):
+def calc_model_devi_v(vs: np.ndarray):
     '''
-    vs : numpy.ndarray, size of `n_models x n_frames x 9`
+    Parameters
+    ----------
+    vs : numpy.ndarray
+        size of `n_models x n_frames x 9`
     '''
     vs_devi = np.std(vs, axis=0)
     max_devi_v = np.max(vs_devi, axis=-1)
@@ -33,10 +42,14 @@ def calc_model_devi_v(vs):
     avg_devi_v = np.linalg.norm(vs_devi, axis=-1) / 3
     return max_devi_v, min_devi_v, avg_devi_v
 
-def write_model_devi_out(devi, fname):
+def write_model_devi_out(devi: np.ndarray, fname: str):
     '''
-    devi : numpy.ndarray, the first column is the steps index
-    fname : str, the file name to dump
+    Parameters
+    ----------
+    devi : numpy.ndarray
+        the first column is the steps index
+    fname : str
+        the file name to dump
     '''
     assert devi.shape[1] == 7
     header = "%10s" % "step"
@@ -75,7 +88,7 @@ def calc_model_devi(coord,
     '''
     Python interface to calculate model deviation
 
-    Parameters:
+    Parameters
     -----------
     coord : numpy.ndarray, `n_frames x n_atoms x 3`
         Coordinates of system to calculate
@@ -92,7 +105,7 @@ def calc_model_devi(coord,
     nopbc : bool
         Whether to use pbc conditions
     
-    Return:
+    Returns
     -------
     model_devi : numpy.ndarray, `n_frames x 7`
         Model deviation results. The first column is index of steps, the other 6 columns are

--- a/deepmd/utils/compat.py
+++ b/deepmd/utils/compat.py
@@ -13,6 +13,7 @@ def convert_input_v0_v1(
     jdata: Dict[str, Any], warning: bool = True, dump: Optional[Union[str, Path]] = None
 ) -> Dict[str, Any]:
     """Convert input from v0 format to v1.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
@@ -21,6 +22,7 @@ def convert_input_v0_v1(
         whether to show deprecation warning, by default True
     dump : Optional[Union[str, Path]], optional
         whether to dump converted file, by default None
+
     Returns
     -------
     Dict[str, Any]
@@ -50,12 +52,14 @@ def _warning_input_v0_v1(fname: Optional[Union[str, Path]]):
 
 def _model(jdata: Dict[str, Any], smooth: bool) -> Dict[str, Dict[str, Any]]:
     """Convert data to v1 input for non-smooth model.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
         parsed input json/yaml data
     smooth : bool
         whether to use smooth or non-smooth descriptor version
+
     Returns
     -------
     Dict[str, Dict[str, Any]]
@@ -72,10 +76,12 @@ def _model(jdata: Dict[str, Any], smooth: bool) -> Dict[str, Dict[str, Any]]:
 
 def _nonsmth_descriptor(jdata: Dict[str, Any]) -> Dict[str, Any]:
     """Convert data to v1 input for non-smooth descriptor.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
         parsed input json/yaml data
+
     Returns
     -------
     Dict[str, Any]
@@ -89,10 +95,12 @@ def _nonsmth_descriptor(jdata: Dict[str, Any]) -> Dict[str, Any]:
 
 def _smth_descriptor(jdata: Dict[str, Any]) -> Dict[str, Any]:
     """Convert data to v1 input for smooth descriptor.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
         parsed input json/yaml data
+
     Returns
     -------
     Dict[str, Any]
@@ -117,10 +125,12 @@ def _smth_descriptor(jdata: Dict[str, Any]) -> Dict[str, Any]:
 
 def _fitting_net(jdata: Dict[str, Any]) -> Dict[str, Any]:
     """Convert data to v1 input for fitting net.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
         parsed input json/yaml data
+
     Returns
     -------
     Dict[str, Any]
@@ -142,10 +152,12 @@ def _fitting_net(jdata: Dict[str, Any]) -> Dict[str, Any]:
 
 def _learning_rate(jdata: Dict[str, Any]) -> Dict[str, Any]:
     """Convert data to v1 input for learning rate section.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
         parsed input json/yaml data
+
     Returns
     -------
     Dict[str, Any]
@@ -159,10 +171,12 @@ def _learning_rate(jdata: Dict[str, Any]) -> Dict[str, Any]:
 
 def _loss(jdata: Dict[str, Any]) -> Dict[str, Any]:
     """Convert data to v1 input for loss function.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
         parsed input json/yaml data
+
     Returns
     -------
     Dict[str, Any]
@@ -190,10 +204,12 @@ def _loss(jdata: Dict[str, Any]) -> Dict[str, Any]:
 
 def _training(jdata: Dict[str, Any]) -> Dict[str, Any]:
     """Convert data to v1 input for training.
+
     Parameters
     ----------
     jdata : Dict[str, Any]
         parsed input json/yaml data
+
     Returns
     -------
     Dict[str, Any]
@@ -223,6 +239,7 @@ def _training(jdata: Dict[str, Any]) -> Dict[str, Any]:
 
 def _jcopy(src: Dict[str, Any], dst: Dict[str, Any], keys: Sequence[str]):
     """Copy specified keys from one dict to another.
+
     Parameters
     ----------
     src : Dict[str, Any]

--- a/deepmd/utils/type_embed.py
+++ b/deepmd/utils/type_embed.py
@@ -68,6 +68,7 @@ class TypeEmbedNet():
     )->None:
         """
         Constructor
+
         Parameters
         ----------
         neuron : list[int]


### PR DESCRIPTION
For example, `Return` should be `Returns`... See [style guide](https://numpydoc.readthedocs.io/en/latest/format.html).