### PR TITLE
skip `data_stat` in `init_from_model` and `restart` mode

### DIFF
--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -282,7 +282,12 @@ class DPTrainer (object):
                 ))
             self.type_map = data.get_type_map()
             self.batch_size = data.get_batch_size()
-            self.model.data_stat(data)
+            if self.run_opt.init_mode not in ('init_from_model', 'restart'):
+                # self.saver.restore (in self._init_session) will restore avg and std variables, so data_stat is useless
+                # currently init_from_frz_model does not restore data_stat variables
+                # TODO: restore avg and std in the init_from_frz_model mode
+                log.info("data stating... (this step may take long time)")
+                self.model.data_stat(data)
 
             # config the init_frz_model command
             if self.run_opt.init_mode == 'init_from_frz_model':


### PR DESCRIPTION
`std` and `avg` are stored as variables. `saver.restore` will restore and override it. So `data_stat` before `saver.restore` is useless.
Note that currently `init_from_frz_model` does not restore these variables.

I also add a message before `data_stat`. It sometimes takes long time.