### PR TITLE
fix lammps plugin creator pointer

### DIFF
--- a/source/lmp/plugin/deepmdplugin.cpp
+++ b/source/lmp/plugin/deepmdplugin.cpp
@@ -41,12 +41,12 @@ extern "C" void lammpsplugin_init(void *lmp, void *handle, void *regfunc)
   plugin.style = "compute";
   plugin.name = "deeptensor/atom";
   plugin.info = "compute deeptensor/atom v2.0";
-  plugin.creator.v1 = (lammpsplugin_factory1 *) &computedeepmdtensoratom;
+  plugin.creator.v2 = (lammpsplugin_factory2 *) &computedeepmdtensoratom;
   (*register_plugin)(&plugin, lmp);
 
   plugin.style = "fix";
   plugin.name = "dplr";
   plugin.info = "fix dplr v2.0";
-  plugin.creator.v1 = (lammpsplugin_factory1 *) &fixdplr;
+  plugin.creator.v2 = (lammpsplugin_factory2 *) &fixdplr;
   (*register_plugin)(&plugin, lmp);
 }


### PR DESCRIPTION
`compute` and `fix` style should use `creator.v2` - see https://docs.lammps.org/stable/Developer_plugins.html
(however, it looks like there is nothing wrong with v1)