### PR TITLE
Speedup scan

### DIFF
--- a/source/lib/src/cuda/neighbor_list.cu
+++ b/source/lib/src/cuda/neighbor_list.cu
@@ -59,6 +59,7 @@ __global__ void parallel_prefix_scan(
     }
     // Store numneigh into the output array
     if (ii == nall - 1) {
+        o_data += i_data == -1 ? 0 : 1;
         numneigh[blockIdx.x] = o_data; 
     }
   }

--- a/source/lib/src/cuda/neighbor_list.cu
+++ b/source/lib/src/cuda/neighbor_list.cu
@@ -2,6 +2,68 @@
 #include "gpu_cuda.h"
 #include "neighbor_list.h"
 
+#include <cub/block/block_scan.cuh>
+// A stateful callback functor that maintains a running prefix to be applied
+// during consecutive scan operations.
+struct parallel_prefix_scan_op
+{
+  // Running prefix
+  int running_total;
+  // Constructor
+  __device__ parallel_prefix_scan_op(int running_total) : running_total(running_total) {}
+  // Callback operator to be entered by the first warp of threads in the block.
+  // Thread-0 is responsible for returning a value for seeding the block-wide scan.
+  __device__ int operator()(int block_aggregate)
+  {
+    int old_prefix = running_total;
+    running_total += block_aggregate;
+    return old_prefix;
+  }
+};
+
+template <
+  int   THREADS_PER_BLOCK>
+__global__ void parallel_prefix_scan(
+  int * numneigh, 
+  int * nei_order, 
+  const int * temp_nlist, 
+  const int mem_size, 
+  const int nloc,
+  const int nall
+)
+{
+  // Specialize BlockLoad, BlockStore, and BlockScan for a 1D block of 128 threads, 4 ints per thread
+  typedef cub::BlockScan<int,  THREADS_PER_BLOCK> BlockScan;
+  // Allocate aliased shared memory for BlockLoad, BlockStore, and BlockScan
+  __shared__ typename BlockScan::TempStorage temp_storage;
+
+  // Initialize running total
+  parallel_prefix_scan_op prefix_op(0);
+
+  // Have the block iterate over segments of items
+  for (int ii = threadIdx.x; ii < nall; ii += THREADS_PER_BLOCK)
+  {
+    int block_offset = blockIdx.x * mem_size; 
+    // Load a segment of consecutive items that are blocked across threads
+    int i_data = temp_nlist[block_offset + ii];
+    int o_data = i_data == -1 ? 0 : 1;
+
+    // Collectively compute the block-wide exclusive prefix sum
+    BlockScan(temp_storage).ExclusiveSum(
+        o_data, o_data, prefix_op);
+
+    __syncthreads();
+    // Store scanned items to output segment
+    if (i_data != -1) {
+        nei_order[block_offset + ii] = o_data; 
+    }
+    // Store numneigh into the output array
+    if (ii == nall - 1) {
+        numneigh[blockIdx.x] = o_data; 
+    }
+  }
+}
+
 template<typename FPTYPE>
 __device__ inline FPTYPE dev_dot(
     FPTYPE * arr1, 
@@ -42,29 +104,6 @@ __global__ void build_nlist(
                 neighbor_row[neighbor_idx]=neighbor_idx;
             }
         }
-    }
-}
-
-__global__ void scan_nlist(
-    int * numneigh, 
-    int * nei_order, 
-    const int * temp_nlist, 
-    const int mem_size, 
-    const int nloc,
-    const int nall)
-{
-    const unsigned int atom_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if(atom_idx<nloc){
-        const int * row_nlist = temp_nlist + atom_idx * mem_size;
-        int * row_order = nei_order + atom_idx * mem_size;
-        int nei_num=0;
-        for(int i=0;i<nall;i++){
-            if(row_nlist[i]!=-1){
-                row_order[i]=nei_num;
-                nei_num++;
-            }
-        }
-        numneigh[atom_idx]=nei_num;
     }
 }
 
@@ -143,14 +182,9 @@ int build_nlist_gpu(
                 mem_size);
     DPErrcheck(cudaGetLastError());
     DPErrcheck(cudaDeviceSynchronize());
-    const int nblock_ = (nloc+TPB-1)/TPB;
-    scan_nlist<<<nblock_, TPB>>>(
-                numneigh, 
-                nei_order, 
-                temp_nlist, 
-                mem_size, 
-                nloc, 
-                nall);
+    parallel_prefix_scan<TPB> <<<nloc, TPB>>>(
+      numneigh, nei_order, 
+      temp_nlist, mem_size, nloc, nall);
     DPErrcheck(cudaGetLastError());
     DPErrcheck(cudaDeviceSynchronize());
     fill_nlist<<<block_grid, thread_grid>>>(

--- a/source/lib/src/rocm/neighbor_list.hip.cu
+++ b/source/lib/src/rocm/neighbor_list.hip.cu
@@ -2,6 +2,68 @@
 #include "device.h"
 #include "neighbor_list.h"
 
+#include "hipcub/hipcub.hpp"
+// A stateful callback functor that maintains a running prefix to be applied
+// during consecutive scan operations.
+struct parallel_prefix_scan_op
+{
+  // Running prefix
+  int running_total;
+  // Constructor
+  __device__ parallel_prefix_scan_op(int running_total) : running_total(running_total) {}
+  // Callback operator to be entered by the first warp of threads in the block.
+  // Thread-0 is responsible for returning a value for seeding the block-wide scan.
+  __device__ int operator()(int block_aggregate)
+  {
+    int old_prefix = running_total;
+    running_total += block_aggregate;
+    return old_prefix;
+  }
+};
+
+template <
+  int   THREADS_PER_BLOCK>
+__global__ void parallel_prefix_scan(
+  int * numneigh, 
+  int * nei_order, 
+  const int * temp_nlist, 
+  const int mem_size, 
+  const int nloc,
+  const int nall
+)
+{
+  // Specialize BlockLoad, BlockStore, and BlockScan for a 1D block of 128 threads, 4 ints per thread
+  typedef hipcub::BlockScan<int,  THREADS_PER_BLOCK> BlockScan;
+  // Allocate aliased shared memory for BlockLoad, BlockStore, and BlockScan
+  __shared__ typename BlockScan::TempStorage temp_storage;
+
+  // Initialize running total
+  parallel_prefix_scan_op prefix_op(0);
+
+  // Have the block iterate over segments of items
+  for (int ii = threadIdx.x; ii < nall; ii += THREADS_PER_BLOCK)
+  {
+    int block_offset = blockIdx.x * mem_size; 
+    // Load a segment of consecutive items that are blocked across threads
+    int i_data = temp_nlist[block_offset + ii];
+    int o_data = i_data == -1 ? 0 : 1;
+
+    // Collectively compute the block-wide exclusive prefix sum
+    BlockScan(temp_storage).ExclusiveSum(
+        o_data, o_data, prefix_op);
+
+    __syncthreads();
+    // Store scanned items to output segment
+    if (i_data != -1) {
+        nei_order[block_offset + ii] = o_data; 
+    }
+    // Store numneigh into the output array
+    if (ii == nall - 1) {
+        numneigh[blockIdx.x] = o_data; 
+    }
+  }
+}
+
 template<typename FPTYPE>
 __device__ inline FPTYPE dev_dot(
     FPTYPE * arr1, 
@@ -42,29 +104,6 @@ __global__ void build_nlist(
                 neighbor_row[neighbor_idx]=neighbor_idx;
             }
         }
-    }
-}
-
-__global__ void scan_nlist(
-    int * numneigh, 
-    int * nei_order, 
-    const int * temp_nlist, 
-    const int mem_size, 
-    const int nloc,
-    const int nall)
-{
-    const unsigned int atom_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if(atom_idx<nloc){
-        const int * row_nlist = temp_nlist + atom_idx * mem_size;
-        int * row_order = nei_order + atom_idx * mem_size;
-        int nei_num=0;
-        for(int i=0;i<nall;i++){
-            if(row_nlist[i]!=-1){
-                row_order[i]=nei_num;
-                nei_num++;
-            }
-        }
-        numneigh[atom_idx]=nei_num;
     }
 }
 
@@ -143,14 +182,10 @@ int build_nlist_gpu_rocm(
                 mem_size);
     DPErrcheck(hipGetLastError());
     DPErrcheck(hipDeviceSynchronize());
-    const int nblock_ = (nloc+TPB-1)/TPB;
-    hipLaunchKernelGGL(scan_nlist, nblock_, TPB, 0, 0, 
-                numneigh, 
-                nei_order, 
-                temp_nlist, 
-                mem_size, 
-                nloc, 
-                nall);
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(parallel_prefix_scan<TPB>), nloc, TPB, 0, 0, 
+        numneigh, nei_order, 
+        temp_nlist, mem_size, nloc, nall);
     DPErrcheck(hipGetLastError());
     DPErrcheck(hipDeviceSynchronize());
     hipLaunchKernelGGL(fill_nlist, block_grid, thread_grid, 0, 0, 

--- a/source/lib/src/rocm/neighbor_list.hip.cu
+++ b/source/lib/src/rocm/neighbor_list.hip.cu
@@ -59,6 +59,7 @@ __global__ void parallel_prefix_scan(
     }
     // Store numneigh into the output array
     if (ii == nall - 1) {
+        o_data += i_data == -1 ? 0 : 1;
         numneigh[blockIdx.x] = o_data; 
     }
   }


### PR DESCRIPTION
Our profiling of the example water benchmark system shows that the `scan_nlist` kernel within the `$deepmd_source_dir/source/lib/src/cuda/neighbor_list.cu` consumes more than 7% of kernel execution time during the `dp train` process. And it consumes more than 20% of the kernel execution time in the `dp init-frz-model` process. 

The original `scan_nlist` kernel uses one thread to scan the neighbor list of a central atom. This is inefficient within the training process. Given the training nloc usually smaller than the threads number per cuda block, `scan_nlist` will typically launch only one cuda thread-block at each training step and causes a huge waste of computing resources.

In the new implementation, I use the nvidia/cub head library to parallelize the scan kernel, and it speedup the `scan_nlist` kernel by more than 50 times. The total training speed-up ratio is about 3%, which is mainly because there's still a considerable part of the training process does not run on the gpu kernel functions. And we still need to perform more detailed profiling of the training process.

The lcurve.out of cpu training(lcurve-cpu.out), gpu training(lcurve-gpu.out) and new scan training(lcurve-parallel.out) show the same results:
```
root se_e2_a $ head lcurve-cpu.out
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      2.65e+01    2.76e+01      6.77e-01    6.79e-01      8.38e-01    8.71e-01    1.0e-03
      1      2.64e+01    2.78e+01      4.32e-01    4.31e-01      8.35e-01    8.78e-01    1.0e-03
      2      2.53e+01    2.52e+01      1.33e-01    1.28e-01      7.99e-01    7.98e-01    1.0e-03
      3      2.44e+01    2.31e+01      9.82e-02    9.90e-02      7.72e-01    7.30e-01    1.0e-03
      4      2.78e+01    2.57e+01      2.39e-01    2.38e-01      8.80e-01    8.12e-01    1.0e-03
      5      2.54e+01    2.54e+01      3.01e-01    3.04e-01      8.04e-01    8.04e-01    1.0e-03
      6      2.58e+01    2.49e+01      2.98e-01    3.03e-01      8.16e-01    7.88e-01    1.0e-03
      7      2.62e+01    2.36e+01      2.37e-01    2.40e-01      8.29e-01    7.46e-01    1.0e-03
      8      2.52e+01    2.58e+01      1.80e-01    1.79e-01      7.97e-01    8.15e-01    1.0e-03

root se_e2_a $ head lcurve-gpu.out
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      2.65e+01    2.76e+01      6.77e-01    6.79e-01      8.38e-01    8.71e-01    1.0e-03
      1      2.64e+01    2.78e+01      4.32e-01    4.31e-01      8.35e-01    8.78e-01    1.0e-03
      2      2.53e+01    2.52e+01      1.33e-01    1.28e-01      7.99e-01    7.98e-01    1.0e-03
      3      2.44e+01    2.31e+01      9.82e-02    9.90e-02      7.72e-01    7.30e-01    1.0e-03
      4      2.78e+01    2.57e+01      2.39e-01    2.38e-01      8.80e-01    8.12e-01    1.0e-03
      5      2.54e+01    2.54e+01      3.01e-01    3.04e-01      8.04e-01    8.04e-01    1.0e-03
      6      2.58e+01    2.49e+01      2.98e-01    3.03e-01      8.16e-01    7.88e-01    1.0e-03
      7      2.62e+01    2.36e+01      2.37e-01    2.40e-01      8.29e-01    7.46e-01    1.0e-03
      8      2.52e+01    2.58e+01      1.80e-01    1.79e-01      7.97e-01    8.15e-01    1.0e-03

root se_e2_a $ head lcurve-parallel.out
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      2.65e+01    2.76e+01      6.77e-01    6.79e-01      8.38e-01    8.71e-01    1.0e-03
      1      2.64e+01    2.78e+01      4.32e-01    4.31e-01      8.35e-01    8.78e-01    1.0e-03
      2      2.53e+01    2.52e+01      1.33e-01    1.28e-01      7.99e-01    7.98e-01    1.0e-03
      3      2.44e+01    2.31e+01      9.81e-02    9.90e-02      7.72e-01    7.30e-01    1.0e-03
      4      2.78e+01    2.57e+01      2.39e-01    2.38e-01      8.80e-01    8.12e-01    1.0e-03
      5      2.54e+01    2.54e+01      3.01e-01    3.04e-01      8.04e-01    8.04e-01    1.0e-03
      6      2.58e+01    2.49e+01      2.98e-01    3.03e-01      8.16e-01    7.88e-01    1.0e-03
      7      2.62e+01    2.36e+01      2.37e-01    2.40e-01      8.29e-01    7.46e-01    1.0e-03
      8      2.52e+01    2.58e+01      1.80e-01    1.79e-01      7.97e-01    8.15e-01    1.0e-03

```
**This ensures the correctness of the new implementation. And all UTs have passed in my local V100 workstation.**