### PR TITLE
add kspace pppm/dplr to lmp plugin library

### DIFF
--- a/source/lmp/plugin/deepmdplugin.cpp
+++ b/source/lmp/plugin/deepmdplugin.cpp
@@ -6,6 +6,9 @@
 #include "pair_deepmd.h"
 #include "fix_dplr.h"
 #include "compute_deeptensor_atom.h"
+#if LAMMPS_VERSION_NUMBER>=99999999
+#include "pppm_dplr.h"
+#endif
 
 using namespace LAMMPS_NS;
 
@@ -23,6 +26,13 @@ static Fix *fixdplr(LAMMPS *lmp, int narg, char **arg)
 {
   return new FixDPLR(lmp, narg, arg);
 }
+
+#if LAMMPS_VERSION_NUMBER>=99999999
+static KSpace *pppmdplr(LAMMPS *lmp)
+{
+  return new PPPMDPLR(lmp);
+}
+#endif
 
 extern "C" void lammpsplugin_init(void *lmp, void *handle, void *regfunc)
 {
@@ -49,4 +59,13 @@ extern "C" void lammpsplugin_init(void *lmp, void *handle, void *regfunc)
   plugin.info = "fix dplr v2.0";
   plugin.creator.v1 = (lammpsplugin_factory1 *) &fixdplr;
   (*register_plugin)(&plugin, lmp);
+
+#if LAMMPS_VERSION_NUMBER>=99999999
+  // lammps/lammps#
+  plugin.style = "kspace";
+  plugin.name = "pppm/dplr";
+  plugin.info = "kspace pppm/dplr v2.0";
+  plugin.creator.v1 = (lammpsplugin_factory1 *) &pppmdplr;
+  (*register_plugin)(&plugin, lmp);
+#endif
 }

--- a/source/lmp/plugin/deepmdplugin.cpp
+++ b/source/lmp/plugin/deepmdplugin.cpp
@@ -6,7 +6,7 @@
 #include "pair_deepmd.h"
 #include "fix_dplr.h"
 #include "compute_deeptensor_atom.h"
-#if LAMMPS_VERSION_NUMBER>=99999999
+#if LAMMPS_VERSION_NUMBER>=20220328
 #include "pppm_dplr.h"
 #endif
 
@@ -27,7 +27,7 @@ static Fix *fixdplr(LAMMPS *lmp, int narg, char **arg)
   return new FixDPLR(lmp, narg, arg);
 }
 
-#if LAMMPS_VERSION_NUMBER>=99999999
+#if LAMMPS_VERSION_NUMBER>=20220328
 static KSpace *pppmdplr(LAMMPS *lmp)
 {
   return new PPPMDPLR(lmp);
@@ -60,7 +60,7 @@ extern "C" void lammpsplugin_init(void *lmp, void *handle, void *regfunc)
   plugin.creator.v1 = (lammpsplugin_factory1 *) &fixdplr;
   (*register_plugin)(&plugin, lmp);
 
-#if LAMMPS_VERSION_NUMBER>=99999999
+#if LAMMPS_VERSION_NUMBER>=20220328
   // lammps/lammps#
   plugin.style = "kspace";
   plugin.name = "pppm/dplr";


### PR DESCRIPTION
<del>Do not merge - `LAMMPS_VERSION_NUMBER` needs to be updated after the next LAMMPS release.</del>

Fix #1567.