### PR TITLE
fill docstring with templates

### DIFF
--- a/deepmd/calculator.py
+++ b/deepmd/calculator.py
@@ -63,6 +63,24 @@ class DP(Calculator):
         type_dict: Dict[str, int] = None,
         **kwargs
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        model : Union[str, "Path"]
+            model
+        label : str
+            label
+        type_dict : Dict[str, int]
+            type_dict
+        kwargs :
+            kwargs
+
+        Returns
+        -------
+        None
+
+        """
         Calculator.__init__(self, label=label, **kwargs)
         self.dp = DeepPotential(str(Path(model).resolve()))
         if type_dict:

--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -191,6 +191,16 @@ class ClassArg:
     """
 
     def __init__(self) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        None
+
+        """
         self.arg_dict = {}
         self.alias_map = {}
 
@@ -246,6 +256,15 @@ class ClassArg:
         return self
 
     def _add_single(self, key: str, data: Any):
+        """_add_single.
+
+        Parameters
+        ----------
+        key : str
+            key
+        data : Any
+            data
+        """
         vtype = type(data)
         if data is None:
             return data
@@ -267,6 +286,8 @@ class ClassArg:
         self.arg_dict[key]["value"] = vv
 
     def _check_must(self):
+        """_check_must.
+        """
         for kk in self.arg_dict:
             if self.arg_dict[kk]["must"] and self.arg_dict[kk]["value"] is None:
                 raise RuntimeError(f"key {kk} must be provided")
@@ -450,6 +471,18 @@ def docstring_parameter(*sub: Tuple[str, ...]):
 
     @wraps
     def dec(obj: "_OBJ") -> "_OBJ":
+        """dec.
+
+        Parameters
+        ----------
+        obj : "_OBJ"
+            obj
+
+        Returns
+        -------
+        "_OBJ"
+
+        """
         if obj.__doc__ is not None:
             obj.__doc__ = obj.__doc__.format(*sub)
         return obj

--- a/deepmd/descriptor/hybrid.py
+++ b/deepmd/descriptor/hybrid.py
@@ -21,6 +21,9 @@ from .se_a_ef import DescrptSeAEf
 from .loc_frame import DescrptLocFrame
 
 class DescrptHybrid ():
+    """DescrptHybrid.
+    """
+
     def __init__ (self, 
                   descrpt_list : list
     ) -> None :

--- a/deepmd/descriptor/loc_frame.py
+++ b/deepmd/descriptor/loc_frame.py
@@ -9,6 +9,9 @@ from deepmd.env import default_tf_session_config
 from deepmd.utils.sess import run_sess
 
 class DescrptLocFrame () :
+    """DescrptLocFrame.
+    """
+
     def __init__(self, 
                  rcut: float,
                  sel_a : List[int],
@@ -331,6 +334,21 @@ class DescrptLocFrame () :
             = run_sess(self.sub_sess, self.stat_descrpt, 
                                 feed_dict = {
                                     self.place_holders['coord']: data_coord,
+        """_compute_dstats_sys_nonsmth.
+
+        Parameters
+        ----------
+        data_coord :
+            data_coord
+        data_box :
+            data_box
+        data_atype :
+            data_atype
+        natoms_vec :
+            natoms_vec
+        mesh :
+            mesh
+        """
                                     self.place_holders['type']: data_atype,
                                     self.place_holders['natoms_vec']: natoms_vec,
                                     self.place_holders['box']: data_box,
@@ -358,6 +376,17 @@ class DescrptLocFrame () :
 
 
     def _compute_std (self,sumv2, sumv, sumn) :
+        """_compute_std.
+
+        Parameters
+        ----------
+        sumv2 :
+            sumv2
+        sumv :
+            sumv
+        sumn :
+            sumn
+        """
         return np.sqrt(sumv2/sumn - np.multiply(sumv/sumn, sumv/sumn))
 
     

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -15,6 +15,9 @@ from deepmd.utils.type_embed import embed_atom_type
 from deepmd.utils.sess import run_sess
 
 class DescrptSeA ():
+    """DescrptSeA.
+    """
+
     @docstring_parameter(list_to_doc(ACTIVATION_FN_DICT.keys()), list_to_doc(PRECISION_DICT.keys()))
     def __init__ (self, 
                   rcut: float,
@@ -461,6 +464,25 @@ class DescrptSeA ():
         output_qmat = []
         if not self.type_one_side and type_embedding is None:
             for type_i in range(self.ntypes):
+        """_pass_filter.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        atype :
+            atype
+        natoms :
+            natoms
+        input_dict :
+            input_dict
+        reuse :
+            reuse
+        suffix :
+            suffix
+        trainable :
+            trainable
+        """
                 inputs_i = tf.slice (inputs,
                                      [ 0, start_index*      self.ndescrpt],
                                      [-1, natoms[2+type_i]* self.ndescrpt] )
@@ -495,6 +517,21 @@ class DescrptSeA ():
             = run_sess(self.sub_sess, self.stat_descrpt, 
                                 feed_dict = {
                                     self.place_holders['coord']: data_coord,
+        """_compute_dstats_sys_smth.
+
+        Parameters
+        ----------
+        data_coord :
+            data_coord
+        data_box :
+            data_box
+        data_atype :
+            data_atype
+        natoms_vec :
+            natoms_vec
+        mesh :
+            mesh
+        """
                                     self.place_holders['type']: data_atype,
                                     self.place_holders['natoms_vec']: natoms_vec,
                                     self.place_holders['box']: data_box,
@@ -531,6 +568,17 @@ class DescrptSeA ():
 
 
     def _compute_std (self,sumv2, sumv, sumn) :
+        """_compute_std.
+
+        Parameters
+        ----------
+        sumv2 :
+            sumv2
+        sumv :
+            sumv
+        sumn :
+            sumn
+        """
         if sumn == 0:
             return 1e-2
         val = np.sqrt(sumv2/sumn - np.multiply(sumv/sumn, sumv/sumn))
@@ -546,6 +594,19 @@ class DescrptSeA ():
             natoms,
             type_embedding,
     ):            
+        """_concat_type_embedding.
+
+        Parameters
+        ----------
+        xyz_scatter :
+            xyz_scatter
+        nframes :
+            nframes
+        natoms :
+            natoms
+        type_embedding :
+            type_embedding
+        """
         te_out_dim = type_embedding.get_shape().as_list()[-1]        
         nei_embed = tf.nn.embedding_lookup(type_embedding,tf.cast(self.nei_type,dtype=tf.int32)) #nnei*nchnl
         nei_embed = tf.tile(nei_embed,(nframes*natoms[0],1))
@@ -645,6 +706,31 @@ class DescrptSeA ():
             name='linear', 
             reuse=None,
             trainable = True):
+        """_filter.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        type_input :
+            type_input
+        natoms :
+            natoms
+        type_embedding :
+            type_embedding
+        activation_fn :
+            activation_fn
+        stddev :
+            stddev
+        bavg :
+            bavg
+        name :
+            name
+        reuse :
+            reuse
+        trainable :
+            trainable
+        """
         nframes = tf.shape(tf.reshape(inputs, [-1, natoms[0], self.ndescrpt]))[0]
         # natom x (nei x 4)
         shape = inputs.get_shape().as_list()

--- a/deepmd/descriptor/se_a_ebd.py
+++ b/deepmd/descriptor/se_a_ebd.py
@@ -12,6 +12,9 @@ from deepmd.utils.network import embedding_net
 from .se_a import DescrptSeA
 
 class DescrptSeAEbd (DescrptSeA):
+    """DescrptSeAEbd.
+    """
+
     def __init__ (self, 
                   rcut: float,
                   rcut_smth: float,
@@ -155,6 +158,21 @@ class DescrptSeAEbd (DescrptSeA):
                     reuse = None, 
                     suffix = '',
                     trainable = True):
+        """_type_embed.
+
+        Parameters
+        ----------
+        atype :
+            atype
+        ndim :
+            ndim
+        reuse :
+            reuse
+        suffix :
+            suffix
+        trainable :
+            trainable
+        """
         ebd_type = tf.cast(atype, self.filter_precision)
         ebd_type = ebd_type / float(self.ntypes)
         ebd_type = tf.reshape(ebd_type, [-1, ndim])
@@ -237,6 +255,25 @@ class DescrptSeAEbd (DescrptSeA):
                                       reuse = None,
                                       seed = None,
                                       trainable = True):
+        """_type_embedding_net_two_sides.
+
+        Parameters
+        ----------
+        mat_g :
+            mat_g
+        atype :
+            atype
+        natoms :
+            natoms
+        name :
+            name
+        reuse :
+            reuse
+        seed :
+            seed
+        trainable :
+            trainable
+        """
         outputs_size = self.filter_neuron[-1]
         nframes = tf.shape(mat_g)[0]
         # (nf x natom x nei) x (outputs_size x chnl x chnl)
@@ -302,6 +339,25 @@ class DescrptSeAEbd (DescrptSeA):
                                      reuse = None,
                                      seed = None,
                                      trainable = True):
+        """_type_embedding_net_one_side.
+
+        Parameters
+        ----------
+        mat_g :
+            mat_g
+        atype :
+            atype
+        natoms :
+            natoms
+        name :
+            name
+        reuse :
+            reuse
+        seed :
+            seed
+        trainable :
+            trainable
+        """
         outputs_size = self.filter_neuron[-1]
         nframes = tf.shape(mat_g)[0]
         # (nf x natom x nei) x (outputs_size x chnl x chnl)
@@ -351,6 +407,27 @@ class DescrptSeAEbd (DescrptSeA):
                                             reuse = None,
                                             seed = None,
                                             trainable = True):
+        """_type_embedding_net_one_side_aparam.
+
+        Parameters
+        ----------
+        mat_g :
+            mat_g
+        atype :
+            atype
+        natoms :
+            natoms
+        aparam :
+            aparam
+        name :
+            name
+        reuse :
+            reuse
+        seed :
+            seed
+        trainable :
+            trainable
+        """
         outputs_size = self.filter_neuron[-1]
         nframes = tf.shape(mat_g)[0]
         # (nf x natom x nei) x (outputs_size x chnl x chnl)
@@ -406,6 +483,25 @@ class DescrptSeAEbd (DescrptSeA):
 
 
     def _pass_filter(self, 
+        """_pass_filter.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        atype :
+            atype
+        natoms :
+            natoms
+        input_dict :
+            input_dict
+        reuse :
+            reuse
+        suffix :
+            suffix
+        trainable :
+            trainable
+        """
                      inputs,
                      atype,
                      natoms,
@@ -442,6 +538,33 @@ class DescrptSeAEbd (DescrptSeA):
                     reuse=None,
                     seed=None, 
                     trainable = True):
+        """_ebd_filter.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        atype :
+            atype
+        natoms :
+            natoms
+        input_dict :
+            input_dict
+        activation_fn :
+            activation_fn
+        stddev :
+            stddev
+        bavg :
+            bavg
+        name :
+            name
+        reuse :
+            reuse
+        seed :
+            seed
+        trainable :
+            trainable
+        """
         outputs_size = self.filter_neuron[-1]
         outputs_size_2 = self.n_axis_neuron
         # nf x natom x (nei x 4)

--- a/deepmd/descriptor/se_a_ef.py
+++ b/deepmd/descriptor/se_a_ef.py
@@ -12,6 +12,9 @@ from deepmd.env import default_tf_session_config
 from .se_a import DescrptSeA
 
 class DescrptSeAEf ():
+    """DescrptSeAEf.
+    """
+
     @docstring_parameter(list_to_doc(ACTIVATION_FN_DICT.keys()), list_to_doc(PRECISION_DICT.keys()))
     def __init__(self,
                  rcut: float,
@@ -288,6 +291,46 @@ class DescrptSeAEfLower (DescrptSeA):
                   precision: str = 'default',
                   uniform_seed : bool = False,
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        op :
+            op
+        rcut : float
+            rcut
+        rcut_smth : float
+            rcut_smth
+        sel : List[str]
+            sel
+        neuron : List[int]
+            neuron
+        axis_neuron : int
+            axis_neuron
+        resnet_dt : bool
+            resnet_dt
+        trainable : bool
+            trainable
+        seed : int
+            seed
+        type_one_side : bool
+            type_one_side
+        exclude_types : List[int]
+            exclude_types
+        set_davg_zero : bool
+            set_davg_zero
+        activation_function : str
+            activation_function
+        precision : str
+            precision
+        uniform_seed : bool
+            uniform_seed
+
+        Returns
+        -------
+        None
+
+        """
         DescrptSeA.__init__(
             self, 
             rcut,
@@ -383,6 +426,23 @@ class DescrptSeAEfLower (DescrptSeA):
 
 
     def compute_input_stats (self,
+        """compute_input_stats.
+
+        Parameters
+        ----------
+        data_coord :
+            data_coord
+        data_box :
+            data_box
+        data_atype :
+            data_atype
+        natoms_vec :
+            natoms_vec
+        mesh :
+            mesh
+        input_dict :
+            input_dict
+        """
                              data_coord, 
                              data_box, 
                              data_atype, 
@@ -427,6 +487,13 @@ class DescrptSeAEfLower (DescrptSeA):
         self.dstd = np.array(all_dstd)
 
     def _normalize_3d(self, a):
+        """_normalize_3d.
+
+        Parameters
+        ----------
+        a :
+            a
+        """
         na = tf.norm(a, axis = 1)
         na = tf.tile(tf.reshape(na, [-1,1]), tf.constant([1, 3]))
         return tf.divide(a, na)
@@ -440,6 +507,27 @@ class DescrptSeAEfLower (DescrptSeA):
                input_dict,
                suffix = '', 
                reuse = None):
+        """build.
+
+        Parameters
+        ----------
+        coord_ :
+            coord_
+        atype_ :
+            atype_
+        natoms :
+            natoms
+        box_ :
+            box_
+        mesh :
+            mesh
+        input_dict :
+            input_dict
+        suffix :
+            suffix
+        reuse :
+            reuse
+        """
         efield = input_dict['efield']
         davg = self.davg
         dstd = self.dstd
@@ -522,6 +610,23 @@ class DescrptSeAEfLower (DescrptSeA):
             = run_sess(self.sub_sess, self.stat_descrpt, 
                                 feed_dict = {
                                     self.place_holders['coord']: data_coord,
+        """_compute_dstats_sys_smth.
+
+        Parameters
+        ----------
+        data_coord :
+            data_coord
+        data_box :
+            data_box
+        data_atype :
+            data_atype
+        natoms_vec :
+            natoms_vec
+        mesh :
+            mesh
+        data_efield :
+            data_efield
+        """
                                     self.place_holders['type']: data_atype,
                                     self.place_holders['natoms_vec']: natoms_vec,
                                     self.place_holders['box']: data_box,

--- a/deepmd/descriptor/se_ar.py
+++ b/deepmd/descriptor/se_ar.py
@@ -7,7 +7,17 @@ from .se_r import DescrptSeR
 from deepmd.env import op_module
 
 class DescrptSeAR ():
+    """DescrptSeAR.
+    """
+
     def __init__ (self, jdata):
+        """__init__.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        """
         args = ClassArg()\
                .add('a',      dict,   must = True) \
                .add('r',      dict,   must = True) 
@@ -21,21 +31,48 @@ class DescrptSeAR ():
         self.dstd = None
 
     def get_rcut (self) :
+        """get_rcut.
+        """
         return np.max([self.descrpt_a.get_rcut(), self.descrpt_r.get_rcut()])
 
     def get_ntypes (self) :
+        """get_ntypes.
+        """
         return self.descrpt_r.get_ntypes()
 
     def get_dim_out (self) :
+        """get_dim_out.
+        """
         return (self.descrpt_a.get_dim_out() + self.descrpt_r.get_dim_out())
 
     def get_nlist_a (self) :
+        """get_nlist_a.
+        """
         return self.descrpt_a.nlist, self.descrpt_a.rij, self.descrpt_a.sel_a, self.descrpt_a.sel_r
 
     def get_nlist_r (self) :
+        """get_nlist_r.
+        """
         return self.descrpt_r.nlist, self.descrpt_r.rij, self.descrpt_r.sel_a, self.descrpt_r.sel_r
 
     def compute_input_stats (self,
+        """compute_input_stats.
+
+        Parameters
+        ----------
+        data_coord :
+            data_coord
+        data_box :
+            data_box
+        data_atype :
+            data_atype
+        natoms_vec :
+            natoms_vec
+        mesh :
+            mesh
+        input_dict :
+            input_dict
+        """
                         data_coord, 
                         data_box, 
                         data_atype, 
@@ -57,6 +94,27 @@ class DescrptSeAR ():
                input_dict,
                suffix = '', 
                reuse = None):
+        """build.
+
+        Parameters
+        ----------
+        coord_ :
+            coord_
+        atype_ :
+            atype_
+        natoms :
+            natoms
+        box :
+            box
+        mesh :
+            mesh
+        input_dict :
+            input_dict
+        suffix :
+            suffix
+        reuse :
+            reuse
+        """
         davg = self.davg
         dstd = self.dstd
         if davg is None:
@@ -78,6 +136,15 @@ class DescrptSeAR ():
 
 
     def prod_force_virial(self, atom_ener, natoms) :
+        """prod_force_virial.
+
+        Parameters
+        ----------
+        atom_ener :
+            atom_ener
+        natoms :
+            natoms
+        """
         f_a, v_a, av_a = self.descrpt_a.prod_force_virial(atom_ener, natoms)
         f_r, v_r, av_r = self.descrpt_r.prod_force_virial(atom_ener, natoms)
         force = f_a + f_r

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -12,6 +12,9 @@ from deepmd.utils.network import embedding_net, embedding_net_rand_seed_shift
 from deepmd.utils.sess import run_sess
 
 class DescrptSeR ():
+    """DescrptSeR.
+    """
+
     @docstring_parameter(list_to_doc(ACTIVATION_FN_DICT.keys()), list_to_doc(PRECISION_DICT.keys()))
     def __init__ (self, 
                   rcut: float,
@@ -377,6 +380,21 @@ class DescrptSeR ():
         output = []
         if not self.type_one_side:
             for type_i in range(self.ntypes):
+        """_pass_filter.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        natoms :
+            natoms
+        reuse :
+            reuse
+        suffix :
+            suffix
+        trainable :
+            trainable
+        """
                 inputs_i = tf.slice (inputs,
                                      [ 0, start_index*      self.ndescrpt],
                                      [-1, natoms[2+type_i]* self.ndescrpt] )
@@ -405,6 +423,21 @@ class DescrptSeR ():
             = run_sess(self.sub_sess, self.stat_descrpt, 
                                 feed_dict = {
                                     self.place_holders['coord']: data_coord,
+        """_compute_dstats_sys_se_r.
+
+        Parameters
+        ----------
+        data_coord :
+            data_coord
+        data_box :
+            data_box
+        data_atype :
+            data_atype
+        natoms_vec :
+            natoms_vec
+        mesh :
+            mesh
+        """
                                     self.place_holders['type']: data_atype,
                                     self.place_holders['natoms_vec']: natoms_vec,
                                     self.place_holders['box']: data_box,
@@ -434,6 +467,17 @@ class DescrptSeR ():
 
 
     def _compute_std (self,sumv2, sumv, sumn) :
+        """_compute_std.
+
+        Parameters
+        ----------
+        sumv2 :
+            sumv2
+        sumv :
+            sumv
+        sumn :
+            sumn
+        """
         val = np.sqrt(sumv2/sumn - np.multiply(sumv/sumn, sumv/sumn))
         if np.abs(val) < 1e-2:
             val = 1e-2
@@ -450,6 +494,29 @@ class DescrptSeR ():
                   name='linear', 
                   reuse=None,
                   trainable = True):
+        """_filter_r.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        type_input :
+            type_input
+        natoms :
+            natoms
+        activation_fn :
+            activation_fn
+        stddev :
+            stddev
+        bavg :
+            bavg
+        name :
+            name
+        reuse :
+            reuse
+        trainable :
+            trainable
+        """
         # natom x nei
         outputs_size = [1] + self.filter_neuron
         with tf.variable_scope(name, reuse=reuse):

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -12,6 +12,9 @@ from deepmd.utils.network import embedding_net, embedding_net_rand_seed_shift
 from deepmd.utils.sess import run_sess
 
 class DescrptSeT ():
+    """DescrptSeT.
+    """
+
     @docstring_parameter(list_to_doc(ACTIVATION_FN_DICT.keys()), list_to_doc(PRECISION_DICT.keys()))
     def __init__ (self, 
                   rcut: float,
@@ -364,6 +367,25 @@ class DescrptSeT ():
         
 
     def _pass_filter(self, 
+        """_pass_filter.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        atype :
+            atype
+        natoms :
+            natoms
+        input_dict :
+            input_dict
+        reuse :
+            reuse
+        suffix :
+            suffix
+        trainable :
+            trainable
+        """
                      inputs,
                      atype,
                      natoms,
@@ -398,6 +420,21 @@ class DescrptSeT ():
             = run_sess(self.sub_sess, self.stat_descrpt, 
                                 feed_dict = {
                                     self.place_holders['coord']: data_coord,
+        """_compute_dstats_sys_smth.
+
+        Parameters
+        ----------
+        data_coord :
+            data_coord
+        data_box :
+            data_box
+        data_atype :
+            data_atype
+        natoms_vec :
+            natoms_vec
+        mesh :
+            mesh
+        """
                                     self.place_holders['type']: data_atype,
                                     self.place_holders['natoms_vec']: natoms_vec,
                                     self.place_holders['box']: data_box,
@@ -434,6 +471,17 @@ class DescrptSeT ():
 
 
     def _compute_std (self,sumv2, sumv, sumn) :
+        """_compute_std.
+
+        Parameters
+        ----------
+        sumv2 :
+            sumv2
+        sumv :
+            sumv
+        sumn :
+            sumn
+        """
         val = np.sqrt(sumv2/sumn - np.multiply(sumv/sumn, sumv/sumn))
         if np.abs(val) < 1e-2:
             val = 1e-2
@@ -450,6 +498,29 @@ class DescrptSeT ():
                 name='linear', 
                 reuse=None,
                 trainable = True):
+        """_filter.
+
+        Parameters
+        ----------
+        inputs :
+            inputs
+        type_input :
+            type_input
+        natoms :
+            natoms
+        activation_fn :
+            activation_fn
+        stddev :
+            stddev
+        bavg :
+            bavg
+        name :
+            name
+        reuse :
+            reuse
+        trainable :
+            trainable
+        """
         # natom x (nei x 4)
         shape = inputs.get_shape().as_list()
         outputs_size = [1] + self.filter_neuron

--- a/deepmd/entrypoints/convert.py
+++ b/deepmd/entrypoints/convert.py
@@ -7,6 +7,19 @@ def convert(
     output_model: str,
     **kwargs,
 ):
+    """convert.
+
+    Parameters
+    ----------
+    FROM : str
+        FROM
+    input_model : str
+        input_model
+    output_model : str
+        output_model
+    kwargs :
+        kwargs
+    """
     if FROM == '1.2':
         convert_12_to_20(input_model, output_model)
     elif FROM == '1.3':

--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -166,6 +166,19 @@ def _do_work(jdata: Dict[str, Any], run_opt: RunOptions, is_compress: bool = Fal
 
 
 def get_data(jdata: Dict[str, Any], rcut, type_map, modifier):
+    """get_data.
+
+    Parameters
+    ----------
+    jdata : Dict[str, Any]
+        jdata
+    rcut :
+        rcut
+    type_map :
+        type_map
+    modifier :
+        modifier
+    """
     systems = j_must_have(jdata, "systems")
     if isinstance(systems, str):
         systems = expand_sys_str(systems)
@@ -208,6 +221,13 @@ def get_data(jdata: Dict[str, Any], rcut, type_map, modifier):
 
 
 def get_modifier(modi_data=None):
+    """get_modifier.
+
+    Parameters
+    ----------
+    modi_data :
+        modi_data
+    """
     modifier: Optional[DipoleChargeModifier]
     if modi_data is not None:
         if modi_data["type"] == "dipole_charge":
@@ -226,6 +246,13 @@ def get_modifier(modi_data=None):
 
 
 def get_rcut(jdata):
+    """get_rcut.
+
+    Parameters
+    ----------
+    jdata :
+        jdata
+    """
     descrpt_data = jdata['model']['descriptor']
     rcut_list = []
     if descrpt_data['type'] == 'hybrid':
@@ -237,10 +264,26 @@ def get_rcut(jdata):
 
 
 def get_type_map(jdata):
+    """get_type_map.
+
+    Parameters
+    ----------
+    jdata :
+        jdata
+    """
     return jdata['model'].get('type_map', None)
 
 
 def get_nbor_stat(jdata, rcut):
+    """get_nbor_stat.
+
+    Parameters
+    ----------
+    jdata :
+        jdata
+    rcut :
+        rcut
+    """
     max_rcut = get_rcut(jdata)
     type_map = get_type_map(jdata)
 
@@ -261,14 +304,39 @@ def get_nbor_stat(jdata, rcut):
     return min_nbor_dist, max_nbor_size
 
 def get_sel(jdata, rcut):
+    """get_sel.
+
+    Parameters
+    ----------
+    jdata :
+        jdata
+    rcut :
+        rcut
+    """
     _, max_nbor_size = get_nbor_stat(jdata, rcut)
     return max_nbor_size
 
 def get_min_nbor_dist(jdata, rcut):
+    """get_min_nbor_dist.
+
+    Parameters
+    ----------
+    jdata :
+        jdata
+    rcut :
+        rcut
+    """
     min_nbor_dist, _ = get_nbor_stat(jdata, rcut)
     return min_nbor_dist
 
 def parse_auto_sel(sel):
+    """parse_auto_sel.
+
+    Parameters
+    ----------
+    sel :
+        sel
+    """
     if type(sel) is not str:
         return False
     words = sel.split(':')
@@ -279,6 +347,13 @@ def parse_auto_sel(sel):
 
     
 def parse_auto_sel_ratio(sel):
+    """parse_auto_sel_ratio.
+
+    Parameters
+    ----------
+    sel :
+        sel
+    """
     if not parse_auto_sel(sel):
         raise RuntimeError(f'invalid auto sel format {sel}')
     else:
@@ -293,10 +368,26 @@ def parse_auto_sel_ratio(sel):
 
 
 def wrap_up_4(xx):
+    """wrap_up_4.
+
+    Parameters
+    ----------
+    xx :
+        xx
+    """
     return 4 * ((int(xx) + 3) // 4)
 
 
 def update_one_sel(jdata, descriptor):
+    """update_one_sel.
+
+    Parameters
+    ----------
+    jdata :
+        jdata
+    descriptor :
+        descriptor
+    """
     rcut = descriptor['rcut']
     tmp_sel = get_sel(jdata, rcut)
     if parse_auto_sel(descriptor['sel']) :
@@ -317,6 +408,13 @@ def update_one_sel(jdata, descriptor):
 
 
 def update_sel(jdata):    
+    """update_sel.
+
+    Parameters
+    ----------
+    jdata :
+        jdata
+    """
     descrpt_data = jdata['model']['descriptor']
     if descrpt_data['type'] == 'hybrid':
         for ii in range(len(descrpt_data['list'])):

--- a/deepmd/entrypoints/transfer.py
+++ b/deepmd/entrypoints/transfer.py
@@ -19,6 +19,18 @@ PRECISION_MAPPING: Dict[int, type] = {
 
 @np.vectorize
 def convert_number(number: int) -> float:
+    """convert_number.
+
+    Parameters
+    ----------
+    number : int
+        number
+
+    Returns
+    -------
+    float
+
+    """
     binary = bin(number).replace("0b", "").zfill(16)
     sign = int(binary[0]) * -2 + 1
     exp = int(binary[1:6], 2)
@@ -167,12 +179,38 @@ def transform_graph(raw_graph: tf.Graph, old_graph: tf.Graph) -> tf.Graph:
 
 
 class CopyNodeAttr:
+    """CopyNodeAttr.
+    """
+
     def __init__(self, node) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        node :
+            node
+
+        Returns
+        -------
+        None
+
+        """
         self.node = node
 
     def from_array(
         self, tensor: np.ndarray, dtype: type, shape: Optional[Sequence[int]] = None
     ):
+        """from_array.
+
+        Parameters
+        ----------
+        tensor : np.ndarray
+            tensor
+        dtype : type
+            dtype
+        shape : Optional[Sequence[int]]
+            shape
+        """
         if shape is None:
             shape = tensor.shape
         self.node.attr["value"].CopyFrom(
@@ -180,10 +218,33 @@ class CopyNodeAttr:
         )
 
     def from_str(self, tensor: np.ndarray):
+        """from_str.
+
+        Parameters
+        ----------
+        tensor : np.ndarray
+            tensor
+        """
         self.node.attr["value"].tensor.tensor_content = tensor.tostring()
 
 
 def load_tensor(node: tf.Tensor, dtype_old: type, dtype_new: type) -> np.ndarray:
+    """load_tensor.
+
+    Parameters
+    ----------
+    node : tf.Tensor
+        node
+    dtype_old : type
+        dtype_old
+    dtype_new : type
+        dtype_new
+
+    Returns
+    -------
+    np.ndarray
+
+    """
     if dtype_old == np.float64:
         tensor = np.array(node.double_val).astype(dtype_new)
     elif dtype_old == np.float32:

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -14,6 +14,9 @@ from deepmd.env import global_cvt_2_tf_float
 from deepmd.env import GLOBAL_TF_FLOAT_PRECISION
 
 class EnerFitting ():
+    """EnerFitting.
+    """
+
     @docstring_parameter(list_to_doc(ACTIVATION_FN_DICT.keys()), list_to_doc(PRECISION_DICT.keys()))
     def __init__ (self, 
                   descrpt : tf.Tensor,
@@ -146,6 +149,15 @@ class EnerFitting ():
 
     @classmethod
     def _compute_output_stats(self, all_stat, rcond = 1e-3):
+        """_compute_output_stats.
+
+        Parameters
+        ----------
+        all_stat :
+            all_stat
+        rcond :
+            rcond
+        """
         data = all_stat['energy']
         # data[sys_idx][batch_idx][frame_idx]
         sys_ener = np.array([])
@@ -213,6 +225,17 @@ class EnerFitting ():
 
 
     def _compute_std (self, sumv2, sumv, sumn) :
+        """_compute_std.
+
+        Parameters
+        ----------
+        sumv2 :
+            sumv2
+        sumv :
+            sumv
+        sumn :
+            sumn
+        """
         return np.sqrt(sumv2/sumn - np.multiply(sumv/sumn, sumv/sumn))
 
     def _build_lower(
@@ -226,6 +249,27 @@ class EnerFitting ():
             suffix = '',
             reuse = None
     ):
+        """_build_lower.
+
+        Parameters
+        ----------
+        start_index :
+            start_index
+        natoms :
+            natoms
+        inputs :
+            inputs
+        fparam :
+            fparam
+        aparam :
+            aparam
+        bias_atom_e :
+            bias_atom_e
+        suffix :
+            suffix
+        reuse :
+            reuse
+        """
         # cut-out inputs
         inputs_i = tf.slice (inputs,
                              [ 0, start_index*      self.dim_descrpt],

--- a/deepmd/fit/polar.py
+++ b/deepmd/fit/polar.py
@@ -18,6 +18,15 @@ class PolarFittingLocFrame () :
     Fitting polarizability with local frame descriptor. not supported anymore. 
     """
     def __init__ (self, jdata, descrpt) :
+        """__init__.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        descrpt :
+            descrpt
+        """
         if not isinstance(descrpt, DescrptLocFrame) :
             raise RuntimeError('PolarFittingLocFrame only supports DescrptLocFrame')
         self.ntypes = descrpt.get_ntypes()
@@ -39,9 +48,13 @@ class PolarFittingLocFrame () :
         self.useBN = False
 
     def get_sel_type(self):
+        """get_sel_type.
+        """
         return self.sel_type
 
     def get_out_size(self):
+        """get_out_size.
+        """
         return 9
 
     def build (self, 
@@ -56,6 +69,21 @@ class PolarFittingLocFrame () :
 
         count = 0
         for type_i in range(self.ntypes):
+        """build.
+
+        Parameters
+        ----------
+        input_d :
+            input_d
+        rot_mat :
+            rot_mat
+        natoms :
+            natoms
+        reuse :
+            reuse
+        suffix :
+            suffix
+        """
             # cut-out inputs
             inputs_i = tf.slice (inputs,
                                  [ 0, start_index*      self.dim_descrpt],

--- a/deepmd/fit/wfc.py
+++ b/deepmd/fit/wfc.py
@@ -16,6 +16,15 @@ class WFCFitting () :
     Fitting Wannier function centers (WFCs) with local frame descriptor. Not supported anymore. 
     """
     def __init__ (self, jdata, descrpt):
+        """__init__.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        descrpt :
+            descrpt
+        """
         if not isinstance(descrpt, DescrptLocFrame) :
             raise RuntimeError('WFC only supports DescrptLocFrame')
         self.ntypes = descrpt.get_ntypes()
@@ -43,12 +52,18 @@ class WFCFitting () :
 
 
     def get_sel_type(self):
+        """get_sel_type.
+        """
         return self.sel_type
 
     def get_wfc_numb(self):
+        """get_wfc_numb.
+        """
         return self.wfc_numb
 
     def get_out_size(self):
+        """get_out_size.
+        """
         return self.wfc_numb * 3
 
     def build (self, 
@@ -63,6 +78,21 @@ class WFCFitting () :
 
         count = 0
         for type_i in range(self.ntypes):
+        """build.
+
+        Parameters
+        ----------
+        input_d :
+            input_d
+        rot_mat :
+            rot_mat
+        natoms :
+            natoms
+        reuse :
+            reuse
+        suffix :
+            suffix
+        """
             # cut-out inputs
             inputs_i = tf.slice (inputs,
                                  [ 0, start_index*      self.dim_descrpt],

--- a/deepmd/infer/data_modifier.py
+++ b/deepmd/infer/data_modifier.py
@@ -16,6 +16,9 @@ from deepmd.utils.sess import run_sess
 
 
 class DipoleChargeModifier(DeepDipole):
+    """DipoleChargeModifier.
+    """
+
     def __init__(self, 
                  model_name : str, 
                  model_charge_map : List[float],
@@ -98,6 +101,8 @@ class DipoleChargeModifier(DeepDipole):
 
 
     def _build_fv_graph_inner(self):
+        """_build_fv_graph_inner.
+        """
         self.t_ef = tf.placeholder(GLOBAL_TF_FLOAT_PRECISION, [None], name = 't_ef')
         nf = 10
         nfxnas = 64*nf
@@ -180,6 +185,15 @@ class DipoleChargeModifier(DeepDipole):
 
 
     def _enrich(self, dipole, dof = 3):
+        """_enrich.
+
+        Parameters
+        ----------
+        dipole :
+            dipole
+        dof :
+            dof
+        """
         coll = []                
         sel_start_idx = 0
         for type_i in range(self.ntypes):
@@ -195,6 +209,13 @@ class DipoleChargeModifier(DeepDipole):
         return tf.concat(coll, axis = 1)
 
     def _slice_descrpt_deriv(self, deriv):
+        """_slice_descrpt_deriv.
+
+        Parameters
+        ----------
+        deriv :
+            deriv
+        """
         coll = []
         start_idx = 0
         for type_i in range(self.ntypes):
@@ -313,6 +334,19 @@ class DipoleChargeModifier(DeepDipole):
 
 
     def _eval_fv(self, coords, cells, atom_types, ext_f) :
+        """_eval_fv.
+
+        Parameters
+        ----------
+        coords :
+            coords
+        cells :
+            cells
+        atom_types :
+            atom_types
+        ext_f :
+            ext_f
+        """
         # reshape the inputs 
         cells = np.reshape(cells, [-1, 9])
         nframes = cells.shape[0]
@@ -347,6 +381,19 @@ class DipoleChargeModifier(DeepDipole):
 
 
     def _extend_system(self, coord, box, atype, charge):
+        """_extend_system.
+
+        Parameters
+        ----------
+        coord :
+            coord
+        box :
+            box
+        atype :
+            atype
+        charge :
+            charge
+        """
         natoms = coord.shape[1] // 3
         nframes = coord.shape[0]
         # sel atoms and setup ref coord

--- a/deepmd/infer/deep_dipole.py
+++ b/deepmd/infer/deep_dipole.py
@@ -28,6 +28,22 @@ class DeepDipole(DeepTensor):
     def __init__(
         self, model_file: "Path", load_prefix: str = "load", default_tf_graph: bool = False
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        model_file : "Path"
+            model_file
+        load_prefix : str
+            load_prefix
+        default_tf_graph : bool
+            default_tf_graph
+
+        Returns
+        -------
+        None
+
+        """
 
         # use this in favor of dict update to move attribute from class to
         # instance namespace

--- a/deepmd/infer/deep_eval.py
+++ b/deepmd/infer/deep_eval.py
@@ -23,6 +23,17 @@ class DeepEval:
         load_prefix: str = "load",
         default_tf_graph: bool = False
     ):
+        """__init__.
+
+        Parameters
+        ----------
+        model_file : "Path"
+            model_file
+        load_prefix : str
+            load_prefix
+        default_tf_graph : bool
+            default_tf_graph
+        """
         self.graph = self._load_graph(
             model_file, prefix=load_prefix, default_tf_graph=default_tf_graph
         )
@@ -115,6 +126,17 @@ class DeepEval:
     def _load_graph(
         frozen_graph_filename: "Path", prefix: str = "load", default_tf_graph: bool = False
     ):
+        """_load_graph.
+
+        Parameters
+        ----------
+        frozen_graph_filename : "Path"
+            frozen_graph_filename
+        prefix : str
+            prefix
+        default_tf_graph : bool
+            default_tf_graph
+        """
         # We load the protobuf file from the disk and parse it to retrieve the
         # unserialized graph_def
         with tf.gfile.GFile(str(frozen_graph_filename), "rb") as f:

--- a/deepmd/infer/deep_polar.py
+++ b/deepmd/infer/deep_polar.py
@@ -29,6 +29,22 @@ class DeepPolar(DeepTensor):
     def __init__(
         self, model_file: "Path", load_prefix: str = "load", default_tf_graph: bool = False
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        model_file : "Path"
+            model_file
+        load_prefix : str
+            load_prefix
+        default_tf_graph : bool
+            default_tf_graph
+
+        Returns
+        -------
+        None
+
+        """
 
         # use this in favor of dict update to move attribute from class to
         # instance namespace
@@ -72,6 +88,22 @@ class DeepGlobalPolar(DeepTensor):
     def __init__(
         self, model_file: str, load_prefix: str = "load", default_tf_graph: bool = False
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        model_file : str
+            model_file
+        load_prefix : str
+            load_prefix
+        default_tf_graph : bool
+            default_tf_graph
+
+        Returns
+        -------
+        None
+
+        """
 
         self.tensors.update(
             {

--- a/deepmd/infer/deep_pot.py
+++ b/deepmd/infer/deep_pot.py
@@ -39,6 +39,22 @@ class DeepPot(DeepEval):
         load_prefix: str = "load",
         default_tf_graph: bool = False
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        model_file : "Path"
+            model_file
+        load_prefix : str
+            load_prefix
+        default_tf_graph : bool
+            default_tf_graph
+
+        Returns
+        -------
+        None
+
+        """
 
         # add these tensors on top of what is defined by DeepTensor Class
         # use this in favor of dict update to move attribute from class to
@@ -130,6 +146,8 @@ class DeepPot(DeepEval):
             self.dm = DipoleChargeModifier(mdl_name, mdl_charge_map, sys_charge_map, ewald_h = ewald_h, ewald_beta = ewald_beta)
 
     def _run_default_sess(self):
+        """_run_default_sess.
+        """
         [self.ntypes, self.rcut, self.dfparam, self.daparam, self.tmap] = run_sess(self.sess, 
             [self.t_ntypes, self.t_rcut, self.t_dfparam, self.t_daparam, self.t_tmap]
         )
@@ -234,6 +252,25 @@ class DeepPot(DeepEval):
         atomic=False,
         efield=None
     ):
+        """_eval_inner.
+
+        Parameters
+        ----------
+        coords :
+            coords
+        cells :
+            cells
+        atom_types :
+            atom_types
+        fparam :
+            fparam
+        aparam :
+            aparam
+        atomic :
+            atomic
+        efield :
+            efield
+        """
         # standarize the shape of inputs
         atom_types = np.array(atom_types, dtype = int).reshape([-1])
         natoms = atom_types.size

--- a/deepmd/infer/deep_tensor.py
+++ b/deepmd/infer/deep_tensor.py
@@ -47,6 +47,22 @@ class DeepTensor(DeepEval):
         load_prefix: str = 'load',
         default_tf_graph: bool = False
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        model_file : "Path"
+            model_file
+        load_prefix : str
+            load_prefix
+        default_tf_graph : bool
+            default_tf_graph
+
+        Returns
+        -------
+        None
+
+        """
         DeepEval.__init__(
             self,
             model_file,
@@ -88,6 +104,8 @@ class DeepTensor(DeepEval):
         self.tmap = self.tmap.decode('UTF-8').split()
 
     def _run_default_sess(self):
+        """_run_default_sess.
+        """
         [self.ntypes, self.rcut, self.tmap, self.tselt, self.output_dim] \
             = run_sess(self.sess, 
                 [self.t_ntypes, self.t_rcut, self.t_tmap, self.t_sel_type, self.t_ouput_dim]

--- a/deepmd/infer/deep_wfc.py
+++ b/deepmd/infer/deep_wfc.py
@@ -28,6 +28,22 @@ class DeepWFC(DeepTensor):
     def __init__(
         self, model_file: "Path", load_prefix: str = "load", default_tf_graph: bool = False
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        model_file : "Path"
+            model_file
+        load_prefix : str
+            load_prefix
+        default_tf_graph : bool
+            default_tf_graph
+
+        Returns
+        -------
+        None
+
+        """
 
         # use this in favor of dict update to move attribute from class to
         # instance namespace

--- a/deepmd/loggers/loggers.py
+++ b/deepmd/loggers/loggers.py
@@ -36,6 +36,13 @@ class _AppFilter(logging.Filter):
     """Add field `app_name` to log messages."""
 
     def filter(self, record):
+        """filter.
+
+        Parameters
+        ----------
+        record :
+            record
+        """
         record.app_name = "DEEPMD"
         return True
 
@@ -44,10 +51,29 @@ class _MPIRankFilter(logging.Filter):
     """Add MPI rank number to log messages, adds field `rank`."""
 
     def __init__(self, rank: int) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        rank : int
+            rank
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(name="MPI_rank_id")
         self.mpi_rank = str(rank)
 
     def filter(self, record):
+        """filter.
+
+        Parameters
+        ----------
+        record :
+            record
+        """
         record.rank = self.mpi_rank
         return True
 
@@ -56,10 +82,29 @@ class _MPIMasterFilter(logging.Filter):
     """Filter that lets through only messages emited from rank==0."""
 
     def __init__(self, rank: int) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        rank : int
+            rank
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(name="MPI_master_log")
         self.mpi_rank = rank
 
     def filter(self, record):
+        """filter.
+
+        Parameters
+        ----------
+        record :
+            record
+        """
         if self.mpi_rank == 0:
             return True
         else:
@@ -82,6 +127,22 @@ class _MPIFileStream:
     def __init__(
         self, filename: "Path", MPI: "MPI", mode: str = "_MPI_APPEND_MODE"
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        filename : "Path"
+            filename
+        MPI : "MPI"
+            MPI
+        mode : str
+            mode
+
+        Returns
+        -------
+        None
+
+        """
         self.stream = MPI.File.Open(MPI.COMM_WORLD, filename, mode)
         self.stream.Set_atomicity(True)
         self.name = "MPIfilestream"
@@ -123,10 +184,28 @@ class _MPIHandler(logging.FileHandler):
         MPI: "MPI",
         mode: str = "_MPI_APPEND_MODE",
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        filename : "Path"
+            filename
+        MPI : "MPI"
+            MPI
+        mode : str
+            mode
+
+        Returns
+        -------
+        None
+
+        """
         self.MPI = MPI
         super().__init__(filename, mode=mode, encoding=None, delay=False)
 
     def _open(self):
+        """_open.
+        """
         return _MPIFileStream(self.baseFilename, self.MPI, self.mode)
 
     def setStream(self, stream):

--- a/deepmd/loss/ener.py
+++ b/deepmd/loss/ener.py
@@ -24,6 +24,40 @@ class EnerStdLoss () :
                   limit_pref_pf : float = 0.0,
                   relative_f : float = None 
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        starter_learning_rate : float
+            starter_learning_rate
+        start_pref_e : float
+            start_pref_e
+        limit_pref_e : float
+            limit_pref_e
+        start_pref_f : float
+            start_pref_f
+        limit_pref_f : float
+            limit_pref_f
+        start_pref_v : float
+            start_pref_v
+        limit_pref_v : float
+            limit_pref_v
+        start_pref_ae : float
+            start_pref_ae
+        limit_pref_ae : float
+            limit_pref_ae
+        start_pref_pf : float
+            start_pref_pf
+        limit_pref_pf : float
+            limit_pref_pf
+        relative_f : float
+            relative_f
+
+        Returns
+        -------
+        None
+
+        """
         self.starter_learning_rate = starter_learning_rate
         self.start_pref_e = start_pref_e
         self.limit_pref_e = limit_pref_e
@@ -54,6 +88,21 @@ class EnerStdLoss () :
                model_dict,
                label_dict,
                suffix):        
+        """build.
+
+        Parameters
+        ----------
+        learning_rate :
+            learning_rate
+        natoms :
+            natoms
+        model_dict :
+            model_dict
+        label_dict :
+            label_dict
+        suffix :
+            suffix
+        """
         energy = model_dict['energy']
         force = model_dict['force']
         virial = model_dict['virial']
@@ -129,6 +178,17 @@ class EnerStdLoss () :
         return l2_loss, more_loss
 
     def eval(self, sess, feed_dict, natoms):
+        """eval.
+
+        Parameters
+        ----------
+        sess :
+            sess
+        feed_dict :
+            feed_dict
+        natoms :
+            natoms
+        """
         run_data = [
             self.l2_l,
             self.l2_more['l2_ener_loss'],
@@ -152,6 +212,8 @@ class EnerStdLoss () :
         return results
 
     def print_header(self):  # depreciated
+        """print_header.
+        """
         prop_fmt = '   %11s %11s'
         print_str = ''
         print_str += prop_fmt % ('rmse_tst', 'rmse_trn')
@@ -174,6 +236,23 @@ class EnerStdLoss () :
                           natoms,
                           feed_dict_test,
                           feed_dict_batch):  # depreciated
+        """print_on_training.
+
+        Parameters
+        ----------
+        tb_writer :
+            tb_writer
+        cur_batch :
+            cur_batch
+        sess :
+            sess
+        natoms :
+            natoms
+        feed_dict_test :
+            feed_dict_test
+        feed_dict_batch :
+            feed_dict_batch
+        """
 
         run_data = [
             self.l2_l,
@@ -221,6 +300,9 @@ class EnerStdLoss () :
 
 
 class EnerDipoleLoss () :
+    """EnerDipoleLoss.
+    """
+
     def __init__ (self, 
                   starter_learning_rate : float,
                   start_pref_e : float = 0.1,
@@ -228,6 +310,26 @@ class EnerDipoleLoss () :
                   start_pref_ed : float = 1.0,
                   limit_pref_ed : float = 1.0
     ) -> None :
+        """__init__.
+
+        Parameters
+        ----------
+        starter_learning_rate : float
+            starter_learning_rate
+        start_pref_e : float
+            start_pref_e
+        limit_pref_e : float
+            limit_pref_e
+        start_pref_ed : float
+            start_pref_ed
+        limit_pref_ed : float
+            limit_pref_ed
+
+        Returns
+        -------
+        None
+
+        """
         self.starter_learning_rate = kwarg['starter_learning_rate']
         args = ClassArg()\
             .add('start_pref_e',        float,  must = True, default = 0.1) \
@@ -249,6 +351,21 @@ class EnerDipoleLoss () :
                model_dict,
                label_dict,
                suffix):        
+        """build.
+
+        Parameters
+        ----------
+        learning_rate :
+            learning_rate
+        natoms :
+            natoms
+        model_dict :
+            model_dict
+        label_dict :
+            label_dict
+        suffix :
+            suffix
+        """
         coord = model_dict['coord']
         energy = model_dict['energy']
         atom_ener = model_dict['atom_ener']
@@ -293,6 +410,17 @@ class EnerDipoleLoss () :
         return l2_loss, more_loss
 
     def eval(self, sess, feed_dict, natoms):
+        """eval.
+
+        Parameters
+        ----------
+        sess :
+            sess
+        feed_dict :
+            feed_dict
+        natoms :
+            natoms
+        """
         run_data = [
             self.l2_l,
             self.l2_more['l2_ener_loss'],
@@ -309,6 +437,8 @@ class EnerDipoleLoss () :
 
     @staticmethod
     def print_header() :  # depreciated
+        """print_header.
+        """
         prop_fmt = '   %9s %9s'
         print_str = ''
         print_str += prop_fmt % ('l2_tst', 'l2_trn')
@@ -323,6 +453,23 @@ class EnerDipoleLoss () :
                           natoms,
                           feed_dict_test,
                           feed_dict_batch):  # depreciated
+        """print_on_training.
+
+        Parameters
+        ----------
+        tb_writer :
+            tb_writer
+        cur_batch :
+            cur_batch
+        sess :
+            sess
+        natoms :
+            natoms
+        feed_dict_test :
+            feed_dict_test
+        feed_dict_batch :
+            feed_dict_batch
+        """
 
         run_data = [
             self.l2_l,

--- a/deepmd/loss/tensor.py
+++ b/deepmd/loss/tensor.py
@@ -11,6 +11,15 @@ class TensorLoss () :
     Loss function for tensorial properties.
     """
     def __init__ (self, jdata, **kwarg) :
+        """__init__.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        kwarg :
+            kwarg
+        """
         model = kwarg.get('model', None)
         if model is not None:
             self.type_sel = model.get_sel_type()
@@ -54,6 +63,21 @@ class TensorLoss () :
                model_dict,
                label_dict,
                suffix):        
+        """build.
+
+        Parameters
+        ----------
+        learning_rate :
+            learning_rate
+        natoms :
+            natoms
+        model_dict :
+            model_dict
+        label_dict :
+            label_dict
+        suffix :
+            suffix
+        """
         polar_hat = label_dict[self.label_name]
         atomic_polar_hat = label_dict["atomic_" + self.label_name]
         polar = tf.reshape(model_dict[self.tensor_name], [-1])
@@ -116,6 +140,17 @@ class TensorLoss () :
         return l2_loss, more_loss
 
     def eval(self, sess, feed_dict, natoms):
+        """eval.
+
+        Parameters
+        ----------
+        sess :
+            sess
+        feed_dict :
+            feed_dict
+        natoms :
+            natoms
+        """
         atoms = 0
         if self.type_sel is not None:
             for w in self.type_sel:
@@ -134,6 +169,8 @@ class TensorLoss () :
         return results
 
     def print_header(self):  # depreciated
+        """print_header.
+        """
         prop_fmt = '   %11s %11s'
         print_str = ''
         print_str += prop_fmt % ('rmse_tst', 'rmse_trn')
@@ -144,6 +181,23 @@ class TensorLoss () :
         return print_str
 
     def print_on_training(self, 
+        """print_on_training.
+
+        Parameters
+        ----------
+        tb_writer :
+            tb_writer
+        cur_batch :
+            cur_batch
+        sess :
+            sess
+        natoms :
+            natoms
+        feed_dict_test :
+            feed_dict_test
+        feed_dict_batch :
+            feed_dict_batch
+        """
                           tb_writer,
                           cur_batch,
                           sess, 

--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -9,6 +9,9 @@ from deepmd.env import op_module
 from .model_stat import make_stat_input, merge_sys_stat
 
 class EnerModel() :
+    """EnerModel.
+    """
+
     model_type = 'ener'
 
     def __init__ (
@@ -76,15 +79,28 @@ class EnerModel() :
 
 
     def get_rcut (self) :
+        """get_rcut.
+        """
         return self.rcut
 
     def get_ntypes (self) :
+        """get_ntypes.
+        """
         return self.ntypes
 
     def get_type_map (self) :
+        """get_type_map.
+        """
         return self.type_map
 
     def data_stat(self, data):
+        """data_stat.
+
+        Parameters
+        ----------
+        data :
+            data
+        """
         all_stat = make_stat_input(data, self.data_stat_nbatch, merge_sys = False)
         m_all_stat = merge_sys_stat(all_stat)
         self._compute_input_stat(m_all_stat, protection = self.data_stat_protect)
@@ -92,6 +108,15 @@ class EnerModel() :
         # self.bias_atom_e = data.compute_energy_shift(self.rcond)
 
     def _compute_input_stat (self, all_stat, protection = 1e-2) :
+        """_compute_input_stat.
+
+        Parameters
+        ----------
+        all_stat :
+            all_stat
+        protection :
+            protection
+        """
         self.descrpt.compute_input_stats(all_stat['coord'],
                                          all_stat['box'],
                                          all_stat['type'],
@@ -101,6 +126,13 @@ class EnerModel() :
         self.fitting.compute_input_stats(all_stat, protection = protection)
 
     def _compute_output_stat (self, all_stat) :
+        """_compute_output_stat.
+
+        Parameters
+        ----------
+        all_stat :
+            all_stat
+        """
         self.fitting.compute_output_stats(all_stat)
 
     
@@ -113,6 +145,27 @@ class EnerModel() :
                input_dict,
                suffix = '', 
                reuse = None):
+        """build.
+
+        Parameters
+        ----------
+        coord_ :
+            coord_
+        atype_ :
+            atype_
+        natoms :
+            natoms
+        box :
+            box
+        mesh :
+            mesh
+        input_dict :
+            input_dict
+        suffix :
+            suffix
+        reuse :
+            reuse
+        """
 
         with tf.variable_scope('model_attr' + suffix, reuse = reuse) :
             t_tmap = tf.constant(' '.join(self.type_map), 

--- a/deepmd/model/model_stat.py
+++ b/deepmd/model/model_stat.py
@@ -2,6 +2,15 @@ import numpy as np
 from collections import defaultdict
 
 def _make_all_stat_ref(data, nbatches):
+    """_make_all_stat_ref.
+
+    Parameters
+    ----------
+    data :
+        data
+    nbatches :
+        nbatches
+    """
     all_stat = defaultdict(list)
     for ii in range(data.get_nsystems()) :
         for jj in range(nbatches) :
@@ -49,6 +58,13 @@ def make_stat_input(data, nbatches, merge_sys = True):
     return all_stat
 
 def merge_sys_stat(all_stat):
+    """merge_sys_stat.
+
+    Parameters
+    ----------
+    all_stat :
+        all_stat
+    """
     first_key = list(all_stat.keys())[0]
     nsys = len(all_stat[first_key])
     ret = defaultdict(list)

--- a/deepmd/model/tensor.py
+++ b/deepmd/model/tensor.py
@@ -8,6 +8,9 @@ from deepmd.env import op_module
 from .model_stat import make_stat_input, merge_sys_stat
 
 class TensorModel() :
+    """TensorModel.
+    """
+
     def __init__ (
             self, 
             tensor_name : str,
@@ -52,27 +55,53 @@ class TensorModel() :
         self.data_stat_protect = data_stat_protect
     
     def get_rcut (self) :
+        """get_rcut.
+        """
         return self.rcut
 
     def get_ntypes (self) :
+        """get_ntypes.
+        """
         return self.ntypes
 
     def get_type_map (self) :
+        """get_type_map.
+        """
         return self.type_map
 
     def get_sel_type(self):
+        """get_sel_type.
+        """
         return self.fitting.get_sel_type()
 
     def get_out_size (self) :
+        """get_out_size.
+        """
         return self.fitting.get_out_size()
 
     def data_stat(self, data):
+        """data_stat.
+
+        Parameters
+        ----------
+        data :
+            data
+        """
         all_stat = make_stat_input(data, self.data_stat_nbatch, merge_sys = False)
         m_all_stat = merge_sys_stat(all_stat)        
         self._compute_input_stat (m_all_stat, protection = self.data_stat_protect)
         self._compute_output_stat(all_stat)
 
     def _compute_input_stat(self, all_stat, protection = 1e-2) :
+        """_compute_input_stat.
+
+        Parameters
+        ----------
+        all_stat :
+            all_stat
+        protection :
+            protection
+        """
         self.descrpt.compute_input_stats(all_stat['coord'],
                                          all_stat['box'],
                                          all_stat['type'],
@@ -83,6 +112,13 @@ class TensorModel() :
             self.fitting.compute_input_stats(all_stat, protection = protection)
 
     def _compute_output_stat (self, all_stat) :
+        """_compute_output_stat.
+
+        Parameters
+        ----------
+        all_stat :
+            all_stat
+        """
         if hasattr(self.fitting, 'compute_output_stats'):
             self.fitting.compute_output_stats(all_stat)
 
@@ -95,6 +131,27 @@ class TensorModel() :
                input_dict,
                suffix = '', 
                reuse = None):
+        """build.
+
+        Parameters
+        ----------
+        coord_ :
+            coord_
+        atype_ :
+            atype_
+        natoms :
+            natoms
+        box :
+            box
+        mesh :
+            mesh
+        input_dict :
+            input_dict
+        suffix :
+            suffix
+        reuse :
+            reuse
+        """
         with tf.variable_scope('model_attr' + suffix, reuse = reuse) :
             t_tmap = tf.constant(' '.join(self.type_map), 
                                  name = 'tmap', 
@@ -172,6 +229,9 @@ class TensorModel() :
 
 
 class WFCModel(TensorModel):
+    """WFCModel.
+    """
+
     def __init__(
             self, 
             descrpt, 
@@ -180,9 +240,32 @@ class WFCModel(TensorModel):
             data_stat_nbatch : int = 10, 
             data_stat_protect : float = 1e-2
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        descrpt :
+            descrpt
+        fitting :
+            fitting
+        type_map : List[str]
+            type_map
+        data_stat_nbatch : int
+            data_stat_nbatch
+        data_stat_protect : float
+            data_stat_protect
+
+        Returns
+        -------
+        None
+
+        """
         TensorModel.__init__(self, 'wfc', descrpt, fitting, type_map, data_stat_nbatch, data_stat_protect)
 
 class DipoleModel(TensorModel):
+    """DipoleModel.
+    """
+
     def __init__(
             self, 
             descrpt, 
@@ -191,9 +274,32 @@ class DipoleModel(TensorModel):
             data_stat_nbatch : int = 10, 
             data_stat_protect : float = 1e-2
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        descrpt :
+            descrpt
+        fitting :
+            fitting
+        type_map : List[str]
+            type_map
+        data_stat_nbatch : int
+            data_stat_nbatch
+        data_stat_protect : float
+            data_stat_protect
+
+        Returns
+        -------
+        None
+
+        """
         TensorModel.__init__(self, 'dipole', descrpt, fitting, type_map, data_stat_nbatch, data_stat_protect)
 
 class PolarModel(TensorModel):
+    """PolarModel.
+    """
+
     def __init__(
             self, 
             descrpt, 
@@ -202,9 +308,32 @@ class PolarModel(TensorModel):
             data_stat_nbatch : int = 10, 
             data_stat_protect : float = 1e-2
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        descrpt :
+            descrpt
+        fitting :
+            fitting
+        type_map : List[str]
+            type_map
+        data_stat_nbatch : int
+            data_stat_nbatch
+        data_stat_protect : float
+            data_stat_protect
+
+        Returns
+        -------
+        None
+
+        """
         TensorModel.__init__(self, 'polar', descrpt, fitting, type_map, data_stat_nbatch, data_stat_protect)
 
 class GlobalPolarModel(TensorModel):
+    """GlobalPolarModel.
+    """
+
     def __init__(
             self, 
             descrpt, 
@@ -213,6 +342,26 @@ class GlobalPolarModel(TensorModel):
             data_stat_nbatch : int = 10, 
             data_stat_protect : float = 1e-2
     ) -> None:
+        """__init__.
+
+        Parameters
+        ----------
+        descrpt :
+            descrpt
+        fitting :
+            fitting
+        type_map : List[str]
+            type_map
+        data_stat_nbatch : int
+            data_stat_nbatch
+        data_stat_protect : float
+            data_stat_protect
+
+        Returns
+        -------
+        None
+
+        """
         TensorModel.__init__(self, 'global_polar', descrpt, fitting, type_map, data_stat_nbatch, data_stat_protect)
 
 

--- a/deepmd/train/run_options.py
+++ b/deepmd/train/run_options.py
@@ -92,6 +92,21 @@ class RunOptions:
         log_level: int = 0,
         mpi_log: str = "master"
     ):
+        """__init__.
+
+        Parameters
+        ----------
+        init_model : Optional[str]
+            init_model
+        restart : Optional[str]
+            restart
+        log_path : Optional[str]
+            log_path
+        log_level : int
+            log_level
+        mpi_log : str
+            mpi_log
+        """
         self._try_init_distrib()
 
         if all((init_model, restart)):
@@ -171,6 +186,8 @@ class RunOptions:
             )
 
     def _try_init_distrib(self):
+        """_try_init_distrib.
+        """
         try:
             import horovod.tensorflow as HVD
             HVD.init()

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -38,6 +38,15 @@ log = logging.getLogger(__name__)
 
 
 def _is_subdir(path, directory):
+    """_is_subdir.
+
+    Parameters
+    ----------
+    path :
+        path
+    directory :
+        directory
+    """
     path = os.path.realpath(path)
     directory = os.path.realpath(directory)
     if path == directory:
@@ -46,6 +55,13 @@ def _is_subdir(path, directory):
     return not relative.startswith(os.pardir + os.sep)
 
 def _generate_descrpt_from_param_dict(descrpt_param):
+    """_generate_descrpt_from_param_dict.
+
+    Parameters
+    ----------
+    descrpt_param :
+        descrpt_param
+    """
     try:
         descrpt_type = descrpt_param['type']
     except KeyError:
@@ -77,15 +93,36 @@ def _generate_descrpt_from_param_dict(descrpt_param):
     
 
 class DPTrainer (object):
+    """DPTrainer.
+    """
+
     def __init__(self, 
                  jdata, 
                  run_opt,
                  is_compress = False):
+        """__init__.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        run_opt :
+            run_opt
+        is_compress :
+            is_compress
+        """
         self.run_opt = run_opt
         self._init_param(jdata)
         self.is_compress = is_compress
 
     def _init_param(self, jdata):
+        """_init_param.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        """
         # model config        
         model_param = j_must_have(jdata, 'model')
         descrpt_param = j_must_have(model_param, 'descriptor')
@@ -273,6 +310,15 @@ class DPTrainer (object):
 
 
     def build (self, 
+        """build.
+
+        Parameters
+        ----------
+        data :
+            data
+        stop_batch :
+            stop_batch
+        """
                data = None, 
                stop_batch = 0) :
         self.ntypes = self.model.get_ntypes()
@@ -312,12 +358,21 @@ class DPTrainer (object):
 
 
     def _build_lr(self):
+        """_build_lr.
+        """
         self._extra_train_ops   = []
         self.global_step = tf.train.get_or_create_global_step()
         self.learning_rate = self.lr.build(self.global_step, self.stop_batch)
         log.info("built lr")
 
     def _build_network(self, data):        
+        """_build_network.
+
+        Parameters
+        ----------
+        data :
+            data
+        """
         self.place_holders = {}
         if self.is_compress :
             for kk in ['coord', 'box']:
@@ -350,6 +405,8 @@ class DPTrainer (object):
         log.info("built network")
 
     def _build_training(self):
+        """_build_training.
+        """
         trainable_variables = tf.trainable_variables()
         if self.run_opt.is_distrib:
             optimizer = tf.train.AdamOptimizer(learning_rate = self.learning_rate*self.run_opt.world_size)
@@ -365,6 +422,8 @@ class DPTrainer (object):
         log.info("built training")
 
     def _init_session(self):
+        """_init_session.
+        """
         config = get_tf_session_config()
         device, idx = self.run_opt.my_device.split(":", 1)
         if device == "gpu":
@@ -408,6 +467,15 @@ class DPTrainer (object):
             run_sess(self.sess, bcast_op)
 
     def train (self, train_data = None, valid_data=None) :
+        """train.
+
+        Parameters
+        ----------
+        train_data :
+            train_data
+        valid_data :
+            valid_data
+        """
 
         # if valid_data is None:  # no validation set specified.
         #     valid_data = train_data  # using training set as validation set.
@@ -520,6 +588,15 @@ class DPTrainer (object):
                 f.write(chrome_trace)
 
     def get_feed_dict(self, batch, is_training):
+        """get_feed_dict.
+
+        Parameters
+        ----------
+        batch :
+            batch
+        is_training :
+            is_training
+        """
         feed_dict = {}
         for kk in batch.keys():
             if kk == 'find_type' or kk == 'type':
@@ -536,6 +613,8 @@ class DPTrainer (object):
         return feed_dict
 
     def get_global_step(self):
+        """get_global_step.
+        """
         return run_sess(self.sess, self.global_step)
 
     # def print_head (self) :  # depreciated
@@ -552,6 +631,19 @@ class DPTrainer (object):
                          train_batches,
                          valid_batches,
                          print_header=False):
+        """valid_on_the_fly.
+
+        Parameters
+        ----------
+        fp :
+            fp
+        train_batches :
+            train_batches
+        valid_batches :
+            valid_batches
+        print_header :
+            print_header
+        """
         train_results = self.get_evaluation_results(train_batches)
         valid_results = self.get_evaluation_results(valid_batches)
 
@@ -563,6 +655,17 @@ class DPTrainer (object):
 
     @staticmethod
     def print_header(fp, train_results, valid_results):
+        """print_header.
+
+        Parameters
+        ----------
+        fp :
+            fp
+        train_results :
+            train_results
+        valid_results :
+            valid_results
+        """
         print_str = ''
         print_str += "# %5s" % 'step'
         if valid_results is not None:
@@ -579,6 +682,21 @@ class DPTrainer (object):
 
     @staticmethod
     def print_on_training(fp, train_results, valid_results, cur_batch, cur_lr):
+        """print_on_training.
+
+        Parameters
+        ----------
+        fp :
+            fp
+        train_results :
+            train_results
+        valid_results :
+            valid_results
+        cur_batch :
+            cur_batch
+        cur_lr :
+            cur_lr
+        """
         print_str = ''
         print_str += "%7d" % cur_batch
         if valid_results is not None:
@@ -595,6 +713,13 @@ class DPTrainer (object):
         fp.flush()
 
     def get_evaluation_results(self, batch_list):
+        """get_evaluation_results.
+
+        Parameters
+        ----------
+        batch_list :
+            batch_list
+        """
         if batch_list is None: return None
         numb_batch = len(batch_list)
 
@@ -623,6 +748,13 @@ class DPTrainer (object):
             self.saver.save (self.sess, os.path.join(os.getcwd(), self.save_ckpt))
 
     def _get_place_horders(self, data_dict):
+        """_get_place_horders.
+
+        Parameters
+        ----------
+        data_dict :
+            data_dict
+        """
         for kk in data_dict.keys():
             if kk == 'type':
                 continue

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -4,6 +4,13 @@ import json
 
 
 def list_to_doc(xx):
+    """list_to_doc.
+
+    Parameters
+    ----------
+    xx :
+        xx
+    """
     items = []
     for ii in xx:
         if len(items) == 0:
@@ -15,11 +22,22 @@ def list_to_doc(xx):
 
 
 def make_link(content, ref_key):
+    """make_link.
+
+    Parameters
+    ----------
+    content :
+        content
+    ref_key :
+        ref_key
+    """
     return f'`{content} <{ref_key}_>`_' if not dargs.RAW_ANCHOR \
         else f'`{content} <#{ref_key}>`_'
 
 
 def type_embedding_args():
+    """type_embedding_args.
+    """
     doc_neuron = 'Number of neurons in each hidden layers of the embedding net. When two layers are of the same size or one layer is twice as large as the previous layer, a skip connection is built.'
     doc_resnet_dt = 'Whether to use a "Timestep" in the skip connection'
     doc_seed = 'Random seed for parameter initialization'
@@ -39,6 +57,8 @@ def type_embedding_args():
 
 #  --- Descriptor configurations: --- #
 def descrpt_local_frame_args ():
+    """descrpt_local_frame_args.
+    """
     doc_sel_a = 'A list of integers. The length of the list should be the same as the number of atom types in the system. `sel_a[i]` gives the selected number of type-i neighbors. The full relative coordinates of the neighbors are used by the descriptor.'
     doc_sel_r = 'A list of integers. The length of the list should be the same as the number of atom types in the system. `sel_r[i]` gives the selected number of type-i neighbors. Only relative distance of the neighbors are used by the descriptor. sel_a[i] + sel_r[i] is recommended to be larger than the maximally possible number of type-i neighbors in the cut-off radius.'
     doc_rcut = 'The cut-off radius. The default value is 6.0'
@@ -59,6 +79,8 @@ def descrpt_local_frame_args ():
 
 
 def descrpt_se_a_args():
+    """descrpt_se_a_args.
+    """
     doc_sel = 'This parameter set the number of selected neighbors for each type of atom. It can be:\n\n\
     - `List[int]`. The length of the list should be the same as the number of atom types in the system. `sel[i]` gives the selected number of type-i neighbors. `sel[i]` is recommended to be larger than the maximally possible number of type-i neighbors in the cut-off radius. It is noted that the total sel value must be less than 4096 in a GPU environment.\n\n\
     - `str`. Can be "auto:factor" or "auto". "factor" is a float number larger than 1. This option will automatically determine the `sel`. In detail it counts the maximal number of neighbors with in the cutoff radius for each type of neighbor, then multiply the maximum by the "factor". Finally the number is wraped up to 4 divisible. The option "auto" is equivalent to "auto:1.1".'
@@ -93,6 +115,8 @@ def descrpt_se_a_args():
 
 
 def descrpt_se_t_args():
+    """descrpt_se_t_args.
+    """
     doc_sel = 'This parameter set the number of selected neighbors for each type of atom. It can be:\n\n\
     - `List[int]`. The length of the list should be the same as the number of atom types in the system. `sel[i]` gives the selected number of type-i neighbors. `sel[i]` is recommended to be larger than the maximally possible number of type-i neighbors in the cut-off radius. It is noted that the total sel value must be less than 4096 in a GPU environment.\n\n\
     - `str`. Can be "auto:factor" or "auto". "factor" is a float number larger than 1. This option will automatically determine the `sel`. In detail it counts the maximal number of neighbors with in the cutoff radius for each type of neighbor, then multiply the maximum by the "factor". Finally the number is wraped up to 4 divisible. The option "auto" is equivalent to "auto:1.1".'
@@ -122,6 +146,8 @@ def descrpt_se_t_args():
 
 
 def descrpt_se_a_tpe_args():
+    """descrpt_se_a_tpe_args.
+    """
     doc_type_nchanl = 'number of channels for type embedding'
     doc_type_nlayer = 'number of hidden layers of type embedding net'
     doc_numb_aparam = 'dimension of atomic parameter. if set to a value > 0, the atomic parameters are embedded.'
@@ -134,6 +160,8 @@ def descrpt_se_a_tpe_args():
 
 
 def descrpt_se_r_args():
+    """descrpt_se_r_args.
+    """
     doc_sel = 'This parameter set the number of selected neighbors for each type of atom. It can be:\n\n\
     - `List[int]`. The length of the list should be the same as the number of atom types in the system. `sel[i]` gives the selected number of type-i neighbors. `sel[i]` is recommended to be larger than the maximally possible number of type-i neighbors in the cut-off radius. It is noted that the total sel value must be less than 4096 in a GPU environment.\n\n\
     - `str`. Can be "auto:factor" or "auto". "factor" is a float number larger than 1. This option will automatically determine the `sel`. In detail it counts the maximal number of neighbors with in the cutoff radius for each type of neighbor, then multiply the maximum by the "factor". Finally the number is wraped up to 4 divisible. The option "auto" is equivalent to "auto:1.1".'
@@ -166,6 +194,8 @@ def descrpt_se_r_args():
 
 
 def descrpt_se_ar_args():
+    """descrpt_se_ar_args.
+    """
     link = make_link('se_a', 'model/descriptor[se_a]')
     doc_a = f'The parameters of descriptor {link}'
     link = make_link('se_r', 'model/descriptor[se_r]')
@@ -178,6 +208,8 @@ def descrpt_se_ar_args():
 
 
 def descrpt_hybrid_args():
+    """descrpt_hybrid_args.
+    """
     doc_list = f'A list of descriptor definitions'
     
     return [
@@ -186,6 +218,8 @@ def descrpt_hybrid_args():
 
 
 def descrpt_variant_type_args():
+    """descrpt_variant_type_args.
+    """
     link_lf = make_link('loc_frame', 'model/descriptor[loc_frame]')
     link_se_e2_a = make_link('se_e2_a', 'model/descriptor[se_e2_a]')
     link_se_e2_r = make_link('se_e2_r', 'model/descriptor[se_e2_r]')
@@ -212,6 +246,8 @@ def descrpt_variant_type_args():
 
 #  --- Fitting net configurations: --- #
 def fitting_ener():
+    """fitting_ener.
+    """
     doc_numb_fparam = 'The dimension of the frame parameter. If set to >0, file `fparam.npy` should be included to provided the input fparams.'
     doc_numb_aparam = 'The dimension of the atomic parameter. If set to >0, file `aparam.npy` should be included to provided the input aparams.'
     doc_neuron = 'The number of neurons in each hidden layers of the fitting net. When two hidden layers are of the same size, a skip connection is built.'
@@ -240,6 +276,8 @@ def fitting_ener():
 
 
 def fitting_polar():
+    """fitting_polar.
+    """
     doc_neuron = 'The number of neurons in each hidden layers of the fitting net. When two hidden layers are of the same size, a skip connection is built.'
     doc_activation_function = f'The activation function in the fitting net. Supported activation functions are {list_to_doc(ACTIVATION_FN_DICT.keys())}'
     doc_resnet_dt = 'Whether to use a "Timestep" in the skip connection'
@@ -272,6 +310,8 @@ def fitting_polar():
 
 
 def fitting_dipole():
+    """fitting_dipole.
+    """
     doc_neuron = 'The number of neurons in each hidden layers of the fitting net. When two hidden layers are of the same size, a skip connection is built.'
     doc_activation_function = f'The activation function in the fitting net. Supported activation functions are {list_to_doc(ACTIVATION_FN_DICT.keys())}'
     doc_resnet_dt = 'Whether to use a "Timestep" in the skip connection'
@@ -289,6 +329,8 @@ def fitting_dipole():
 
 #   YWolfeee: Delete global polar mode, merge it into polar mode and use loss setting to support.
 def fitting_variant_type_args():
+    """fitting_variant_type_args.
+    """
     doc_descrpt_type = 'The type of the fitting. See explanation below. \n\n\
 - `ener`: Fit an energy model (potential energy surface).\n\n\
 - `dipole`: Fit an atomic dipole model. Global dipole labels or atomic dipole labels for all the selected atoms (see `sel_type`) should be provided by `dipole.npy` in each data system. The file either has number of frames lines and 3 times of number of selected atoms columns, or has number of frames lines and 3 columns. See `loss` parameter.\n\n\
@@ -305,6 +347,8 @@ def fitting_variant_type_args():
 
 #  --- Modifier configurations: --- #
 def modifier_dipole_charge():
+    """modifier_dipole_charge.
+    """
     doc_model_name = "The name of the frozen dipole model file."
     doc_model_charge_map = f"The charge of the WFCC. The list length should be the same as the {make_link('sel_type', 'model/fitting_net[dipole]/sel_type')}. "
     doc_sys_charge_map = f"The charge of real atoms. The list length should be the same as the {make_link('type_map', 'model/type_map')}"
@@ -321,6 +365,8 @@ def modifier_dipole_charge():
 
 
 def modifier_variant_type_args():
+    """modifier_variant_type_args.
+    """
     doc_modifier_type = "The type of modifier. See explanation below.\n\n\
 -`dipole_charge`: Use WFCC to model the electronic structure of the system. Correct the long-range interaction"
     return Variant("type", 
@@ -332,6 +378,8 @@ def modifier_variant_type_args():
 
 #  --- model compression configurations: --- #
 def model_compression():
+    """model_compression.
+    """
     doc_compress = f"The name of the frozen model file."
     doc_model_file = f"The input model file, which will be compressed by the DeePMD-kit."
     doc_table_config = f"The arguments of model compression, including extrapolate(scale of model extrapolation), stride(uniform stride of tabulation's first and second table), and frequency(frequency of tabulation overflow check)."
@@ -346,6 +394,8 @@ def model_compression():
 
 #  --- model compression configurations: --- #
 def model_compression_type_args():
+    """model_compression_type_args.
+    """
     doc_compress_type = "The type of model compression, which should be consistent with the descriptor type."
     
     return Variant("type", [
@@ -357,6 +407,8 @@ def model_compression_type_args():
 
 
 def model_args ():    
+    """model_args.
+    """
     doc_type_map = 'A list of strings. Give the name to each type of atoms. It is noted that the number of atom type of training system must be less than 128 in a GPU environment.'
     doc_data_stat_nbatch = 'The model determines the normalization from the statistics of the data. This key specifies the number of `frames` in each `system` used for statistics.'
     doc_data_stat_protect = 'Protect parameter for atomic energy regression.'
@@ -390,6 +442,8 @@ def model_args ():
 
 #  --- Learning rate configurations: --- #
 def learning_rate_exp():
+    """learning_rate_exp.
+    """
     doc_start_lr = 'The learning rate the start of the training.'
     doc_stop_lr = 'The desired learning rate at the end of the training.'
     doc_decay_steps = 'The learning rate is decaying every this number of training steps.'
@@ -403,6 +457,8 @@ def learning_rate_exp():
     
 
 def learning_rate_variant_type_args():
+    """learning_rate_variant_type_args.
+    """
     doc_lr = 'The type of the learning rate.'
 
     return Variant("type", 
@@ -413,6 +469,8 @@ def learning_rate_variant_type_args():
 
 
 def learning_rate_args():
+    """learning_rate_args.
+    """
     doc_lr = "The definitio of learning rate" 
     return Argument("learning_rate", dict, [], 
                     [learning_rate_variant_type_args()],
@@ -421,14 +479,30 @@ def learning_rate_args():
 
 #  --- Loss configurations: --- #
 def start_pref(item):
+    """start_pref.
+
+    Parameters
+    ----------
+    item :
+        item
+    """
     return f'The prefactor of {item} loss at the start of the training. Should be larger than or equal to 0. If set to none-zero value, the {item} label should be provided by file {item}.npy in each data system. If both start_pref_{item} and limit_pref_{item} are set to 0, then the {item} will be ignored.'
 
 
 def limit_pref(item):
+    """limit_pref.
+
+    Parameters
+    ----------
+    item :
+        item
+    """
     return f'The prefactor of {item} loss at the limit of the training, Should be larger than or equal to 0. i.e. the training step goes to infinity.'
 
 
 def loss_ener():
+    """loss_ener.
+    """
     doc_start_pref_e = start_pref('energy')
     doc_limit_pref_e = limit_pref('energy')
     doc_start_pref_f = start_pref('force')
@@ -452,6 +526,8 @@ def loss_ener():
 
 # YWolfeee: Modified to support tensor type of loss args.
 def loss_tensor():
+    """loss_tensor.
+    """
     #doc_global_weight = "The prefactor of the weight of global loss. It should be larger than or equal to 0. If only `pref` is provided or both are not provided, training will be global mode, i.e. the shape of 'polarizability.npy` or `dipole.npy` should be #frams x [9 or 3]." 
     #doc_local_weight =  "The prefactor of the weight of atomic loss. It should be larger than or equal to 0. If only `pref_atomic` is provided, training will be atomic mode, i.e. the shape of `polarizability.npy` or `dipole.npy` should be #frames x ([9 or 3] x #selected atoms). If both `pref` and `pref_atomic` are provided, training will be combined mode, and atomic label should be provided as well." 
     doc_global_weight = "The prefactor of the weight of global loss. It should be larger than or equal to 0. If controls the weight of loss corresponding to global label, i.e. 'polarizability.npy` or `dipole.npy`, whose shape should be #frames x [9 or 3]. If it's larger than 0.0, this npy should be included." 
@@ -463,6 +539,8 @@ def loss_tensor():
 
 
 def loss_variant_type_args():
+    """loss_variant_type_args.
+    """
     doc_loss = 'The type of the loss. When the fitting type is `ener`, the loss type should be set to `ener` or left unset. When the fitting type is `dipole` or `polar`, the loss type should be set to `tensor`. \n\.'
 
     
@@ -478,6 +556,8 @@ def loss_variant_type_args():
 
 
 def loss_args():
+    """loss_args.
+    """
     doc_loss = 'The definition of loss function. The loss type should be set to `tensor`, `ener` or left unset.\n\.'
     ca = Argument('loss', dict, [], 
                   [loss_variant_type_args()],
@@ -488,6 +568,8 @@ def loss_args():
 
 #  --- Training configurations: --- #
 def training_data_args():  # ! added by Ziyao: new specification style for data systems.
+    """training_data_args.
+    """
     link_sys = make_link("systems", "training/training_data/systems")
     doc_systems = 'The data systems for training. ' \
         'This key can be provided with a list that specifies the systems, or be provided with a string ' \
@@ -522,6 +604,8 @@ def training_data_args():  # ! added by Ziyao: new specification style for data 
 
 
 def validation_data_args():  # ! added by Ziyao: new specification style for data systems.
+    """validation_data_args.
+    """
     link_sys = make_link("systems", "training/validation_data/systems")
     doc_systems = 'The data systems for validation. ' \
                   'This key can be provided with a list that specifies the systems, or be provided with a string ' \
@@ -558,6 +642,8 @@ def validation_data_args():  # ! added by Ziyao: new specification style for dat
 
 
 def training_args():  # ! modified by Ziyao: data configuration isolated.
+    """training_args.
+    """
     doc_numb_steps = 'Number of training batch. Each training uses one batch of data.'
     doc_seed = 'The random seed for getting frames from the training data set.'
     doc_disp_file = 'The file for printing learning curve.'
@@ -600,6 +686,13 @@ def training_args():  # ! modified by Ziyao: data configuration isolated.
 
 
 def make_index(keys):
+    """make_index.
+
+    Parameters
+    ----------
+    keys :
+        keys
+    """
     ret = []
     for ii in keys:
         ret.append(make_link(ii, ii))
@@ -607,6 +700,17 @@ def make_index(keys):
 
 
 def gen_doc(*, make_anchor=True, make_link=True, **kwargs):
+    """gen_doc.
+
+    Parameters
+    ----------
+    make_anchor :
+        make_anchor
+    make_link :
+        make_link
+    kwargs :
+        kwargs
+    """
     if make_link:
         make_anchor = True
     ma = model_args()
@@ -628,6 +732,13 @@ def gen_doc(*, make_anchor=True, make_link=True, **kwargs):
     return "\n\n".join(ptr)
 
 def gen_json(**kwargs):
+    """gen_json.
+
+    Parameters
+    ----------
+    kwargs :
+        kwargs
+    """
     return json.dumps((
         model_args(),
         learning_rate_args(),
@@ -636,6 +747,13 @@ def gen_json(**kwargs):
     ), cls=ArgumentEncoder)
 
 def normalize_hybrid_list(hy_list):
+    """normalize_hybrid_list.
+
+    Parameters
+    ----------
+    hy_list :
+        hy_list
+    """
     new_list = []
     base = Argument("base", dict, [], [descrpt_variant_type_args()], doc = "")
     for ii in range(len(hy_list)):
@@ -646,6 +764,13 @@ def normalize_hybrid_list(hy_list):
 
 
 def normalize(data):
+    """normalize.
+
+    Parameters
+    ----------
+    data :
+        data
+    """
     if "hybrid" == data["model"]["descriptor"]["type"]:
         data["model"]["descriptor"]["list"] \
             = normalize_hybrid_list(data["model"]["descriptor"]["list"])

--- a/deepmd/utils/compat.py
+++ b/deepmd/utils/compat.py
@@ -41,6 +41,13 @@ def convert_input_v0_v1(
 
 
 def _warning_input_v0_v1(fname: Optional[Union[str, Path]]):
+    """_warning_input_v0_v1.
+
+    Parameters
+    ----------
+    fname : Optional[Union[str, Path]]
+        fname
+    """
     msg = "It seems that you are using a deepmd-kit input of version 0.x.x, " \
           "which is deprecated. we have converted the input to >2.0.0 compatible"
     if fname is not None:
@@ -260,6 +267,22 @@ def remove_decay_rate(jdata: Dict[str, Any]):
 def convert_input_v1_v2(jdata: Dict[str, Any],
                         warning: bool = True,
                         dump: Optional[Union[str, Path]] = None) -> Dict[str, Any]:
+    """convert_input_v1_v2.
+
+    Parameters
+    ----------
+    jdata : Dict[str, Any]
+        jdata
+    warning : bool
+        warning
+    dump : Optional[Union[str, Path]]
+        dump
+
+    Returns
+    -------
+    Dict[str, Any]
+
+    """
 
     tr_cfg = jdata["training"]
     tr_data_keys = {
@@ -292,6 +315,13 @@ def convert_input_v1_v2(jdata: Dict[str, Any],
 
 
 def _warning_input_v1_v2(fname: Optional[Union[str, Path]]):
+    """_warning_input_v1_v2.
+
+    Parameters
+    ----------
+    fname : Optional[Union[str, Path]]
+        fname
+    """
     msg = "It seems that you are using a deepmd-kit input of version 1.x.x, " \
           "which is deprecated. we have converted the input to >2.0.0 compatible"
     if fname is not None:
@@ -302,10 +332,40 @@ def _warning_input_v1_v2(fname: Optional[Union[str, Path]]):
 def updata_deepmd_input(jdata: Dict[str, Any],
                         warning: bool = True,
                         dump: Optional[Union[str, Path]] = None) -> Dict[str, Any]:
+    """updata_deepmd_input.
+
+    Parameters
+    ----------
+    jdata : Dict[str, Any]
+        jdata
+    warning : bool
+        warning
+    dump : Optional[Union[str, Path]]
+        dump
+
+    Returns
+    -------
+    Dict[str, Any]
+
+    """
     def is_deepmd_v0_input(jdata):
+        """is_deepmd_v0_input.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        """
         return "model" not in jdata.keys()
 
     def is_deepmd_v1_input(jdata):
+        """is_deepmd_v1_input.
+
+        Parameters
+        ----------
+        jdata :
+            jdata
+        """
         return "systems" in j_must_have(jdata, "training").keys()
 
     if is_deepmd_v0_input(jdata):

--- a/deepmd/utils/convert.py
+++ b/deepmd/utils/convert.py
@@ -4,6 +4,15 @@ from google.protobuf import text_format
 from tensorflow.python.platform import gfile
 
 def convert_13_to_20(input_model: str, output_model: str):
+    """convert_13_to_20.
+
+    Parameters
+    ----------
+    input_model : str
+        input_model
+    output_model : str
+        output_model
+    """
     convert_pb_to_pbtxt(input_model, 'frozen_model.pbtxt')
     convert_dp13_to_dp20('frozen_model.pbtxt')
     convert_pbtxt_to_pb('frozen_model.pbtxt', output_model)
@@ -12,6 +21,15 @@ def convert_13_to_20(input_model: str, output_model: str):
     print("the converted output model (2.0 support) is saved in %s" % output_model)
 
 def convert_12_to_20(input_model: str, output_model: str):
+    """convert_12_to_20.
+
+    Parameters
+    ----------
+    input_model : str
+        input_model
+    output_model : str
+        output_model
+    """
     convert_pb_to_pbtxt(input_model, 'frozen_model.pbtxt')
     convert_dp12_to_dp13('frozen_model.pbtxt')
     convert_dp13_to_dp20('frozen_model.pbtxt')
@@ -21,6 +39,15 @@ def convert_12_to_20(input_model: str, output_model: str):
     print("the converted output model (2.0 support) is saved in %s" % output_model)
 
 def convert_pb_to_pbtxt(pbfile: str, pbtxtfile: str):
+    """convert_pb_to_pbtxt.
+
+    Parameters
+    ----------
+    pbfile : str
+        pbfile
+    pbtxtfile : str
+        pbtxtfile
+    """
     with gfile.FastGFile(pbfile, 'rb') as f:
         graph_def = tf.GraphDef()
         graph_def.ParseFromString(f.read())
@@ -28,6 +55,15 @@ def convert_pb_to_pbtxt(pbfile: str, pbtxtfile: str):
         tf.train.write_graph(graph_def, './', pbtxtfile, as_text=True)
 
 def convert_pbtxt_to_pb(pbtxtfile: str, pbfile: str):
+    """convert_pbtxt_to_pb.
+
+    Parameters
+    ----------
+    pbtxtfile : str
+        pbtxtfile
+    pbfile : str
+        pbfile
+    """
     with tf.gfile.FastGFile(pbtxtfile, 'r') as f:
         graph_def = tf.GraphDef()
         file_content = f.read()
@@ -36,6 +72,13 @@ def convert_pbtxt_to_pb(pbtxtfile: str, pbfile: str):
         tf.train.write_graph(graph_def, './', pbfile, as_text=False)
 
 def convert_dp12_to_dp13(file):
+    """convert_dp12_to_dp13.
+
+    Parameters
+    ----------
+    file :
+        file
+    """
     file_data = ""
     with open(file, "r", encoding="utf-8") as f:
         ii = 0
@@ -58,6 +101,13 @@ def convert_dp12_to_dp13(file):
         f.write(file_data)
 
 def convert_dp13_to_dp20(fname: str):
+    """convert_dp13_to_dp20.
+
+    Parameters
+    ----------
+    fname : str
+        fname
+    """
     with open(fname) as fp:
         file_content = fp.read()
     file_content += """

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -343,6 +343,15 @@ class DeepmdData() :
             return np.average(eners, axis = 0)
 
     def _idx_map_sel(self, atom_type, type_sel) :
+        """_idx_map_sel.
+
+        Parameters
+        ----------
+        atom_type :
+            atom_type
+        type_sel :
+            type_sel
+        """
         new_types = []
         for ii in atom_type :
             if ii in type_sel:
@@ -354,6 +363,13 @@ class DeepmdData() :
         return idx_map
 
     def _get_natoms_2 (self, ntypes) :
+        """_get_natoms_2.
+
+        Parameters
+        ----------
+        ntypes :
+            ntypes
+        """
         sample_type = self.atom_type
         natoms = len(sample_type)
         natoms_vec = np.zeros (ntypes).astype(int)
@@ -362,6 +378,15 @@ class DeepmdData() :
         return natoms, natoms_vec
 
     def _get_subdata(self, data, idx = None) :
+        """_get_subdata.
+
+        Parameters
+        ----------
+        data :
+            data
+        idx :
+            idx
+        """
         new_data = {}
         for ii in data:
             dd = data[ii]
@@ -375,15 +400,33 @@ class DeepmdData() :
         return new_data
 
     def _load_batch_set (self,
+        """_load_batch_set.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        """
                          set_name) :
         self.batch_set = self._load_set(set_name)
         self.batch_set, _ = self._shuffle_data(self.batch_set)
         self.reset_get_batch()
 
     def reset_get_batch(self):
+        """reset_get_batch.
+        """
         self.iterator = 0
 
     def _load_test_set (self,
+        """_load_test_set.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        shuffle_test :
+            shuffle_test
+        """
                        set_name, 
                        shuffle_test) :
         self.test_set = self._load_set(set_name)        
@@ -391,6 +434,13 @@ class DeepmdData() :
             self.test_set, _ = self._shuffle_data(self.test_set)
 
     def _shuffle_data (self,
+        """_shuffle_data.
+
+        Parameters
+        ----------
+        data :
+            data
+        """
                        data) :
         ret = {}
         nframes = data['coord'].shape[0]
@@ -408,6 +458,13 @@ class DeepmdData() :
         return ret, idx
 
     def _load_set(self, set_name) :
+        """_load_set.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        """
         # get nframes
         path = os.path.join(set_name, "coord.npy")
         if self.data_dict['coord']['high_prec'] :
@@ -445,6 +502,29 @@ class DeepmdData() :
 
 
     def _load_data(self, set_name, key, nframes, ndof_, atomic = False, must = True, repeat = 1, high_prec = False, type_sel = None):
+        """_load_data.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        key :
+            key
+        nframes :
+            nframes
+        ndof_ :
+            ndof_
+        atomic :
+            atomic
+        must :
+            must
+        repeat :
+            repeat
+        high_prec :
+            high_prec
+        type_sel :
+            type_sel
+        """
         if atomic:
             natoms = self.natoms
             idx_map = self.idx_map
@@ -490,16 +570,37 @@ class DeepmdData() :
 
         
     def _load_type (self, sys_path) :
+        """_load_type.
+
+        Parameters
+        ----------
+        sys_path :
+            sys_path
+        """
         atom_type = np.loadtxt (os.path.join(sys_path, "type.raw"), dtype=np.int32, ndmin=1)
         return atom_type
 
     def _make_idx_map(self, atom_type):
+        """_make_idx_map.
+
+        Parameters
+        ----------
+        atom_type :
+            atom_type
+        """
         natoms = atom_type.shape[0]
         idx = np.arange (natoms)
         idx_map = np.lexsort ((idx, atom_type))
         return idx_map
 
     def _load_type_map(self, sys_path) :
+        """_load_type_map.
+
+        Parameters
+        ----------
+        sys_path :
+            sys_path
+        """
         fname = os.path.join(sys_path, 'type_map.raw')
         if os.path.isfile(fname) :            
             with open(os.path.join(sys_path, 'type_map.raw')) as fp:
@@ -508,6 +609,13 @@ class DeepmdData() :
             return None
 
     def _check_pbc(self, sys_path):
+        """_check_pbc.
+
+        Parameters
+        ----------
+        sys_path :
+            sys_path
+        """
         pbc = True
         if os.path.isfile(os.path.join(sys_path, 'nopbc')) :
             pbc = False
@@ -519,6 +627,19 @@ class DataSets (object):
     Outdated class for one data system. Not maintained anymore.
     """
     def __init__ (self, 
+        """__init__.
+
+        Parameters
+        ----------
+        sys_path :
+            sys_path
+        set_prefix :
+            set_prefix
+        seed :
+            seed
+        shuffle_test :
+            shuffle_test
+        """
                   sys_path,
                   set_prefix,
                   seed = None, 
@@ -561,6 +682,13 @@ class DataSets (object):
         self.load_test_set (self.test_dir, shuffle_test)
 
     def check_batch_size (self, batch_size) :
+        """check_batch_size.
+
+        Parameters
+        ----------
+        batch_size :
+            batch_size
+        """
         for ii in self.train_dirs :
             tmpe = np.load(os.path.join(ii, "coord.npy"))
             if tmpe.shape[0] < batch_size :
@@ -568,6 +696,13 @@ class DataSets (object):
         return None
 
     def check_test_size (self, test_size) :
+        """check_test_size.
+
+        Parameters
+        ----------
+        test_size :
+            test_size
+        """
         tmpe = np.load(os.path.join(self.test_dir, "coord.npy"))
         if tmpe.shape[0] < test_size :
             return self.test_dir, tmpe.shape[0]
@@ -575,6 +710,13 @@ class DataSets (object):
             return None
 
     def load_type (self, sys_path) :
+        """load_type.
+
+        Parameters
+        ----------
+        sys_path :
+            sys_path
+        """
         atom_type = np.loadtxt (os.path.join(sys_path, "type.raw"), dtype=np.int32, ndmin=1)
         natoms = atom_type.shape[0]
         idx = np.arange (natoms)
@@ -585,6 +727,13 @@ class DataSets (object):
         return atom_type, idx_map, idx3_map
 
     def load_type_map(self, sys_path) :
+        """load_type_map.
+
+        Parameters
+        ----------
+        sys_path :
+            sys_path
+        """
         fname = os.path.join(sys_path, 'type_map.raw')
         if os.path.isfile(fname) :            
             with open(os.path.join(sys_path, 'type_map.raw')) as fp:
@@ -593,12 +742,18 @@ class DataSets (object):
             return None
 
     def get_type_map(self) :
+        """get_type_map.
+        """
         return self.type_map
 
     def get_numb_set (self) :
+        """get_numb_set.
+        """
         return len (self.train_dirs)
     
     def stats_energy (self) :
+        """stats_energy.
+        """
         eners = np.array([])
         for ii in self.train_dirs:
             ener_file = os.path.join(ii, "energy.npy")
@@ -631,6 +786,19 @@ class DataSets (object):
         return coeff_ener, ener, coeff_atom_ener, atom_ener
 
     def load_data(self, set_name, data_name, shape, is_necessary = True):
+        """load_data.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        data_name :
+            data_name
+        shape :
+            shape
+        is_necessary :
+            is_necessary
+        """
         path = os.path.join(set_name, data_name+".npy")
         if os.path.isfile (path) :
             data = np.load(path)
@@ -645,6 +813,15 @@ class DataSets (object):
         return 0, data
 
     def load_set(self, set_name, shuffle = True):
+        """load_set.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        shuffle :
+            shuffle
+        """
         data = {}
         data["box"] = self.load_data(set_name, "box", [-1, 9])
         nframe = data["box"].shape[0]
@@ -685,20 +862,47 @@ class DataSets (object):
         return data
 
     def load_batch_set (self,
+        """load_batch_set.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        """
                         set_name) :
         self.batch_set = self.load_set(set_name, True)
         self.reset_iter ()
 
     def load_test_set (self,
+        """load_test_set.
+
+        Parameters
+        ----------
+        set_name :
+            set_name
+        shuffle_test :
+            shuffle_test
+        """
                        set_name, 
                        shuffle_test) :
         self.test_set = self.load_set(set_name, shuffle_test)
         
     def reset_iter (self) :
+        """reset_iter.
+        """
         self.iterator = 0              
         self.set_count += 1
     
     def get_set(self, data, idx = None) :
+        """get_set.
+
+        Parameters
+        ----------
+        data :
+            data
+        idx :
+            idx
+        """
         new_data = {}
         for ii in data:
             dd = data[ii]
@@ -740,11 +944,20 @@ class DataSets (object):
         return self.get_set(self.batch_set, idx)
     
     def get_natoms (self) :
+        """get_natoms.
+        """
         sample_type = self.batch_set["type"][0]
         natoms = len(sample_type)
         return natoms
 
     def get_natoms_2 (self, ntypes) :
+        """get_natoms_2.
+
+        Parameters
+        ----------
+        ntypes :
+            ntypes
+        """
         sample_type = self.batch_set["type"][0]
         natoms = len(sample_type)
         natoms_vec = np.zeros (ntypes).astype(int)
@@ -753,24 +966,51 @@ class DataSets (object):
         return natoms, natoms_vec
 
     def get_natoms_vec (self, ntypes) :
+        """get_natoms_vec.
+
+        Parameters
+        ----------
+        ntypes :
+            ntypes
+        """
         natoms, natoms_vec = self.get_natoms_2 (ntypes)
         tmp = [natoms, natoms]
         tmp = np.append (tmp, natoms_vec)
         return tmp.astype(np.int32)
 
     def set_numb_batch (self, 
+        """set_numb_batch.
+
+        Parameters
+        ----------
+        batch_size :
+            batch_size
+        """
                         batch_size) :
         return self.batch_set["energy"].shape[0] // batch_size
 
     def get_sys_numb_batch (self, batch_size) :
+        """get_sys_numb_batch.
+
+        Parameters
+        ----------
+        batch_size :
+            batch_size
+        """
         return self.set_numb_batch(batch_size) * self.get_numb_set()
 
     def get_ener (self) :
+        """get_ener.
+        """
         return self.eavg
 
     def numb_fparam(self) :
+        """numb_fparam.
+        """
         return self.has_fparam
 
     def numb_aparam(self) :
+        """numb_aparam.
+        """
         return self.has_aparam
 

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -162,6 +162,13 @@ class DeepmdDataSystem() :
 
 
     def _load_test(self, ntests = -1):
+        """_load_test.
+
+        Parameters
+        ----------
+        ntests :
+            ntests
+        """
         self.test_data = collections.defaultdict(list)
         for ii in range(self.nsystems) :
             test_system_data = self.data_systems[ii].get_test(ntests = ntests)
@@ -170,6 +177,8 @@ class DeepmdDataSystem() :
 
 
     def _make_default_mesh(self):
+        """_make_default_mesh.
+        """
         self.default_mesh = []
         cell_size = np.max (self.rcut)
         for ii in range(self.nsystems) :
@@ -189,6 +198,15 @@ class DeepmdDataSystem() :
 
 
     def compute_energy_shift(self, rcond = 1e-3, key = 'energy') :
+        """compute_energy_shift.
+
+        Parameters
+        ----------
+        rcond :
+            rcond
+        key :
+            key
+        """
         sys_ener = np.array([])
         for ss in self.data_systems :
             sys_ener = np.append(sys_ener, ss.avg(key))
@@ -272,10 +290,31 @@ class DeepmdDataSystem() :
             ii.reduce(key_out, key_in)
 
     def get_data_dict(self, ii: int = 0) -> dict:
+        """get_data_dict.
+
+        Parameters
+        ----------
+        ii : int
+            ii
+
+        Returns
+        -------
+        dict
+
+        """
         return self.data_systems[ii].get_data_dict()
 
     def set_sys_probs(self, sys_probs=None,
                       auto_prob_style: str = "prob_sys_size"):
+        """set_sys_probs.
+
+        Parameters
+        ----------
+        sys_probs :
+            sys_probs
+        auto_prob_style : str
+            auto_prob_style
+        """
         if sys_probs is None :
             if auto_prob_style == "prob_uniform":
                 prob_v = 1./float(self.nsystems)
@@ -291,6 +330,15 @@ class DeepmdDataSystem() :
         self.sys_probs = probs
 
     def _get_sys_probs(self,
+        """_get_sys_probs.
+
+        Parameters
+        ----------
+        sys_probs :
+            sys_probs
+        auto_prob_style :
+            auto_prob_style
+        """
                        sys_probs,
                        auto_prob_style) :  # depreciated
         if sys_probs is None :
@@ -413,6 +461,15 @@ class DeepmdDataSystem() :
         return self.batch_size
 
     def _format_name_length(self, name, width) :
+        """_format_name_length.
+
+        Parameters
+        ----------
+        name :
+            name
+        width :
+            width
+        """
         if len(name) <= width:
             return '{: >{}}'.format(name, width)
         else :
@@ -421,6 +478,13 @@ class DeepmdDataSystem() :
             return name 
 
     def print_summary(self, name) :
+        """print_summary.
+
+        Parameters
+        ----------
+        name :
+            name
+        """
         # width 65
         sys_width = 42
         log.info(f"---Summary of DataSystem: {name:13s}-----------------------------------------------")
@@ -440,6 +504,13 @@ class DeepmdDataSystem() :
         log.info("--------------------------------------------------------------------------------------")
 
     def _make_auto_bs(self, rule) :
+        """_make_auto_bs.
+
+        Parameters
+        ----------
+        rule :
+            rule
+        """
         bs = []
         for ii in self.data_systems:
             ni = ii.get_natoms()
@@ -451,6 +522,13 @@ class DeepmdDataSystem() :
 
     # ! added by Marián Rynik
     def _make_auto_ts(self, percent):
+        """_make_auto_ts.
+
+        Parameters
+        ----------
+        percent :
+            percent
+        """
         ts = []
         for ii in range(self.nsystems):
             ni = self.batch_size[ii] * self.nbatches[ii]
@@ -460,6 +538,13 @@ class DeepmdDataSystem() :
         return ts
 
     def _check_type_map_consistency(self, type_map_list):
+        """_check_type_map_consistency.
+
+        Parameters
+        ----------
+        type_map_list :
+            type_map_list
+        """
         ret = []
         for ii in type_map_list:
             if ii is not None:
@@ -472,6 +557,13 @@ class DeepmdDataSystem() :
         return ret
 
     def _process_sys_probs(self, sys_probs) :
+        """_process_sys_probs.
+
+        Parameters
+        ----------
+        sys_probs :
+            sys_probs
+        """
         sys_probs = np.array(sys_probs)
         type_filter = sys_probs >= 0
         assigned_sum_prob = np.sum(type_filter * sys_probs)
@@ -487,6 +579,13 @@ class DeepmdDataSystem() :
         return ret_prob
     
     def _prob_sys_size_ext(self, keywords):
+        """_prob_sys_size_ext.
+
+        Parameters
+        ----------
+        keywords :
+            keywords
+        """
         block_str = keywords.split(';')[1:]
         block_stt = []
         block_end = []
@@ -515,6 +614,23 @@ class DataSystem (object) :
     Outdated class for the data systems. Not maintained anymore.    
     """
     def __init__ (self,
+        """__init__.
+
+        Parameters
+        ----------
+        systems :
+            systems
+        set_prefix :
+            set_prefix
+        batch_size :
+            batch_size
+        test_size :
+            test_size
+        rcut :
+            rcut
+        run_opt :
+            run_opt
+        """
                   systems,
                   set_prefix,
                   batch_size,
@@ -587,6 +703,13 @@ class DataSystem (object) :
 
 
     def check_type_map_consistency(self, type_map_list):
+        """check_type_map_consistency.
+
+        Parameters
+        ----------
+        type_map_list :
+            type_map_list
+        """
         ret = []
         for ii in type_map_list:
             if ii is not None:
@@ -600,10 +723,21 @@ class DataSystem (object) :
 
 
     def get_type_map(self):
+        """get_type_map.
+        """
         return self.type_map
 
 
     def format_name_length(self, name, width) :
+        """format_name_length.
+
+        Parameters
+        ----------
+        name :
+            name
+        width :
+            width
+        """
         if len(name) <= width:
             return '{: >{}}'.format(name, width)
         else :
@@ -612,6 +746,8 @@ class DataSystem (object) :
             return name 
 
     def print_summary(self) :
+        """print_summary.
+        """
         tmp_msg = ""
         # width 65
         sys_width = 42
@@ -629,6 +765,8 @@ class DataSystem (object) :
         log.info(tmp_msg)
 
     def compute_energy_shift(self) :
+        """compute_energy_shift.
+        """
         sys_ener = np.array([])
         for ss in self.data_systems :
             sys_ener = np.append(sys_ener, ss.get_ener())
@@ -640,6 +778,13 @@ class DataSystem (object) :
         return energy_shift
 
     def process_sys_weights(self, sys_weights) :
+        """process_sys_weights.
+
+        Parameters
+        ----------
+        sys_weights :
+            sys_weights
+        """
         sys_weights = np.array(sys_weights)
         type_filter = sys_weights >= 0
         assigned_sum_prob = np.sum(type_filter * sys_weights)
@@ -652,6 +797,17 @@ class DataSystem (object) :
         return ret_prob
 
     def get_batch (self, 
+        """get_batch.
+
+        Parameters
+        ----------
+        sys_idx :
+            sys_idx
+        sys_weights :
+            sys_weights
+        style :
+            style
+        """
                    sys_idx = None,
                    sys_weights = None,
                    style = "prob_sys_size") :
@@ -674,6 +830,13 @@ class DataSystem (object) :
         return b_data
 
     def get_test (self, 
+        """get_test.
+
+        Parameters
+        ----------
+        sys_idx :
+            sys_idx
+        """
                   sys_idx = None) :
         if sys_idx is not None :
             idx = sys_idx
@@ -687,24 +850,43 @@ class DataSystem (object) :
         return test_system_data
             
     def get_nbatches (self) : 
+        """get_nbatches.
+        """
         return self.nbatches
     
     def get_ntypes (self) :
+        """get_ntypes.
+        """
         return self.sys_ntypes
 
     def get_nsystems (self) :
+        """get_nsystems.
+        """
         return self.nsystems
 
     def get_sys (self, sys_idx) :
+        """get_sys.
+
+        Parameters
+        ----------
+        sys_idx :
+            sys_idx
+        """
         return self.data_systems[sys_idx]
 
     def get_batch_size(self) :
+        """get_batch_size.
+        """
         return self.batch_size
 
     def numb_fparam(self) :
+        """numb_fparam.
+        """
         return self.has_fparam
 
 def _main () :
+    """_main.
+    """
     sys =  ['/home/wanghan/study/deep.md/results.01/data/mos2/only_raws/20', 
             '/home/wanghan/study/deep.md/results.01/data/mos2/only_raws/30', 
             '/home/wanghan/study/deep.md/results.01/data/mos2/only_raws/38', 

--- a/deepmd/utils/errors.py
+++ b/deepmd/utils/errors.py
@@ -1,5 +1,11 @@
 class GraphTooLargeError(Exception):
+    """GraphTooLargeError.
+    """
+
     pass
 
 class GraphWithoutTensorError(Exception):
+    """GraphWithoutTensorError.
+    """
+
     pass

--- a/deepmd/utils/network.py
+++ b/deepmd/utils/network.py
@@ -4,6 +4,8 @@ from deepmd.env import tf
 from deepmd.env import GLOBAL_TF_FLOAT_PRECISION
 
 def one_layer_rand_seed_shift():
+    """one_layer_rand_seed_shift.
+    """
     return 3
 
 def one_layer(inputs, 
@@ -19,6 +21,37 @@ def one_layer(inputs,
               trainable = True,
               useBN = False, 
               uniform_seed = False):
+    """one_layer.
+
+    Parameters
+    ----------
+    inputs :
+        inputs
+    outputs_size :
+        outputs_size
+    activation_fn :
+        activation_fn
+    precision :
+        precision
+    stddev :
+        stddev
+    bavg :
+        bavg
+    name :
+        name
+    reuse :
+        reuse
+    seed :
+        seed
+    use_timestep :
+        use_timestep
+    trainable :
+        trainable
+    useBN :
+        useBN
+    uniform_seed :
+        uniform_seed
+    """
     with tf.variable_scope(name, reuse=reuse):
         shape = inputs.get_shape().as_list()
         w = tf.get_variable('matrix', 
@@ -73,6 +106,13 @@ def one_layer(inputs,
 def embedding_net_rand_seed_shift(
         network_size
 ):
+    """embedding_net_rand_seed_shift.
+
+    Parameters
+    ----------
+    network_size :
+        network_size
+    """
     shift = 3 * (len(network_size) + 1)
     return shift
 

--- a/deepmd/utils/pair_tab.py
+++ b/deepmd/utils/pair_tab.py
@@ -6,6 +6,9 @@ from typing import Tuple, List
 from scipy.interpolate import CubicSpline
 
 class PairTab (object):
+    """PairTab.
+    """
+
     def __init__(self,
                  filename : str
     ) -> None:
@@ -59,6 +62,8 @@ class PairTab (object):
         return self.tab_info, self.tab_data
 
     def _make_data(self) :
+        """_make_data.
+        """
         data = np.zeros([self.ntypes * self.ntypes * 4 * self.nspline])
         stride = 4 * self.nspline
         idx_iter = 0

--- a/deepmd/utils/tabulate.py
+++ b/deepmd/utils/tabulate.py
@@ -144,6 +144,8 @@ class DeepTabulate():
         return lower, upper
 
     def _load_graph(self):
+        """_load_graph.
+        """
         graph_def = tf.GraphDef()
         with open(self.model_file, "rb") as f:
             graph_def.ParseFromString(f.read())
@@ -152,18 +154,29 @@ class DeepTabulate():
         return graph, graph_def
 
     def _load_sub_graph(self):
+        """_load_sub_graph.
+        """
         sub_graph_def = tf.GraphDef()
         with tf.Graph().as_default() as sub_graph:
             tf.import_graph_def(sub_graph_def, name = "")
         return sub_graph, sub_graph_def
 
     def _get_tensor_value(self, tensor) :
+        """_get_tensor_value.
+
+        Parameters
+        ----------
+        tensor :
+            tensor
+        """
         with self.sess.as_default():
             run_sess(self.sess, tensor)
             value = tensor.eval()
         return value
 
     def _load_matrix_node(self):
+        """_load_matrix_node.
+        """
         matrix_node = {}
         matrix_node_pattern = "filter_type_\d+/matrix_\d+_\d+|filter_type_\d+/bias_\d+_\d+|filter_type_\d+/idt_\d+_\d+|filter_type_all/matrix_\d+_\d+|filter_type_all/bias_\d+_\d+|filter_type_all/idt_\d+_\d"
         for node in self.graph_def.node:
@@ -174,6 +187,8 @@ class DeepTabulate():
         return matrix_node
 
     def _get_bias(self):
+        """_get_bias.
+        """
         bias = {}
         for layer in range(1, self.layer_size + 1):
             bias["layer_" + str(layer)] = []
@@ -193,6 +208,8 @@ class DeepTabulate():
         return bias
 
     def _get_matrix(self):
+        """_get_matrix.
+        """
         matrix = {}
         for layer in range(1, self.layer_size + 1):
             matrix["layer_" + str(layer)] = []
@@ -213,6 +230,15 @@ class DeepTabulate():
 
     # one-by-one executions
     def _make_data(self, xx, idx):
+        """_make_data.
+
+        Parameters
+        ----------
+        xx :
+            xx
+        idx :
+            idx
+        """
         with self.sub_graph.as_default():
             with self.sub_sess.as_default():
                 xx = tf.reshape(xx, [xx.size, -1])
@@ -233,19 +259,50 @@ class DeepTabulate():
         return vv, dd, d2
 
     def _layer_0(self, x, w, b):
+        """_layer_0.
+
+        Parameters
+        ----------
+        x :
+            x
+        w :
+            w
+        b :
+            b
+        """
         return tf.nn.tanh(tf.matmul(x, w) + b)
 
     def _layer_1(self, x, w, b):
+        """_layer_1.
+
+        Parameters
+        ----------
+        x :
+            x
+        w :
+            w
+        b :
+            b
+        """
         t = tf.concat([x, x], axis = 1)
         return t, tf.nn.tanh(tf.matmul(x, w) + b) + t
 
     def _save_data(self):
+        """_save_data.
+        """
         for ii in range(self.ntypes * self.ntypes):
             net = "filter_" + str(ii // self.ntypes) + "_net_" + str(int(ii % self.ntypes))
             np.savetxt('data_' + str(ii), self.data[net])
 
     def _get_env_mat_range(self,
                            min_nbor_dist):
+        """_get_env_mat_range.
+
+        Parameters
+        ----------
+        min_nbor_dist :
+            min_nbor_dist
+        """
         lower = 100.0
         upper = -10.0
         sw    = self._spline5_switch(min_nbor_dist, self.rcut_smth, self.rcut)
@@ -262,6 +319,17 @@ class DeepTabulate():
                         xx,
                         rmin,
                         rmax):
+        """_spline5_switch.
+
+        Parameters
+        ----------
+        xx :
+            xx
+        rmin :
+            rmin
+        rmax :
+            rmax
+        """
         if xx < rmin:
             vv = 1
         elif xx < rmax:

--- a/deepmd/utils/type_embed.py
+++ b/deepmd/utils/type_embed.py
@@ -55,6 +55,9 @@ def embed_atom_type(
     
 
 class TypeEmbedNet():
+    """TypeEmbedNet.
+    """
+
     @docstring_parameter(list_to_doc(ACTIVATION_FN_DICT.keys()), list_to_doc(PRECISION_DICT.keys()))
     def __init__(
             self,


### PR DESCRIPTION
This commit uses `doq` to fill the docstring:
```sh
pip install doq
for ii in deepmd/*/*.py; do doq -f $ii -w --formatter=numpy; done
```

It just fill with the templates without any real documents. However, it
will be much easier to add documents to those that haven't had docstring
yet.
