### PR TITLE
fix LAMMPS_VERSION_NUMBER condition

### DIFF
--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -41,7 +41,7 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
      efield_fsum_all(4, 0.0), 
      efield_force_flag(0)
 {
-#if LAMMPS_VERSION_NUMBER>=20210702
+#if LAMMPS_VERSION_NUMBER>=20210210
   // lammps/lammps#2560
   energy_global_flag = 1;
   virial_global_flag = 1;
@@ -123,7 +123,7 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
 int FixDPLR::setmask()
 {
   int mask = 0;
-#if LAMMPS_VERSION_NUMBER<20210702
+#if LAMMPS_VERSION_NUMBER<20210210
   // THERMO_ENERGY removed in lammps/lammps#2560
   mask |= THERMO_ENERGY;
 #endif

--- a/source/lmp/pppm_dplr.cpp
+++ b/source/lmp/pppm_dplr.cpp
@@ -28,7 +28,7 @@ enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
 
 /* ---------------------------------------------------------------------- */
 
-#if LAMMPS_VERSION_NUMBER<20190201
+#if LAMMPS_VERSION_NUMBER<20181109
 // See lammps/lammps#1165
 PPPMDPLR::PPPMDPLR(LAMMPS *lmp, int narg, char **arg) :
   PPPM(lmp, narg, arg)

--- a/source/lmp/pppm_dplr.h
+++ b/source/lmp/pppm_dplr.h
@@ -21,7 +21,7 @@ namespace LAMMPS_NS {
 
   class PPPMDPLR : public PPPM {
 public:
-#if LAMMPS_VERSION_NUMBER<20190201
+#if LAMMPS_VERSION_NUMBER<20181109
 // See lammps/lammps#1165
     PPPMDPLR(class LAMMPS *, int, char **);
 #else


### PR DESCRIPTION
When I debug #1109, I accidentally find the LAMMPS_VERSION_NUMBER condition is wrong, making builds fail. (but this is not related to #1109)