### PR TITLE
fix(entrypoints/main): remove the argument -S

### DIFF
--- a/source/lib/src/cuda/CMakeLists.txt
+++ b/source/lib/src/cuda/CMakeLists.txt
@@ -15,7 +15,12 @@ SET(CMAKE_CUDA_STANDARD 11)
 # nvcc -o libdeepmd_op_cuda.so -I/usr/local/cub-1.8.0 -rdc=true -DHIGH_PREC=true -gencode arch=compute_61,code=sm_61 -shared -Xcompiler -fPIC deepmd_op.cu -L/usr/local/cuda/lib64 -lcudadevrt
 # very important here! Include path to cub.
 # for searching device compute capability, https://developer.nvidia.com/cuda-gpus
+
+# cub has been included in CUDA Toolkit 11, we do not need to include it any more
+# see https://github.com/NVIDIA/cub
+if (${CUDA_VERSION_MAJOR} LESS_EQUAL "10")
 include_directories(cub)
+endif ()
 
 message(STATUS "CUDA major version is " ${CUDA_VERSION_MAJOR})
 


### PR DESCRIPTION
the function `expand_sys_str(system)`  in test.py  has walked through all the sub directories in `system path`,
An error from utils/data.py will occur when  `set prefix` is delivered

if one has Multi-systems, the `system path` should be the parent path of all systems