### PR TITLE
Fix cell and virial transpose bug in dp_ipi

### DIFF
--- a/source/ipi/driver.cc
+++ b/source/ipi/driver.cc
@@ -158,7 +158,7 @@ int main(int argc, char * argv[])
       readbuffer_ (&socket, (char *)(cell_h),  9*sizeof(double));
       readbuffer_ (&socket, (char *)(cell_ih), 9*sizeof(double));
       for (int dd = 0; dd < 9; ++dd){
-	dbox[dd] = cell_h[dd] * cvt_len;
+	dbox[dd] = cell_ih[dd] * cvt_len;
       }
       region.reinitBox (&dbox[0]);
       
@@ -209,7 +209,7 @@ int main(int argc, char * argv[])
 	msg_buff[ii] = dforce[ii] * icvt_f;
       }
       for (int ii = 0; ii < 9; ++ii){
-	virial[ii] = dvirial[ii] * icvt_ener * (1.0);
+	virial[ii] = dvirial[(ii%3)*3+(ii/3)] * icvt_ener * (1.0);
       }
       if (b_verb) std::cout << "# energy of sys. : " << std::scientific << std::setprecision(10) << dener << std::endl;
       writebuffer_ (&socket, msg_forceready, MSGLEN);

--- a/source/ipi/driver.cc
+++ b/source/ipi/driver.cc
@@ -158,7 +158,7 @@ int main(int argc, char * argv[])
       readbuffer_ (&socket, (char *)(cell_h),  9*sizeof(double));
       readbuffer_ (&socket, (char *)(cell_ih), 9*sizeof(double));
       for (int dd = 0; dd < 9; ++dd){
-	dbox[dd] = cell_ih[dd] * cvt_len;
+	dbox[dd] = cell_h[(ii%3)*3+(ii/3)] * cvt_len;
       }
       region.reinitBox (&dbox[0]);
       

--- a/source/ipi/driver.cc
+++ b/source/ipi/driver.cc
@@ -158,7 +158,7 @@ int main(int argc, char * argv[])
       readbuffer_ (&socket, (char *)(cell_h),  9*sizeof(double));
       readbuffer_ (&socket, (char *)(cell_ih), 9*sizeof(double));
       for (int dd = 0; dd < 9; ++dd){
-	dbox[dd] = cell_h[(ii%3)*3+(ii/3)] * cvt_len;
+	dbox[dd] = cell_h[(dd%3)*3+(dd/3)] * cvt_len;
       }
       region.reinitBox (&dbox[0]);
       


### PR DESCRIPTION
i-Pi assumes column-major storage to store cell and virial.

Fix #1351.
See i-Pi manual: https://ipi-code.org/i-pi/_static/manual.pdf (page 33 and page 78)
See also i-pi/i-pi#48 and i-pi/i-pi#196.