### PR TITLE
fix bug of model compression training with se_e2_r type descriptor

### DIFF
--- a/source/op/tabulate_multi_device.cc
+++ b/source/op/tabulate_multi_device.cc
@@ -666,7 +666,7 @@ class TabulateFusionSeRGradGradOp : public OpKernel {
     const Tensor& dz_dy_dem_tensor	= context->input(context_input_index++);
     const Tensor& descriptor_tensor = context->input(context_input_index++);
     // set size of the sample
-    OP_REQUIRES (context, (dz_dy_dem_tensor.shape().dims() == 3),      errors::InvalidArgument ("Dim of input should be 3"));
+    OP_REQUIRES (context, (dz_dy_dem_tensor.shape().dims() == 2),      errors::InvalidArgument ("Dim of input should be 3"));
     int context_output_index = 0;
     Tensor* dz_dy_tensor = NULL;
     OP_REQUIRES_OK(context, context->allocate_output(

--- a/source/op/tabulate_multi_device.cc
+++ b/source/op/tabulate_multi_device.cc
@@ -666,7 +666,7 @@ class TabulateFusionSeRGradGradOp : public OpKernel {
     const Tensor& dz_dy_dem_tensor	= context->input(context_input_index++);
     const Tensor& descriptor_tensor = context->input(context_input_index++);
     // set size of the sample
-    OP_REQUIRES (context, (dz_dy_dem_tensor.shape().dims() == 2),      errors::InvalidArgument ("Dim of input should be 3"));
+    OP_REQUIRES (context, (dz_dy_dem_tensor.shape().dims() == 2),      errors::InvalidArgument ("Dim of input should be 2"));
     int context_output_index = 0;
     Tensor* dz_dy_tensor = NULL;
     OP_REQUIRES_OK(context, context->allocate_output(


### PR DESCRIPTION
Fix #1681.
And the result of dp train shows the correctness of model compression training:
`dp train input.json -f frozen_model_compressed.pb`
```
(tensorflow_venv) root@iZ8vb672g6x8vab6ywhddcZ:~/deepmd-kit/examples/water/se_e2_r# cat lcurve.out 
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      9.07e+00    9.24e+00      2.93e-01    2.95e-01      2.86e-01    2.92e-01    5.0e-03
    100      6.94e+00    6.68e+00      1.20e-01    1.19e-01      2.19e-01    2.11e-01    5.0e-03
    200      7.01e+00    7.15e+00      4.73e-02    4.52e-02      2.22e-01    2.26e-01    5.0e-03
    300      7.06e+00    6.93e+00      5.68e-02    5.37e-02      2.23e-01    2.19e-01    5.0e-03
    400      6.80e+00    7.43e+00      2.92e-01    2.91e-01      2.14e-01    2.34e-01    5.0e-03
    500      6.85e+00    6.88e+00      1.78e-01    1.76e-01      2.16e-01    2.17e-01    5.0e-03
```
`dp train input.json -f frozen_model.pb`
```
(tensorflow_venv) root@iZ8vb672g6x8vab6ywhddcZ:~/deepmd-kit/examples/water/se_e2_r# cat lcurve.out 
#  step      rmse_val    rmse_trn    rmse_e_val  rmse_e_trn    rmse_f_val  rmse_f_trn         lr
      0      9.07e+00    9.24e+00      2.93e-01    2.95e-01      2.86e-01    2.92e-01    5.0e-03
    100      7.18e+00    6.85e+00      3.19e-02    3.22e-02      2.27e-01    2.17e-01    5.0e-03
    200      7.14e+00    7.57e+00      1.80e-03    9.59e-05      2.26e-01    2.39e-01    5.0e-03
    300      7.00e+00    7.05e+00      3.32e-01    3.29e-01      2.20e-01    2.22e-01    5.0e-03
    400      7.51e+00    7.99e+00      4.59e-01    4.58e-01      2.36e-01    2.51e-01    5.0e-03
    500      7.88e+00    7.79e+00      2.09e-01    2.06e-01      2.49e-01    2.46e-01    5.0e-03
```