### PR TITLE
replace `tf.no_op`

### DIFF
--- a/deepmd/loss/ener.py
+++ b/deepmd/loss/ener.py
@@ -129,7 +129,7 @@ class EnerStdLoss () :
         return l2_loss, more_loss
 
     def eval(self, sess, feed_dict, natoms):
-        placeholder = tf.no_op()
+        placeholder = self.l2_l
         run_data = [
             self.l2_l,
             self.l2_more['l2_ener_loss'] if self.has_e else placeholder,


### PR DESCRIPTION
`tf.no_op` has a strange pefermance issue... We need to use another tensor as placeholder.

(cherry picked from commit f3b7189f8b3f9df85172cea51c84148423bc4bf8)