### PR TITLE
Instantiate RunOptions first when training.

### DIFF
--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -67,6 +67,18 @@ def train(
     RuntimeError
         if distributed training job nem is wrong
     """
+    run_opt = RunOptions(
+        init_model=init_model,
+        restart=restart,
+        init_frz_model=init_frz_model,
+        log_path=log_path,
+        log_level=log_level,
+        mpi_log=mpi_log
+    )
+    if run_opt.is_distrib and len(run_opt.gpus or []) > 1:
+        # avoid conflict of visible gpus among multipe tf sessions in one process
+        reset_default_tf_session_config(cpu_only=True)
+
     # load json database
     jdata = j_loader(INPUT)
 
@@ -82,16 +94,6 @@ def train(
 
     # save the training script into the graph
     tf.constant(json.dumps(jdata), name='train_attr/training_script', dtype=tf.string)
-
-    # run options
-    run_opt = RunOptions(
-        init_model=init_model,
-        restart=restart,
-        init_frz_model=init_frz_model,
-        log_path=log_path,
-        log_level=log_level,
-        mpi_log=mpi_log
-    )
 
     for message in WELCOME + CITATION + BUILD:
         log.info(message)
@@ -119,10 +121,6 @@ def _do_work(jdata: Dict[str, Any], run_opt: RunOptions, is_compress: bool = Fal
     """
     # make necessary checks
     assert "training" in jdata
-
-    # avoid conflict of visible gpus among multipe tf sessions in one process
-    if run_opt.is_distrib and len(run_opt.gpus or []) > 1:
-        reset_default_tf_session_config(cpu_only=True)
 
     # init the model
     model = DPTrainer(jdata, run_opt=run_opt, is_compress = is_compress)

--- a/source/tests/test_parallel_training.py
+++ b/source/tests/test_parallel_training.py
@@ -1,0 +1,35 @@
+import os
+import subprocess as sp
+import unittest
+
+from deepmd.cluster.local import get_gpus
+
+from common import tests_path
+
+
+class TestSingleMachine(unittest.TestCase):
+    def setUp(self):
+        try:
+            import horovod
+        except ImportError:
+            raise unittest.SkipTest("Package horovod is required for parallel-training tests.")
+        if len(get_gpus() or []) < 2:
+            raise unittest.SkipTest("At least 2 GPU cards are required for parallel training.")
+        self.input_file = str(tests_path / "model_compression" / "input.json")
+
+    def test_two_workers(self):
+        command = 'horovodrun -np 2 dp train -m workers ' + self.input_file
+        penv = os.environ.copy()
+        penv['CUDA_VISIBLE_DEVICES'] = '0,1'
+        popen = sp.Popen(command, shell=True, env=penv, stdout=sp.PIPE, stderr=sp.STDOUT)
+        for line in iter(popen.stdout.readline, b''):
+            if hasattr(line, 'decode'):
+                line = line.decode('utf-8')
+            line = line.rstrip()
+            print(line)
+        popen.wait()
+        self.assertEqual(0, popen.returncode, 'Parallel training failed!')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/source/tests/test_parallel_training.py
+++ b/source/tests/test_parallel_training.py
@@ -13,14 +13,13 @@ class TestSingleMachine(unittest.TestCase):
             import horovod
         except ImportError:
             raise unittest.SkipTest("Package horovod is required for parallel-training tests.")
-        if len(get_gpus() or []) < 2:
-            raise unittest.SkipTest("At least 2 GPU cards are required for parallel training.")
         self.input_file = str(tests_path / "model_compression" / "input.json")
 
     def test_two_workers(self):
         command = 'horovodrun -np 2 dp train -m workers ' + self.input_file
         penv = os.environ.copy()
-        penv['CUDA_VISIBLE_DEVICES'] = '0,1'
+        if len(get_gpus() or []) > 1:
+            penv['CUDA_VISIBLE_DEVICES'] = '0,1'
         popen = sp.Popen(command, shell=True, env=penv, stdout=sp.PIPE, stderr=sp.STDOUT)
         for line in iter(popen.stdout.readline, b''):
             if hasattr(line, 'decode'):


### PR DESCRIPTION
PR #914 breaks down the parallel training with multiple GPU cards because `NeightStat` creates a `tf.Session` covering all GPUs before the default `tf.ConfigProto` is reset to only use CPU. Then, the trainer will fail when it binds to only 1 GPU card with a different device ID.

Since there is no GPU machines in GitHub CI, regression test cannot be activated to ensure new PRs won't effect the feature of parallel training. We have to test multi-GPU training at local.
