### PR TITLE
implement parallelism for neighbor stat

### DIFF
--- a/deepmd/utils/neighbor_stat.py
+++ b/deepmd/utils/neighbor_stat.py
@@ -87,7 +87,7 @@ class NeighborStat():
                             'natoms_vec': np.array(data.natoms_vec[ii]),
                             'box': np.array(data_set['box'])[kk].reshape([-1, 9]),
                             'default_mesh': np.array(data.default_mesh[ii]),
-                            'dir': jj,
+                            'dir': str(jj),
                         }
 
         for mn, dt, jj in self.p.generate(self.sub_sess, feed()):

--- a/deepmd/utils/neighbor_stat.py
+++ b/deepmd/utils/neighbor_stat.py
@@ -7,7 +7,7 @@ from deepmd.env import op_module
 from deepmd.env import default_tf_session_config
 from deepmd.env import GLOBAL_NP_FLOAT_PRECISION
 from deepmd.utils.data_system import DeepmdDataSystem
-from deepmd.utils.sess import run_sess
+from deepmd.utils.parallel_op import ParallelOp
 
 log = logging.getLogger(__name__)
 
@@ -32,21 +32,28 @@ class NeighborStat():
         """
         self.rcut = rcut
         self.ntypes = ntypes
-        self.place_holders = {}
         sub_graph = tf.Graph()
-        with sub_graph.as_default():
+
+        def builder():
+            place_holders = {}
             for ii in ['coord', 'box']:
-                self.place_holders[ii] = tf.placeholder(GLOBAL_NP_FLOAT_PRECISION, [None, None], name='t_'+ii)
-            self.place_holders['type'] = tf.placeholder(tf.int32, [None, None], name='t_type')
-            self.place_holders['natoms_vec'] = tf.placeholder(tf.int32, [self.ntypes+2], name='t_natoms')
-            self.place_holders['default_mesh'] = tf.placeholder(tf.int32, [None], name='t_mesh')
-            self._max_nbor_size, self._min_nbor_dist \
-                = op_module.neighbor_stat(self.place_holders['coord'],
-                                         self.place_holders['type'],
-                                         self.place_holders['natoms_vec'],
-                                         self.place_holders['box'],
-                                         self.place_holders['default_mesh'],
+                place_holders[ii] = tf.placeholder(GLOBAL_NP_FLOAT_PRECISION, [None, None], name='t_'+ii)
+            place_holders['type'] = tf.placeholder(tf.int32, [None, None], name='t_type')
+            place_holders['natoms_vec'] = tf.placeholder(tf.int32, [self.ntypes+2], name='t_natoms')
+            place_holders['default_mesh'] = tf.placeholder(tf.int32, [None], name='t_mesh')
+            _max_nbor_size, _min_nbor_dist \
+                = op_module.neighbor_stat(place_holders['coord'],
+                                         place_holders['type'],
+                                         place_holders['natoms_vec'],
+                                         place_holders['box'],
+                                         place_holders['default_mesh'],
                                          rcut = self.rcut)
+            place_holders['dir'] = tf.placeholder(tf.string)
+            return place_holders, (_max_nbor_size, _min_nbor_dist, place_holders['dir'])
+
+        with sub_graph.as_default():
+            self.p = ParallelOp(builder, config=default_tf_session_config)
+
         self.sub_sess = tf.Session(graph = sub_graph, config=default_tf_session_config)
 
     def get_stat(self,
@@ -69,39 +76,37 @@ class NeighborStat():
         self.min_nbor_dist = 100.0
         self.max_nbor_size = [0] * self.ntypes
 
-        # for ii in tqdm(range(len(data.system_dirs)), desc = 'DEEPMD INFO    |-> deepmd.utils.neighbor_stat\t\t\tgetting neighbor status'):
-        for ii in range(len(data.system_dirs)):
-            for jj in data.data_systems[ii].dirs:
-                data_set = data.data_systems[ii]._load_set(jj)
-                for kk in range(np.array(data_set['type']).shape[0]):
-                    mn, dt \
-                        = run_sess(self.sub_sess, [self._max_nbor_size, self._min_nbor_dist], 
-                                            feed_dict = {
-                                                self.place_holders['coord']: np.array(data_set['coord'])[kk].reshape([-1, data.natoms[ii] * 3]),
-                                                self.place_holders['type']: np.array(data_set['type'])[kk].reshape([-1, data.natoms[ii]]),
-                                                self.place_holders['natoms_vec']: np.array(data.natoms_vec[ii]),
-                                                self.place_holders['box']: np.array(data_set['box'])[kk].reshape([-1, 9]),
-                                                self.place_holders['default_mesh']: np.array(data.default_mesh[ii]),
-                                            })
-                    if dt.size != 0:
-                        dt = np.min(dt)              
-                    else:
-                        dt = self.rcut
-                        log.warning("Atoms with no neighbors found in %s. Please make sure it's what you expected."%jj)
-                        
-                    if dt < self.min_nbor_dist:
-                        if math.isclose(dt, 0., rel_tol=1e-6):
-                            # it's unexpected that the distance between two atoms is zero
-                            # zero distance will cause nan (#874) 
-                            raise RuntimeError(
-                                "Some atoms in %s are overlapping. Please check your"
-                                " training data to remove duplicated atoms." % jj
-                            )
-                        self.min_nbor_dist = dt
-                    for ww in range(self.ntypes):
-                        var = np.max(mn[:, ww])
-                        if var > self.max_nbor_size[ww]:
-                            self.max_nbor_size[ww] = var
+        def feed():
+            for ii in range(len(data.system_dirs)):
+                for jj in data.data_systems[ii].dirs:
+                    data_set = data.data_systems[ii]._load_set(jj)
+                    for kk in range(np.array(data_set['type']).shape[0]):
+                        yield {
+                            'coord': np.array(data_set['coord'])[kk].reshape([-1, data.natoms[ii] * 3]),
+                            'type': np.array(data_set['type'])[kk].reshape([-1, data.natoms[ii]]),
+                            'natoms_vec': np.array(data.natoms_vec[ii]),
+                            'box': np.array(data_set['box'])[kk].reshape([-1, 9]),
+                            'default_mesh': np.array(data.default_mesh[ii]),
+                            'dir': jj,
+                        }
+
+        for mn, dt, jj in self.p.generate(self.sub_sess, feed()):
+            if dt.size != 0:
+                dt = np.min(dt)
+            else:
+                dt = self.rcut
+                log.warning("Atoms with no neighbors found in %s. Please make sure it's what you expected." % jj)
+            if dt < self.min_nbor_dist:
+                if math.isclose(dt, 0., rel_tol=1e-6):
+                    # it's unexpected that the distance between two atoms is zero
+                    # zero distance will cause nan (#874) 
+                    raise RuntimeError(
+                        "Some atoms are overlapping in %s. Please check your"
+                        " training data to remove duplicated atoms." % jj
+                    )
+                self.min_nbor_dist = dt
+            var = np.max(mn, axis=0)
+            self.max_nbor_size = np.maximum(var, self.max_nbor_size)
 
         log.info('training data with min nbor dist: ' + str(self.min_nbor_dist))
         log.info('training data with max nbor size: ' + str(self.max_nbor_size))

--- a/deepmd/utils/parallel_op.py
+++ b/deepmd/utils/parallel_op.py
@@ -1,0 +1,80 @@
+from typing import Callable, Generator, Tuple, Dict, Any
+
+from deepmd.env import tf
+from deepmd.utils.sess import run_sess
+
+
+class ParallelOp:
+    """Run an op with data parallelism.
+    
+    Parameters
+    ----------
+    builder : Callable[..., Tuple[Dict[str, tf.Tensor], Tuple[tf.Tensor]]]
+        returns two objects: a dict which stores placeholders by key, and a tuple with the final op(s)
+    nthreads : int, optional
+        the number of threads
+    config : tf.ConfigProto, optional
+        tf.ConfigProto
+    
+    Examples
+    --------
+    >>> from deepmd.env import tf
+    >>> from deepmd.utils.parallel_op import ParallelOp
+    >>> def builder():
+    ...     x = tf.placeholder(tf.int32, [1])
+    ...     return {"x": x}, (x + 1)
+    ...
+    >>> p = ParallelOp(builder, nthreads=4)
+    >>> def feed():
+    ...     for ii in range(10):
+    ...         yield {"x": [ii]}
+    ...
+    >>> print(*p.generate(tf.Session(), feed()))
+    [1] [2] [3] [4] [5] [6] [7] [8] [9] [10]
+    """
+    def __init__(self, builder: Callable[..., Tuple[Dict[str, tf.Tensor], Tuple[tf.Tensor]]], nthreads: int = None, config: tf.ConfigProto = None) -> None:
+        if nthreads is not None:
+            self.nthreads = nthreads
+        elif config is not None:
+            self.nthreads = max(config.inter_op_parallelism_threads, 1)
+        else:
+            self.nthreads = 1
+        
+        self.placeholders = []
+        self.ops = []
+        for ii in range(self.nthreads):
+            with tf.name_scope("task_%d" % ii) as scope:
+                placeholder, op = builder()
+                self.placeholders.append(placeholder)
+                self.ops.append(op)
+
+    def generate(self, sess: tf.Session, feed: Generator[Dict[str, Any], None, None]) -> Generator[Tuple, None, None]:
+        """Returns a generator.
+
+        Parameters
+        ----------
+        feed: Generator[dict, None, None]
+            generator which yields feed_dict
+        
+        Yields
+        ------
+        Generator[Tuple, None, None]
+            generator which yields session returns
+        """
+        nn = self.nthreads
+        while True:
+            feed_dict = {}
+            for ii in range(self.nthreads):
+                try:
+                    fd = next(feed)
+                except StopIteration:
+                    if ii == 0:
+                        return
+                    nn = ii
+                    break
+                for kk, vv in fd.items():
+                    feed_dict[self.placeholders[ii][kk]] = vv  
+            ops = self.ops[:nn]       
+            for yy in run_sess(sess, ops, feed_dict=feed_dict):
+                yield yy
+        

--- a/deepmd/utils/parallel_op.py
+++ b/deepmd/utils/parallel_op.py
@@ -53,7 +53,7 @@ class ParallelOp:
 
         Parameters
         ----------
-        feed: Generator[dict, None, None]
+        feed : Generator[dict, None, None]
             generator which yields feed_dict
         
         Yields


### PR DESCRIPTION
benchmark on ANI-1x dataset: 19:25 -> 14:32
when setting `OMP_NUM_THREADS=1 TF_INTRA_OP_PARALLELISM_THREADS=1 TF_INTER_OP_PARALLELISM_THREADS=12`

![aedc851c1fab2e04fb410988f952182](https://user-images.githubusercontent.com/9496702/162385405-13e9ba4d-0ecd-4544-9bc3-b95b275f1085.png)
![image](https://user-images.githubusercontent.com/9496702/162385427-b8aa862c-7dc7-4121-aa16-2c50d13b598e.png)

(I think `OMP_NUM_THREADS=2 TF_INTRA_OP_PARALLELISM_THREADS=2 TF_INTER_OP_PARALLELISM_THREADS=6` may have better performance, but I have no interest to test it)