### PR TITLE
add css to style parameters

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,3 +1,9 @@
 pre{
 	overflow: auto;
 }
+
+.classifier:before {
+    font-style: normal;
+    margin: 0.2em;
+    content: ": ";
+}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/9496702/130345754-f571a94b-a94f-4e94-b008-12d22de6cec6.png)
No space between parameter key and type

after:
![image](https://user-images.githubusercontent.com/9496702/130345764-2203db17-0c02-40a9-a375-db964eec4234.png)


Ref: spyder-ide/spyder#11270