### PR TITLE
migrate sphinx mathjax from jsdelivr to cdnjs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,3 +251,4 @@ html_css_files = ['css/custom.css']
 autodoc_default_flags = ['members']
 autosummary_generate = True
 master_doc = 'index'
+mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-mml-chtml.min.js'


### PR DESCRIPTION
jsdelivr, which is the default mathjax path in the sphinx, has been blocked in China. See jsdelivr/jsdelivr#18392. Of course, we hope our rendered equations can be shown in China.