### PR TITLE
Fix typo: CMAKE_COMPILER_IS_GNUCXX

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 project(DeePMD)
-if (CMAKE_COMPILER_IS_GNU)
+if (CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_LINK_WHAT_YOU_USE TRUE)
 endif ()
 


### PR DESCRIPTION
The flag won't work without language specified.
See https://cmake.org/cmake/help/v3.4/variable/CMAKE_COMPILER_IS_GNULANG.html, https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILER_IS_GNUCXX.html