### PR TITLE
fix type hints and add doc for `exclude_types`

### DIFF
--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -56,8 +56,9 @@ class DescrptSeA ():
                 Random seed for initializing the network parameters.
         type_one_side
                 Try to build N_types embedding nets. Otherwise, building N_types^2 embedding nets
-        exclude_types : list[int]
-                The Excluded types
+        exclude_types : List[List[int]]
+                The excluded pairs of types which have no interaction with each other.
+                For example, `[[0, 1]]` means no interaction between type 0 and type 1.
         set_davg_zero
                 Set the shift of embedding net input to zero.
         activation_function

--- a/deepmd/descriptor/se_a_ebd.py
+++ b/deepmd/descriptor/se_a_ebd.py
@@ -28,7 +28,7 @@ class DescrptSeAEbd (DescrptSeA):
                   set_davg_zero: bool = False,
                   activation_function: str = 'tanh',
                   precision: str = 'default',
-                  exclude_types: List[int] = [],
+                  exclude_types: List[List[int]] = [],
     ) -> None:
         """
         Constructor
@@ -66,6 +66,9 @@ class DescrptSeAEbd (DescrptSeA):
                 The activation function in the embedding net. Supported options are {0}
         precision
                 The precision of the embedding net parameters. Supported options are {1}
+        exclude_types : List[List[int]]
+                The excluded pairs of types which have no interaction with each other.
+                For example, `[[0, 1]]` means no interaction between type 0 and type 1.
         """
         # args = ClassArg()\
         #        .add('type_nchanl',      int,    default = 4) \

--- a/deepmd/descriptor/se_a_ef.py
+++ b/deepmd/descriptor/se_a_ef.py
@@ -23,7 +23,7 @@ class DescrptSeAEf ():
                  trainable: bool = True,
                  seed: int = None,
                  type_one_side: bool = True,
-                 exclude_types: List[int] = [],
+                 exclude_types: List[List[int]] = [],
                  set_davg_zero: bool = False,
                  activation_function: str = 'tanh',
                  precision: str = 'default',
@@ -53,8 +53,9 @@ class DescrptSeAEf ():
                 Random seed for initializing the network parameters.
         type_one_side
                 Try to build N_types embedding nets. Otherwise, building N_types^2 embedding nets
-        exclude_types : list[int]
-                The Excluded types
+        exclude_types : List[List[int]]
+                The excluded pairs of types which have no interaction with each other.
+                For example, `[[0, 1]]` means no interaction between type 0 and type 1.
         set_davg_zero
                 Set the shift of embedding net input to zero.
         activation_function
@@ -282,7 +283,7 @@ class DescrptSeAEfLower (DescrptSeA):
                   trainable: bool = True,
                   seed: int = None,
                   type_one_side: bool = True,
-                  exclude_types: List[int] = [],
+                  exclude_types: List[List[int]] = [],
                   set_davg_zero: bool = False,
                   activation_function: str = 'tanh',
                   precision: str = 'default',

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -22,7 +22,7 @@ class DescrptSeR ():
                   trainable: bool = True,
                   seed: int = None,
                   type_one_side: bool = True,
-                  exclude_types: List[int] = [],
+                  exclude_types: List[List[int]] = [],
                   set_davg_zero: bool = False,
                   activation_function: str = 'tanh',
                   precision: str = 'default',
@@ -50,8 +50,9 @@ class DescrptSeR ():
                 Random seed for initializing the network parameters.
         type_one_side
                 Try to build N_types embedding nets. Otherwise, building N_types^2 embedding nets
-        exclude_types : list[int]
-                The Excluded types
+        exclude_types : List[List[int]]
+                The excluded pairs of types which have no interaction with each other.
+                For example, `[[0, 1]]` means no interaction between type 0 and type 1.
         activation_function
                 The activation function in the embedding net. Supported options are {0}
         precision

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -72,7 +72,7 @@ def descrpt_se_a_args():
     doc_precision = f'The precision of the embedding net parameters, supported options are {list_to_doc(PRECISION_DICT.keys())}'
     doc_trainable = 'If the parameters in the embedding net is trainable'
     doc_seed = 'Random seed for parameter initialization'
-    doc_exclude_types = 'The Excluded types'
+    doc_exclude_types = 'The excluded pairs of types which have no interaction with each other. For example, `[[0, 1]]` means no interaction between type 0 and type 1.'
     doc_set_davg_zero = 'Set the normalization average to zero. This option should be set when `atom_ener` in the energy fitting is used'
     
     return [
@@ -146,7 +146,7 @@ def descrpt_se_r_args():
     doc_precision = f'The precision of the embedding net parameters, supported options are {list_to_doc(PRECISION_DICT.keys())}'
     doc_trainable = 'If the parameters in the embedding net are trainable'
     doc_seed = 'Random seed for parameter initialization'
-    doc_exclude_types = 'The Excluded types'
+    doc_exclude_types = 'The excluded pairs of types which have no interaction with each other. For example, `[[0, 1]]` means no interaction between type 0 and type 1.'
     doc_set_davg_zero = 'Set the normalization average to zero. This option should be set when `atom_ener` in the energy fitting is used'
     
     return [

--- a/deepmd/utils/tabulate.py
+++ b/deepmd/utils/tabulate.py
@@ -31,8 +31,9 @@ class DeepTabulate():
                 The frozen model
         type_one_side
                 Try to build N_types tables. Otherwise, building N_types^2 tables
-        exclude_types : list[list[int]]
-                The Excluded types
+        exclude_types : List[List[int]]
+                The excluded pairs of types which have no interaction with each other.
+                For example, `[[0, 1]]` means no interaction between type 0 and type 1.
         """
 
         self.model_file = model_file

--- a/doc/model/train-se-e2-a.md
+++ b/doc/model/train-se-e2-a.md
@@ -6,14 +6,8 @@ In this example we will train a DeepPot-SE model for a water system.  A complete
 ```bash
 $deepmd_source_dir/examples/water/se_e2_a/input.json
 ```
-With the training input script, data (please read the [warning](#warning)) are also provided in the example directory. One may train the model with the DeePMD-kit from the directory.
+With the training input script, data are also provided in the example directory. One may train the model with the DeePMD-kit from the directory.
 
-The contents of the example:
-- [The training input](#the-training-input-script)
-- [Warning](#warning)
-
-
-#### Descriptor
 The construction of the descriptor is given by section `descriptor`. An example of the descriptor is provided as follows
 ```json
 	"descriptor" :{

--- a/doc/train-input-auto.rst
+++ b/doc/train-input-auto.rst
@@ -257,7 +257,7 @@ model:
         .. _`model/descriptor[se_e2_a]/axis_neuron`: 
 
         axis_neuron: 
-            | type: ``int``, optional, default: ``4``
+            | type: ``int``, optional, default: ``4``, alias: *n_axis_neuron*
             | argument path: ``model/descriptor[se_e2_a]/axis_neuron``
 
             Size of the submatrix of G (embedding matrix).
@@ -316,7 +316,7 @@ model:
             | type: ``list``, optional, default: ``[]``
             | argument path: ``model/descriptor[se_e2_a]/exclude_types``
 
-            The Excluded types
+            The excluded pairs of types which have no interaction with each other. For example, `[[0, 1]]` means no interaction between type 0 and type 1.
 
         .. _`model/descriptor[se_e2_a]/set_davg_zero`: 
 
@@ -421,7 +421,7 @@ model:
             | type: ``list``, optional, default: ``[]``
             | argument path: ``model/descriptor[se_e2_r]/exclude_types``
 
-            The Excluded types
+            The excluded pairs of types which have no interaction with each other. For example, `[[0, 1]]` means no interaction between type 0 and type 1.
 
         .. _`model/descriptor[se_e2_r]/set_davg_zero`: 
 
@@ -564,7 +564,7 @@ model:
         .. _`model/descriptor[se_a_tpe]/axis_neuron`: 
 
         axis_neuron: 
-            | type: ``int``, optional, default: ``4``
+            | type: ``int``, optional, default: ``4``, alias: *n_axis_neuron*
             | argument path: ``model/descriptor[se_a_tpe]/axis_neuron``
 
             Size of the submatrix of G (embedding matrix).
@@ -623,7 +623,7 @@ model:
             | type: ``list``, optional, default: ``[]``
             | argument path: ``model/descriptor[se_a_tpe]/exclude_types``
 
-            The Excluded types
+            The excluded pairs of types which have no interaction with each other. For example, `[[0, 1]]` means no interaction between type 0 and type 1.
 
         .. _`model/descriptor[se_a_tpe]/set_davg_zero`: 
 
@@ -732,7 +732,7 @@ model:
         .. _`model/fitting_net[ener]/neuron`: 
 
         neuron: 
-            | type: ``list``, optional, default: ``[120, 120, 120]``
+            | type: ``list``, optional, default: ``[120, 120, 120]``, alias: *n_neuron*
             | argument path: ``model/fitting_net[ener]/neuron``
 
             The number of neurons in each hidden layers of the fitting net. When two hidden layers are of the same size, a skip connection is built.
@@ -805,7 +805,7 @@ model:
         .. _`model/fitting_net[dipole]/neuron`: 
 
         neuron: 
-            | type: ``list``, optional, default: ``[120, 120, 120]``
+            | type: ``list``, optional, default: ``[120, 120, 120]``, alias: *n_neuron*
             | argument path: ``model/fitting_net[dipole]/neuron``
 
             The number of neurons in each hidden layers of the fitting net. When two hidden layers are of the same size, a skip connection is built.
@@ -837,7 +837,7 @@ model:
         .. _`model/fitting_net[dipole]/sel_type`: 
 
         sel_type: 
-            | type: ``list`` | ``int`` | ``NoneType``, optional
+            | type: ``list`` | ``int`` | ``NoneType``, optional, alias: *dipole_type*
             | argument path: ``model/fitting_net[dipole]/sel_type``
 
             The atom types for which the atomic dipole will be provided. If not set, all types will be selected.
@@ -858,7 +858,7 @@ model:
         .. _`model/fitting_net[polar]/neuron`: 
 
         neuron: 
-            | type: ``list``, optional, default: ``[120, 120, 120]``
+            | type: ``list``, optional, default: ``[120, 120, 120]``, alias: *n_neuron*
             | argument path: ``model/fitting_net[polar]/neuron``
 
             The number of neurons in each hidden layers of the fitting net. When two hidden layers are of the same size, a skip connection is built.
@@ -914,7 +914,7 @@ model:
         .. _`model/fitting_net[polar]/sel_type`: 
 
         sel_type: 
-            | type: ``list`` | ``int`` | ``NoneType``, optional
+            | type: ``list`` | ``int`` | ``NoneType``, optional, alias: *pol_type*
             | argument path: ``model/fitting_net[polar]/sel_type``
 
             The atom types for which the atomic polarizability will be provided. If not set, all types will be selected.
@@ -1055,6 +1055,14 @@ model:
 
             The arguments of model compression, including extrapolate(scale of model extrapolation), stride(uniform stride of tabulation's first and second table), and frequency(frequency of tabulation overflow check).
 
+        .. _`model/compress[se_e2_a]/min_nbor_dist`: 
+
+        min_nbor_dist: 
+            | type: ``float``
+            | argument path: ``model/compress[se_e2_a]/min_nbor_dist``
+
+            The nearest distance between neighbor atoms saved in the frozen model.
+
 
 .. _`loss`: 
 
@@ -1158,7 +1166,7 @@ loss:
     .. _`loss[ener]/relative_f`: 
 
     relative_f: 
-        | type: ``float`` | ``NoneType``, optional
+        | type: ``NoneType`` | ``float``, optional
         | argument path: ``loss[ener]/relative_f``
 
         If provided, relative force error will be used in the loss. The difference of force will be normalized by the magnitude of the force in the label with a shift given by `relative_f`, i.e. DF_i / ( || F || + relative_f ) with DF denoting the difference between prediction and label and || F || denoting the L2 norm of the label.
@@ -1276,7 +1284,7 @@ training:
         .. _`training/training_data/batch_size`: 
 
         batch_size: 
-            | type: ``list`` | ``str`` | ``int``, optional, default: ``auto``
+            | type: ``list`` | ``int`` | ``str``, optional, default: ``auto``
             | argument path: ``training/training_data/batch_size``
 
             This key can be 
@@ -1338,7 +1346,7 @@ training:
         .. _`training/validation_data/batch_size`: 
 
         batch_size: 
-            | type: ``list`` | ``str`` | ``int``, optional, default: ``auto``
+            | type: ``list`` | ``int`` | ``str``, optional, default: ``auto``
             | argument path: ``training/validation_data/batch_size``
 
             This key can be 
@@ -1416,7 +1424,7 @@ training:
     .. _`training/numb_test`: 
 
     numb_test: 
-        | type: ``list`` | ``str`` | ``int``, optional, default: ``1``
+        | type: ``list`` | ``int`` | ``str``, optional, default: ``1``
         | argument path: ``training/numb_test``
 
         Number of frames used for the test during training.
@@ -1492,3 +1500,4 @@ training:
         | argument path: ``training/tensorboard_freq``
 
         The frequency of writing tensorboard events.
+


### PR DESCRIPTION
Also regenerates `train-input-auto.rst`.
