### PR TITLE
Add model compression support for se_t type descriptor

### DIFF
--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -264,12 +264,12 @@ class DescrptSeT (DescrptSe):
         self.compress = True
         self.table = DPTabulate(
             self.descrpt_name, model_file, activation_fn = self.filter_activation_fn, suffix=suffix)
-        self.table_config = [table_extrapolate, table_stride_1, table_stride_2, check_frequency]
+        self.table_config = [table_extrapolate, table_stride_1 * 10, table_stride_2 * 10, check_frequency]
         self.lower, self.upper \
             = self.table.build(min_nbor_dist, 
                                table_extrapolate, 
-                               table_stride_1, 
-                               table_stride_2)
+                               table_stride_1 * 10, 
+                               table_stride_2 * 10)
         
         graph, _ = load_graph_def(model_file)
         self.davg = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_avg' % suffix)

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -2,7 +2,7 @@ import numpy as np
 from typing import Tuple, List
 
 from deepmd.env import tf
-from deepmd.common import get_activation_func, get_precision, ACTIVATION_FN_DICT, PRECISION_DICT, docstring_parameter
+from deepmd.common import get_activation_func, get_precision, ACTIVATION_FN_DICT, PRECISION_DICT, docstring_parameter, get_np_precision
 from deepmd.utils.argcheck import list_to_doc
 from deepmd.env import GLOBAL_TF_FLOAT_PRECISION
 from deepmd.env import GLOBAL_NP_FLOAT_PRECISION
@@ -10,6 +10,8 @@ from deepmd.env import op_module
 from deepmd.env import default_tf_session_config
 from deepmd.utils.network import embedding_net, embedding_net_rand_seed_shift
 from deepmd.utils.sess import run_sess
+from deepmd.utils.graph import load_graph_def, get_tensor_by_name_from_graph
+from deepmd.utils.tabulate import DPTabulate
 from .descriptor import Descriptor
 from .se import DescrptSe
 
@@ -76,6 +78,7 @@ class DescrptSeT (DescrptSe):
         self.trainable = trainable
         self.filter_activation_fn = get_activation_func(activation_function)
         self.filter_precision = get_precision(precision)
+        self.filter_np_precision = get_np_precision(precision)
         # self.exclude_types = set()
         # for tt in exclude_types:
         #     assert(len(tt) == 2)
@@ -98,7 +101,9 @@ class DescrptSeT (DescrptSe):
         self.useBN = False
         self.dstd = None
         self.davg = None
+        self.compress = False
         self.embedding_net_variables = None
+        self.descrpt_name = type(self).__name__
 
         self.place_holders = {}
         avg_zero = np.zeros([self.ntypes,self.ndescrpt]).astype(GLOBAL_NP_FLOAT_PRECISION)
@@ -222,6 +227,53 @@ class DescrptSeT (DescrptSe):
         if not self.set_davg_zero:
             self.davg = np.array(all_davg)
         self.dstd = np.array(all_dstd)
+
+
+    def enable_compression(self,
+                           min_nbor_dist : float,
+                           model_file : str = 'frozon_model.pb',
+                           table_extrapolate : float = 5,
+                           table_stride_1 : float = 0.01,
+                           table_stride_2 : float = 0.1,
+                           check_frequency : int = -1,
+                           suffix : str = "",
+    ) -> None:
+        """
+        Reveive the statisitcs (distance, max_nbor_size and env_mat_range) of the training data.
+
+        Parameters
+        ----------
+        min_nbor_dist
+                The nearest distance between atoms
+        model_file
+                The original frozen model, which will be compressed by the program
+        table_extrapolate
+                The scale of model extrapolation
+        table_stride_1
+                The uniform stride of the first table
+        table_stride_2
+                The uniform stride of the second table
+        check_frequency
+                The overflow check frequency
+        suffix : str, optional
+                The suffix of the scope
+        """
+        assert (
+            not self.filter_resnet_dt
+        ), "Model compression error: descriptor resnet_dt must be false!"
+        self.compress = True
+        self.table = DPTabulate(
+            self.descrpt_name, model_file, activation_fn = self.filter_activation_fn, suffix=suffix)
+        self.table_config = [table_extrapolate, table_stride_1, table_stride_2, check_frequency]
+        self.lower, self.upper \
+            = self.table.build(min_nbor_dist, 
+                               table_extrapolate, 
+                               table_stride_1, 
+                               table_stride_2)
+        
+        graph, _ = load_graph_def(model_file)
+        self.davg = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_avg' % suffix)
+        self.dstd = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_std' % suffix)
 
 
     def build (self, 
@@ -497,25 +549,30 @@ class DescrptSeT (DescrptSe):
                     env_ij = tf.einsum('ijm,ikm->ijk', env_i, env_j)
                     # with (natom x nei_type_i x nei_type_j)
                     ebd_env_ij = tf.reshape(env_ij, [-1, 1])
-                    # with (natom x nei_type_i x nei_type_j) x out_size
-                    ebd_env_ij = embedding_net(ebd_env_ij, 
-                                               self.filter_neuron, 
-                                               self.filter_precision, 
-                                               activation_fn = activation_fn, 
-                                               resnet_dt = self.filter_resnet_dt,
-                                               name_suffix = f"_{type_i}_{type_j}",
-                                               stddev = stddev,
-                                               bavg = bavg,
-                                               seed = self.seed,
-                                               trainable = trainable, 
-                                               uniform_seed = self.uniform_seed,
-                                               initial_variables = self.embedding_net_variables,
-                                               )
-                    if (not self.uniform_seed) and (self.seed is not None): self.seed += self.seed_shift
-                    # with natom x nei_type_i x nei_type_j x out_size
-                    ebd_env_ij = tf.reshape(ebd_env_ij, [-1, nei_type_i, nei_type_j, outputs_size[-1]])
-                    # with natom x out_size
-                    res_ij = tf.einsum('ijk,ijkm->im', env_ij, ebd_env_ij)
+                    if self.compress:
+                        info = [self.lower, self.upper, self.upper * self.table_config[0], self.table_config[1], self.table_config[2], self.table_config[3]]
+                        net = 'filter_' + str(type_i) + '_net_' + str(type_j)
+                        res_ij = op_module.tabulate_fusion_se_t(self.table.data[net].astype(self.filter_np_precision), info, ebd_env_ij, env_ij, last_layer_size = outputs_size[-1]) 
+                    else:
+                        # with (natom x nei_type_i x nei_type_j) x out_size
+                        ebd_env_ij = embedding_net(ebd_env_ij, 
+                                                   self.filter_neuron, 
+                                                   self.filter_precision, 
+                                                   activation_fn = activation_fn, 
+                                                   resnet_dt = self.filter_resnet_dt,
+                                                   name_suffix = f"_{type_i}_{type_j}",
+                                                   stddev = stddev,
+                                                   bavg = bavg,
+                                                   seed = self.seed,
+                                                   trainable = trainable, 
+                                                   uniform_seed = self.uniform_seed,
+                                                   initial_variables = self.embedding_net_variables,
+                                                   )
+                        if (not self.uniform_seed) and (self.seed is not None): self.seed += self.seed_shift
+                        # with natom x nei_type_i x nei_type_j x out_size
+                        ebd_env_ij = tf.reshape(ebd_env_ij, [-1, nei_type_i, nei_type_j, outputs_size[-1]])
+                        # with natom x out_size
+                        res_ij = tf.einsum('ijk,ijkm->im', env_ij, ebd_env_ij)
                     res_ij = res_ij * (1.0 / float(nei_type_i) / float(nei_type_j))
                     if result is None:
                         result = res_ij

--- a/deepmd/entrypoints/compress.py
+++ b/deepmd/entrypoints/compress.py
@@ -93,8 +93,6 @@ def compress(
         name = 'train_attr/min_nbor_dist',
         dtype = GLOBAL_ENER_FLOAT_PRECISION)
     jdata["model"]["compress"] = {}
-    jdata["model"]["compress"]["type"] = 'se_e2_a'
-    jdata["model"]["compress"]["compress"] = True
     jdata["model"]["compress"]["model_file"] = input
     jdata["model"]["compress"]["min_nbor_dist"] = t_min_nbor_dist
     jdata["model"]["compress"]["table_config"] = [

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -371,13 +371,11 @@ def modifier_variant_type_args():
 
 #  --- model compression configurations: --- #
 def model_compression():
-    doc_compress = f"The name of the frozen model file."
     doc_model_file = f"The input model file, which will be compressed by the DeePMD-kit."
     doc_table_config = f"The arguments of model compression, including extrapolate(scale of model extrapolation), stride(uniform stride of tabulation's first and second table), and frequency(frequency of tabulation overflow check)."
     doc_min_nbor_dist = f"The nearest distance between neighbor atoms saved in the frozen model."
     
     return [
-        Argument("compress", bool, optional = False, doc = doc_compress),
         Argument("model_file", str, optional = False, doc = doc_model_file),
         Argument("table_config", list, optional = False, doc = doc_table_config),
         Argument("min_nbor_dist", float, optional = False, doc = doc_min_nbor_dist),

--- a/examples/water/se_e3/input.json
+++ b/examples/water/se_e3/input.json
@@ -7,7 +7,7 @@
 	    "sel":		"auto",
 	    "rcut_smth":	0.50,
 	    "rcut":		5.80,
-	    "neuron":		[2, 4, 8],
+	    "neuron":		[4, 8, 16],
 	    "resnet_dt":	false,
 	    "seed":		1,
 	    "_comment":		" that's all"

--- a/source/lib/include/tabulate.h
+++ b/source/lib/include/tabulate.h
@@ -3,7 +3,7 @@
 namespace deepmd{
 
 template<typename FPTYPE>
-void tabulate_fusion_cpu(
+void tabulate_fusion_se_a_cpu(
     FPTYPE * out,
     const FPTYPE * table, 
     const FPTYPE * table_info, 
@@ -14,7 +14,7 @@ void tabulate_fusion_cpu(
     const int last_layer_size);
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_cpu(
+void tabulate_fusion_se_a_grad_cpu(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,
     const FPTYPE * table, 
@@ -27,7 +27,7 @@ void tabulate_fusion_grad_cpu(
     const int last_layer_size);
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_grad_cpu(
+void tabulate_fusion_se_a_grad_grad_cpu(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * table_info,
@@ -41,7 +41,7 @@ void tabulate_fusion_grad_grad_cpu(
 
 #if GOOGLE_CUDA
 template<typename FPTYPE>
-void tabulate_fusion_gpu_cuda(
+void tabulate_fusion_se_a_gpu_cuda(
     FPTYPE * out,
     const FPTYPE * table, 
     const FPTYPE * table_info, 
@@ -52,7 +52,7 @@ void tabulate_fusion_gpu_cuda(
     const int last_layer_size);
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_gpu_cuda(
+void tabulate_fusion_se_a_grad_gpu_cuda(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,
     const FPTYPE * table, 
@@ -65,7 +65,7 @@ void tabulate_fusion_grad_gpu_cuda(
     const int last_layer_size);
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_grad_gpu_cuda(
+void tabulate_fusion_se_a_grad_grad_gpu_cuda(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * table_info,
@@ -76,11 +76,51 @@ void tabulate_fusion_grad_grad_gpu_cuda(
     const int nloc,
     const int nnei,
     const int last_layer_size);
+
+template<typename FPTYPE>
+void tabulate_fusion_se_t_gpu_cuda(
+    FPTYPE * out,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const int nloc,
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size);
+
+template<typename FPTYPE>
+void tabulate_fusion_se_t_grad_gpu_cuda(
+    FPTYPE * dy_dem_x, 
+    FPTYPE * dy_dem,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const FPTYPE * dy, 
+    const int nloc, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size);
+
+template<typename FPTYPE>
+void tabulate_fusion_se_t_grad_grad_gpu_cuda(
+    FPTYPE * dz_dy,
+    const FPTYPE * table,
+    const FPTYPE * table_info,
+    const FPTYPE * em_x,
+    const FPTYPE * em,
+    const FPTYPE * dz_dy_dem_x,
+    const FPTYPE * dz_dy_dem,
+    const int nloc,
+    const int nnei_i,
+    const int nnei_j,
+    const int last_layer_size);
 #endif // GOOGLE_CUDA
 
 #if TENSORFLOW_USE_ROCM
 template<typename FPTYPE>
-void tabulate_fusion_gpu_rocm(
+void tabulate_fusion_se_a_gpu_rocm(
     FPTYPE * out,
     const FPTYPE * table, 
     const FPTYPE * table_info, 
@@ -91,7 +131,7 @@ void tabulate_fusion_gpu_rocm(
     const int last_layer_size);
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_gpu_rocm(
+void tabulate_fusion_se_a_grad_gpu_rocm(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,
     const FPTYPE * table, 
@@ -104,7 +144,7 @@ void tabulate_fusion_grad_gpu_rocm(
     const int last_layer_size);
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_grad_gpu_rocm(
+void tabulate_fusion_se_a_grad_grad_gpu_rocm(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * table_info,

--- a/source/lib/include/tabulate.h
+++ b/source/lib/include/tabulate.h
@@ -39,6 +39,46 @@ void tabulate_fusion_se_a_grad_grad_cpu(
     const int nnei,
     const int last_layer_size);
 
+template<typename FPTYPE>
+void tabulate_fusion_se_t_cpu(
+    FPTYPE * out,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const int nloc, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size);
+
+template<typename FPTYPE>
+void tabulate_fusion_se_t_grad_cpu(
+    FPTYPE * dy_dem_x, 
+    FPTYPE * dy_dem,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const FPTYPE * dy, 
+    const int nloc, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size);
+
+template<typename FPTYPE>
+void tabulate_fusion_se_t_grad_grad_cpu(
+    FPTYPE * dz_dy,
+    const FPTYPE * table,
+    const FPTYPE * table_info,
+    const FPTYPE * em_x,
+    const FPTYPE * em,
+    const FPTYPE * dz_dy_dem_x,
+    const FPTYPE * dz_dy_dem,
+    const int nloc,
+    const int nnei_i,
+    const int nnei_j,
+    const int last_layer_size);
+
 #if GOOGLE_CUDA
 template<typename FPTYPE>
 void tabulate_fusion_se_a_gpu_cuda(

--- a/source/lib/src/cuda/tabulate.cu
+++ b/source/lib/src/cuda/tabulate.cu
@@ -38,6 +38,42 @@ void locate_xx(
 }
 
 template <typename FPTYPE>
+__forceinline__ __device__
+void locate_xx_se_t(
+    FPTYPE& xx, 
+    int& table_idx,
+    const FPTYPE& lower, 
+    const FPTYPE& upper,  
+    const FPTYPE& min, 
+    const FPTYPE& max, 
+    const FPTYPE& stride0, 
+    const FPTYPE& stride1)
+{
+  if (xx < min) {
+    table_idx = 0;
+    xx = 0;
+  }
+  else if (xx < lower) {
+    table_idx = (int)((xx - min) / stride1);
+    xx -= (table_idx * stride1 + min);
+  }
+  else if (xx < upper) {
+    int first_stride = int((lower - min) / stride1);
+    table_idx = first_stride + (int)((xx - lower) / stride0);
+    xx -= ((table_idx - first_stride) * stride0 + lower);
+  }
+  else if (xx < max) {
+    int first_stride = int((lower - min) / stride1) + int((upper - lower) / stride0);
+    table_idx = first_stride + (int)((xx - upper) / stride1);
+    xx -= ((table_idx - first_stride) * stride1 + upper);
+  }
+  else {
+    table_idx = int((lower - min) / stride1) + int((upper - lower) / stride0) + (int)((max - upper) / stride1) - 1;
+    xx = 0;
+  }
+}
+
+template <typename FPTYPE>
 __forceinline__ __device__ 
 FPTYPE dot(
     FPTYPE ll[4], 
@@ -60,7 +96,7 @@ template <
     typename FPTYPE,
     int      MTILE,
     int      KTILE> 
-__global__ void tabulate_fusion_fifth_order_polynomial(
+__global__ void tabulate_fusion_se_a_fifth_order_polynomial(
     FPTYPE * out, 
     const FPTYPE * table, 
     const FPTYPE * em_x, 
@@ -111,7 +147,7 @@ template <
     typename FPTYPE,
     int      MTILE,
     int      KTILE> 
-__global__ void tabulate_fusion_grad_fifth_order_polynomial(
+__global__ void tabulate_fusion_se_a_grad_fifth_order_polynomial(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,   
     const FPTYPE * table, 
@@ -191,7 +227,7 @@ template <
     typename FPTYPE,
     int      MTILE,
     int      KTILE>
-__global__ void tabulate_fusion_grad_grad_fifth_order_polynomial(
+__global__ void tabulate_fusion_se_a_grad_grad_fifth_order_polynomial(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * em_x,
@@ -247,9 +283,191 @@ __global__ void tabulate_fusion_grad_grad_fifth_order_polynomial(
   }
 }
 
+template <
+    typename FPTYPE,
+    int      MTILE,
+    int      KTILE> 
+__global__ void tabulate_fusion_se_t_fifth_order_polynomial(
+    FPTYPE * out, 
+    const FPTYPE * table, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const FPTYPE lower, 
+    const FPTYPE upper, 
+    const FPTYPE max, 
+    const FPTYPE stride0, 
+    const FPTYPE stride1, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size) 
+{
+  const int block_idx = blockIdx.x;   // nloc
+  const int thread_idx = threadIdx.x; // last_layer_size
+
+  FPTYPE sum = 0.f;
+  for (int ii = 0; ii < nnei_i; ii++) {
+    FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + nnei_j - 1], 0);
+    int breakpoint = nnei_j - 1;
+    bool unloop = false;
+    for (int jj = 0; jj < nnei_j; jj++) {
+      FPTYPE xx  = em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE tmp = xx;
+      if (xx == ago) {
+        unloop = true;
+        breakpoint = jj - 1;
+      }
+      int table_idx = 0;
+      locate_xx(xx, table_idx, lower, upper, max, stride0, stride1);
+      FPTYPE var[6];
+      var[0] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 0];
+      var[1] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 1];
+      var[2] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 2];
+      var[3] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 3];
+      var[4] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 4];
+      var[5] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 5];
+      FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
+
+      sum += (nnei_j - breakpoint) * tmp * res;
+      if (unloop) break;
+    }
+  }
+  out[block_idx * last_layer_size + thread_idx] = sum;
+}
+
+template <
+    typename FPTYPE,
+    int      MTILE,
+    int      KTILE> 
+__global__ void tabulate_fusion_se_t_grad_fifth_order_polynomial(
+    FPTYPE * dy_dem_x, 
+    FPTYPE * dy_dem,   
+    const FPTYPE * table, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const FPTYPE * dy, 
+    const FPTYPE lower, 
+    const FPTYPE upper, 
+    const FPTYPE max, 
+    const FPTYPE stride0, 
+    const FPTYPE stride1, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size) 
+{
+  extern __shared__ int _data[];
+  const int block_idx = blockIdx.x;  // nloc
+  const int thread_idx = threadIdx.x; // KTILE * WARP_SIZE, usally 128 here~
+  int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / WARP_SIZE, 0);
+  int lane_idx = threadIdx.x % WARP_SIZE;
+  FPTYPE * iteratorA = (FPTYPE *)&_data[0]; // dy
+  for (int ii = thread_idx; ii < last_layer_size; ii += blockDim.x) {
+    iteratorA[ii] = dy[block_idx * last_layer_size + ii];
+  }
+  __syncthreads();
+
+  for (int ii = 0; ii < nnei_i; ii++) {
+    FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + nnei_j - 1], 0);
+    bool unloop = false;
+    for (int jj = warp_idx; jj < nnei_j; jj += KTILE) {
+      FPTYPE xx  = em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE tmp = xx;
+      if (ago == xx) { 
+        unloop = true;
+      }
+      int table_idx = 0;
+      locate_xx(xx, table_idx, lower, upper, max, stride0, stride1);
+      FPTYPE sum  = 0.f;
+      FPTYPE Csub = 0.f;
+      for (int kk = lane_idx; kk < last_layer_size; kk += WARP_SIZE) {
+        FPTYPE var[6]; 
+        // load iteratorB through table 
+        var[0]  = table[table_idx * last_layer_size * 6 + 6 * kk + 0]; 
+        var[1]  = table[table_idx * last_layer_size * 6 + 6 * kk + 1]; 
+        var[2]  = table[table_idx * last_layer_size * 6 + 6 * kk + 2]; 
+        var[3]  = table[table_idx * last_layer_size * 6 + 6 * kk + 3];
+        var[4]  = table[table_idx * last_layer_size * 6 + 6 * kk + 4];
+        var[5]  = table[table_idx * last_layer_size * 6 + 6 * kk + 5];
+        FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
+
+        sum  += iteratorA[kk] * res;
+        Csub += iteratorA[kk] * tmp * (var[1] + (2 * var[2] + (3 * var[3] + (4 * var[4] + 5 * var[5] * xx) * xx) * xx) * xx);
+      }
+      __syncwarp();
+      warp_reduce(sum);
+      warp_reduce(Csub);
+      if (lane_idx == 0) {
+        dy_dem  [block_idx * nnei_i * nnei_j + ii * nnei_j + jj] = sum;
+        dy_dem_x[block_idx * nnei_i * nnei_j + ii * nnei_j + jj] = Csub;
+      }
+      if (unloop) break;
+    }
+  }
+}
+
+template <
+    typename FPTYPE,
+    int      MTILE,
+    int      KTILE>
+__global__ void tabulate_fusion_se_t_grad_grad_fifth_order_polynomial(
+    FPTYPE * dz_dy,
+    const FPTYPE * table,
+    const FPTYPE * em_x,
+    const FPTYPE * em,
+    const FPTYPE * dz_dy_dem_x,
+    const FPTYPE * dz_dy_dem,
+    const FPTYPE lower,
+    const FPTYPE upper,
+    const FPTYPE max,
+    const FPTYPE stride0,
+    const FPTYPE stride1,
+    const int nnei,
+    const int nnei_j,
+    const int last_layer_size)
+{
+  extern __shared__ int _data[];
+  const int block_idx = blockIdx.x;   // nloc
+  const int thread_idx = threadIdx.x; // last_layer_size
+  FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei + nnei - 1], 0);
+  bool unloop = false;
+  int breakpoint = nnei - 1;
+  FPTYPE * iteratorC = (FPTYPE*) &_data[0];
+  for (int kk = 0; kk < MTILE; kk++)
+    iteratorC[kk * last_layer_size + thread_idx] = 0.f;
+  __syncthreads();
+
+  for (int ii = 0; ii < nnei; ii++) {
+    FPTYPE var[6];
+    FPTYPE xx = em_x[block_idx * nnei + ii];
+    FPTYPE dz_xx = dz_dy_dem_x[block_idx * nnei + ii];
+    if (xx == ago) {
+      unloop = true;
+      breakpoint = ii;
+    }
+    int table_idx = 0;
+    locate_xx_se_t(xx, table_idx, lower, upper, -max, max, stride0, stride1);
+    var[0] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 0];
+    var[1] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 1];
+    var[2] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 2];
+    var[3] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 3];
+    var[4] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 4];
+    var[5] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 5];
+    FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
+    FPTYPE res_grad = var[1] + (2 * var[2] + (3 * var[3] + (4 * var[4] + 5 * var[5] * xx) * xx) * xx) * xx;
+
+    for (int kk = 0; kk < MTILE; kk++) {
+      int em_index = block_idx * nnei * MTILE + ii * MTILE + kk;
+      iteratorC[kk * last_layer_size + thread_idx] += (nnei - breakpoint) * (em[em_index] * res_grad * dz_xx + dz_dy_dem[em_index] * res);
+    }
+    if (unloop) break;
+  }
+  for (int ii = 0; ii < MTILE; ii++) {
+    dz_dy[block_idx * MTILE * last_layer_size + ii * last_layer_size + thread_idx] = iteratorC[ii * last_layer_size + thread_idx];
+  }
+}
+
 namespace deepmd {
 template<typename FPTYPE>
-void tabulate_fusion_gpu_cuda(
+void tabulate_fusion_se_a_gpu_cuda(
     FPTYPE * out,
     const FPTYPE * table, 
     const FPTYPE * table_info, 
@@ -260,7 +478,7 @@ void tabulate_fusion_gpu_cuda(
     const int last_layer_size) 
 {
   if (nloc <= 0) {return;}
-  tabulate_fusion_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size>>>(
+  tabulate_fusion_se_a_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size>>>(
       out, 
       table, em_x, em, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei, last_layer_size);
   DPErrcheck(cudaGetLastError());
@@ -268,7 +486,7 @@ void tabulate_fusion_gpu_cuda(
 }
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_gpu_cuda(
+void tabulate_fusion_se_a_grad_gpu_cuda(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,
     const FPTYPE * table, 
@@ -288,7 +506,7 @@ void tabulate_fusion_grad_gpu_cuda(
       dy_dem,
       0.0, sizeof(FPTYPE) * nloc * nnei * 4));
 
-  tabulate_fusion_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, KK * WARP_SIZE, sizeof(FPTYPE) * MM * last_layer_size>>>(
+  tabulate_fusion_se_a_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, KK * WARP_SIZE, sizeof(FPTYPE) * MM * last_layer_size>>>(
       dy_dem_x, dy_dem,
       table, em_x, em, dy,  table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei, last_layer_size);
   DPErrcheck(cudaGetLastError());
@@ -296,7 +514,7 @@ void tabulate_fusion_grad_gpu_cuda(
 }
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_grad_gpu_cuda(
+void tabulate_fusion_se_a_grad_grad_gpu_cuda(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * table_info,
@@ -312,17 +530,98 @@ void tabulate_fusion_grad_grad_gpu_cuda(
   DPErrcheck(cudaMemset(
     dz_dy,
     0.0, sizeof(FPTYPE) * nloc * 4 * last_layer_size));
-  tabulate_fusion_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size>>>(
+  tabulate_fusion_se_a_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size>>>(
       dz_dy,
       table, em_x, em, dz_dy_dem_x, dz_dy_dem, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei, last_layer_size);
   DPErrcheck(cudaGetLastError());
   DPErrcheck(cudaDeviceSynchronize());
 }
 
-template void tabulate_fusion_gpu_cuda<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_gpu_cuda<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_grad_gpu_cuda<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei, const int last_layer_size); 
-template void tabulate_fusion_grad_gpu_cuda<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_grad_grad_gpu_cuda<float> (float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_grad_grad_gpu_cuda<double> (double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+template<typename FPTYPE>
+void tabulate_fusion_se_t_gpu_cuda(
+    FPTYPE * out,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const int nloc,
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size) 
+{
+  if (nloc <= 0) {return;}
+  tabulate_fusion_se_t_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size>>>(
+      out, 
+      table, em_x, em, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei_i, nnei_j, last_layer_size);
+  DPErrcheck(cudaGetLastError());
+  DPErrcheck(cudaDeviceSynchronize());
+}
+
+template<typename FPTYPE>
+void tabulate_fusion_se_t_grad_gpu_cuda(
+    FPTYPE * dy_dem_x, 
+    FPTYPE * dy_dem,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const FPTYPE * dy, 
+    const int nloc, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size)
+{
+  if (nloc <= 0) {return;}
+  DPErrcheck(cudaMemset(
+      dy_dem_x,
+      0.0, sizeof(FPTYPE) * nloc * nnei_i * nnei_j));
+  DPErrcheck(cudaMemset(
+      dy_dem,
+      0.0, sizeof(FPTYPE) * nloc * nnei_i * nnei_j));
+
+  tabulate_fusion_se_t_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, KK * WARP_SIZE, sizeof(FPTYPE) * last_layer_size>>>(
+      dy_dem_x, dy_dem,
+      table, em_x, em, dy,  table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei_i, nnei_j, last_layer_size);
+  DPErrcheck(cudaGetLastError());
+  DPErrcheck(cudaDeviceSynchronize());
+}
+
+template<typename FPTYPE>
+void tabulate_fusion_se_t_grad_grad_gpu_cuda(
+    FPTYPE * dz_dy,
+    const FPTYPE * table,
+    const FPTYPE * table_info,
+    const FPTYPE * em_x,
+    const FPTYPE * em,
+    const FPTYPE * dz_dy_dem_x,
+    const FPTYPE * dz_dy_dem,
+    const int nloc,
+    const int nnei_i,
+    const int nnei_j,
+    const int last_layer_size)
+{
+  if (nloc <= 0) {return;}
+  DPErrcheck(cudaMemset(
+    dz_dy,
+    0.0, sizeof(FPTYPE) * nloc * last_layer_size));
+  tabulate_fusion_se_t_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size>>>(
+      dz_dy,
+      table, em_x, em, dz_dy_dem_x, dz_dy_dem, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei_i, nnei_j, last_layer_size);
+  DPErrcheck(cudaGetLastError());
+  DPErrcheck(cudaDeviceSynchronize());
+}
+
+template void tabulate_fusion_se_a_gpu_cuda<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_gpu_cuda<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_grad_gpu_cuda<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei, const int last_layer_size); 
+template void tabulate_fusion_se_a_grad_gpu_cuda<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_grad_grad_gpu_cuda<float> (float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_grad_grad_gpu_cuda<double> (double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+
+template void tabulate_fusion_se_t_gpu_cuda<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void tabulate_fusion_se_t_gpu_cuda<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void tabulate_fusion_se_t_grad_gpu_cuda<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size); 
+template void tabulate_fusion_se_t_grad_gpu_cuda<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void tabulate_fusion_se_t_grad_grad_gpu_cuda<float> (float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void tabulate_fusion_se_t_grad_grad_gpu_cuda<double> (double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
 }

--- a/source/lib/src/cuda/tabulate.cu
+++ b/source/lib/src/cuda/tabulate.cu
@@ -317,7 +317,7 @@ __global__ void tabulate_fusion_se_t_fifth_order_polynomial(
         breakpoint = jj - 1;
       }
       int table_idx = 0;
-      locate_xx(xx, table_idx, lower, upper, max, stride0, stride1);
+      locate_xx_se_t(xx, table_idx, lower, upper, -max, max, stride0, stride1);
       FPTYPE var[6];
       var[0] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 0];
       var[1] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 1];
@@ -375,7 +375,7 @@ __global__ void tabulate_fusion_se_t_grad_fifth_order_polynomial(
         unloop = true;
       }
       int table_idx = 0;
-      locate_xx(xx, table_idx, lower, upper, max, stride0, stride1);
+      locate_xx_se_t(xx, table_idx, lower, upper, -max, max, stride0, stride1);
       FPTYPE sum  = 0.f;
       FPTYPE Csub = 0.f;
       for (int kk = lane_idx; kk < last_layer_size; kk += WARP_SIZE) {

--- a/source/lib/src/rocm/tabulate.hip.cu
+++ b/source/lib/src/rocm/tabulate.hip.cu
@@ -60,7 +60,7 @@ template <
     typename FPTYPE,
     int      MTILE,
     int      KTILE> 
-__global__ void tabulate_fusion_fifth_order_polynomial(
+__global__ void tabulate_fusion_se_a_fifth_order_polynomial(
     FPTYPE * out, 
     const FPTYPE * table, 
     const FPTYPE * em_x, 
@@ -115,7 +115,7 @@ template <
     typename FPTYPE,
     int      MTILE,
     int      KTILE> 
-__global__ void tabulate_fusion_grad_fifth_order_polynomial(
+__global__ void tabulate_fusion_se_a_grad_fifth_order_polynomial(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,   
     const FPTYPE * table, 
@@ -196,7 +196,7 @@ template <
     typename FPTYPE,
     int      MTILE,
     int      KTILE>
-__global__ void tabulate_fusion_grad_grad_fifth_order_polynomial(
+__global__ void tabulate_fusion_se_a_grad_grad_fifth_order_polynomial(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * em_x,
@@ -254,7 +254,7 @@ __global__ void tabulate_fusion_grad_grad_fifth_order_polynomial(
 
 namespace deepmd {
 template<typename FPTYPE>
-void tabulate_fusion_gpu_rocm(
+void tabulate_fusion_se_a_gpu_rocm(
     FPTYPE * out,
     const FPTYPE * table, 
     const FPTYPE * table_info, 
@@ -265,7 +265,7 @@ void tabulate_fusion_gpu_rocm(
     const int last_layer_size) 
 {
   if(nloc <= 0){return;}
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size, 0, 
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_se_a_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size, 0, 
       out, 
       table, em_x, em, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei, last_layer_size);
   DPErrcheck(hipGetLastError());
@@ -273,7 +273,7 @@ void tabulate_fusion_gpu_rocm(
 }
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_gpu_rocm(
+void tabulate_fusion_se_a_grad_gpu_rocm(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,
     const FPTYPE * table, 
@@ -293,7 +293,7 @@ void tabulate_fusion_grad_gpu_rocm(
       dy_dem,
       0.0, sizeof(FPTYPE) * nloc * nnei * 4));
 
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_grad_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, KK * WARP_SIZE, sizeof(FPTYPE) * MM * last_layer_size, 0, 
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_se_a_grad_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, KK * WARP_SIZE, sizeof(FPTYPE) * MM * last_layer_size, 0, 
       dy_dem_x, dy_dem,
       table, em_x, em, dy,  table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei, last_layer_size);
   DPErrcheck(hipGetLastError());
@@ -301,7 +301,7 @@ void tabulate_fusion_grad_gpu_rocm(
 }
 
 template<typename FPTYPE>
-void tabulate_fusion_grad_grad_gpu_rocm(
+void tabulate_fusion_se_a_grad_grad_gpu_rocm(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * table_info,
@@ -317,17 +317,17 @@ void tabulate_fusion_grad_grad_gpu_rocm(
   DPErrcheck(hipMemset(
     dz_dy,
     0.0, sizeof(FPTYPE) * nloc * 4 * last_layer_size));
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size, 0, 
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_se_a_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size, 0, 
     dz_dy,
     table, em_x, em, dz_dy_dem_x, dz_dy_dem, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei, last_layer_size);
   DPErrcheck(hipGetLastError());
   DPErrcheck(hipDeviceSynchronize());
 }
 
-template void tabulate_fusion_gpu_rocm<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_gpu_rocm<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_grad_gpu_rocm<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei, const int last_layer_size); 
-template void tabulate_fusion_grad_gpu_rocm<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_grad_grad_gpu_rocm<float> (float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
-template void tabulate_fusion_grad_grad_gpu_rocm<double> (double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_gpu_rocm<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_gpu_rocm<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_grad_gpu_rocm<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei, const int last_layer_size); 
+template void tabulate_fusion_se_a_grad_gpu_rocm<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_grad_grad_gpu_rocm<float> (float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+template void tabulate_fusion_se_a_grad_grad_gpu_rocm<double> (double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
 }

--- a/source/lib/src/tabulate.cc
+++ b/source/lib/src/tabulate.cc
@@ -51,7 +51,7 @@ inline FPTYPE dot(
 }
 
 template<typename FPTYPE>
-void deepmd::tabulate_fusion_cpu(
+void deepmd::tabulate_fusion_se_a_cpu(
     FPTYPE * out,
     const FPTYPE * table, 
     const FPTYPE * table_info, 
@@ -112,7 +112,7 @@ void deepmd::tabulate_fusion_cpu(
 }
 
 template<typename FPTYPE>
-void deepmd::tabulate_fusion_grad_cpu(
+void deepmd::tabulate_fusion_se_a_grad_cpu(
     FPTYPE * dy_dem_x, 
     FPTYPE * dy_dem,
     const FPTYPE * table, 
@@ -187,7 +187,7 @@ void deepmd::tabulate_fusion_grad_cpu(
 }
 
 template<typename FPTYPE>
-void deepmd::tabulate_fusion_grad_grad_cpu(
+void deepmd::tabulate_fusion_se_a_grad_grad_cpu(
     FPTYPE * dz_dy,
     const FPTYPE * table,
     const FPTYPE * table_info,
@@ -256,9 +256,9 @@ void deepmd::tabulate_fusion_grad_grad_cpu(
   }
 }
 
-template void deepmd::tabulate_fusion_cpu<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei, const int last_layer_size);
-template void deepmd::tabulate_fusion_cpu<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei, const int last_layer_size);
-template void deepmd::tabulate_fusion_grad_cpu<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei, const int last_layer_size); 
-template void deepmd::tabulate_fusion_grad_cpu<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei, const int last_layer_size);
-template void deepmd::tabulate_fusion_grad_grad_cpu<float>(float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
-template void deepmd::tabulate_fusion_grad_grad_cpu<double>(double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_a_cpu<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_a_cpu<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_a_grad_cpu<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei, const int last_layer_size); 
+template void deepmd::tabulate_fusion_se_a_grad_cpu<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_a_grad_grad_cpu<float>(float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_a_grad_grad_cpu<double>(double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);

--- a/source/lib/src/tabulate.cc
+++ b/source/lib/src/tabulate.cc
@@ -42,6 +42,42 @@ inline void locate_xx(
   }
 }
 
+
+template <typename FPTYPE>
+inline void locate_xx_se_t(
+    const FPTYPE& lower, 
+    const FPTYPE& upper,  
+    const FPTYPE& min, 
+    const FPTYPE& max, 
+    const FPTYPE& stride0, 
+    const FPTYPE& stride1,
+    FPTYPE& xx, 
+    int& table_idx)
+{
+  if (xx < min) {
+    table_idx = 0;
+    xx = 0;
+  }
+  else if (xx < lower) {
+    table_idx = (int)((xx - min) / stride1);
+    xx -= (table_idx * stride1 + min);
+  }
+  else if (xx < upper) {
+    int first_stride = int((lower - min) / stride1);
+    table_idx = first_stride + (int)((xx - lower) / stride0);
+    xx -= ((table_idx - first_stride) * stride0 + lower);
+  }
+  else if (xx < max) {
+    int first_stride = int((lower - min) / stride1) + int((upper - lower) / stride0);
+    table_idx = first_stride + (int)((xx - upper) / stride1);
+    xx -= ((table_idx - first_stride) * stride1 + upper);
+  }
+  else {
+    table_idx = int((lower - min) / stride1) + int((upper - lower) / stride0) + (int)((max - upper) / stride1) - 1;
+    xx = 0;
+  }
+}
+
 template <typename FPTYPE>
 inline FPTYPE dot(
     FPTYPE a[4], 
@@ -256,9 +292,207 @@ void deepmd::tabulate_fusion_se_a_grad_grad_cpu(
   }
 }
 
+template<typename FPTYPE>
+void deepmd::tabulate_fusion_se_t_cpu(
+    FPTYPE * out,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const int nloc, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size)
+{
+  memset(out, 0.0, sizeof(FPTYPE) * nloc * last_layer_size);
+  const FPTYPE lower   = table_info[0];
+  const FPTYPE upper   = table_info[1];
+  const FPTYPE _max    = table_info[2];
+  const FPTYPE stride0 = table_info[3];
+  const FPTYPE stride1 = table_info[4];
+  // for every atom, execute a small manual gemm ~
+  // FPTYPE * res = new FPTYPE[4 * last_layer_size];
+  #pragma omp parallel for
+  for (int ii = 0; ii < nloc; ii++) {
+    for (int jj = 0; jj < nnei_i; jj++) {
+      FPTYPE ago = em_x[ii * nnei_i * nnei_j + jj * nnei_j + nnei_j - 1];
+      bool unloop = false; 
+      for (int kk = 0; kk < nnei_j; kk++) { 
+        FPTYPE xx = em_x[ii * nnei_i * nnei_j + jj * nnei_j + kk];
+        FPTYPE ll = xx;
+        if (ago == xx) {
+          unloop = true;
+        }
+        int table_idx = 0;
+        locate_xx_se_t(lower, upper, -_max, _max, stride0, stride1, xx, table_idx);
+        for (int mm = 0; mm < last_layer_size; mm++) {
+          FPTYPE a0  = table[table_idx * last_layer_size * 6 + 6 * mm + 0]; 
+          FPTYPE a1  = table[table_idx * last_layer_size * 6 + 6 * mm + 1]; 
+          FPTYPE a2  = table[table_idx * last_layer_size * 6 + 6 * mm + 2]; 
+          FPTYPE a3  = table[table_idx * last_layer_size * 6 + 6 * mm + 3];
+          FPTYPE a4  = table[table_idx * last_layer_size * 6 + 6 * mm + 4];
+          FPTYPE a5  = table[table_idx * last_layer_size * 6 + 6 * mm + 5];
+          FPTYPE var = a0 + (a1 + (a2 + (a3 + (a4 + a5 * xx) * xx) * xx) * xx) * xx;
+          if (unloop) {
+            out[ii * last_layer_size + mm] += (nnei_j - kk) * var * ll;
+          }
+          else {
+            out[ii * last_layer_size + mm] += var * ll;
+          }
+        }
+        if (unloop) break;
+      }
+    }
+  }
+}
+
+template<typename FPTYPE>
+void deepmd::tabulate_fusion_se_t_grad_cpu(
+    FPTYPE * dy_dem_x, 
+    FPTYPE * dy_dem,
+    const FPTYPE * table, 
+    const FPTYPE * table_info, 
+    const FPTYPE * em_x, 
+    const FPTYPE * em, 
+    const FPTYPE * dy, 
+    const int nloc, 
+    const int nnei_i, 
+    const int nnei_j, 
+    const int last_layer_size) 
+{
+  memset(dy_dem_x, 0.0, sizeof(FPTYPE) * nloc * nnei_i * nnei_j);
+  memset(dy_dem,   0.0, sizeof(FPTYPE) * nloc * nnei_i * nnei_j);
+  FPTYPE const lower   = table_info[0];
+  FPTYPE const upper   = table_info[1];
+  FPTYPE const _max    = table_info[2];
+  FPTYPE const stride0 = table_info[3];
+  FPTYPE const stride1 = table_info[4];
+  // for every atom, execute a small gemm~
+  // FPTYPE * res = new FPTYPE[4 * last_layer_size];
+  #pragma omp parallel for
+  for (int ii = 0; ii < nloc; ii++) {
+    FPTYPE ll = 0;
+    FPTYPE rr = 0;
+    for (int jj = 0; jj < nnei_i; jj++) {
+      FPTYPE ago = em_x[ii * nnei_i * nnei_j + jj * nnei_j + nnei_j - 1];
+      bool unloop = false;
+      for (int kk = 0; kk < nnei_j; kk++) {
+        // construct the dy/dx
+        FPTYPE xx = em_x[ii * nnei_i * nnei_j + jj * nnei_j + kk];
+        ll = xx;
+        if (ago == xx) {
+          unloop = true;
+        }
+        int table_idx = 0;
+        locate_xx_se_t(lower, upper, -_max, _max, stride0, stride1, xx, table_idx);
+        FPTYPE grad = 0.0;
+        for (int mm = 0; mm < last_layer_size; mm++) {
+          rr = dy[ii * last_layer_size + mm];
+          FPTYPE a0  = table[table_idx * last_layer_size * 6 + 6 * mm + 0]; 
+          FPTYPE a1  = table[table_idx * last_layer_size * 6 + 6 * mm + 1]; 
+          FPTYPE a2  = table[table_idx * last_layer_size * 6 + 6 * mm + 2]; 
+          FPTYPE a3  = table[table_idx * last_layer_size * 6 + 6 * mm + 3];
+          FPTYPE a4  = table[table_idx * last_layer_size * 6 + 6 * mm + 4];
+          FPTYPE a5  = table[table_idx * last_layer_size * 6 + 6 * mm + 5];
+          FPTYPE res = a0 + (a1 + (a2 + (a3 + (a4 + a5 * xx) * xx) * xx) * xx) * xx;
+
+          if (unloop) {
+            grad += (a1 + (2 * a2 + (3 * a3 + (4 * a4 + 5 * a5 * xx) * xx) * xx) * xx) * ll * rr * (nnei_j - kk);
+            dy_dem[ii * nnei_i * nnei_j + jj * nnei_j + kk] += res * rr * (nnei_j - kk);
+          }
+          else {
+            grad += (a1 + (2 * a2 + (3 * a3 + (4 * a4 + 5 * a5 * xx) * xx) * xx) * xx) * ll * rr;
+            dy_dem[ii * nnei_i * nnei_j + jj * nnei_j + kk] += res * rr;
+          }
+        }
+        dy_dem_x[ii * nnei_i * nnei_j + jj * nnei_j + kk] = grad;
+        if (unloop) break;
+      }
+    }
+  }
+}
+
+template<typename FPTYPE>
+void deepmd::tabulate_fusion_se_t_grad_grad_cpu(
+    FPTYPE * dz_dy,
+    const FPTYPE * table,
+    const FPTYPE * table_info,
+    const FPTYPE * em_x,
+    const FPTYPE * em,
+    const FPTYPE * dz_dy_dem_x,
+    const FPTYPE * dz_dy_dem,
+    const int nloc,
+    const int nnei,
+    const int nnei_j,
+    const int last_layer_size)
+{
+  memset(dz_dy, 0.0, sizeof(FPTYPE) * nloc * 4 * last_layer_size);
+  const FPTYPE lower   = table_info[0];
+  const FPTYPE upper   = table_info[1];
+  const FPTYPE _max    = table_info[2];
+  const FPTYPE stride0 = table_info[3];
+  const FPTYPE stride1 = table_info[4];
+  // for every atom, execute a small manual gemm ~
+  // FPTYPE * res = new FPTYPE[4 * last_layer_size];
+  #pragma omp parallel for
+  for (int ii = 0; ii < nloc; ii++) {
+    FPTYPE ll[4];
+    FPTYPE hh[4];
+    FPTYPE ago = em_x[ii * nnei + nnei - 1];
+    bool unloop = false;
+    for (int jj = 0; jj < nnei; jj++) {
+      ll[0] = em[ii * nnei * 4 + jj * 4 + 0];
+      ll[1] = em[ii * nnei * 4 + jj * 4 + 1];
+      ll[2] = em[ii * nnei * 4 + jj * 4 + 2];
+      ll[3] = em[ii * nnei * 4 + jj * 4 + 3];
+      hh[0] = dz_dy_dem[ii * nnei * 4 + jj * 4 + 0];
+      hh[1] = dz_dy_dem[ii * nnei * 4 + jj * 4 + 1];
+      hh[2] = dz_dy_dem[ii * nnei * 4 + jj * 4 + 2];
+      hh[3] = dz_dy_dem[ii * nnei * 4 + jj * 4 + 3];
+      FPTYPE xx = em_x[ii * nnei + jj];
+      FPTYPE dz_xx = dz_dy_dem_x[ii * nnei + jj];
+      if (ago == xx) {
+        unloop = true;
+      }
+      int table_idx = 0;
+      locate_xx(lower, upper, _max, stride0, stride1, xx, table_idx);
+      for (int kk = 0; kk < last_layer_size; kk++) {
+        FPTYPE a0  = table[table_idx * last_layer_size * 6 + 6 * kk + 0];
+        FPTYPE a1  = table[table_idx * last_layer_size * 6 + 6 * kk + 1];
+        FPTYPE a2  = table[table_idx * last_layer_size * 6 + 6 * kk + 2];
+        FPTYPE a3  = table[table_idx * last_layer_size * 6 + 6 * kk + 3];
+        FPTYPE a4  = table[table_idx * last_layer_size * 6 + 6 * kk + 4];
+        FPTYPE a5  = table[table_idx * last_layer_size * 6 + 6 * kk + 5];
+        FPTYPE var = a0 + (a1 + (a2 + (a3 + (a4 + a5 * xx) * xx) * xx) * xx) * xx;
+        FPTYPE var_grad = a1 + (2 * a2 + (3 * a3 + (4 * a4 + 5 * a5 * xx) * xx) * xx) * xx;
+        if (unloop) {
+          dz_dy[ii * last_layer_size * 4 + 0 * last_layer_size + kk] += (nnei - jj) * (var * hh[0] + dz_xx * var_grad * ll[0]);
+          dz_dy[ii * last_layer_size * 4 + 1 * last_layer_size + kk] += (nnei - jj) * (var * hh[1] + dz_xx * var_grad * ll[1]);
+          dz_dy[ii * last_layer_size * 4 + 2 * last_layer_size + kk] += (nnei - jj) * (var * hh[2] + dz_xx * var_grad * ll[2]);
+          dz_dy[ii * last_layer_size * 4 + 3 * last_layer_size + kk] += (nnei - jj) * (var * hh[3] + dz_xx * var_grad * ll[3]);
+        }
+        else {
+          dz_dy[ii * last_layer_size * 4 + 0 * last_layer_size + kk] += var * hh[0] + dz_xx * var_grad * ll[0];
+          dz_dy[ii * last_layer_size * 4 + 1 * last_layer_size + kk] += var * hh[1] + dz_xx * var_grad * ll[1];
+          dz_dy[ii * last_layer_size * 4 + 2 * last_layer_size + kk] += var * hh[2] + dz_xx * var_grad * ll[2];
+          dz_dy[ii * last_layer_size * 4 + 3 * last_layer_size + kk] += var * hh[3] + dz_xx * var_grad * ll[3];
+        }
+      }
+      if (unloop) break;
+    }
+  }
+}
+
 template void deepmd::tabulate_fusion_se_a_cpu<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei, const int last_layer_size);
 template void deepmd::tabulate_fusion_se_a_cpu<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei, const int last_layer_size);
 template void deepmd::tabulate_fusion_se_a_grad_cpu<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei, const int last_layer_size); 
 template void deepmd::tabulate_fusion_se_a_grad_cpu<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei, const int last_layer_size);
 template void deepmd::tabulate_fusion_se_a_grad_grad_cpu<float>(float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
 template void deepmd::tabulate_fusion_se_a_grad_grad_cpu<double>(double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei, const int last_layer_size);
+
+template void deepmd::tabulate_fusion_se_t_cpu<float>(float * out, const float * table, const float * table_info, const float * em_x, const float * em, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_t_cpu<double>(double * out, const double * table, const double * table_info, const double * em_x, const double * em, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_t_grad_cpu<float> (float * dy_dem_x, float * dy_dem, const float * table, const float * table_info, const float * em_x, const float * em, const float * dy, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size); 
+template void deepmd::tabulate_fusion_se_t_grad_cpu<double> (double * dy_dem_x, double * dy_dem, const double * table, const double * table_info, const double * em_x, const double * em, const double * dy, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_t_grad_grad_cpu<float>(float * dz_dy, const float * table, const float * table_info, const float * em_x, const float * em, const float * dz_dy_dem_x, const float * dz_dy_dem, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);
+template void deepmd::tabulate_fusion_se_t_grad_grad_cpu<double>(double * dz_dy, const double * table, const double * table_info, const double * em_x, const double * em, const double * dz_dy_dem_x, const double * dz_dy_dem, const int nloc, const int nnei_i, const int nnei_j, const int last_layer_size);

--- a/source/lib/tests/test_tabulate.cc
+++ b/source/lib/tests/test_tabulate.cc
@@ -144,10 +144,10 @@ protected:
   }
 };
 
-TEST_F(TestTabulate, tabulate_fusion_cpu)
+TEST_F(TestTabulate, tabulate_fusion_se_a_cpu)
 {
   std::vector<double> xyz_scatter(nloc * nnei * last_layer_size);
-  deepmd::tabulate_fusion_cpu<double>(&xyz_scatter[0], &table[0], &info[0], &em_x[0], &em[0], nloc, nnei, last_layer_size);
+  deepmd::tabulate_fusion_se_a_cpu<double>(&xyz_scatter[0], &table[0], &info[0], &em_x[0], &em[0], nloc, nnei, last_layer_size);
   EXPECT_EQ(xyz_scatter.size(), nloc * nnei * last_layer_size);
   EXPECT_EQ(xyz_scatter.size(), expected_xyz_scatter.size());
   for (int jj = 0; jj < xyz_scatter.size(); ++jj){
@@ -155,12 +155,12 @@ TEST_F(TestTabulate, tabulate_fusion_cpu)
   }
 }
 
-TEST_F(TestTabulate, tabulate_fusion_grad_cpu)
+TEST_F(TestTabulate, tabulate_fusion_se_a_grad_cpu)
 {
   std::vector<double> dy_dem_x(em_x.size());
   std::vector<double> dy_dem(em.size());
   std::vector<double> dy(nloc * nnei * last_layer_size, 1.0);
-  deepmd::tabulate_fusion_grad_cpu<double>(&dy_dem_x[0], &dy_dem[0], &table[0], &info[0], &em_x[0], &em[0], &dy[0], nloc, nnei, last_layer_size);
+  deepmd::tabulate_fusion_se_a_grad_cpu<double>(&dy_dem_x[0], &dy_dem[0], &table[0], &info[0], &em_x[0], &em[0], &dy[0], nloc, nnei, last_layer_size);
   EXPECT_EQ(dy_dem_x.size(), nloc * nnei);
   EXPECT_EQ(dy_dem.size(), nloc * nnei * 4);
   EXPECT_EQ(dy_dem_x.size(), expected_dy_dem_x.size());
@@ -174,7 +174,7 @@ TEST_F(TestTabulate, tabulate_fusion_grad_cpu)
 }
 
 #if GOOGLE_CUDA
-TEST_F(TestTabulate, tabulate_fusion_gpu_cuda)
+TEST_F(TestTabulate, tabulate_fusion_se_a_gpu_cuda)
 {
   std::vector<double> xyz_scatter(nloc * nnei * last_layer_size, 0.0);
 
@@ -183,7 +183,7 @@ TEST_F(TestTabulate, tabulate_fusion_gpu_cuda)
   deepmd::malloc_device_memory_sync(table_dev, table);
   deepmd::malloc_device_memory_sync(em_x_dev, em_x);
   deepmd::malloc_device_memory_sync(em_dev, em);
-  deepmd::tabulate_fusion_gpu_cuda<double>(xyz_scatter_dev, table_dev, &info[0], em_x_dev, em_dev, nloc, nnei, last_layer_size);
+  deepmd::tabulate_fusion_se_a_gpu_cuda<double>(xyz_scatter_dev, table_dev, &info[0], em_x_dev, em_dev, nloc, nnei, last_layer_size);
   deepmd::memcpy_device_to_host(xyz_scatter_dev, xyz_scatter);
   deepmd::delete_device_memory(xyz_scatter_dev);
   deepmd::delete_device_memory(table_dev);
@@ -197,7 +197,7 @@ TEST_F(TestTabulate, tabulate_fusion_gpu_cuda)
   }
 }
 
-TEST_F(TestTabulate, tabulate_fusion_grad_gpu_cuda)
+TEST_F(TestTabulate, tabulate_fusion_se_a_grad_gpu_cuda)
 {
   std::vector<double> dy_dem_x(em_x.size(), 0.0);
   std::vector<double> dy_dem(em.size(), 0.0);
@@ -210,7 +210,7 @@ TEST_F(TestTabulate, tabulate_fusion_grad_gpu_cuda)
   deepmd::malloc_device_memory_sync(em_x_dev, em_x);
   deepmd::malloc_device_memory_sync(em_dev, em);
   deepmd::malloc_device_memory_sync(dy_dev, dy);
-  deepmd::tabulate_fusion_grad_gpu_cuda<double>(dy_dem_x_dev, dy_dem_dev, table_dev, &info[0], em_x_dev, em_dev, dy_dev, nloc, nnei, last_layer_size);
+  deepmd::tabulate_fusion_se_a_grad_gpu_cuda<double>(dy_dem_x_dev, dy_dem_dev, table_dev, &info[0], em_x_dev, em_dev, dy_dev, nloc, nnei, last_layer_size);
   deepmd::memcpy_device_to_host(dy_dem_x_dev, dy_dem_x);
   deepmd::memcpy_device_to_host(dy_dem_dev, dy_dem);
   deepmd::delete_device_memory(dy_dem_x_dev);
@@ -234,7 +234,7 @@ TEST_F(TestTabulate, tabulate_fusion_grad_gpu_cuda)
 #endif // GOOGLE_CUDA
 
 #if TENSORFLOW_USE_ROCM
-TEST_F(TestTabulate, tabulate_fusion_gpu_rocm)
+TEST_F(TestTabulate, tabulate_fusion_se_a_gpu_rocm)
 {
   std::vector<double> xyz_scatter(nloc * nnei * last_layer_size, 0.0);
 
@@ -243,7 +243,7 @@ TEST_F(TestTabulate, tabulate_fusion_gpu_rocm)
   deepmd::malloc_device_memory_sync(table_dev, table);
   deepmd::malloc_device_memory_sync(em_x_dev, em_x);
   deepmd::malloc_device_memory_sync(em_dev, em);
-  deepmd::tabulate_fusion_gpu_rocm<double>(xyz_scatter_dev, table_dev, &info[0], em_x_dev, em_dev, nloc, nnei, last_layer_size);
+  deepmd::tabulate_fusion_se_a_gpu_rocm<double>(xyz_scatter_dev, table_dev, &info[0], em_x_dev, em_dev, nloc, nnei, last_layer_size);
   deepmd::memcpy_device_to_host(xyz_scatter_dev, xyz_scatter);
   deepmd::delete_device_memory(xyz_scatter_dev);
   deepmd::delete_device_memory(table_dev);
@@ -257,7 +257,7 @@ TEST_F(TestTabulate, tabulate_fusion_gpu_rocm)
   }
 }
 
-TEST_F(TestTabulate, tabulate_fusion_grad_gpu_rocm)
+TEST_F(TestTabulate, tabulate_fusion_se_a_grad_gpu_rocm)
 {
   std::vector<double> dy_dem_x(em_x.size(), 0.0);
   std::vector<double> dy_dem(em.size(), 0.0);
@@ -270,7 +270,7 @@ TEST_F(TestTabulate, tabulate_fusion_grad_gpu_rocm)
   deepmd::malloc_device_memory_sync(em_x_dev, em_x);
   deepmd::malloc_device_memory_sync(em_dev, em);
   deepmd::malloc_device_memory_sync(dy_dev, dy);
-  deepmd::tabulate_fusion_grad_gpu_rocm<double>(dy_dem_x_dev, dy_dem_dev, table_dev, &info[0], em_x_dev, em_dev, dy_dev, nloc, nnei, last_layer_size);
+  deepmd::tabulate_fusion_se_a_grad_gpu_rocm<double>(dy_dem_x_dev, dy_dem_dev, table_dev, &info[0], em_x_dev, em_dev, dy_dev, nloc, nnei, last_layer_size);
   deepmd::memcpy_device_to_host(dy_dem_x_dev, dy_dem_x);
   deepmd::memcpy_device_to_host(dy_dem_dev, dy_dem);
   deepmd::delete_device_memory(dy_dem_x_dev);

--- a/source/op/_tabulate_grad.py
+++ b/source/op/_tabulate_grad.py
@@ -8,12 +8,22 @@ from deepmd.env import op_module
 from deepmd.env import tf
 # from deepmd.DescrptSeATabulate import last_layer_size
 
-@ops.RegisterGradient("TabulateFusion")
-def _tabulate_fusion_grad_cc (op, dy):    
-    dy_dx, dy_df = op_module.tabulate_fusion_grad(op.inputs[0], op.inputs[1], op.inputs[2], op.inputs[3], dy, op.outputs[0])
+@ops.RegisterGradient("TabulateFusionSeA")
+def _tabulate_fusion_se_a_grad_cc (op, dy):    
+    dy_dx, dy_df = op_module.tabulate_fusion_se_a_grad(op.inputs[0], op.inputs[1], op.inputs[2], op.inputs[3], dy, op.outputs[0])
     return [None, None, dy_dx, dy_df]
 
-@ops.RegisterGradient("TabulateFusionGrad")
-def _tabulate_fusion_grad_grad_cc (op, dy, dy_):
-    dz_dy = op_module.tabulate_fusion_grad_grad(op.inputs[0], op.inputs[1], op.inputs[2], op.inputs[3], dy, dy_, op.inputs[5])
+@ops.RegisterGradient("TabulateFusionSeAGrad")
+def _tabulate_fusion_se_a_grad_grad_cc (op, dy, dy_):
+    dz_dy = op_module.tabulate_fusion_se_a_grad_grad(op.inputs[0], op.inputs[1], op.inputs[2], op.inputs[3], dy, dy_, op.inputs[5])
+    return [None, None, None, None, dz_dy, None]
+
+@ops.RegisterGradient("TabulateFusionSeT")
+def _tabulate_fusion_se_t_grad_cc (op, dy):    
+    dy_dx, dy_df = op_module.tabulate_fusion_se_t_grad(op.inputs[0], op.inputs[1], op.inputs[2], op.inputs[3], dy, op.outputs[0])
+    return [None, None, dy_dx, dy_df]
+
+@ops.RegisterGradient("TabulateFusionSeTGrad")
+def _tabulate_fusion_se_t_grad_grad_cc (op, dy, dy_):
+    dz_dy = op_module.tabulate_fusion_se_t_grad_grad(op.inputs[0], op.inputs[1], op.inputs[2], op.inputs[3], dy, dy_, op.inputs[5])
     return [None, None, None, None, dz_dy, None]

--- a/source/op/tabulate_multi_device.cc
+++ b/source/op/tabulate_multi_device.cc
@@ -354,9 +354,9 @@ class TabulateFusionSeTOp : public OpKernel {
       #endif // TENSORFLOW_USE_ROCM
     }
     else if (device == "CPU") {
-    //   deepmd::tabulate_fusion_se_t_cpu(    
-    //       descriptor,
-    //       table, table_info, em_x, em, nloc, nnei_i, nnei_j, last_layer_size);
+      deepmd::tabulate_fusion_se_t_cpu(    
+          descriptor,
+          table, table_info, em_x, em, nloc, nnei_i, nnei_j, last_layer_size);
     }
   }
 private:
@@ -427,9 +427,9 @@ class TabulateFusionSeTGradOp : public OpKernel {
       #endif // TENSORFLOW_USE_ROCM
     }
     else if (device == "CPU") {
-    //   deepmd::tabulate_fusion_se_t_grad_cpu(    
-    //       dy_dem_x, dy_dem,
-    //       table, table_info, em_x, em, dy, nloc, nnei_i, nnei_j, last_layer_size);
+      deepmd::tabulate_fusion_se_t_grad_cpu(    
+          dy_dem_x, dy_dem,
+          table, table_info, em_x, em, dy, nloc, nnei_i, nnei_j, last_layer_size);
     }
   }
 private:
@@ -491,9 +491,9 @@ class TabulateFusionSeTGradGradOp : public OpKernel {
       OP_REQUIRES (context, (last_layer_size <= 1024),      errors::InvalidArgument ("In the process of model compression, the size of the last layer of embedding net must be less than 1024!"));
     }
     else if (device == "CPU") {
-    //   deepmd::tabulate_fusion_se_t_grad_grad_cpu(
-    //       dz_dy,
-    //       table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei, last_layer_size);
+      deepmd::tabulate_fusion_se_t_grad_grad_cpu(
+          dz_dy,
+          table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei_i, nnei_j, last_layer_size);
     }
   }
 private:

--- a/source/op/tabulate_multi_device.cc
+++ b/source/op/tabulate_multi_device.cc
@@ -32,10 +32,72 @@ REGISTER_OP("TabulateFusionGradGrad")
     .Input("descriptor: T")
     .Output("dz_dy: T");
 
+REGISTER_OP("TabulateFusionSeA")
+    .Attr("T: {float, double} = DT_DOUBLE")
+    .Input("table: T")
+    .Input("table_info: T")
+    .Input("em_x: T")
+    .Input("em: T")
+    .Attr("last_layer_size: int")
+    .Output("descriptor: T");
+
+REGISTER_OP("TabulateFusionSeAGrad")
+    .Attr("T: {float, double} = DT_DOUBLE")
+    .Input("table: T")
+    .Input("table_info: T")
+    .Input("em_x: T")
+    .Input("em: T")
+    .Input("dy: T")        
+    .Input("descriptor: T")         
+    .Output("dy_dem_x: T")
+    .Output("dy_dem: T");
+
+REGISTER_OP("TabulateFusionSeAGradGrad")
+    .Attr("T: {float, double}")
+    .Input("table: T")
+    .Input("table_info: T")
+    .Input("em_x: T")
+    .Input("em: T")
+    .Input("dz_dy_dem_x: T")
+    .Input("dz_dy_dem: T")
+    .Input("descriptor: T")
+    .Output("dz_dy: T");
+
+REGISTER_OP("TabulateFusionSeT")
+    .Attr("T: {float, double} = DT_DOUBLE")
+    .Input("table: T")
+    .Input("table_info: T")
+    .Input("em_x: T")
+    .Input("em: T")
+    .Attr("last_layer_size: int")
+    .Output("descriptor: T");
+
+REGISTER_OP("TabulateFusionSeTGrad")
+    .Attr("T: {float, double} = DT_DOUBLE")
+    .Input("table: T")
+    .Input("table_info: T")
+    .Input("em_x: T")
+    .Input("em: T")
+    .Input("dy: T")        
+    .Input("descriptor: T")  
+    .Output("dy_dem_x: T")
+    .Output("dy_dem: T");
+
+REGISTER_OP("TabulateFusionSeTGradGrad")
+    .Attr("T: {float, double}")
+    .Input("table: T")
+    .Input("table_info: T")
+    .Input("em_x: T")
+    .Input("em: T")
+    .Input("dz_dy_dem_x: T")
+    .Input("dz_dy_dem: T")
+    .Input("descriptor: T")
+    .Output("dz_dy: T");
+
 template<typename Device, typename FPTYPE>
-class TabulateFusionOp : public OpKernel {
+class TabulateFusionSeAOp : public OpKernel {
  public:
-  explicit TabulateFusionOp(OpKernelConstruction* context) : OpKernel(context) {
+  explicit TabulateFusionSeAOp(OpKernelConstruction* context) : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("last_layer_size", &last_layer_size));
   }
   void Compute(OpKernelContext* context) override {
@@ -78,19 +140,19 @@ class TabulateFusionOp : public OpKernel {
 
     if (device == "GPU") {
       #if GOOGLE_CUDA
-      deepmd::tabulate_fusion_gpu_cuda(    
+      deepmd::tabulate_fusion_se_a_gpu_cuda(    
           descriptor,
           table, table_info, em_x, em, nloc, nnei, last_layer_size);
       #endif // GOOGLE_CUDA
 
       #if TENSORFLOW_USE_ROCM
-      deepmd::tabulate_fusion_gpu_rocm(    
+      deepmd::tabulate_fusion_se_a_gpu_rocm(    
           descriptor,
           table, table_info, em_x, em, nloc, nnei, last_layer_size);
       #endif // TENSORFLOW_USE_ROCM
     }
     else if (device == "CPU") {
-      deepmd::tabulate_fusion_cpu(    
+      deepmd::tabulate_fusion_se_a_cpu(    
           descriptor,
           table, table_info, em_x, em, nloc, nnei, last_layer_size);
     }
@@ -101,9 +163,9 @@ private:
 };
 
 template<typename Device, typename FPTYPE>
-class TabulateFusionGradOp : public OpKernel {
+class TabulateFusionSeAGradOp : public OpKernel {
  public:
-  explicit TabulateFusionGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+  explicit TabulateFusionSeAGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
       deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
   }
@@ -150,19 +212,19 @@ class TabulateFusionGradOp : public OpKernel {
 
     if (device == "GPU") {
       #if GOOGLE_CUDA
-      deepmd::tabulate_fusion_grad_gpu_cuda(    
+      deepmd::tabulate_fusion_se_a_grad_gpu_cuda(    
           dy_dem_x, dy_dem,
           table, table_info, em_x, em, dy, nloc, nnei, last_layer_size);
       #endif // GOOGLE_CUDA
       
       #if TENSORFLOW_USE_ROCM
-      deepmd::tabulate_fusion_grad_gpu_rocm(    
+      deepmd::tabulate_fusion_se_a_grad_gpu_rocm(    
           dy_dem_x, dy_dem,
           table, table_info, em_x, em, dy, nloc, nnei, last_layer_size);
       #endif // TENSORFLOW_USE_ROCM
     }
     else if (device == "CPU") {
-      deepmd::tabulate_fusion_grad_cpu(    
+      deepmd::tabulate_fusion_se_a_grad_cpu(    
           dy_dem_x, dy_dem,
           table, table_info, em_x, em, dy, nloc, nnei, last_layer_size);
     }
@@ -172,9 +234,9 @@ private:
 };
 
 template<typename Device, typename FPTYPE>
-class TabulateFusionGradGradOp : public OpKernel {
+class TabulateFusionSeAGradGradOp : public OpKernel {
  public:
-  explicit TabulateFusionGradGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+  explicit TabulateFusionSeAGradGradOp(OpKernelConstruction* context) : OpKernel(context) {}
   void Compute(OpKernelContext* context) override {
     // Grab the input tensor
     int context_input_index = 0;
@@ -213,19 +275,19 @@ class TabulateFusionGradGradOp : public OpKernel {
 
     if (device == "GPU") {
       #if GOOGLE_CUDA
-      deepmd::tabulate_fusion_grad_grad_gpu_cuda(
+      deepmd::tabulate_fusion_se_a_grad_grad_gpu_cuda(
           dz_dy,
           table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei, last_layer_size);
       #endif // GOOGLE_CUDA
       #if TENSORFLOW_USE_ROCM
-      deepmd::tabulate_fusion_grad_grad_gpu_rocm(
+      deepmd::tabulate_fusion_se_a_grad_grad_gpu_rocm(
           dz_dy,
           table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei, last_layer_size);
       #endif // TENSORFLOW_USE_ROCM
       OP_REQUIRES (context, (last_layer_size <= 1024),      errors::InvalidArgument ("In the process of model compression, the size of the last layer of embedding net must be less than 1024!"));
     }
     else if (device == "CPU") {
-      deepmd::tabulate_fusion_grad_grad_cpu(
+      deepmd::tabulate_fusion_se_a_grad_grad_cpu(
           dz_dy,
           table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei, last_layer_size);
     }
@@ -234,30 +296,270 @@ private:
     std::string device;
 };
 
-#define REGISTER_CPU(T)                                                                                 \
-REGISTER_KERNEL_BUILDER(                                                                                \
-    Name("TabulateFusion").Device(DEVICE_CPU).TypeConstraint<T>("T").HostMemory("table_info"),          \
-    TabulateFusionOp<CPUDevice, T>);                                                                    \
-REGISTER_KERNEL_BUILDER(                                                                                \
-    Name("TabulateFusionGrad").Device(DEVICE_CPU).TypeConstraint<T>("T").HostMemory("table_info"),      \
-    TabulateFusionGradOp<CPUDevice, T>);                                                                \
-REGISTER_KERNEL_BUILDER(                                                                                \
-    Name("TabulateFusionGradGrad").Device(DEVICE_CPU).TypeConstraint<T>("T").HostMemory("table_info"),  \
-    TabulateFusionGradGradOp<CPUDevice, T>);                                              
+template<typename Device, typename FPTYPE>
+class TabulateFusionSeTOp : public OpKernel {
+ public:
+  explicit TabulateFusionSeTOp(OpKernelConstruction* context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("last_layer_size", &last_layer_size));
+  }
+  void Compute(OpKernelContext* context) override {
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
+    // Grab the input tensor
+    int context_input_index = 0;
+    const Tensor& table_tensor	= context->input(context_input_index++);
+    const Tensor& table_info_tensor = context->input(context_input_index++);
+    const Tensor& em_x_tensor	= context->input(context_input_index++);
+    const Tensor& em_tensor	= context->input(context_input_index++);
+    // set size of the sample
+    OP_REQUIRES (context, (table_tensor.shape().dims() == 2),   errors::InvalidArgument ("Dim of table should be 2"));
+    OP_REQUIRES (context, (em_x_tensor.shape().dims() == 2),    errors::InvalidArgument ("Dim of em_x_tensor should be 2"));
+    OP_REQUIRES (context, (em_tensor.shape().dims() == 3),      errors::InvalidArgument ("Dim of em_tensor should be 3"));
+    TensorShape descriptor_shape;
+    descriptor_shape.AddDim (em_tensor.shape().dim_size(0));
+    descriptor_shape.AddDim (last_layer_size);
+    int context_output_index = 0;
+    Tensor* descriptor_tensor = NULL;
+    OP_REQUIRES_OK(context, context->allocate_output(
+        context_output_index++,
+	  		descriptor_shape,
+	  		&descriptor_tensor));
+    DeviceFunctor() (
+        device,
+        context->eigen_device<Device>()
+    );
+    // flat the tensors
+    FPTYPE * descriptor = descriptor_tensor->flat<FPTYPE>().data();
+    const FPTYPE * table = table_tensor.flat<FPTYPE>().data();
+    const FPTYPE * table_info = table_info_tensor.flat<FPTYPE>().data();
+    const FPTYPE * em_x = em_x_tensor.flat<FPTYPE>().data();
+    const FPTYPE * em = em_tensor.flat<FPTYPE>().data();
+    const int nloc = em_tensor.shape().dim_size(0);
+    const int nnei_i = em_tensor.shape().dim_size(1);
+    const int nnei_j = em_tensor.shape().dim_size(2);
+
+    if (device == "GPU") {
+      #if GOOGLE_CUDA
+      deepmd::tabulate_fusion_se_t_gpu_cuda(    
+          descriptor,
+          table, table_info, em_x, em, nloc, nnei_i, nnei_j, last_layer_size);
+      #endif // GOOGLE_CUDA
+
+      #if TENSORFLOW_USE_ROCM
+      deepmd::tabulate_fusion_se_t_gpu_rocm(    
+          descriptor,
+          table, table_info, em_x, em, nloc, nnei_i, nnei_j, last_layer_size);
+      #endif // TENSORFLOW_USE_ROCM
+    }
+    else if (device == "CPU") {
+    //   deepmd::tabulate_fusion_se_t_cpu(    
+    //       descriptor,
+    //       table, table_info, em_x, em, nloc, nnei_i, nnei_j, last_layer_size);
+    }
+  }
+private:
+    int last_layer_size;
+    std::string device;
+};
+
+template<typename Device, typename FPTYPE>
+class TabulateFusionSeTGradOp : public OpKernel {
+ public:
+  explicit TabulateFusionSeTGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+  void Compute(OpKernelContext* context) override {
+      deepmd::safe_compute(context, [this](OpKernelContext* context) {this->_Compute(context);});
+  }
+
+  void _Compute(OpKernelContext* context) {
+    // Grab the input tensor
+    int context_input_index = 0;
+    const Tensor& table_tensor	= context->input(context_input_index++);
+    const Tensor& table_info_tensor = context->input(context_input_index++);
+    const Tensor& em_x_tensor	= context->input(context_input_index++);
+    const Tensor& em_tensor	= context->input(context_input_index++);
+    const Tensor& dy_tensor	= context->input(context_input_index++);
+    const Tensor& descriptor_tensor = context->input(context_input_index++);
+    // set size of the sample
+    OP_REQUIRES (context, (dy_tensor.shape().dims() == 2), errors::InvalidArgument ("Dim of dy_tensor should be 2"));
+    int context_output_index = 0;
+    Tensor* dy_dem_x_tensor = NULL;
+    OP_REQUIRES_OK(context, context->allocate_output(
+        context_output_index++,
+	  		em_x_tensor.shape(),
+        &dy_dem_x_tensor));
+    Tensor* dy_dem_tensor = NULL;
+    OP_REQUIRES_OK(context, context->allocate_output(
+        context_output_index++,
+	  		em_tensor.shape(),
+	  		&dy_dem_tensor));
+    DeviceFunctor() (
+        device,
+        context->eigen_device<Device>()
+    );
+
+    // flat the tensors
+    FPTYPE * dy_dem_x = dy_dem_x_tensor->flat<FPTYPE>().data();
+    FPTYPE * dy_dem = dy_dem_tensor->flat<FPTYPE>().data();
+    const FPTYPE * descriptor = descriptor_tensor.flat<FPTYPE>().data();
+    const FPTYPE * table = table_tensor.flat<FPTYPE>().data();
+    const FPTYPE * table_info = table_info_tensor.flat<FPTYPE>().data();
+    const FPTYPE * em_x = em_x_tensor.flat<FPTYPE>().data();
+    const FPTYPE * em = em_tensor.flat<FPTYPE>().data();
+    const FPTYPE * dy = dy_tensor.flat<FPTYPE>().data();
+    const int nloc = em_tensor.shape().dim_size(0);
+    const int nnei_i = em_tensor.shape().dim_size(1);
+    const int nnei_j = em_tensor.shape().dim_size(2);
+    const int last_layer_size = descriptor_tensor.shape().dim_size(1);
+
+    if (device == "GPU") {
+      #if GOOGLE_CUDA
+      deepmd::tabulate_fusion_se_t_grad_gpu_cuda(    
+          dy_dem_x, dy_dem,
+          table, table_info, em_x, em, dy, nloc, nnei_i, nnei_j, last_layer_size);
+      #endif // GOOGLE_CUDA
+      
+      #if TENSORFLOW_USE_ROCM
+      deepmd::tabulate_fusion_se_t_grad_gpu_rocm(    
+          dy_dem_x, dy_dem,
+          table, table_info, em_x, em, dy, nloc, nnei_i, nnei_j, last_layer_size);
+      #endif // TENSORFLOW_USE_ROCM
+    }
+    else if (device == "CPU") {
+    //   deepmd::tabulate_fusion_se_t_grad_cpu(    
+    //       dy_dem_x, dy_dem,
+    //       table, table_info, em_x, em, dy, nloc, nnei_i, nnei_j, last_layer_size);
+    }
+  }
+private:
+    std::string device;
+};
+
+template<typename Device, typename FPTYPE>
+class TabulateFusionSeTGradGradOp : public OpKernel {
+ public:
+  explicit TabulateFusionSeTGradGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+  void Compute(OpKernelContext* context) override {
+    // Grab the input tensor
+    int context_input_index = 0;
+    const Tensor& table_tensor	= context->input(context_input_index++);
+    const Tensor& table_info_tensor = context->input(context_input_index++);
+    const Tensor& em_x_tensor	= context->input(context_input_index++);
+    const Tensor& em_tensor	= context->input(context_input_index++);
+    const Tensor& dz_dy_dem_x_tensor	= context->input(context_input_index++);
+    const Tensor& dz_dy_dem_tensor	= context->input(context_input_index++);
+    const Tensor& descriptor_tensor = context->input(context_input_index++);
+    // set size of the sample
+    OP_REQUIRES (context, (dz_dy_dem_x_tensor.shape().dims() == 2),    errors::InvalidArgument ("Dim of input should be 2"));
+    OP_REQUIRES (context, (dz_dy_dem_tensor.shape().dims() == 3),      errors::InvalidArgument ("Dim of input should be 3"));
+    int context_output_index = 0;
+    Tensor* dz_dy_tensor = NULL;
+    OP_REQUIRES_OK(context, context->allocate_output(
+        context_output_index++,
+	  		descriptor_tensor.shape(),
+        &dz_dy_tensor));
+    DeviceFunctor() (
+        device,
+        context->eigen_device<Device>()
+    );
+
+    // flat the tensors
+    FPTYPE * dz_dy = dz_dy_tensor->flat<FPTYPE>().data();
+    const FPTYPE * table = table_tensor.flat<FPTYPE>().data();
+    const FPTYPE * table_info = table_info_tensor.flat<FPTYPE>().data();
+    const FPTYPE * em_x = em_x_tensor.flat<FPTYPE>().data();
+    const FPTYPE * em = em_tensor.flat<FPTYPE>().data();
+    const FPTYPE * dz_dy_dem_x = dz_dy_dem_x_tensor.flat<FPTYPE>().data();
+    const FPTYPE * dz_dy_dem = dz_dy_dem_tensor.flat<FPTYPE>().data();
+    const int nloc = em_tensor.shape().dim_size(0);
+    const int nnei_i = em_tensor.shape().dim_size(1);
+    const int nnei_j = em_tensor.shape().dim_size(2);
+    const int last_layer_size = descriptor_tensor.shape().dim_size(2);
+
+    if (device == "GPU") {
+      #if GOOGLE_CUDA
+      deepmd::tabulate_fusion_se_t_grad_grad_gpu_cuda(
+          dz_dy,
+          table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei_i, nnei_j, last_layer_size);
+      #endif // GOOGLE_CUDA
+      #if TENSORFLOW_USE_ROCM
+      deepmd::tabulate_fusion_se_t_grad_grad_gpu_rocm(
+          dz_dy,
+          table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei_i, nnei_j, last_layer_size);
+      #endif // TENSORFLOW_USE_ROCM
+      OP_REQUIRES (context, (last_layer_size <= 1024),      errors::InvalidArgument ("In the process of model compression, the size of the last layer of embedding net must be less than 1024!"));
+    }
+    else if (device == "CPU") {
+    //   deepmd::tabulate_fusion_se_t_grad_grad_cpu(
+    //       dz_dy,
+    //       table, table_info, em_x, em, dz_dy_dem_x, dz_dy_dem, nloc, nnei, last_layer_size);
+    }
+  }
+private:
+    std::string device;
+};
+
+#define REGISTER_CPU(T)                                                                \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusion").Device(DEVICE_CPU).TypeConstraint<T>("T"),                  \
+    TabulateFusionSeAOp<CPUDevice, T>);                                                \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"),              \
+    TabulateFusionSeAGradOp<CPUDevice, T>);                                            \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionGradGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"),          \
+    TabulateFusionSeAGradGradOp<CPUDevice, T>);                                        \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionSeA").Device(DEVICE_CPU).TypeConstraint<T>("T"),               \
+    TabulateFusionSeAOp<CPUDevice, T>);                                                \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionSeAGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"),           \
+    TabulateFusionSeAGradOp<CPUDevice, T>);                                            \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionSeAGradGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"),       \
+    TabulateFusionSeAGradGradOp<CPUDevice, T>);                                        \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionSeT").Device(DEVICE_CPU).TypeConstraint<T>("T"),               \
+    TabulateFusionSeTOp<CPUDevice, T>);                                                \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionSeTGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"),           \
+    TabulateFusionSeTGradOp<CPUDevice, T>);                                            \
+REGISTER_KERNEL_BUILDER(                                                               \
+    Name("TabulateFusionSeTGradGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"),       \
+    TabulateFusionSeTGradGradOp<CPUDevice, T>);                                              
 REGISTER_CPU(float);
 REGISTER_CPU(double);
 
 #if  GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-#define REGISTER_GPU(T)                                                                                 \
-REGISTER_KERNEL_BUILDER(                                                                                \
-    Name("TabulateFusion").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),          \
-    TabulateFusionOp<GPUDevice, T>);                                                                    \
-REGISTER_KERNEL_BUILDER(                                                                                \
-    Name("TabulateFusionGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),      \
-    TabulateFusionGradOp<GPUDevice, T>);                                                                \
-REGISTER_KERNEL_BUILDER(                                                                                \
-    Name("TabulateFusionGradGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),  \
-    TabulateFusionGradGradOp<GPUDevice, T>);                                                      
+#define REGISTER_GPU(T)                                                                                     \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusion").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),              \
+    TabulateFusionSeAOp<GPUDevice, T>);                                                                     \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),          \
+    TabulateFusionSeAGradOp<GPUDevice, T>);                                                                 \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionGradGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),      \
+    TabulateFusionSeAGradGradOp<GPUDevice, T>);                                                             \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionSeA").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),           \
+    TabulateFusionSeAOp<GPUDevice, T>);                                                                     \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionSeAGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),       \
+    TabulateFusionSeAGradOp<GPUDevice, T>);                                                                 \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionSeAGradGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),   \
+    TabulateFusionSeAGradGradOp<GPUDevice, T>);                                                             \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionSeT").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),           \
+    TabulateFusionSeTOp<GPUDevice, T>);                                                                     \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionSeTGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),       \
+    TabulateFusionSeTGradOp<GPUDevice, T>);                                                                 \
+REGISTER_KERNEL_BUILDER(                                                                                    \
+    Name("TabulateFusionSeTGradGrad").Device(DEVICE_GPU).TypeConstraint<T>("T").HostMemory("table_info"),   \
+    TabulateFusionSeTGradGradOp<GPUDevice, T>);                                                     
 REGISTER_GPU(float);
 REGISTER_GPU(double);
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
With the help of @liangadam , we have added the  model compression support for the `se_t` type descriptor. The main changes are:

- Reconstruct the DPTabulate class for the support the of 'se_t' type;
- Change the op name from `TabulateFusion` to `TabulateFusionSeA` for `se_a` type;
- Add op `TabulateFusionSeT` for 'se_t' type, and put the corresponding CPU and GPU implementations in tabulate.cc and tabulate.cu;
- Add enable_model_compression method for 'se_t.py';
- The default step of 'se_t' is 10 times larger than 'se_a'.

By using the default water example benchmark system, we found that the lammps output of the se_t compressed model is consistent. And with the embedding net size setting[25, 50, 100], [4, 8, 16], the compressed model gains speedup by a factor of 20(single V100 GPU) and 12(CPU) correspondingly.

TODO:

- [ ] Add unit test for 'se_t' model compression;
- [ ] Add doc support for 'se_t' model compression;
- [ ] Fix the bug of accuracy when the last_layer_size of embedding net is equal to 8.