### PR TITLE
add init-frz-model support for se-t type descriptor

### DIFF
--- a/source/lib/src/cuda/tabulate.cu
+++ b/source/lib/src/cuda/tabulate.cu
@@ -420,49 +420,43 @@ __global__ void tabulate_fusion_se_t_grad_grad_fifth_order_polynomial(
     const FPTYPE max,
     const FPTYPE stride0,
     const FPTYPE stride1,
-    const int nnei,
+    const int nnei_i,
     const int nnei_j,
     const int last_layer_size)
 {
-  extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;   // nloc
+  const int block_idx  = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
-  FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei + nnei - 1], 0);
-  bool unloop = false;
-  int breakpoint = nnei - 1;
-  FPTYPE * iteratorC = (FPTYPE*) &_data[0];
-  for (int kk = 0; kk < MTILE; kk++)
-    iteratorC[kk * last_layer_size + thread_idx] = 0.f;
-  __syncthreads();
 
-  for (int ii = 0; ii < nnei; ii++) {
-    FPTYPE var[6];
-    FPTYPE xx = em_x[block_idx * nnei + ii];
-    FPTYPE dz_xx = dz_dy_dem_x[block_idx * nnei + ii];
-    if (xx == ago) {
-      unloop = true;
-      breakpoint = ii;
-    }
-    int table_idx = 0;
-    locate_xx_se_t(xx, table_idx, lower, upper, -max, max, stride0, stride1);
-    var[0] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 0];
-    var[1] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 1];
-    var[2] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 2];
-    var[3] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 3];
-    var[4] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 4];
-    var[5] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 5];
-    FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
-    FPTYPE res_grad = var[1] + (2 * var[2] + (3 * var[3] + (4 * var[4] + 5 * var[5] * xx) * xx) * xx) * xx;
+  FPTYPE sum = 0.f;
+  for (int ii = 0; ii < nnei_i; ii++) { 
+    FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + nnei_j - 1], 0);
+    bool unloop = false;
+    for (int jj = 0; ii < nnei_j; jj++) {
+      FPTYPE xx  = em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE tmp = xx;
+      FPTYPE dz_xx = dz_dy_dem_x[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE dz_em = dz_dy_dem[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE var[6];
+      if (ago == xx) { 
+        unloop = true;
+      }
 
-    for (int kk = 0; kk < MTILE; kk++) {
-      int em_index = block_idx * nnei * MTILE + ii * MTILE + kk;
-      iteratorC[kk * last_layer_size + thread_idx] += (nnei - breakpoint) * (em[em_index] * res_grad * dz_xx + dz_dy_dem[em_index] * res);
+      int table_idx = 0;
+      locate_xx_se_t(xx, table_idx, lower, upper, -max, max, stride0, stride1);
+      var[0] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 0];
+      var[1] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 1];
+      var[2] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 2];
+      var[3] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 3];
+      var[4] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 4];
+      var[5] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 5];
+      FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
+      FPTYPE res_grad = var[1] + (2 * var[2] + (3 * var[3] + (4 * var[4] + 5 * var[5] * xx) * xx) * xx) * xx;
+  
+      sum += (tmp * res_grad * dz_xx + dz_em * res);
+      if (unloop) break;
     }
-    if (unloop) break;
   }
-  for (int ii = 0; ii < MTILE; ii++) {
-    dz_dy[block_idx * MTILE * last_layer_size + ii * last_layer_size + thread_idx] = iteratorC[ii * last_layer_size + thread_idx];
-  }
+  dz_dy[block_idx * last_layer_size + thread_idx] = sum;
 }
 
 namespace deepmd {
@@ -604,7 +598,8 @@ void tabulate_fusion_se_t_grad_grad_gpu_cuda(
   DPErrcheck(cudaMemset(
     dz_dy,
     0.0, sizeof(FPTYPE) * nloc * last_layer_size));
-  tabulate_fusion_se_t_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size, sizeof(FPTYPE) * MM * last_layer_size>>>(
+
+  tabulate_fusion_se_t_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK> <<<nloc, last_layer_size>>>(
       dz_dy,
       table, em_x, em, dz_dy_dem_x, dz_dy_dem, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei_i, nnei_j, last_layer_size);
   DPErrcheck(cudaGetLastError());

--- a/source/lib/src/rocm/tabulate.hip.cu
+++ b/source/lib/src/rocm/tabulate.hip.cu
@@ -430,45 +430,39 @@ __global__ void tabulate_fusion_se_t_grad_grad_fifth_order_polynomial(
     const int nnei_j,
     const int last_layer_size)
 {
-  extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;   // nloc
+  const int block_idx  = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
-  FPTYPE ago = __shfl( em_x[block_idx * nnei + nnei - 1], 0);
-  bool unloop = false;
-  int breakpoint = nnei - 1;
-  FPTYPE * iteratorC = (FPTYPE*) &_data[0];
-  for (int kk = 0; kk < MTILE; kk++)
-    iteratorC[kk * last_layer_size + thread_idx] = 0.f;
-  __syncthreads();
 
-  for (int ii = 0; ii < nnei; ii++) {
-    FPTYPE var[6];
-    FPTYPE xx = em_x[block_idx * nnei + ii];
-    FPTYPE dz_xx = dz_dy_dem_x[block_idx * nnei + ii];
-    if (xx == ago) {
-      unloop = true;
-      breakpoint = ii;
-    }
-    int table_idx = 0;
-    locate_xx(xx, table_idx, lower, upper, max, stride0, stride1);
-    var[0] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 0];
-    var[1] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 1];
-    var[2] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 2];
-    var[3] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 3];
-    var[4] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 4];
-    var[5] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 5];
-    FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
-    FPTYPE res_grad = var[1] + (2 * var[2] + (3 * var[3] + (4 * var[4] + 5 * var[5] * xx) * xx) * xx) * xx;
+  FPTYPE sum = 0.f;
+  for (int ii = 0; ii < nnei_i; ii++) { 
+    FPTYPE ago = __shfl(em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + nnei_j - 1], 0);
+    bool unloop = false;
+    for (int jj = 0; ii < nnei_j; jj++) {
+      FPTYPE xx  = em_x[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE tmp = xx;
+      FPTYPE dz_xx = dz_dy_dem_x[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE dz_em = dz_dy_dem[block_idx * nnei_i * nnei_j + ii * nnei_j + jj];
+      FPTYPE var[6];
+      if (ago == xx) { 
+        unloop = true;
+      }
 
-    for (int kk = 0; kk < MTILE; kk++) {
-      int em_index = block_idx * nnei * MTILE + ii * MTILE + kk;
-      iteratorC[kk * last_layer_size + thread_idx] += (nnei - breakpoint) * (em[em_index] * res_grad * dz_xx + dz_dy_dem[em_index] * res);
+      int table_idx = 0;
+      locate_xx_se_t(xx, table_idx, lower, upper, -max, max, stride0, stride1);
+      var[0] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 0];
+      var[1] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 1];
+      var[2] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 2];
+      var[3] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 3];
+      var[4] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 4];
+      var[5] = table[table_idx * last_layer_size * 6 + thread_idx * 6 + 5];
+      FPTYPE res = var[0] + (var[1] + (var[2] + (var[3] + (var[4] + var[5] * xx) * xx) * xx) * xx) * xx;
+      FPTYPE res_grad = var[1] + (2 * var[2] + (3 * var[3] + (4 * var[4] + 5 * var[5] * xx) * xx) * xx) * xx;
+  
+      sum += (tmp * res_grad * dz_xx + dz_em * res);
+      if (unloop) break;
     }
-    if (unloop) break;
   }
-  for (int ii = 0; ii < MTILE; ii++) {
-    dz_dy[block_idx * MTILE * last_layer_size + ii * last_layer_size + thread_idx] = iteratorC[ii * last_layer_size + thread_idx];
-  }
+  dz_dy[block_idx * last_layer_size + thread_idx] = sum;
 }
 
 namespace deepmd {
@@ -610,7 +604,7 @@ void tabulate_fusion_se_t_grad_grad_gpu_rocm(
   DPErrcheck(hipMemset(
     dz_dy,
     0.0, sizeof(FPTYPE) * nloc * last_layer_size));
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_se_t_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, last_layer_size, sizeof(FPTYPE) * last_layer_size, 0, 
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(tabulate_fusion_se_t_grad_grad_fifth_order_polynomial<FPTYPE, MM, KK>), nloc, last_layer_size, 0, 0, 
     dz_dy,
     table, em_x, em, dz_dy_dem_x, dz_dy_dem, table_info[0], table_info[1], table_info[2], table_info[3], table_info[4], nnei_i, nnei_j, last_layer_size);
   DPErrcheck(hipGetLastError());

--- a/source/op/tabulate_multi_device.cc
+++ b/source/op/tabulate_multi_device.cc
@@ -472,10 +472,10 @@ class TabulateFusionSeTGradGradOp : public OpKernel {
     const FPTYPE * em = em_tensor.flat<FPTYPE>().data();
     const FPTYPE * dz_dy_dem_x = dz_dy_dem_x_tensor.flat<FPTYPE>().data();
     const FPTYPE * dz_dy_dem = dz_dy_dem_tensor.flat<FPTYPE>().data();
-    const int nloc = em_tensor.shape().dim_size(0);
+    const int nloc   = em_tensor.shape().dim_size(0);
     const int nnei_i = em_tensor.shape().dim_size(1);
     const int nnei_j = em_tensor.shape().dim_size(2);
-    const int last_layer_size = descriptor_tensor.shape().dim_size(2);
+    const int last_layer_size = descriptor_tensor.shape().dim_size(1);
 
     if (device == "GPU") {
       #if GOOGLE_CUDA


### PR DESCRIPTION
Add `init-frz-model` support for set-t type descriptors.

lcurve.out shows that the compression training process of the se_t type has the same result as the original training process of the first step:

```
root se_e3 $ head compress.out 
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      2.16e+01    1.86e+01      1.91e-02    1.30e-02      6.83e-01    5.89e-01    1.0e-03
     10      2.11e+01    2.23e+01      4.25e-01    4.27e-01      6.67e-01    7.06e-01    1.0e-03
     20      2.13e+01    2.16e+01      2.11e-02    2.04e-02      6.73e-01    6.84e-01    1.0e-03
     30      2.13e+01    2.17e+01      3.94e-02    3.30e-02      6.72e-01    6.88e-01    1.0e-03
     40      1.99e+01    2.23e+01      9.17e-02    8.79e-02      6.30e-01    7.05e-01    1.0e-03
     50      2.13e+01    2.05e+01      3.32e-02    2.76e-02      6.74e-01    6.49e-01    1.0e-03
     60      2.14e+01    2.35e+01      5.49e-03    9.87e-03      6.77e-01    7.42e-01    1.0e-03
     70      2.15e+01    1.89e+01      4.85e-02    5.44e-02      6.79e-01    5.96e-01    1.0e-03
     80      2.23e+01    2.08e+01      2.84e-02    3.15e-02      7.05e-01    6.58e-01    1.0e-03
root se_e3 $ head original.out 
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      2.16e+01    1.86e+01      1.91e-02    1.30e-02      6.83e-01    5.89e-01    1.0e-03
     10      2.11e+01    2.23e+01      4.27e-01    4.28e-01      6.68e-01    7.06e-01    1.0e-03
     20      2.13e+01    2.16e+01      1.91e-02    1.84e-02      6.72e-01    6.84e-01    1.0e-03
     30      2.13e+01    2.17e+01      3.76e-02    3.12e-02      6.72e-01    6.88e-01    1.0e-03
     40      1.99e+01    2.23e+01      9.20e-02    8.82e-02      6.30e-01    7.05e-01    1.0e-03
     50      2.13e+01    2.05e+01      3.11e-02    2.55e-02      6.74e-01    6.49e-01    1.0e-03
     60      2.14e+01    2.34e+01      6.78e-03    1.12e-02      6.76e-01    7.41e-01    1.0e-03
     70      2.15e+01    1.88e+01      4.86e-02    5.44e-02      6.79e-01    5.96e-01    1.0e-03
     80      2.23e+01    2.08e+01      2.74e-02    3.05e-02      7.04e-01    6.58e-01    1.0e-03
```