### PR TITLE
assign energy shift stats if atomic energies are assigned

### DIFF
--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -129,6 +129,7 @@ class EnerFitting (Fitting):
             self.trainable = [self.trainable] * (len(self.n_neuron)+1)
         assert(len(self.trainable) == len(self.n_neuron) + 1), 'length of trainable should be that of n_neuron + 1'
         self.atom_ener = []
+        self.atom_ener_v = atom_ener
         for at, ae in enumerate(atom_ener):
             if ae is not None:
                 self.atom_ener.append(tf.constant(ae, self.fitting_precision, name = "atom_%d_ener" % at))
@@ -178,7 +179,6 @@ class EnerFitting (Fitting):
         """
         self.bias_atom_e = self._compute_output_stats(all_stat, rcond = self.rcond)
 
-    @classmethod
     def _compute_output_stats(self, all_stat, rcond = 1e-3):
         data = all_stat['energy']
         # data[sys_idx][batch_idx][frame_idx]
@@ -197,8 +197,19 @@ class EnerFitting (Fitting):
             sys_tynatom = np.append(sys_tynatom, data[ss][0].astype(np.float64))
         sys_tynatom = np.reshape(sys_tynatom, [nsys,-1])
         sys_tynatom = sys_tynatom[:,2:]
+        if len(self.atom_ener) > 0:
+            # Atomic energies stats are incorrect if atomic energies are assigned.
+            # In this situation, we directly use these assigned energies instead of computing stats.
+            # This will make the loss decrease quickly
+            tot_assigned_ener = np.sum((ee for ee in self.atom_ener_v if ee is not None))
+            sys_ener -= tot_assigned_ener
+            assigned_ener_idx = list((ii for ii, ee in enumerate(self.atom_ener_v) if ee is not None))
+            sys_tynatom[:, assigned_ener_idx] = 0.
         energy_shift,resd,rank,s_value \
             = np.linalg.lstsq(sys_tynatom, sys_ener, rcond = rcond)
+        if len(self.atom_ener) > 0:
+            for ii in assigned_ener_idx:
+                energy_shift[ii] = self.atom_ener_v[ii]
         return energy_shift    
 
     def compute_input_stats(self, 

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -201,9 +201,10 @@ class EnerFitting (Fitting):
             # Atomic energies stats are incorrect if atomic energies are assigned.
             # In this situation, we directly use these assigned energies instead of computing stats.
             # This will make the loss decrease quickly
-            tot_assigned_ener = np.sum((ee for ee in self.atom_ener_v if ee is not None))
-            sys_ener -= tot_assigned_ener
+            assigned_atom_ener = np.array(list((ee for ee in self.atom_ener_v if ee is not None)))
             assigned_ener_idx = list((ii for ii, ee in enumerate(self.atom_ener_v) if ee is not None))
+            # np.dot out size: nframe
+            sys_ener -= np.dot(sys_tynatom[:, assigned_ener_idx], assigned_atom_ener)
             sys_tynatom[:, assigned_ener_idx] = 0.
         energy_shift,resd,rank,s_value \
             = np.linalg.lstsq(sys_tynatom, sys_ener, rcond = rcond)

--- a/source/tests/test_gen_stat_data.py
+++ b/source/tests/test_gen_stat_data.py
@@ -6,7 +6,7 @@ import dpdata
 from deepmd.utils import random as dp_random
 from deepmd.utils.data_system import DeepmdDataSystem
 from deepmd.descriptor import DescrptSeA
-from deepmd.fit import EnerFitting, ener
+from deepmd.fit import EnerFitting
 from deepmd.model.model_stat import make_stat_input, merge_sys_stat, _make_all_stat_ref
 
 def gen_sys(nframes, atom_types):

--- a/source/tests/test_gen_stat_data.py
+++ b/source/tests/test_gen_stat_data.py
@@ -6,7 +6,7 @@ import dpdata
 from deepmd.utils import random as dp_random
 from deepmd.utils.data_system import DeepmdDataSystem
 from deepmd.descriptor import DescrptSeA
-from deepmd.fit import EnerFitting
+from deepmd.fit import EnerFitting, ener
 from deepmd.model.model_stat import make_stat_input, merge_sys_stat, _make_all_stat_ref
 
 def gen_sys(nframes, atom_types):
@@ -126,3 +126,24 @@ class TestEnerShift(unittest.TestCase):
                               resnet_dt = True)
         ener_shift1 = fitting._compute_output_stats(all_stat, rcond = 1)        
         np.testing.assert_almost_equal(ener_shift0, ener_shift1)
+
+    def test_ener_shift_assigned(self):
+        dp_random.seed(0)
+        ae0 = dp_random.random()
+        data = DeepmdDataSystem(['system_0'],
+                                5,
+                                10,
+                                1.0)
+        data.add('energy', 1, must = True)
+        all_stat = make_stat_input(data, 4, merge_sys = False)
+        descrpt = DescrptSeA(6.0,
+                             5.8,
+                             [46, 92],
+                             neuron = [25, 50, 100],
+                             axis_neuron = 16)
+        fitting = EnerFitting(descrpt,
+                              neuron = [240, 240, 240],
+                              resnet_dt = True,
+                              atom_ener=[ae0, None, None])
+        ener_shift1 = fitting._compute_output_stats(all_stat, rcond = 1)
+        np.testing.assert_almost_equal(ae0, ener_shift1[0])

--- a/source/tests/test_gen_stat_data.py
+++ b/source/tests/test_gen_stat_data.py
@@ -146,4 +146,10 @@ class TestEnerShift(unittest.TestCase):
                               resnet_dt = True,
                               atom_ener=[ae0, None, None])
         ener_shift1 = fitting._compute_output_stats(all_stat, rcond = 1)
+        # check assigned energy
         np.testing.assert_almost_equal(ae0, ener_shift1[0])
+        # check if total energy are the same
+        natoms = data.natoms_vec[0][2:]
+        tot0 = np.dot(data.compute_energy_shift(rcond = 1), natoms)
+        tot1 = np.dot(ener_shift1, natoms)
+        np.testing.assert_almost_equal(tot0, tot1)

--- a/source/tests/test_gen_stat_data.py
+++ b/source/tests/test_gen_stat_data.py
@@ -5,6 +5,7 @@ import dpdata
 
 from deepmd.utils import random as dp_random
 from deepmd.utils.data_system import DeepmdDataSystem
+from deepmd.descriptor import DescrptSeA
 from deepmd.fit import EnerFitting
 from deepmd.model.model_stat import make_stat_input, merge_sys_stat, _make_all_stat_ref
 
@@ -115,5 +116,13 @@ class TestEnerShift(unittest.TestCase):
         data.add('energy', 1, must = True)
         ener_shift0 = data.compute_energy_shift(rcond = 1)
         all_stat = make_stat_input(data, 4, merge_sys = False)
-        ener_shift1 = EnerFitting._compute_output_stats(all_stat, rcond = 1)        
+        descrpt = DescrptSeA(6.0, 
+                             5.8,
+                             [46, 92],
+                             neuron = [25, 50, 100], 
+                             axis_neuron = 16)
+        fitting = EnerFitting(descrpt,
+                              neuron = [240, 240, 240],
+                              resnet_dt = True)
+        ener_shift1 = fitting._compute_output_stats(all_stat, rcond = 1)        
         np.testing.assert_almost_equal(ener_shift0, ener_shift1)


### PR DESCRIPTION
Atomic energies stats may be incorrect. Here, we use assigned atomic energies instead.
I am training a model against multiple systems, where some atoms should not contribute energies. Before this commit, the loss of my model could not decrease. After this commit, it decreased quickly.