### PR TITLE
fix github git url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source/lib/src/cuda/cub"]
 	path = source/lib/src/cuda/cub
-	url = git://github.com/NVIDIA/cub.git
+	url = https://github.com/NVIDIA/cub.git


### PR DESCRIPTION
Since today, GitHub disabled unencrypted `git://`. See https://github.blog/2021-09-01-improving-git-protocol-security-github/. We use `https://` instead.

The PR should be cherry-picked to the previous version.