### PR TITLE
remove the dependency on `inputs` from `inputs_zero`

### DIFF
--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -332,6 +332,7 @@ class EnerFitting (Fitting):
     def build (self, 
                inputs : tf.Tensor,
                natoms : tf.Tensor,
+               nframes : tf.Tensor,
                input_dict : dict = {},
                reuse : bool = None,
                suffix : str = '', 
@@ -352,6 +353,8 @@ class EnerFitting (Fitting):
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
+        nframes : tf.Tensor
+                The number of frames
         reuse
                 The weights in the networks should be reused when get the variable.
         suffix
@@ -398,10 +401,11 @@ class EnerFitting (Fitting):
                                                 trainable = False,
                                                 initializer = tf.constant_initializer(self.aparam_inv_std))
             
-        inputs = tf.reshape(inputs, [-1, self.dim_descrpt * natoms[0]])
+        inputs = tf.reshape(inputs, [nframes, self.dim_descrpt * natoms[0]])
         if len(self.atom_ener):
             # only for atom_ener
-            inputs_zero = tf.zeros_like(inputs, dtype=self.fitting_precision)
+            # like inputs, but we don't want to add a dependency on inputs
+            inputs_zero = tf.zeros((nframes, self.dim_descrpt * natoms[0]), dtype=self.fitting_precision)
         
 
         if bias_atom_e is not None :

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -332,7 +332,6 @@ class EnerFitting (Fitting):
     def build (self, 
                inputs : tf.Tensor,
                natoms : tf.Tensor,
-               nframes : tf.Tensor,
                input_dict : dict = {},
                reuse : bool = None,
                suffix : str = '', 
@@ -353,8 +352,6 @@ class EnerFitting (Fitting):
                 natoms[0]: number of local atoms
                 natoms[1]: total number of atoms held by this processor
                 natoms[i]: 2 <= i < Ntypes+2, number of type i atoms
-        nframes : tf.Tensor
-                The number of frames
         reuse
                 The weights in the networks should be reused when get the variable.
         suffix
@@ -401,11 +398,15 @@ class EnerFitting (Fitting):
                                                 trainable = False,
                                                 initializer = tf.constant_initializer(self.aparam_inv_std))
             
-        inputs = tf.reshape(inputs, [nframes, self.dim_descrpt * natoms[0]])
+        inputs = tf.reshape(inputs, [-1, self.dim_descrpt * natoms[0]])
         if len(self.atom_ener):
             # only for atom_ener
-            # like inputs, but we don't want to add a dependency on inputs
-            inputs_zero = tf.zeros((nframes, self.dim_descrpt * natoms[0]), dtype=self.fitting_precision)
+            nframes = input_dict.get('nframes')
+            if nframes is not None:
+                # like inputs, but we don't want to add a dependency on inputs
+                inputs_zero = tf.zeros((nframes, self.dim_descrpt * natoms[0]), dtype=self.fitting_precision)
+            else:
+                inputs_zero = tf.zeros((nframes, self.dim_descrpt * natoms[0]), dtype=self.fitting_precision)
         
 
         if bias_atom_e is not None :

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -406,7 +406,7 @@ class EnerFitting (Fitting):
                 # like inputs, but we don't want to add a dependency on inputs
                 inputs_zero = tf.zeros((nframes, self.dim_descrpt * natoms[0]), dtype=self.fitting_precision)
             else:
-                inputs_zero = tf.zeros((nframes, self.dim_descrpt * natoms[0]), dtype=self.fitting_precision)
+                inputs_zero = tf.zeros_like(inputs, dtype=self.fitting_precision)
         
 
         if bias_atom_e is not None :

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -332,7 +332,7 @@ class EnerFitting (Fitting):
     def build (self, 
                inputs : tf.Tensor,
                natoms : tf.Tensor,
-               input_dict : dict = {},
+               input_dict : dict = None,
                reuse : bool = None,
                suffix : str = '', 
     ) -> tf.Tensor:
@@ -362,6 +362,8 @@ class EnerFitting (Fitting):
         ener
                 The system energy
         """
+        if input_dict is None:
+            input_dict = {}
         bias_atom_e = self.bias_atom_e
         if self.numb_fparam > 0 and ( self.fparam_avg is None or self.fparam_inv_std is None ):
             raise RuntimeError('No data stat result. one should do data statisitic, before build')
@@ -424,10 +426,7 @@ class EnerFitting (Fitting):
             aparam = (aparam - t_aparam_avg) * t_aparam_istd
             aparam = tf.reshape(aparam, [-1, self.numb_aparam * natoms[0]])
             
-        if input_dict is not None:
-            type_embedding = input_dict.get('type_embedding', None)
-        else:
-            type_embedding = None
+        type_embedding = input_dict.get('type_embedding', None)
         if type_embedding is not None:
             atype_embed = embed_atom_type(self.ntypes, natoms, type_embedding)
             atype_embed = tf.tile(atype_embed,[tf.shape(inputs)[0],1])

--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -144,6 +144,7 @@ class EnerModel() :
 
         coord = tf.reshape (coord_, [-1, natoms[1] * 3])
         atype = tf.reshape (atype_, [-1, natoms[1]])
+        nframes = tf.shape(coord)[0]
 
         # type embedding if any
         if self.typeebd is not None:
@@ -187,6 +188,7 @@ class EnerModel() :
 
         atom_ener = self.fitting.build (dout, 
                                         natoms, 
+                                        nframes,
                                         input_dict, 
                                         reuse = reuse, 
                                         suffix = suffix)

--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -117,7 +117,9 @@ class EnerModel() :
                frz_model = None,
                suffix = '', 
                reuse = None):
-
+ 
+        if input_dict is None:
+            input_dict = {}
         with tf.variable_scope('model_attr' + suffix, reuse = reuse) :
             t_tmap = tf.constant(' '.join(self.type_map), 
                                  name = 'tmap', 

--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -144,7 +144,7 @@ class EnerModel() :
 
         coord = tf.reshape (coord_, [-1, natoms[1] * 3])
         atype = tf.reshape (atype_, [-1, natoms[1]])
-        nframes = tf.shape(coord)[0]
+        input_dict['nframes'] = tf.shape(coord)[0]
 
         # type embedding if any
         if self.typeebd is not None:
@@ -188,7 +188,6 @@ class EnerModel() :
 
         atom_ener = self.fitting.build (dout, 
                                         natoms, 
-                                        nframes,
                                         input_dict, 
                                         reuse = reuse, 
                                         suffix = suffix)

--- a/source/tests/test_fitting_ener_type.py
+++ b/source/tests/test_fitting_ener_type.py
@@ -81,6 +81,7 @@ class TestModel(tf.test.TestCase):
         type_embedding = type_embedding.reshape([ntypes,-1])
         atom_ener = fitting.build(tf.convert_to_tensor(dout),
                                   t_natoms, 
+                                  tf.constant(numb_test, dtype=tf.int32),
                                   {'type_embedding':tf.convert_to_tensor(type_embedding)},
                                   reuse = False,
                                   suffix = "se_a_type_fit_")

--- a/source/tests/test_fitting_ener_type.py
+++ b/source/tests/test_fitting_ener_type.py
@@ -81,7 +81,6 @@ class TestModel(tf.test.TestCase):
         type_embedding = type_embedding.reshape([ntypes,-1])
         atom_ener = fitting.build(tf.convert_to_tensor(dout),
                                   t_natoms, 
-                                  tf.constant(numb_test, dtype=tf.int32),
                                   {'type_embedding':tf.convert_to_tensor(type_embedding)},
                                   reuse = False,
                                   suffix = "se_a_type_fit_")


### PR DESCRIPTION
When profiling on multiple CPU threads, I notice that `inputs_zero` always runs after descriptor is computed. However, Some threads have nothing to do during `ProdEnvMatA`.

![image](https://user-images.githubusercontent.com/9496702/149322131-5cd88390-85e6-44f6-a40e-bbb7313ee075.png)

`inputs_zero` can be used to fill waiting time and runs with `ProdEnvMatA` at the same time...

![image](https://user-images.githubusercontent.com/9496702/149322632-be1a030f-5200-46c6-9c95-c8c1bee0d264.png)


(cherry picked from commit e704b4af1df7c23465615454bf7dfc0fc2f8d18f)