### PR TITLE
explicitly set neighbor request to full to fix bug #1109

### DIFF
--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -992,7 +992,7 @@ void PairDeepMD::init_style()
 {
   int irequest = neighbor->request(this,instance_me);
   neighbor->requests[irequest]->half = 0;
-  // neighbor->requests[irequest]->full = 1;  
+  neighbor->requests[irequest]->full = 1;  
   // neighbor->requests[irequest]->newton = 2;  
   if (out_each == 1){
     int ntotal = atom->natoms;


### PR DESCRIPTION
It seems that the default behavior of handling neigh_request is changed in Lammps `patch_14May2021`, which introduces a wrong stencil for the neighbor list. 

Before this fix the stencil is half
```
  (1) pair deepmd, perpetual
      attributes: , newton on
      pair build: full/bin/atomonly
      stencil: half/bin/3d/tri
      bin: standard
```
After this fix the stencil is full,
```
  (1) pair deepmd, perpetual
      attributes: full, newton on
      pair build: full/bin/atomonly
      stencil: full/bin/3d
      bin: standard
```

