### PR TITLE
Fix the bug when type_map has only one element

### DIFF
--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -507,15 +507,9 @@ class DeepmdData() :
 
     def _load_type_map(self, sys_path: DPPath) :
         fname = sys_path / 'type_map.raw'
-        if fname.is_file():
-            tmap = fname.load_txt(dtype=str).tolist()
-            # if there is an array file of length=1 array will load only the string
-            # not an array of length=1 containing the string 
-            if isinstance(tmap, str):
-                return [tmap]
-            else:
-                return tmap
-        else:
+        if fname.is_file() :            
+            return fname.load_txt(dtype=str, ndmin=1).tolist()
+        else :
             return None
 
     def _check_pbc(self, sys_path: DPPath):


### PR DESCRIPTION
Numpy has a bit odd behavior I ran into. The method `ndarray.loadtxt()` when loading from array file of length 1 outputs only the array element, not array of length=1.

```python
import numpy as np

np.__version__
"1.20.3"

!cat array.raw
A

np.loadtxt("array.raw").tolist()
"A"
```

This breaks code in this place: https://github.com/deepmodeling/deepmd-kit/blob/5a8479660a28f2fd31bafd2e5f3ab2a6549b7cfa/deepmd/utils/data.py#L62 the list comprehension will try to iterate through characters in string and fail.