### PR TITLE
bump the Python version to 3.10

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
           CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/deepmodeling/manylinux2010_x86_64_tensorflow
           CIBW_BEFORE_BUILD: pip install tensorflow
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -42,10 +42,10 @@ jobs:
           - python: 3.7
             gcc: 8
             tf:
-          - python: 3.8
+          - python: 3.10
             gcc: 5
             tf:
-          - python: 3.8
+          - python: 3.10
             gcc: 8
             tf:
 

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -42,10 +42,10 @@ jobs:
           - python: 3.7
             gcc: 8
             tf:
-          - python: 3.10
+          - python: "3.10"
             gcc: 5
             tf:
-          - python: 3.10
+          - python: "3.10"
             gcc: 8
             tf:
 


### PR DESCRIPTION
Test whether deepmd-kit is compatible with the latest Python. Also add Python 3.10 to wheel building.
TF 2.8 was just released with Python 3.10 support.

Also note that Python 3.6 is reaching its end of life as of December 2021.