### PR TITLE
Enable init-frz-model support for the original model

### DIFF
--- a/deepmd/descriptor/descriptor.py
+++ b/deepmd/descriptor/descriptor.py
@@ -283,3 +283,23 @@ class Descriptor(ABC):
         # TODO: currently only SeA has this method, but I think the method can be
         # moved here as it doesn't contain anything related to a specific descriptor
         raise NotImplementedError
+
+    def init_variables(self,
+                       embedding_net_variables: dict
+                       ) -> None:
+        """
+        Init the embedding net variables with the given dict
+
+        Parameters
+        ----------
+        embedding_net_variables
+                The input dict which stores the embedding net variables
+        
+        Notes
+        -----
+        This method is called by others when the descriptor supported initialization from the given variables.
+        """
+        # TODO: currently only SeA has this method, but I think the method can be
+        # moved here as it doesn't contain anything related to a specific descriptor
+        raise NotImplementedError(
+            "Descriptor %s doesn't support initialization from the given variables!" % type(self).__name__)

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -157,6 +157,7 @@ class DescrptSeA (Descriptor):
         self.dstd = None
         self.davg = None
         self.compress = False
+        self.embedding_net_variables = None
         self.place_holders = {}
         nei_type = np.array([])
         for ii in range(self.ntypes):
@@ -521,6 +522,21 @@ class DescrptSeA (Descriptor):
         }
         return feed_dict
 
+
+    def init_variables(self,
+                       embedding_net_variables: dict
+    ) -> None:
+        """
+        Init the embedding net variables with the given dict
+
+        Parameters
+        ----------
+        embedding_net_variables
+                The input dict which stores the embedding net variables
+        """
+        self.embedding_net_variables = embedding_net_variables
+
+
     def prod_force_virial(self, 
                           atom_ener : tf.Tensor, 
                           natoms : tf.Tensor
@@ -766,7 +782,8 @@ class DescrptSeA (Descriptor):
                   bavg = bavg,
                   seed = self.seed,
                   trainable = trainable, 
-                  uniform_seed = self.uniform_seed)
+                  uniform_seed = self.uniform_seed,
+                  initial_variables = self.embedding_net_variables)
               if (not self.uniform_seed) and (self.seed is not None): self.seed += self.seed_shift
           else:
             # we can safely return the final xyz_scatter filled with zero directly

--- a/deepmd/utils/network.py
+++ b/deepmd/utils/network.py
@@ -92,7 +92,8 @@ def embedding_net(xx,
                   bavg = 0.0,
                   seed = None,
                   trainable = True, 
-                  uniform_seed = False):
+                  uniform_seed = False,
+                  initial_variables = None):
     r"""The embedding network.
 
     The embedding network function :math:`\mathcal{N}` is constructed by is the
@@ -152,37 +153,47 @@ def embedding_net(xx,
     outputs_size = [input_shape[1]] + network_size
 
     for ii in range(1, len(outputs_size)):
-        w = tf.get_variable('matrix_'+str(ii)+name_suffix, 
+        w_initializer = tf.random_normal_initializer(
+                            stddev=stddev/np.sqrt(outputs_size[ii]+outputs_size[ii-1]), 
+                            seed = seed if (seed is None or uniform_seed)  else seed + ii*3+0
+                        )
+        b_initializer = tf.random_normal_initializer(
+                            stddev=stddev, 
+                            mean = bavg, 
+                            seed = seed if (seed is None or uniform_seed) else seed + 3*ii+1
+                        )
+        if initial_variables is not None:
+            scope = tf.get_variable_scope().name
+            w_initializer = tf.constant_initializer(initial_variables[scope+'/matrix_'+str(ii)+name_suffix])
+            b_initializer = tf.constant_initializer(initial_variables[scope+'/bias_'+str(ii)+name_suffix])
+        w = tf.get_variable('matrix_'+str(ii)+name_suffix,
                             [outputs_size[ii - 1], outputs_size[ii]], 
                             precision,
-                            tf.random_normal_initializer(
-                                stddev=stddev/np.sqrt(outputs_size[ii]+outputs_size[ii-1]), 
-                                seed = seed if (seed is None or uniform_seed)  else seed + ii*3+0
-                            ), 
+                            w_initializer,
                             trainable = trainable)
         variable_summaries(w, 'matrix_'+str(ii)+name_suffix)
 
         b = tf.get_variable('bias_'+str(ii)+name_suffix, 
                             [1, outputs_size[ii]], 
                             precision,
-                            tf.random_normal_initializer(
-                                stddev=stddev, 
-                                mean = bavg, 
-                                seed = seed if (seed is None or uniform_seed) else seed + 3*ii+1
-                            ), 
+                            b_initializer, 
                             trainable = trainable)
         variable_summaries(b, 'bias_'+str(ii)+name_suffix)
 
         hidden = tf.reshape(activation_fn(tf.matmul(xx, w) + b), [-1, outputs_size[ii]])
         if resnet_dt :
+            idt_initializer = tf.random_normal_initializer(
+                                  stddev=0.001, 
+                                  mean = 1.0, 
+                                  seed = seed if (seed is None or uniform_seed) else seed + 3*ii+2
+                              )
+            if initial_variables is not None:
+                scope = tf.get_variable_scope().name
+                idt_initializer = tf.constant_initializer(initial_variables[scope+'/idt_'+str(ii)+name_suffix])
             idt = tf.get_variable('idt_'+str(ii)+name_suffix, 
                                   [1, outputs_size[ii]], 
                                   precision,
-                                  tf.random_normal_initializer(
-                                      stddev=0.001, 
-                                      mean = 1.0, 
-                                      seed = seed if (seed is None or uniform_seed) else seed + 3*ii+2
-                                  ), 
+                                  idt_initializer, 
                                   trainable = trainable)
             variable_summaries(idt, 'idt_'+str(ii)+name_suffix)
 

--- a/deepmd/utils/network.py
+++ b/deepmd/utils/network.py
@@ -142,6 +142,11 @@ def embedding_net(xx,
         Random seed for initializing network parameters
     trainable: boolean
         If the network is trainable
+    uniform_seed : boolean
+        Only for the purpose of backward compatibility, retrieves the old behavior of using the random seed
+    initial_variables : dict
+        The input dict which stores the embedding net variables
+
 
     References
     ----------


### PR DESCRIPTION
This PR enables `init-frz-model` support for the original model within the `dp train` interface. Now both original and compress pb file(with `se_a` type descriptor) can be used to initialize the dp train interface.

The results in the example water benchmark system show that the `step 0` of the `lcurve.out` output of the original model(`original.out`) and the compressed model(`compress.out`) under the `dp train --init-frz-model` interface is consistent:

result of original.out:
```
root se_e2_a $ head original.out 
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      2.58e+00    2.40e+00      2.81e-02    2.74e-02      8.17e-02    7.58e-02    1.0e-03
```

result of compress.out:
```
root se_e2_a $ head compress.out 
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      2.58e+00    2.40e+00      2.81e-02    2.74e-02      8.17e-02    7.58e-02    1.0e-03
```
