### PR TITLE
Added all activation functions for model compression.

### DIFF
--- a/deepmd/utils/tabulate.py
+++ b/deepmd/utils/tabulate.py
@@ -68,6 +68,14 @@ class DPTabulate():
             self.functype = 1
         elif activation_fn == ACTIVATION_FN_DICT["gelu"]:
             self.functype = 2
+        elif activation_fn == ACTIVATION_FN_DICT["relu"]:
+            self.functype = 3
+        elif activation_fn == ACTIVATION_FN_DICT["relu6"]:
+            self.functype = 4
+        elif activation_fn == ACTIVATION_FN_DICT["softplus"]:
+            self.functype = 5
+        elif activation_fn == ACTIVATION_FN_DICT["sigmoid"]:
+            self.functype = 6
         else:
             raise RuntimeError("Unknown actication function type!")
         self.activation_fn = activation_fn

--- a/doc/freeze/compress.md
+++ b/doc/freeze/compress.md
@@ -83,3 +83,14 @@ The model compression interface requires the version of deepmd-kit used in origi
 **Acceptable descriptor type**
 
 Note only descriptors with `se_e2_a` or `se_e3` type are supported by the model compression feature. Hybrid mixed with above descriptors is also supported.
+
+
+**Available activation functions for descriptor:**
+- tanh
+- gelu
+- relu
+- relu6
+- softplus
+- sigmoid
+
+

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -5,7 +5,9 @@ Training Parameters
    
    
    **Available activation functions for descriptor:**
+   
    tanh
+   
    gelu
    relu
    relu6

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -4,8 +4,8 @@ Training Parameters
    One can load, modify, and export the input file by using our effective web-based tool `DP-GUI <https://deepmodeling.org/dpgui/input/deepmd-kit-2.0>`_. All training parameters below can be set in DP-GUI. By clicking "SAVE JSON", one can download the input file for furthur training.
    
    
-   **Available activation functions for descriptor**:
-   - tanh
+   **Available activation functions for descriptor:**
+- tanh
    - gelu
    - relu
    - relu6

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -5,12 +5,12 @@ Training Parameters
    
    
    **Available activation functions for descriptor:**
-      -tanh
-      -gelu
-      -relu
-      -relu6
-      -softplus
-      -sigmoid
+   -tanh
+   -gelu
+   -relu
+   -relu6
+   -softplus
+   -sigmoid
    You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
    For example:
       "activation_function": "sigmoid"

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -2,18 +2,5 @@ Training Parameters
 ======================================
 .. note::
    One can load, modify, and export the input file by using our effective web-based tool `DP-GUI <https://deepmodeling.org/dpgui/input/deepmd-kit-2.0>`_. All training parameters below can be set in DP-GUI. By clicking "SAVE JSON", one can download the input file for furthur training.
-   
-   
-   **Available activation functions for descriptor:**
-- tanh
-- gelu
-- relu
-- relu6
-- softplus
-- sigmoid
-
-You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
-For example:
-      "activation_function": "sigmoid"
 
 .. include:: ../train-input-auto.rst

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -11,6 +11,7 @@ Training Parameters
 - relu6
 - softplus
 - sigmoid
+
    You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
    For example:
       "activation_function": "sigmoid"

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -2,5 +2,17 @@ Training Parameters
 ======================================
 .. note::
    One can load, modify, and export the input file by using our effective web-based tool `DP-GUI <https://deepmodeling.org/dpgui/input/deepmd-kit-2.0>`_. All training parameters below can be set in DP-GUI. By clicking "SAVE JSON", one can download the input file for furthur training.
+   
+   
+   Available activation functions for descriptor:
+      tanh
+      gelu
+      relu
+      relu6
+      softplus
+      sigmoid
+   You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
+   For example:
+      "activation_function": "sigmoid"
 
 .. include:: ../train-input-auto.rst

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -5,12 +5,12 @@ Training Parameters
    
    
    **Available activation functions for descriptor:**
-   -tanh
-   -gelu
-   -relu
-   -relu6
-   -softplus
-   -sigmoid
+   tanh
+   gelu
+   relu
+   relu6
+   softplus
+   sigmoid
    You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
    For example:
       "activation_function": "sigmoid"

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -4,7 +4,7 @@ Training Parameters
    One can load, modify, and export the input file by using our effective web-based tool `DP-GUI <https://deepmodeling.org/dpgui/input/deepmd-kit-2.0>`_. All training parameters below can be set in DP-GUI. By clicking "SAVE JSON", one can download the input file for furthur training.
    
    
-   **Available activation functions for descriptor:**   
+   **Available activation functions for descriptor**:
    - tanh
    - gelu
    - relu

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -6,10 +6,10 @@ Training Parameters
    
    **Available activation functions for descriptor:**
    
-   tanh
+   -tanh
    
-   gelu
-   relu
+   -gelu
+-relu
    relu6
    softplus
    sigmoid

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -6,9 +6,8 @@ Training Parameters
    
    **Available activation functions for descriptor:**
    
-   -tanh
-   
-   -gelu
+-tanh
+-gelu
 -relu
    relu6
    softplus

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -12,8 +12,8 @@ Training Parameters
 - softplus
 - sigmoid
 
-   You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
-   For example:
+You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
+For example:
       "activation_function": "sigmoid"
 
 .. include:: ../train-input-auto.rst

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -4,14 +4,13 @@ Training Parameters
    One can load, modify, and export the input file by using our effective web-based tool `DP-GUI <https://deepmodeling.org/dpgui/input/deepmd-kit-2.0>`_. All training parameters below can be set in DP-GUI. By clicking "SAVE JSON", one can download the input file for furthur training.
    
    
-   **Available activation functions for descriptor:**
-   
--tanh
--gelu
--relu
-   relu6
-   softplus
-   sigmoid
+   **Available activation functions for descriptor:**   
+   - tanh
+   - gelu
+   - relu
+   - relu6
+   - softplus
+   - sigmoid
    You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
    For example:
       "activation_function": "sigmoid"

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -6,11 +6,11 @@ Training Parameters
    
    **Available activation functions for descriptor:**
 - tanh
-   - gelu
-   - relu
-   - relu6
-   - softplus
-   - sigmoid
+- gelu
+- relu
+- relu6
+- softplus
+- sigmoid
    You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
    For example:
       "activation_function": "sigmoid"

--- a/doc/train/train-input.rst
+++ b/doc/train/train-input.rst
@@ -4,13 +4,13 @@ Training Parameters
    One can load, modify, and export the input file by using our effective web-based tool `DP-GUI <https://deepmodeling.org/dpgui/input/deepmd-kit-2.0>`_. All training parameters below can be set in DP-GUI. By clicking "SAVE JSON", one can download the input file for furthur training.
    
    
-   Available activation functions for descriptor:
-      tanh
-      gelu
-      relu
-      relu6
-      softplus
-      sigmoid
+   **Available activation functions for descriptor:**
+      -tanh
+      -gelu
+      -relu
+      -relu6
+      -softplus
+      -sigmoid
    You can specify one of the above functions as the activation function in the descriptor's configuration in "input.json".
    For example:
       "activation_function": "sigmoid"

--- a/source/op/unaggregated_grad.cc
+++ b/source/op/unaggregated_grad.cc
@@ -52,6 +52,36 @@ FPTYPE grad(const FPTYPE xbar, const FPTYPE y, const int functype)  //functype=t
             const FPTYPE var = tanh(SQRT_2_PI * (xbar + GGELU * xbar * xbar * xbar));
             return 0.5 * SQRT_2_PI * xbar * (1 - var * var) * (3 * GGELU * xbar * xbar + 1) + 0.5 * var + 0.5;
         }
+        case 3:
+        {
+            if(xbar<=0)
+            {
+                return 0;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+        case 4:
+        {
+            if(xbar<=0 || xbar>=6)
+            {
+                return 0;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+        case 5:
+        {
+            return 1.0-1.0/(1.0+exp(xbar));
+        }
+        case 6:
+        {
+            return y*(1-y);
+        }
         default:
             return -1;
     }
@@ -70,6 +100,22 @@ FPTYPE grad_grad(const FPTYPE xbar, const FPTYPE y, const int functype)
             const FPTYPE var1 = tanh(SQRT_2_PI * (xbar + GGELU * xbar * xbar * xbar));
             const FPTYPE var2 = SQRT_2_PI * (1 - var1 * var1) * (3 * GGELU * xbar * xbar + 1);
             return  3 * GGELU * SQRT_2_PI * xbar * xbar * (1 - var1 * var1) - SQRT_2_PI * xbar * var2 * (3 * GGELU * xbar * xbar + 1) * var1 + var2;
+        }
+        case 3:
+        {
+            return 0;
+        }
+        case 4:
+        {
+            return 0;
+        }
+        case 5:
+        {
+            return exp(xbar)/((1+exp(xbar))*(1+exp(xbar)));
+        }
+        case 6:
+        {
+            return y*(1-y)*(1-2*y);
         }
         default:
             return -1;


### PR DESCRIPTION
Now the model with activation functions such as  'relu', 'relu6', 'softplus', 'sigmoid'  in descriptor can be compressed, and the output results have been well tested.

Modified related document with activation function.