### PR TITLE
refactor init_variable and support type embedding

### DIFF
--- a/deepmd/descriptor/descriptor.py
+++ b/deepmd/descriptor/descriptor.py
@@ -351,7 +351,8 @@ class Descriptor(PluginVariant):
         return feed_dict
 
     def init_variables(self,
-                       model_file: str,
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
                        suffix : str = "",
     ) -> None:
         """
@@ -359,8 +360,10 @@ class Descriptor(PluginVariant):
 
         Parameters
         ----------
-        model_file : str
-            The input model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
         suffix : str, optional
             The suffix of the scope
         

--- a/deepmd/descriptor/hybrid.py
+++ b/deepmd/descriptor/hybrid.py
@@ -279,7 +279,8 @@ class DescrptHybrid (Descriptor):
 
 
     def init_variables(self,
-                       model_file : str,
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
                        suffix : str = "",
     ) -> None:
         """
@@ -287,13 +288,15 @@ class DescrptHybrid (Descriptor):
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
         suffix : str, optional
             The suffix of the scope
         """
         for idx, ii in enumerate(self.descrpt_list):
-            ii.init_variables(model_file, suffix=f"{suffix}_{idx}")
+            ii.init_variables(graph, graph_def, suffix=f"{suffix}_{idx}")
 
     def get_tensor_names(self, suffix : str = "") -> Tuple[str]:
         """Get names of tensors.

--- a/deepmd/descriptor/loc_frame.py
+++ b/deepmd/descriptor/loc_frame.py
@@ -8,7 +8,7 @@ from deepmd.env import op_module
 from deepmd.env import default_tf_session_config
 from deepmd.utils.sess import run_sess
 from .descriptor import Descriptor
-from deepmd.utils.graph import get_tensor_by_name
+from deepmd.utils.graph import get_tensor_by_name_from_graph
 
 @Descriptor.register("loc_frame")
 class DescrptLocFrame (Descriptor) :
@@ -369,18 +369,21 @@ class DescrptLocFrame (Descriptor) :
         return np.sqrt(sumv2/sumn - np.multiply(sumv/sumn, sumv/sumn))
 
     def init_variables(self,
-                       model_file : str,
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
                        suffix : str = "",
     ) -> None:
         """
-        Init the embedding net variables with the given frozen model
+        Init the embedding net variables with the given dict
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
         suffix : str, optional
             The suffix of the scope
         """
-        self.davg = get_tensor_by_name(model_file, 'descrpt_attr%s/t_avg' % suffix)
-        self.dstd = get_tensor_by_name(model_file, 'descrpt_attr%s/t_std' % suffix)
+        self.davg = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_avg' % suffix)
+        self.dstd = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_std' % suffix)

--- a/deepmd/descriptor/se.py
+++ b/deepmd/descriptor/se.py
@@ -1,7 +1,7 @@
 from typing import Tuple, List
 
 from deepmd.env import tf
-from deepmd.utils.graph import get_embedding_net_variables, get_tensor_by_name
+from deepmd.utils.graph import get_embedding_net_variables_from_graph_def, get_tensor_by_name_from_graph
 from .descriptor import Descriptor
 
 
@@ -92,22 +92,25 @@ class DescrptSe (Descriptor):
         self.descrpt_reshape = descrpt_reshape
 
     def init_variables(self,
-                       model_file : str,
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
                        suffix : str = "",
     ) -> None:
         """
-        Init the embedding net variables with the given frozen model
+        Init the embedding net variables with the given dict
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
         suffix : str, optional
             The suffix of the scope
         """
-        self.embedding_net_variables = get_embedding_net_variables(model_file, suffix = suffix)
-        self.davg = get_tensor_by_name(model_file, 'descrpt_attr%s/t_avg' % suffix)
-        self.dstd = get_tensor_by_name(model_file, 'descrpt_attr%s/t_std' % suffix)
+        self.embedding_net_variables = get_embedding_net_variables_from_graph_def(graph_def, suffix = suffix)
+        self.davg = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_avg' % suffix)
+        self.dstd = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_std' % suffix)
 
     @property
     def precision(self) -> tf.DType:

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -855,28 +855,31 @@ class DescrptSeA (DescrptSe):
         return result, qmat
 
     def init_variables(self,
-                       model_file : str,
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
                        suffix : str = "",
     ) -> None:
         """
-        Init the embedding net variables with the given frozen model
+        Init the embedding net variables with the given dict
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
         suffix : str, optional
             The suffix of the scope
         """
-        super().init_variables(model_file=model_file, suffix=suffix)
+        super().init_variables(graph=graph, graph_def=graph_def, suffix=suffix)
         try:
-            self.original_sel = get_tensor_by_name(model_file, 'descrpt_attr%s/original_sel' % suffix)
+            self.original_sel = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/original_sel' % suffix)
         except GraphWithoutTensorError:
             # original_sel is not restored in old graphs, assume sel never changed before
             pass
         # check sel == original sel?
         try:
-            sel = get_tensor_by_name(model_file, 'descrpt_attr%s/sel' % suffix)
+            sel = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/sel' % suffix)
         except GraphWithoutTensorError:
             # sel is not restored in old graphs
             pass

--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -67,9 +67,16 @@ FITTING_NET_PATTERN = str(
     r"final_layer_type_\d+/bias|"
 )
 
+TYPE_EMBEDDING_PATTERN = str(
+    r"type_embed_net+/matrix_\d+|"
+    r"type_embed_net+/bias_\d+|"
+    r"type_embed_net+/idt_\d+|"
+)
+
 TRANSFER_PATTERN = \
     EMBEDDING_NET_PATTERN + \
     FITTING_NET_PATTERN + \
+    TYPE_EMBEDDING_PATTERN + \
     str(
         r"descrpt_attr/t_avg|"
         r"descrpt_attr/t_std|"

--- a/deepmd/fit/dipole.py
+++ b/deepmd/fit/dipole.py
@@ -6,7 +6,7 @@ from deepmd.env import tf
 from deepmd.common import add_data_requirement, get_activation_func, get_precision, ACTIVATION_FN_DICT, PRECISION_DICT, docstring_parameter, cast_precision
 from deepmd.utils.argcheck import list_to_doc
 from deepmd.utils.network import one_layer, one_layer_rand_seed_shift
-from deepmd.utils.graph import get_fitting_net_variables
+from deepmd.utils.graph import get_fitting_net_variables_from_graph_def
 from deepmd.descriptor import DescrptSeA
 from deepmd.fit.fitting import Fitting
 
@@ -168,17 +168,23 @@ class DipoleFittingSeA (Fitting) :
         # return tf.reshape(outs, [tf.shape(inputs)[0] * natoms[0] * 3 // 3])
 
     def init_variables(self,
-                       model_file: str
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
+                       suffix : str = "",
     ) -> None:
         """
-        Init the fitting net variables with the given frozen model
+        Init the fitting net variables with the given dict
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        suffix : str
+            suffix to name scope
         """
-        self.fitting_net_variables = get_fitting_net_variables(model_file)
+        self.fitting_net_variables = get_fitting_net_variables_from_graph_def(graph_def)
 
 
     def enable_mixed_precision(self, mixed_prec : dict = None) -> None:

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -8,7 +8,7 @@ from deepmd.common import add_data_requirement, get_activation_func, get_precisi
 from deepmd.utils.argcheck import list_to_doc
 from deepmd.utils.network import one_layer, one_layer_rand_seed_shift
 from deepmd.utils.type_embed import embed_atom_type
-from deepmd.utils.graph import get_fitting_net_variables, load_graph_def, get_tensor_by_name_from_graph
+from deepmd.utils.graph import get_fitting_net_variables_from_graph_def, load_graph_def, get_tensor_by_name_from_graph
 from deepmd.fit.fitting import Fitting
 
 from deepmd.env import global_cvt_2_tf_float
@@ -510,17 +510,23 @@ class EnerFitting (Fitting):
 
 
     def init_variables(self,
-                       model_file: str
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
+                       suffix : str = "",
     ) -> None:
         """
-        Init the fitting net variables with the given frozen model
+        Init the fitting net variables with the given dict
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        suffix : str
+            suffix to name scope
         """
-        self.fitting_net_variables = get_fitting_net_variables(model_file)
+        self.fitting_net_variables = get_fitting_net_variables_from_graph_def(graph_def)
 
 
     def enable_compression(self,

--- a/deepmd/fit/fitting.py
+++ b/deepmd/fit/fitting.py
@@ -6,3 +6,27 @@ class Fitting:
     def precision(self) -> tf.DType:
         """Precision of fitting network."""
         return self.fitting_precision
+
+    def init_variables(self,
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
+                       suffix : str = "",
+    ) -> None:
+        """
+        Init the fitting net variables with the given dict
+
+        Parameters
+        ----------
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        suffix : str
+            suffix to name scope
+        
+        Notes
+        -----
+        This method is called by others when the fitting supported initialization from the given variables.
+        """
+        raise NotImplementedError(
+            "Fitting %s doesn't support initialization from the given variables!" % type(self).__name__)

--- a/deepmd/fit/polar.py
+++ b/deepmd/fit/polar.py
@@ -6,7 +6,7 @@ from deepmd.env import tf
 from deepmd.common import add_data_requirement, cast_precision, get_activation_func, get_precision, ACTIVATION_FN_DICT, PRECISION_DICT, docstring_parameter
 from deepmd.utils.argcheck import list_to_doc
 from deepmd.utils.network import one_layer, one_layer_rand_seed_shift
-from deepmd.utils.graph import get_fitting_net_variables
+from deepmd.utils.graph import get_fitting_net_variables_from_graph_def
 from deepmd.descriptor import DescrptLocFrame
 from deepmd.descriptor import DescrptSeA
 from deepmd.fit.fitting import Fitting
@@ -375,17 +375,23 @@ class PolarFittingSeA (Fitting) :
         return tf.reshape(outs, [-1])
 
     def init_variables(self,
-                       model_file: str
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
+                       suffix : str = "",
     ) -> None:
         """
-        Init the fitting net variables with the given frozen model
+        Init the fitting net variables with the given dict
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        suffix : str
+            suffix to name scope
         """
-        self.fitting_net_variables = get_fitting_net_variables(model_file)
+        self.fitting_net_variables = get_fitting_net_variables_from_graph_def(graph_def)
 
 
     def enable_mixed_precision(self, mixed_prec : dict = None) -> None:
@@ -511,17 +517,23 @@ class GlobalPolarFittingSeA () :
         return tf.reshape(outs, [-1])
     
     def init_variables(self,
-                       model_file: str
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
+                       suffix : str = "",
     ) -> None:
         """
-        Init the fitting net variables with the given frozen model
+        Init the fitting net variables with the given dict
 
         Parameters
         ----------
-        model_file : str
-            The input frozen model file
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        suffix : str
+            suffix to name scope
         """
-        self.polar_fitting.init_variables(model_file)
+        self.polar_fitting.init_variables(graph=graph, graph_def=graph_def, suffix=suffix)
 
 
     def enable_mixed_precision(self, mixed_prec : dict = None) -> None:

--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -3,13 +3,15 @@ from typing import Tuple, List
 
 from deepmd.env import tf
 from deepmd.utils.pair_tab import PairTab
-from deepmd.utils.graph import load_graph_def
+from deepmd.utils.graph import load_graph_def, get_tensor_by_name_from_graph
+from deepmd.utils.errors import GraphWithoutTensorError
 from deepmd.common import ClassArg
 from deepmd.env import global_cvt_2_ener_float, MODEL_VERSION, GLOBAL_TF_FLOAT_PRECISION
 from deepmd.env import op_module
+from .model import Model
 from .model_stat import make_stat_input, merge_sys_stat
 
-class EnerModel() :
+class EnerModel(Model) :
     """Energy model.
     
     Parameters
@@ -274,3 +276,37 @@ class EnerModel() :
     def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
         graph, graph_def = load_graph_def(frz_model)
         return tf.import_graph_def(graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
+
+    def init_variables(self,
+                       graph : tf.Graph,
+                       graph_def : tf.GraphDef,
+                       model_type : str = "original_model",
+                       suffix : str = "",
+    ) -> None:
+        """
+        Init the embedding net variables with the given frozen model
+
+        Parameters
+        ----------
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        model_type : str
+            the type of the model
+        suffix : str
+            suffix to name scope
+        """
+        # self.frz_model will control the self.model to import the descriptor from the given frozen model instead of building from scratch...
+        # initialize fitting net with the given compressed frozen model
+        if model_type == 'original_model':
+            self.descrpt.init_variables(graph, graph_def, suffix=suffix)
+            self.fitting.init_variables(graph, graph_def, suffix=suffix)
+            tf.constant("original_model", name = 'model_type', dtype = tf.string)
+        elif model_type == 'compressed_model':
+            self.fitting.init_variables(graph, graph_def, suffix=suffix)
+            tf.constant("compressed_model", name = 'model_type', dtype = tf.string)
+        else:
+            raise RuntimeError("Unknown model type %s" % model_type)
+        if self.typeebd is not None:
+            self.typeebd.init_variables(graph, graph_def, suffix=suffix)

--- a/deepmd/model/model.py
+++ b/deepmd/model/model.py
@@ -1,0 +1,25 @@
+from deepmd.env import tf
+
+
+class Model:
+    def init_variables(self,
+                       graph : tf.Graph,
+                       graph_def : tf.GraphDef,
+                       model_type : str = "original_model",
+                       suffix : str = "",
+    ) -> None:
+        """
+        Init the embedding net variables with the given frozen model
+
+        Parameters
+        ----------
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        model_type : str
+            the type of the model
+        suffix : str
+            suffix to name scope
+        """
+        raise RuntimeError("The 'dp train init-frz-model' command do not support this model!")

--- a/deepmd/model/tensor.py
+++ b/deepmd/model/tensor.py
@@ -6,9 +6,10 @@ from deepmd.common import ClassArg
 from deepmd.env import global_cvt_2_ener_float, MODEL_VERSION, GLOBAL_TF_FLOAT_PRECISION
 from deepmd.env import op_module
 from deepmd.utils.graph import load_graph_def
+from .model import Model
 from .model_stat import make_stat_input, merge_sys_stat
 
-class TensorModel() :
+class TensorModel(Model) :
     """Tensor model.
 
     Parameters
@@ -192,6 +193,37 @@ class TensorModel() :
     def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
         graph, graph_def = load_graph_def(frz_model)
         return tf.import_graph_def(graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
+
+    def init_variables(self,
+                       graph : tf.Graph,
+                       graph_def : tf.GraphDef,
+                       model_type : str = "original_model",
+                       suffix : str = "",
+    ) -> None:
+        """
+        Init the embedding net variables with the given frozen model
+
+        Parameters
+        ----------
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        model_type : str
+            the type of the model
+        suffix : str
+            suffix to name scope
+        """
+        if model_type == 'original_model':
+            self.descrpt.init_variables(graph, graph_def, suffix=suffix)
+            self.fitting.init_variables(graph, graph_def, suffix=suffix)
+            tf.constant("original_model", name = 'model_type', dtype = tf.string)
+        elif model_type == 'compressed_model':
+            self.fitting.init_variables(graph, graph_def, suffix=suffix)
+            tf.constant("compressed_model", name = 'model_type', dtype = tf.string)
+        else:
+            raise RuntimeError("Unknown model type %s" % model_type)
+
 
 class WFCModel(TensorModel):
     def __init__(

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -22,7 +22,7 @@ from deepmd.utils.learning_rate import LearningRateExp
 from deepmd.utils.neighbor_stat import NeighborStat
 from deepmd.utils.sess import run_sess
 from deepmd.utils.type_embed import TypeEmbedNet
-from deepmd.utils.graph import get_tensor_by_name
+from deepmd.utils.graph import load_graph_def, get_tensor_by_name_from_graph
 
 from tensorflow.python.client import timeline
 from deepmd.env import op_module, TF_VERSION
@@ -680,34 +680,22 @@ class DPTrainer (object):
             self.place_holders['find_' + kk] = tf.placeholder(tf.float32, name = 't_find_' + kk)
 
     def _init_from_frz_model(self):
+        try:
+            graph, graph_def = load_graph_def(self.run_opt.init_frz_model)
+        except FileNotFoundError as e:
+            # throw runtime error if there's no frozen model
+            raise RuntimeError(
+                "The input frozen model %s (%s) does not exist! Please check the path of the frozen model. " % (self.run_opt.init_frz_model, os.path.abspath(self.run_opt.init_frz_model))
+            ) from e
         # get the model type from the frozen model(self.run_opt.init_frz_model)
         try:
-            t_model_type = get_tensor_by_name(self.run_opt.init_frz_model, 'model_type')
-            self.model_type = bytes.decode(t_model_type)
+            t_model_type = get_tensor_by_name_from_graph(graph, 'model_type')
         except GraphWithoutTensorError as e:
-            # throw runtime error if there's no frozen model
-            if not os.path.exists(self.run_opt.init_frz_model):
-                raise RuntimeError(
-                    "The input frozen model %s (%s) does not exist! Please check the path of the frozen model. " % (self.run_opt.init_frz_model, os.path.abspath(self.run_opt.init_frz_model))
-                ) from e
             # throw runtime error if the frozen_model has no model type information...
-            else:
-                raise RuntimeError(
-                    "The input frozen model: %s has no 'model_type' information, "
-                    "which is not supported by the 'dp train init-frz-model' interface. " % self.run_opt.init_frz_model
-                ) from e
-        
-        if self.fitting_type != 'ener':
-            raise RuntimeError("The 'dp train init-frz-model' command only supports the 'ener' type fitting net currently!")
-        # self.frz_model will control the self.model to import the descriptor from the given frozen model instead of building from scratch...
-        # initialize fitting net with the given compressed frozen model
-        if self.model_type == 'original_model':
-            self.descrpt.init_variables(self.run_opt.init_frz_model)
-            self.fitting.init_variables(self.run_opt.init_frz_model)
-            tf.constant("original_model", name = 'model_type', dtype = tf.string)
-        elif self.model_type == 'compressed_model':
-            self.frz_model = self.run_opt.init_frz_model
-            self.fitting.init_variables(self.frz_model)
-            tf.constant("compressed_model", name = 'model_type', dtype = tf.string)
+            raise RuntimeError(
+                "The input frozen model: %s has no 'model_type' information, "
+                "which is not supported by the 'dp train init-frz-model' interface. " % self.run_opt.init_frz_model
+            ) from e
         else:
-            raise RuntimeError("Unknown model type %s" % self.model_type)
+            self.model_type = bytes.decode(t_model_type)
+        self.model.init_variables(graph, graph_def, model_type=self.model_type)

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -296,8 +296,9 @@ class DPTrainer (object):
             # TODO: this is a simple fix but we should have a clear
             #       architecture to call neighbor stat
         else :
+            graph, graph_def = load_graph_def(self.model_param['compress']['model_file'])
             self.descrpt.enable_compression(self.model_param['compress']["min_nbor_dist"], self.model_param['compress']['model_file'], self.model_param['compress']['table_config'][0], self.model_param['compress']['table_config'][1], self.model_param['compress']['table_config'][2], self.model_param['compress']['table_config'][3])
-            self.fitting.init_variables(self.model_param['compress']['model_file'])
+            self.fitting.init_variables(graph, graph_def)
             # for fparam or aparam settings in 'ener' type fitting net
             if self.fitting_type == 'ener':
                 self.fitting.enable_compression(self.model_param['compress']['model_file'])

--- a/deepmd/utils/type_embed.py
+++ b/deepmd/utils/type_embed.py
@@ -9,7 +9,7 @@ from deepmd.env import op_module
 from deepmd.env import default_tf_session_config
 from deepmd.utils.network import  embedding_net
 
-import math
+from deepmd.utils.graph import get_type_embedding_net_variables_from_graph_def
 from deepmd.common import get_activation_func, get_precision, ACTIVATION_FN_DICT, PRECISION_DICT, docstring_parameter, get_np_precision
 from deepmd.utils.argcheck import list_to_doc
 
@@ -95,6 +95,7 @@ class TypeEmbedNet():
         self.filter_activation_fn = get_activation_func(activation_function)
         self.trainable = trainable
         self.uniform_seed = uniform_seed
+        self.type_embedding_net_variables = None
 
 
     def build(
@@ -136,9 +137,27 @@ class TypeEmbedNet():
                 resnet_dt = self.filter_resnet_dt,
                 seed = self.seed,
                 trainable = self.trainable, 
+                initial_variables = self.type_embedding_net_variables,
                 uniform_seed = self.uniform_seed)
         ebd_type = tf.reshape(ebd_type, [-1, self.neuron[-1]]) # nnei * neuron[-1]
         self.ebd_type = tf.identity(ebd_type, name ='t_typeebd')
         return self.ebd_type 
 
+    def init_variables(self,
+                       graph: tf.Graph,
+                       graph_def: tf.GraphDef,
+                       suffix = '',
+    ) -> None:
+        """
+        Init the type embedding net variables with the given dict
 
+        Parameters
+        ----------
+        graph : tf.Graph
+            The input frozen model graph
+        graph_def : tf.GraphDef
+            The input frozen model graph_def
+        suffix
+            Name suffix to identify this descriptor
+        """
+        self.type_embedding_net_variables = get_type_embedding_net_variables_from_graph_def(graph_def, suffix = suffix)


### PR DESCRIPTION
Fix #1578. This commit refactors init_variable for both Descriptor and Fitting, so they can accept graph and graph_def instead of the filename. Opening the same file multiple times is bad behavior.
Moves some codes in Trainer to Model. Indeed Trainer should not operate Descriptor and Fitting directly.
Add init_variable method to type_embedding.

@denghuilu - I think `enable_compression` may have some similar issues.