### PR TITLE
unify C++ errors and pass message to LAMMPS

### DIFF
--- a/source/api_cc/include/common.h
+++ b/source/api_cc/include/common.h
@@ -6,6 +6,7 @@
 #include "version.h"
 #include "neighbor_list.h"
 #include "AtomMap.h"
+#include "errors.h"
 
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/public/session.h"
@@ -115,8 +116,17 @@ void
 get_env_nthreads(int & num_intra_nthreads,
 		 int & num_inter_nthreads);
 
+/** @struct deepmd::deepmd_exception
+ **/
+
+/**
+* @brief Throw exception if TensorFlow doesn't work.
+**/
 struct
-tf_exception: public std::exception {
+tf_exception: public deepmd::deepmd_exception {
+public:
+	tf_exception(): deepmd::deepmd_exception("TensorFlow Error!") {};
+	tf_exception(const std::string& msg): deepmd::deepmd_exception(std::string("TensorFlow Error: ") + msg) {};
 };
 
 /**

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -220,7 +220,7 @@ init (const std::string & model, const int & gpu_rank, const std::string & file_
     model_version = "0.0";
   }
   if(! model_compatable(model_version)){
-    throw std::runtime_error(
+    throw deepmd::deepmd_exception(
 	"incompatable model: version " + model_version 
 	+ " in graph, but version " + global_model_version 
 	+ " supported ");
@@ -307,10 +307,10 @@ validate_fparam_aparam(const int & nloc,
 		       const std::vector<VALUETYPE> &aparam)const 
 {
   if (fparam.size() != dfparam) {
-    throw std::runtime_error("the dim of frame parameter provided is not consistent with what the model uses");
+    throw deepmd::deepmd_exception("the dim of frame parameter provided is not consistent with what the model uses");
   }
   if (aparam.size() != daparam * nloc) {
-    throw std::runtime_error("the dim of atom parameter provided is not consistent with what the model uses");
+    throw deepmd::deepmd_exception("the dim of atom parameter provided is not consistent with what the model uses");
   }  
 }
 
@@ -552,7 +552,7 @@ init (const std::vector<std::string> & models, const int & gpu_rank, const std::
   model_type = get_scalar<STRINGTYPE>("model_attr/model_type");
   model_version = get_scalar<STRINGTYPE>("model_attr/model_version");
   if(! model_compatable(model_version)){
-    throw std::runtime_error(
+    throw deepmd::deepmd_exception(
 	"incompatable model: version " + model_version 
 	+ " in graph, but version " + global_model_version 
 	+ " supported ");
@@ -636,10 +636,10 @@ validate_fparam_aparam(const int & nloc,
 		       const std::vector<VALUETYPE> &aparam)const 
 {
   if (fparam.size() != dfparam) {
-    throw std::runtime_error("the dim of frame parameter provided is not consistent with what the model uses");
+    throw deepmd::deepmd_exception("the dim of frame parameter provided is not consistent with what the model uses");
   }
   if (aparam.size() != daparam * nloc) {
-    throw std::runtime_error("the dim of atom parameter provided is not consistent with what the model uses");
+    throw deepmd::deepmd_exception("the dim of atom parameter provided is not consistent with what the model uses");
   }  
 }
 

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -44,7 +44,7 @@ init (const std::string & model,
   model_type = get_scalar<STRINGTYPE>("model_attr/model_type");
   model_version = get_scalar<STRINGTYPE>("model_attr/model_version");
   if(! model_compatable(model_version)){
-    throw std::runtime_error(
+    throw deepmd::deepmd_exception(
 	"incompatable model: version " + model_version 
 	+ " in graph, but version " + global_model_version 
 	+ " supported ");

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -27,10 +27,10 @@ model_compatable(
   std::vector<std::string> words_mv = split(model_version, ".");
   std::vector<std::string> words_gmv = split(global_model_version, ".");
   if(words_mv.size() != 2){
-    throw std::runtime_error("invalid graph model version string " + model_version);
+    throw deepmd::deepmd_exception("invalid graph model version string " + model_version);
   }
   if(words_gmv.size() != 2){
-    throw std::runtime_error("invalid supported model version string " + global_model_version);
+    throw deepmd::deepmd_exception("invalid supported model version string " + global_model_version);
   }
   int model_version_major = atoi(words_mv[0].c_str());
   int model_version_minor = atoi(words_mv[1].c_str());
@@ -201,7 +201,7 @@ deepmd::
 check_status(const tensorflow::Status& status) {
   if (!status.ok()) {
     std::cout << status.ToString() << std::endl;
-    throw deepmd::tf_exception();
+    throw deepmd::tf_exception(status.ToString());
   }
 }
 

--- a/source/lib/include/errors.h
+++ b/source/lib/include/errors.h
@@ -4,6 +4,9 @@
 #include <string>
 
 namespace deepmd{
+    /**
+    * @brief General DeePMD-kit exception. Throw if anything doesn't work.
+    **/
     struct
     deepmd_exception: public std::runtime_error {
     public:
@@ -12,9 +15,9 @@ namespace deepmd{
     };
 
     struct
-    deepmd_exception_oom: public std::runtime_error{
+    deepmd_exception_oom: public deepmd_exception{
     public:
-        deepmd_exception_oom(): runtime_error("DeePMD-kit OOM!") {};
-        deepmd_exception_oom(const std::string& msg): runtime_error(std::string("DeePMD-kit OOM: ") + msg) {};
+        deepmd_exception_oom(): deepmd_exception("DeePMD-kit OOM!") {};
+        deepmd_exception_oom(const std::string& msg): deepmd_exception(std::string("DeePMD-kit OOM: ") + msg) {};
     };
 };

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -379,7 +379,11 @@ void PairDeepMD::compute(int eflag, int vflag)
       //cvflag_atom is the right flag for the cvatom matrix 
       if ( ! (eflag_atom || cvflag_atom) ) {      
 #ifdef HIGH_PREC
+  try {
 	deep_pot.compute (dener, dforce, dvirial, dcoord, dtype, dbox, nghost, lmp_list, ago, fparam, daparam);
+  } catch(deepmd::deepmd_exception& e) {
+    error->all(FLERR, e.what());
+  }
 #else
 	vector<float> dcoord_(dcoord.size());
 	vector<float> dbox_(dbox.size());
@@ -388,7 +392,11 @@ void PairDeepMD::compute(int eflag, int vflag)
 	vector<float> dforce_(dforce.size(), 0);
 	vector<float> dvirial_(dvirial.size(), 0);
 	double dener_ = 0;
+  try {
 	deep_pot.compute (dener_, dforce_, dvirial_, dcoord_, dtype, dbox_, nghost, lmp_list, ago, fparam, daparam);
+  } catch(deepmd::deepmd_exception& e) {
+    error->all(FLERR, e.what());
+  }
 	for (unsigned dd = 0; dd < dforce.size(); ++dd) dforce[dd] = dforce_[dd];	
 	for (unsigned dd = 0; dd < dvirial.size(); ++dd) dvirial[dd] = dvirial_[dd];	
 	dener = dener_;
@@ -410,7 +418,11 @@ void PairDeepMD::compute(int eflag, int vflag)
 	vector<float> deatom_(dforce.size(), 0);
 	vector<float> dvatom_(dforce.size(), 0);
 	double dener_ = 0;
+  try {
 	deep_pot.compute (dener_, dforce_, dvirial_, deatom_, dvatom_, dcoord_, dtype, dbox_, nghost, lmp_list, ago, fparam, daparam);
+  } catch(deepmd::deepmd_exception& e) {
+    error->all(FLERR, e.what());
+  }
 	for (unsigned dd = 0; dd < dforce.size(); ++dd) dforce[dd] = dforce_[dd];	
 	for (unsigned dd = 0; dd < dvirial.size(); ++dd) dvirial[dd] = dvirial_[dd];	
 	for (unsigned dd = 0; dd < deatom.size(); ++dd) deatom[dd] = deatom_[dd];	
@@ -452,7 +464,11 @@ void PairDeepMD::compute(int eflag, int vflag)
       vector<double> 		all_energy;
       vector<vector<double>> 	all_atom_energy;
       vector<vector<double>> 	all_atom_virial;
+      try {
       deep_pot_model_devi.compute(all_energy, all_force, all_virial, all_atom_energy, all_atom_virial, dcoord, dtype, dbox, nghost, lmp_list, ago, fparam, daparam);
+      } catch(deepmd::deepmd_exception& e) {
+        error->all(FLERR, e.what());
+      }
       // deep_pot_model_devi.compute_avg (dener, all_energy);
       // deep_pot_model_devi.compute_avg (dforce, all_force);
       // deep_pot_model_devi.compute_avg (dvirial, all_virial);
@@ -478,7 +494,11 @@ void PairDeepMD::compute(int eflag, int vflag)
       vector<vector<float>> 	all_virial_;	       
       vector<vector<float>> 	all_atom_energy_;
       vector<vector<float>> 	all_atom_virial_;
+      try {
       deep_pot_model_devi.compute(all_energy_, all_force_, all_virial_, all_atom_energy_, all_atom_virial_, dcoord_, dtype, dbox_, nghost, lmp_list, ago, fparam, daparam);
+      } catch(deepmd::deepmd_exception& e) {
+        error->all(FLERR, e.what());
+      }
       // deep_pot_model_devi.compute_avg (dener_, all_energy_);
       // deep_pot_model_devi.compute_avg (dforce_, all_force_);
       // deep_pot_model_devi.compute_avg (dvirial_, all_virial_);
@@ -688,7 +708,11 @@ void PairDeepMD::compute(int eflag, int vflag)
   else {
     if (numb_models == 1) {
 #ifdef HIGH_PREC
+      try {
       deep_pot.compute (dener, dforce, dvirial, dcoord, dtype, dbox);
+      } catch(deepmd::deepmd_exception& e) {
+        error->all(FLERR, e.what());
+      }
 #else
       vector<float> dcoord_(dcoord.size());
       vector<float> dbox_(dbox.size());
@@ -697,7 +721,11 @@ void PairDeepMD::compute(int eflag, int vflag)
       vector<float> dforce_(dforce.size(), 0);
       vector<float> dvirial_(dvirial.size(), 0);
       double dener_ = 0;
+      try {
       deep_pot.compute (dener_, dforce_, dvirial_, dcoord_, dtype, dbox_);
+      } catch(deepmd::deepmd_exception& e) {
+        error->all(FLERR, e.what());
+      }
       for (unsigned dd = 0; dd < dforce.size(); ++dd) dforce[dd] = dforce_[dd];	
       for (unsigned dd = 0; dd < dvirial.size(); ++dd) dvirial[dd] = dvirial_[dd];	
       dener = dener_;      
@@ -793,15 +821,23 @@ void PairDeepMD::settings(int narg, char **arg)
   }
   numb_models = models.size();
   if (numb_models == 1) {
+    try {
     deep_pot.init (arg[0], get_node_rank(), get_file_content(arg[0]));
+    } catch(deepmd::deepmd_exception& e) {
+      error->all(FLERR, e.what());
+    }
     cutoff = deep_pot.cutoff ();
     numb_types = deep_pot.numb_types();
     dim_fparam = deep_pot.dim_fparam();
     dim_aparam = deep_pot.dim_aparam();
   }
   else {
+    try {
     deep_pot.init (arg[0], get_node_rank(), get_file_content(arg[0]));
     deep_pot_model_devi.init(models, get_node_rank(), get_file_content(models));
+    } catch(deepmd::deepmd_exception& e) {
+      error->all(FLERR, e.what());
+    }
     cutoff = deep_pot_model_devi.cutoff();
     numb_types = deep_pot_model_devi.numb_types();
     dim_fparam = deep_pot_model_devi.dim_fparam();


### PR DESCRIPTION
This commits unifies all C++ errors (including TF) into `deepmd::deepmd_exception`
and passes the error message to LAMMPS.