### PR TITLE
Fix freezing error on checkpoint from parallel training.

### DIFF
--- a/deepmd/entrypoints/freeze.py
+++ b/deepmd/entrypoints/freeze.py
@@ -159,6 +159,11 @@ def freeze(
     clear_devices = True
 
     # We import the meta graph and retrieve a Saver
+    try:
+        # In case paralle training
+        import horovod.tensorflow as _
+    except ImportError:
+        pass
     saver = tf.train.import_meta_graph(
         f"{input_checkpoint}.meta", clear_devices=clear_devices
     )


### PR DESCRIPTION
Fix error when executing `dp test` on checkpoint saved by parallel training:
```
  File "/usr/local/lib/python3.7/dist-packages/deepmd_kit-2.0.0b3.dev51+gae6a5ab-py3.7-linux-x86_64.egg/deepmd/entrypoints/freeze.py", line 155, in freeze
    f"{input_checkpoint}.meta", clear_devices=clear_devices
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/training/saver.py", line 1461, in import_meta_graph
    **kwargs)[0]
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/training/saver.py", line 1485, in _import_meta_graph_with_return_elements
    **kwargs))
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/meta_graph.py", line 804, in import_scoped_meta_graph_with_return_elements
    return_elements=return_elements)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/util/deprecation.py", line 538, in new_func
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/importer.py", line 405, in import_graph_def
    producer_op_list=producer_op_list)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/importer.py", line 497, in _import_graph_def_internal
    graph._c_graph, serialized, options)  # pylint: disable=protected-access
tensorflow.python.framework.errors_impl.NotFoundError: Op type not registered 'HorovodAllreduce' in binary running on n136-080-018. Make sure the Op and Kernel are registered in the binary running in this process. Note that if you are loading a saved graph which used ops from tf.contrib, accessing (e.g.) `tf.contrib.resampler` should be done before importing the graph, as contrib ops are lazily registered when the module is first accessed.
```