### PR TITLE
Fix init-frz-model command implementation

### DIFF
--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -270,4 +270,4 @@ class EnerModel() :
 
     def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
         graph, graph_def = load_graph_def(frz_model)
-        return tf.import_graph_def(graph_def, input_map = feed_dict, return_elements = return_elements)
+        return tf.import_graph_def(graph_def, input_map = feed_dict, return_elements = return_elements, name = "")

--- a/deepmd/model/tensor.py
+++ b/deepmd/model/tensor.py
@@ -191,7 +191,7 @@ class TensorModel() :
 
     def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
         graph, graph_def = load_graph_def(frz_model)
-        return tf.import_graph_def(graph_def, input_map = feed_dict, return_elements = return_elements)
+        return tf.import_graph_def(graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
 
 class WFCModel(TensorModel):
     def __init__(


### PR DESCRIPTION
The `tf.import_graph_def` function prepends 'import' to tensor names, so that we could not load the tensors, such as `o_rmat`, from the frozen model generated by the `init-frz-model` command, which is also discussed by #1133 .

This PR should fix this problem by pass `""` to the `tf.import_graph_def`.

Note this PR was inspired by the related tensorflow [issue](https://github.com/tensorflow/tensorflow/issues/7212).