### PR TITLE
Model compression checkpoint

### DIFF
--- a/deepmd/entrypoints/compress.py
+++ b/deepmd/entrypoints/compress.py
@@ -101,6 +101,7 @@ def compress(
         10 * step,
         int(frequency),
     ]
+    jdata["training"]["save_ckpt"] = "model-compression/model.ckpt"
     jdata = normalize(jdata)
 
     # check the descriptor info of the input file

--- a/deepmd/entrypoints/main.py
+++ b/deepmd/entrypoints/main.py
@@ -311,7 +311,7 @@ def parse_args(args: Optional[List[str]] = None):
         "-c",
         "--checkpoint-folder",
         type=str,
-        default=".",
+        default="model-compression",
         help="path to checkpoint folder",
     )
     parser_compress.add_argument(

--- a/source/tests/test_model_compression.py
+++ b/source/tests/test_model_compression.py
@@ -317,11 +317,10 @@ class TestDeepPotAPBCExcludeTypes(unittest.TestCase) :
         _file_delete(COMPRESSED_MODEL)
         _file_delete("out.json")
         _file_delete("compress.json")
-        _file_delete("checkpoint")
-        _file_delete("lcurve.out")
-        _file_delete("model.ckpt.meta")
-        _file_delete("model.ckpt.index")
-        _file_delete("model.ckpt.data-00000-of-00001")
+        _file_delete("model-compression/checkpoint")
+        _file_delete("model-compression/model.ckpt.meta")
+        _file_delete("model-compression/model.ckpt.index")
+        _file_delete("model-compression/model.ckpt.data-00000-of-00001")
 
     def test_attrs(self):
         self.assertEqual(self.dp_original.get_ntypes(), 2)


### PR DESCRIPTION
This PR change the default model compression checkpoint path from '.' to 'model-compression'.

 In the original implementation, the model compression process will overwrite the checkpoint in the current directory, which may cause damage to the checkpoint of the original model.