### PR TITLE
support `dp convert-from 1.1`

### DIFF
--- a/deepmd/entrypoints/convert.py
+++ b/deepmd/entrypoints/convert.py
@@ -7,7 +7,8 @@ def convert(
     output_model: str,
     **kwargs,
 ):
-    if FROM == '1.2':
+    if FROM in ['1.1', '1.2']:
+        # no difference between 1.1 and 1.2
         convert_12_to_21(input_model, output_model)
     elif FROM == '1.3':
         convert_13_to_21(input_model, output_model)

--- a/deepmd/entrypoints/main.py
+++ b/deepmd/entrypoints/main.py
@@ -392,7 +392,7 @@ def parse_args(args: Optional[List[str]] = None):
     parser_transform.add_argument(
         'FROM',
         type = str,
-        choices = ['1.2', '1.3', '2.0'],
+        choices = ['1.1', '1.2', '1.3', '2.0'],
         help="The original model compatibility",
     )
     parser_transform.add_argument(

--- a/doc/troubleshooting/model-compatability.md
+++ b/doc/troubleshooting/model-compatability.md
@@ -8,7 +8,7 @@ One can execute `dp convert-from` to convert an old model to a new one.
 
 | Model version | v0.12 | v1.0 | v1.1 | v1.2 | v1.3 | v2.0 | v2.1 |
 |:-:|:-----------:|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
-| Compatibility  | 😢 | 😢 | 😢 | 😊 | 😊 | 😄 | 😄 |
+| Compatibility  | 😢 | 😢 | 😊 | 😊 | 😊 | 😄 | 😄 |
 
 **Legend**:
 - 😄: The model is compatible with the DeePMD-kit package.


### PR DESCRIPTION
#1583
It looks like there's no breaking changes between v1.1 and v1.2. https://github.com/deepmodeling/deepmd-kit/compare/v1.1.5...v1.2.0