### PR TITLE
[r1.2] Fix typo: CMAKE_COMPILER_IS_GNUCXX  

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 project(DeePMD)
-if (CMAKE_COMPILER_IS_GNU)
+if (CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_LINK_WHAT_YOU_USE TRUE)
 endif ()
 


### PR DESCRIPTION
Cherry picked from #1038.

----
The flag won't work without language specified.
See https://cmake.org/cmake/help/v3.4/variable/CMAKE_COMPILER_IS_GNULANG.html

(cherry picked from commit 8bbe565c876d3e1424ac9840c466e502e98da528)
