### PR TITLE
generate sphinx doc on the fly for training parameters

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -133,8 +133,6 @@ def generate_doxygen_xml(app):
 def generate_train_input(app):
     with open("train-input-auto.rst", 'w') as f:
         f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input"), universal_newlines=True))
-    with open("train-input-auto.json", 'w') as f:
-        f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input", "--out-type", "json"), universal_newlines=True))
 
 def run_apidoc(_):
     from sphinx.ext.apidoc import main

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import subprocess
-# import sys
+import sys
 import recommonmark
 from recommonmark.transform import AutoStructify
 
@@ -130,6 +130,12 @@ def generate_doxygen_xml(app):
     else:
         subprocess.call("doxygen Doxyfile", shell=True)
 
+def generate_train_input(app):
+    with open("train-input-auto.rst", 'w') as f:
+        f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input")))
+    with open("train-input-auto.json", 'w') as f:
+        f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input", "--out-type", "json")))
+
 def run_apidoc(_):
     from sphinx.ext.apidoc import main
     import sys
@@ -143,6 +149,7 @@ def setup(app):
     # Add hook for building doxygen xml when needed
     app.connect("builder-inited", generate_doxygen_xml)
     app.connect('builder-inited', run_apidoc)
+    app.connect('builder-inited', generate_train_input)
 
 # -- General configuration ---------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,9 +132,9 @@ def generate_doxygen_xml(app):
 
 def generate_train_input(app):
     with open("train-input-auto.rst", 'w') as f:
-        f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input")))
+        f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input"), universal_newlines=True))
     with open("train-input-auto.json", 'w') as f:
-        f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input", "--out-type", "json")))
+        f.write(subprocess.check_output((sys.executable, "-m", "deepmd", "doc-train-input", "--out-type", "json"), universal_newlines=True))
 
 def run_apidoc(_):
     from sphinx.ext.apidoc import main


### PR DESCRIPTION
Sometimes we will forget re-generating train-input-auto.rst (e.g. in #1167), so we may want to regenerate it when running sphinx. This will not affect that file on the GitHub.