### PR TITLE
explicitly set neighbor request to full in compute deeptensor/atom to fix bug #1381

### DIFF
--- a/source/lmp/compute_deeptensor_atom.cpp
+++ b/source/lmp/compute_deeptensor_atom.cpp
@@ -70,7 +70,7 @@ void ComputeDeeptensorAtom::init()
   neighbor->requests[irequest]->half = 0;
   neighbor->requests[irequest]->pair = 0;
   neighbor->requests[irequest]->compute = 1;
-  // neighbor->requests[irequest]->full = 1;
+  neighbor->requests[irequest]->full = 1;
   neighbor->requests[irequest]->occasional = 1;
 }
 


### PR DESCRIPTION
The similar change to pull #1128. This pull request fixes bug #1381.