### PR TITLE
fix "Call to method DeepTensor.__init__ with too many arguments"

### DIFF
--- a/deepmd/infer/deep_polar.py
+++ b/deepmd/infer/deep_polar.py
@@ -84,7 +84,6 @@ class DeepGlobalPolar(DeepTensor):
         DeepTensor.__init__(
             self,
             model_file,
-            9,
             load_prefix=load_prefix,
             default_tf_graph=default_tf_graph,
         )


### PR DESCRIPTION
As detected by LGTM, here is an error:
Call to method DeepTensor.__init__ with too many arguments; should be no more than 4.

I agree with the automatic code analysis tool.