### PR TITLE
fix the atomic virial bug introduced by lammps PR #2481

### DIFF
--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -238,7 +238,11 @@ PairDeepMD::PairDeepMD(LAMMPS *lmp)
     error->all(FLERR,"Pair deepmd requires metal unit, please set it by \"units metal\"");
   }
   restartinfo = 1;
+#if LAMMPS_VERSION_NUMBER>=20201130
   centroidstressflag = CENTROID_AVAIL ; // set centroidstressflag = CENTROID_AVAIL to allow the use of the centroid/stress/atom. Added by Davide Tisi
+#else 
+  centroidstressflag = 2 ; // set centroidstressflag = 2 to allow the use of the centroid/stress/atom. Added by Davide Tisi
+#endif
   pppmflag = 1;
   respa_enable = 0;
   writedata = 0;

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -238,7 +238,7 @@ PairDeepMD::PairDeepMD(LAMMPS *lmp)
     error->all(FLERR,"Pair deepmd requires metal unit, please set it by \"units metal\"");
   }
   restartinfo = 1;
-  centroidstressflag = 2 ; // set centroidstressflag = 2 to allow the use of the centroid/stress/atom. Added by Davide Tisi
+  centroidstressflag = CENTROID_AVAIL ; // set centroidstressflag = CENTROID_AVAIL to allow the use of the centroid/stress/atom. Added by Davide Tisi
   pppmflag = 1;
   respa_enable = 0;
   writedata = 0;


### PR DESCRIPTION
The compute style centroid/stress/atom does not work due to [lammps/lammps#2481](https://github.com/lammps/lammps/pull/2481) 

I change the constant of `centroidstressflag` according to the [definition](https://github.com/lammps/lammps/blob/e1835250c7351a2ba0145e448753216f8346168c/src/pair.h#L71-L74).

LAMMPS version : 24Mar2022

DeePMD-kit version: devel

This PR fixes the issue #1589