### PR TITLE
only test/eval fitting properties

### DIFF
--- a/deepmd/loss/ener.py
+++ b/deepmd/loss/ener.py
@@ -129,13 +129,14 @@ class EnerStdLoss () :
         return l2_loss, more_loss
 
     def eval(self, sess, feed_dict, natoms):
+        placeholder = tf.no_op()
         run_data = [
             self.l2_l,
-            self.l2_more['l2_ener_loss'],
-            self.l2_more['l2_force_loss'],
-            self.l2_more['l2_virial_loss'],
-            self.l2_more['l2_atom_ener_loss'],
-            self.l2_more['l2_pref_force_loss']
+            self.l2_more['l2_ener_loss'] if self.has_e else placeholder,
+            self.l2_more['l2_force_loss'] if self.has_f else placeholder,
+            self.l2_more['l2_virial_loss'] if self.has_v else placeholder,
+            self.l2_more['l2_atom_ener_loss'] if self.has_ae else placeholder,
+            self.l2_more['l2_pref_force_loss'] if self.has_pf else placeholder,
         ]
         error, error_e, error_f, error_v, error_ae, error_pf = run_sess(sess, run_data, feed_dict=feed_dict)
         results = {"natoms": natoms[0], "rmse": np.sqrt(error)}


### PR DESCRIPTION
During profiling, I found that the virial will be calculated in the test process even if I don't provide virial data.
This is meaningless and the viral has never been outputted.
This commit removes such behavior.

(cherry picked from commit 9a55069b40dc2892adeed8b153c67ba2d407a62b)

![image](https://user-images.githubusercontent.com/9496702/149280153-e515b1ba-2a4f-43d7-a51a-f77645f07a91.png)
