### PR TITLE
convert constants (which may change) to variables

### DIFF
--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -837,7 +837,7 @@ class DescrptSeA (DescrptSe):
               # shape[1] = nnei * 4
               nnei = shape[1] / 4
           else:
-              nnei = tf.Variable(np.sum(self.original_sel), trainable=False, name="nnei")
+              nnei = tf.Variable(np.sum(self.original_sel), dtype=tf.int32, trainable=False, name="nnei")
           xyz_scatter_1 = xyz_scatter_1 / nnei
           # natom x 4 x outputs_size_2
           xyz_scatter_2 = tf.slice(xyz_scatter_1, [0,0,0],[-1,-1,outputs_size_2])

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -837,7 +837,7 @@ class DescrptSeA (DescrptSe):
               # shape[1] = nnei * 4
               nnei = shape[1] / 4
           else:
-              nnei = np.sum(self.original_sel)
+              nnei = tf.Variable(np.sum(self.original_sel), trainable=False, name="nnei")
           xyz_scatter_1 = xyz_scatter_1 / nnei
           # natom x 4 x outputs_size_2
           xyz_scatter_2 = tf.slice(xyz_scatter_1, [0,0,0],[-1,-1,outputs_size_2])

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -837,7 +837,7 @@ class DescrptSeA (DescrptSe):
               # shape[1] = nnei * 4
               nnei = shape[1] / 4
           else:
-              nnei = tf.Variable(np.sum(self.original_sel), dtype=tf.int32, trainable=False, name="nnei")
+              nnei = tf.cast(tf.Variable(np.sum(self.original_sel), dtype=tf.int32, trainable=False, name="nnei"), self.filter_precision)
           xyz_scatter_1 = xyz_scatter_1 / nnei
           # natom x 4 x outputs_size_2
           xyz_scatter_2 = tf.slice(xyz_scatter_1, [0,0,0],[-1,-1,outputs_size_2])

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -495,7 +495,8 @@ class EnerFitting (Fitting):
             # tf.repeat is avaiable in TF>=2.1 or TF 1.15
             _TF_VERSION = Version(TF_VERSION)
             if (Version('1.15') <= _TF_VERSION < Version('2') or _TF_VERSION >= Version('2.1')) and self.bias_atom_e is not None:
-                outs += tf.repeat(tf.constant(self.bias_atom_e, dtype=self.fitting_precision), natoms[2:])
+                bias_atom_ei = tf.repeat(tf.constant(self.bias_atom_e, dtype=self.fitting_precision), natoms[2:])
+                outs += tf.Variable(bias_atom_ei, trainable=False, name="bias_atom_ei")
 
         if self.tot_ener_zero:
             force_tot_ener = 0.0

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -137,7 +137,7 @@ class EnerFitting (Fitting):
             else:
                 self.atom_ener.append(None)
         self.useBN = False
-        self.bias_atom_e = None
+        self.bias_atom_e = np.zeros(self.ntypes, dtype=np.float64)
         # data requirement
         if self.numb_fparam > 0 :
             add_data_requirement('fparam', self.numb_fparam, atomic=False, must=True, high_prec=False)

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -496,7 +496,7 @@ class EnerFitting (Fitting):
             _TF_VERSION = Version(TF_VERSION)
             if (Version('1.15') <= _TF_VERSION < Version('2') or _TF_VERSION >= Version('2.1')) and self.bias_atom_e is not None:
                 bias_atom_ei = tf.repeat(tf.constant(self.bias_atom_e, dtype=self.fitting_precision), natoms[2:])
-                outs += tf.Variable(bias_atom_ei, trainable=False, name="bias_atom_ei")
+                outs += tf.Variable(bias_atom_ei, trainable=False, name="bias_atom_ei", dtype=self.fitting_precision)
 
         if self.tot_ener_zero:
             force_tot_ener = 0.0

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -495,8 +495,7 @@ class EnerFitting (Fitting):
             # tf.repeat is avaiable in TF>=2.1 or TF 1.15
             _TF_VERSION = Version(TF_VERSION)
             if (Version('1.15') <= _TF_VERSION < Version('2') or _TF_VERSION >= Version('2.1')) and self.bias_atom_e is not None:
-                bias_atom_ei = tf.repeat(tf.constant(self.bias_atom_e, dtype=self.fitting_precision), natoms[2:])
-                outs += tf.Variable(bias_atom_ei, trainable=False, name="bias_atom_ei", dtype=self.fitting_precision)
+                outs += tf.repeat(tf.Variable(self.bias_atom_e, dtype=self.fitting_precision, trainable=False, name="bias_atom_ei"), natoms[2:])
 
         if self.tot_ener_zero:
             force_tot_ener = 0.0


### PR DESCRIPTION
Following #1592, I noticed that constants cannot be recovered when restart training.

(but it can be recovered automatically if it is a variable instead)