### PR TITLE
fix TF version bug in #1429

### DIFF
--- a/source/op/optimizer/parallel.cc
+++ b/source/op/optimizer/parallel.cc
@@ -1,5 +1,6 @@
 // only support v1.15 or v2
-#if TF_MAJOR_VERSION >= 2 && (TF_MAJOR_VERSION == 1 || TF_MINOR_VERSION >= 15)
+#include "tensorflow/core/public/version.h"
+#if TF_MAJOR_VERSION >= 2 || (TF_MAJOR_VERSION == 1 && TF_MINOR_VERSION >= 15)
 
 #include "parallel.h"
 


### PR DESCRIPTION
1. "and" should be "or" and "or" should be "and"
2. forgot to introduce `TF_MAJOR_VERSION` and `TF_MINOR_VERSION` from `version.h`
So it couldn't be compiled...