### PR TITLE
Revert "get library extension suffix from built-in method"

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-import distutils.ccompiler
+import platform
 from configparser import ConfigParser
 from imp import reload
 from pathlib import Path
@@ -157,8 +157,12 @@ def get_module(module_name: str) -> "ModuleType":
     FileNotFoundError
         if module is not found in directory
     """
-    # https://discuss.python.org/t/how-to-get-the-file-extension-of-dynamic-libraries-for-current-os/3916/5
-    ext = distutils.ccompiler.new_compiler().shared_lib_extension
+    if platform.system() == "Windows":
+        ext = ".dll"
+    elif platform.system() == "Darwin":
+        ext = ".dylib"
+    else:
+        ext = ".so"
 
     module_file = (
         (Path(__file__).parent / SHARED_LIB_MODULE / module_name)


### PR DESCRIPTION
Reverts deepmodeling/deepmd-kit#1036

It doesn't work on macos, so I'm going to revert.