### PR TITLE
fix finding TF 2.9 ABI

### DIFF
--- a/source/cmake/tf_cxx_abi.cpp
+++ b/source/cmake/tf_cxx_abi.cpp
@@ -3,8 +3,11 @@
 int main(int argc, char * argv[])
 {
 #if (TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION>=9) || TF_MAJOR_VERSION > 2 
-#include "tensorflow/core/util/version_info.h"
-  std::cout << TF_CXX11_ABI_FLAG;
+#ifdef _GLIBCXX_USE_CXX11_ABI
+  std::cout << _GLIBCXX_USE_CXX11_ABI;
+#else
+  std::cout << 0;
+#endif
 #else
   std::cout << tf_cxx11_abi_flag();
 #endif


### PR DESCRIPTION
Follow up #1723. It's quite confusing that no `version_info.h` is generated
when building TF 2.9 C++ library only (but Python library has). So the
definition is copied here..
