### PR TITLE
reset the graph before freezing the compressed model

### DIFF
--- a/deepmd/entrypoints/compress.py
+++ b/deepmd/entrypoints/compress.py
@@ -135,6 +135,9 @@ def compress(
             "increase the step size." % step
         ) from e
 
+    # reset the graph, otherwise the size limitation will be only 2 GB / 2 = 1 GB
+    tf.reset_default_graph()
+
     # stage 2: freeze the model
     log.info("\n\n")
     log.info("stage 2: freeze the model")


### PR DESCRIPTION
A graph has a size limitation of 2 GB, so if we do not clean the graph, the limitation will be indeed 1GB...

This PR will increase the limitation from 1 GB to 2 GB.