### PR TITLE
upgrade os.system to subporcess.popen method

### DIFF
--- a/source/tests/test_model_compression.py
+++ b/source/tests/test_model_compression.py
@@ -40,11 +40,11 @@ def _init_models():
         json.dump(jdata, fp, indent=4)
 
     ret = _subprocess_run("dp train " + INPUT)
-    np.testing.assertEqual(ret, 0, 'DP train failed!')
+    np.testing.assert_equal(ret, 0, 'DP train failed!')
     ret = _subprocess_run("dp freeze -o " + frozen_model)
-    np.testing.assertEqual(ret, 0, 'DP freeze failed!')
+    np.testing.assert_equal(ret, 0, 'DP freeze failed!')
     ret = _subprocess_run("dp compress " + " -i " + frozen_model + " -o " + compressed_model)
-    np.testing.assertEqual(ret, 0, 'DP model compression failed!')
+    np.testing.assert_equal(ret, 0, 'DP model compression failed!')
     return INPUT, frozen_model, compressed_model
 
 INPUT, FROZEN_MODEL, COMPRESSED_MODEL = _init_models()

--- a/source/tests/test_model_compression.py
+++ b/source/tests/test_model_compression.py
@@ -19,7 +19,7 @@ def _file_delete(file) :
         os.remove(file)
 
 def _subprocess_run(command):
-    popen = sp.Popen(command, shell=True, stdout=sp.PIPE, stderr=sp.STDOUT)
+    popen = sp.Popen(command.split(), shell=False, stdout=sp.PIPE, stderr=sp.STDOUT)
     for line in iter(popen.stdout.readline, b''):
         if hasattr(line, 'decode'):
             line = line.decode('utf-8')

--- a/source/tests/test_transfer.py
+++ b/source/tests/test_transfer.py
@@ -38,7 +38,7 @@ class TestTransform(unittest.TestCase) :
         convert_pbtxt_to_pb(str(tests_path / os.path.join("infer","deeppot.pbtxt")), self.old_model)
         convert_pbtxt_to_pb(str(tests_path / os.path.join("infer","deeppot-1.pbtxt")), self.raw_model)
         ret = _subprocess_run("dp transfer -O " + self.old_model + " -r " + self.raw_model + " -o " + self.new_model)
-        self.assertEqual(ret, 0, 'DP transfer failed!')
+        np.testing.assert_equal(ret, 0, 'DP transfer failed!')
 
         self.dp = DeepPot(self.new_model)
         self.coords = np.array([12.83, 2.56, 2.18,

--- a/source/tests/test_transfer.py
+++ b/source/tests/test_transfer.py
@@ -20,7 +20,7 @@ def _file_delete(file) :
         os.remove(file)
 
 def _subprocess_run(command):
-    popen = sp.Popen(command, shell=True, stdout=sp.PIPE, stderr=sp.STDOUT)
+    popen = sp.Popen(command.split(), shell=False, stdout=sp.PIPE, stderr=sp.STDOUT)
     for line in iter(popen.stdout.readline, b''):
         if hasattr(line, 'decode'):
             line = line.decode('utf-8')


### PR DESCRIPTION
Upgrade the os.system to subporcess.popen method. According to the [doc](https://docs.python.org/3/library/os.html#os.system) of os.system method:

> The subprocess module provides more powerful facilities for spawning new processes and retrieving their results; using that module is preferable to using this function. See the Replacing Older Functions with the subprocess Module section in the subprocess documentation for some helpful recipes.

In general, `subprocess.Popen()` is super-set of `os.system()`.

