### PR TITLE
set `allow_growth` in `default_tf_session_config`

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -119,6 +119,7 @@ def get_tf_session_config() -> Any:
     set_tf_default_nthreads()
     intra, inter = get_tf_default_nthreads()
     config = tf.ConfigProto(
+        gpu_options=tf.GPUOptions(allow_growth=True),
         intra_op_parallelism_threads=intra, inter_op_parallelism_threads=inter
     )
     return config


### PR DESCRIPTION
Currently, TF only initializes GPUs once, and never releases memory. As a result, we must set `allow_growth` in the first Session (or every session?), otherwise it doesn't work.

Please confirm the `allow_growth` config in `trainer.py` is expected, otherwise we should remove it instead.
https://github.com/deepmodeling/deepmd-kit/blob/1a25414dcd18b12316250baa330b690f3f5510fe/deepmd/train/trainer.py#L400