### PR TITLE
fix macos library name

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -208,8 +208,8 @@ def get_module(module_name: str) -> "ModuleType":
     """
     if platform.system() == "Windows":
         ext = ".dll"
-    elif platform.system() == "Darwin":
-        ext = ".dylib"
+    #elif platform.system() == "Darwin":
+    #    ext = ".dylib"
     else:
         ext = ".so"
 


### PR DESCRIPTION
The library type was changed from SHARED to MODULE in #1384.

Fixes errors in conda-forge/deepmd-kit-feedstock#31
