### PR TITLE
using int64 within the memory allocation operations

### DIFF
--- a/deepmd/descriptor/hybrid.py
+++ b/deepmd/descriptor/hybrid.py
@@ -189,7 +189,7 @@ class DescrptHybrid (Descriptor):
             dout = tf.reshape(dout, [-1, ii.get_dim_out()])
             all_dout.append(dout)
         dout = tf.concat(all_dout, axis = 1)
-        dout = tf.reshape(dout, [-1, natoms[0] * self.get_dim_out()])
+        dout = tf.reshape(dout, [-1, natoms[0], self.get_dim_out()])
         return dout
         
 

--- a/deepmd/descriptor/loc_frame.py
+++ b/deepmd/descriptor/loc_frame.py
@@ -305,7 +305,7 @@ class DescrptLocFrame (Descriptor) :
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt)
         tf.summary.histogram('net_derivative', net_deriv)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])
+        net_deriv_reshape = tf.reshape (net_deriv, [np.cast['int64'](-1), natoms[0] * np.cast['int64'](self.ndescrpt)])
         force = op_module.prod_force (net_deriv_reshape,
                                       self.descrpt_deriv,
                                       self.nlist,

--- a/deepmd/descriptor/loc_frame.py
+++ b/deepmd/descriptor/loc_frame.py
@@ -305,7 +305,7 @@ class DescrptLocFrame (Descriptor) :
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt)
         tf.summary.histogram('net_derivative', net_deriv)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, natoms[0] * self.ndescrpt])
+        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])
         force = op_module.prod_force (net_deriv_reshape,
                                       self.descrpt_deriv,
                                       self.nlist,

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -517,7 +517,7 @@ class DescrptSeA (DescrptSe):
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt_reshape)
         tf.summary.histogram('net_derivative', net_deriv)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])        
+        net_deriv_reshape = tf.reshape (net_deriv, [np.cast['int64'](-1), natoms[0] * np.cast['int64'](self.ndescrpt)])        
         force \
             = op_module.prod_force_se_a (net_deriv_reshape,
                                           self.descrpt_deriv,

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -517,7 +517,7 @@ class DescrptSeA (DescrptSe):
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt_reshape)
         tf.summary.histogram('net_derivative', net_deriv)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, natoms[0] * self.ndescrpt])        
+        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])        
         force \
             = op_module.prod_force_se_a (net_deriv_reshape,
                                           self.descrpt_deriv,
@@ -553,14 +553,14 @@ class DescrptSeA (DescrptSe):
         else:
             type_embedding = None
         start_index = 0
-        inputs = tf.reshape(inputs, [-1, self.ndescrpt * natoms[0]])
+        inputs = tf.reshape(inputs, [-1, natoms[0], self.ndescrpt])
         output = []
         output_qmat = []
         if not (self.type_one_side and len(self.exclude_types) == 0) and type_embedding is None:
             for type_i in range(self.ntypes):
                 inputs_i = tf.slice (inputs,
-                                     [ 0, start_index*      self.ndescrpt],
-                                     [-1, natoms[2+type_i]* self.ndescrpt] )
+                                     [ 0, start_index, 0],
+                                     [-1, natoms[2+type_i], -1] )
                 inputs_i = tf.reshape(inputs_i, [-1, self.ndescrpt])
                 if self.type_one_side:
                     # reuse NN parameters for all types to support type_one_side along with exclude_types
@@ -569,8 +569,8 @@ class DescrptSeA (DescrptSe):
                 else:
                     filter_name = 'filter_type_'+str(type_i)+suffix
                 layer, qmat = self._filter(inputs_i, type_i, name=filter_name, natoms=natoms, reuse=reuse, trainable = trainable, activation_fn = self.filter_activation_fn)
-                layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[2+type_i] * self.get_dim_out()])
-                qmat  = tf.reshape(qmat,  [tf.shape(inputs)[0], natoms[2+type_i] * self.get_dim_rot_mat_1() * 3])
+                layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[2+type_i], self.get_dim_out()])
+                qmat  = tf.reshape(qmat,  [tf.shape(inputs)[0], natoms[2+type_i], self.get_dim_rot_mat_1() * 3])
                 output.append(layer)
                 output_qmat.append(qmat)
                 start_index += natoms[2+type_i]
@@ -579,8 +579,8 @@ class DescrptSeA (DescrptSe):
             inputs_i = tf.reshape(inputs_i, [-1, self.ndescrpt])
             type_i = -1
             layer, qmat = self._filter(inputs_i, type_i, name='filter_type_all'+suffix, natoms=natoms, reuse=reuse, trainable = trainable, activation_fn = self.filter_activation_fn, type_embedding=type_embedding)
-            layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0] * self.get_dim_out()])
-            qmat  = tf.reshape(qmat,  [tf.shape(inputs)[0], natoms[0] * self.get_dim_rot_mat_1() * 3])
+            layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0], self.get_dim_out()])
+            qmat  = tf.reshape(qmat,  [tf.shape(inputs)[0], natoms[0], self.get_dim_rot_mat_1() * 3])
             output.append(layer)
             output_qmat.append(qmat)
         output = tf.concat(output, axis = 1)

--- a/deepmd/descriptor/se_a_ebd.py
+++ b/deepmd/descriptor/se_a_ebd.py
@@ -433,8 +433,8 @@ class DescrptSeAEbd (DescrptSeA):
                                        seed = self.seed, 
                                        trainable = trainable, 
                                        activation_fn = self.filter_activation_fn)
-        output      = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0] * self.get_dim_out()])
-        output_qmat = tf.reshape(qmat,  [tf.shape(inputs)[0], natoms[0] * self.get_dim_rot_mat_1() * 3])
+        output      = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0], self.get_dim_out()])
+        output_qmat = tf.reshape(qmat,  [tf.shape(inputs)[0], natoms[0], self.get_dim_rot_mat_1() * 3])
         return output, output_qmat
 
 

--- a/deepmd/descriptor/se_a_ef.py
+++ b/deepmd/descriptor/se_a_ef.py
@@ -230,7 +230,7 @@ class DescrptSeAEf (Descriptor):
         self.dout_vert = tf.reshape(self.dout_vert, [nframes * natoms[0], self.descrpt_vert.get_dim_out()])
         self.dout_para = tf.reshape(self.dout_para, [nframes * natoms[0], self.descrpt_para.get_dim_out()])
         self.dout = tf.concat([self.dout_vert, self.dout_para], axis = 1)
-        self.dout = tf.reshape(self.dout, [nframes, natoms[0] * self.get_dim_out()])
+        self.dout = tf.reshape(self.dout, [nframes, natoms[0], self.get_dim_out()])
         self.qmat = self.descrpt_vert.qmat + self.descrpt_para.qmat
 
         tf.summary.histogram('embedding_net_output', self.dout)

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -415,7 +415,7 @@ class DescrptSeR (DescrptSe):
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt_reshape)
         tf.summary.histogram('net_derivative', net_deriv)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])        
+        net_deriv_reshape = tf.reshape (net_deriv, [np.cast['int64'](-1), natoms[0] * np.cast['int64'](self.ndescrpt)])        
         force \
             = op_module.prod_force_se_r (net_deriv_reshape,
                                          self.descrpt_deriv,

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -415,7 +415,7 @@ class DescrptSeR (DescrptSe):
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt_reshape)
         tf.summary.histogram('net_derivative', net_deriv)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, natoms[0] * self.ndescrpt])        
+        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])        
         force \
             = op_module.prod_force_se_r (net_deriv_reshape,
                                          self.descrpt_deriv,
@@ -441,13 +441,13 @@ class DescrptSeR (DescrptSe):
                      suffix = '', 
                      trainable = True) :
         start_index = 0
-        inputs = tf.reshape(inputs, [-1, self.ndescrpt * natoms[0]])
+        inputs = tf.reshape(inputs, [-1, natoms[0], self.ndescrpt])
         output = []
         if not (self.type_one_side and len(self.exclude_types) == 0):
             for type_i in range(self.ntypes):
                 inputs_i = tf.slice (inputs,
-                                     [ 0, start_index*      self.ndescrpt],
-                                     [-1, natoms[2+type_i]* self.ndescrpt] )
+                                     [ 0, start_index, 0],
+                                     [-1, natoms[2+type_i], -1] )
                 inputs_i = tf.reshape(inputs_i, [-1, self.ndescrpt])
                 if self.type_one_side:
                     # reuse NN parameters for all types to support type_one_side along with exclude_types
@@ -456,7 +456,7 @@ class DescrptSeR (DescrptSe):
                 else:
                     filter_name = 'filter_type_'+str(type_i)+suffix
                 layer = self._filter_r(inputs_i, type_i, name=filter_name, natoms=natoms, reuse=reuse, trainable = trainable, activation_fn = self.filter_activation_fn)
-                layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[2+type_i] * self.get_dim_out()])
+                layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[2+type_i], self.get_dim_out()])
                 output.append(layer)
                 start_index += natoms[2+type_i]
         else :
@@ -464,7 +464,7 @@ class DescrptSeR (DescrptSe):
             inputs_i = tf.reshape(inputs_i, [-1, self.ndescrpt])
             type_i = -1
             layer = self._filter_r(inputs_i, type_i, name='filter_type_all'+suffix, natoms=natoms, reuse=reuse, trainable = trainable, activation_fn = self.filter_activation_fn)
-            layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0] * self.get_dim_out()])
+            layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0], self.get_dim_out()])
             output.append(layer)
         output = tf.concat(output, axis = 1)
         return output

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -414,7 +414,7 @@ class DescrptSeT (DescrptSe):
                 The atomic virial
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt_reshape)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, natoms[0] * self.ndescrpt])        
+        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])        
         force \
             = op_module.prod_force_se_a (net_deriv_reshape,
                                           self.descrpt_deriv,
@@ -442,14 +442,14 @@ class DescrptSeT (DescrptSe):
                      suffix = '', 
                      trainable = True) :
         start_index = 0
-        inputs = tf.reshape(inputs, [-1, self.ndescrpt * natoms[0]])
+        inputs = tf.reshape(inputs, [-1, natoms[0], self.ndescrpt])
         output = []
         output_qmat = []
         inputs_i = inputs
         inputs_i = tf.reshape(inputs_i, [-1, self.ndescrpt])
         type_i = -1
         layer, qmat = self._filter(inputs_i, type_i, name='filter_type_all'+suffix, natoms=natoms, reuse=reuse, trainable = trainable, activation_fn = self.filter_activation_fn)
-        layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0] * self.get_dim_out()])
+        layer = tf.reshape(layer, [tf.shape(inputs)[0], natoms[0], self.get_dim_out()])
         # qmat  = tf.reshape(qmat,  [tf.shape(inputs)[0], natoms[0] * self.get_dim_rot_mat_1() * 3])
         output.append(layer)
         # output_qmat.append(qmat)

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -414,7 +414,7 @@ class DescrptSeT (DescrptSe):
                 The atomic virial
         """
         [net_deriv] = tf.gradients (atom_ener, self.descrpt_reshape)
-        net_deriv_reshape = tf.reshape (net_deriv, [-1, tf.cast(natoms[0], tf.int64) * tf.cast(self.ndescrpt, tf.int64)])        
+        net_deriv_reshape = tf.reshape (net_deriv, [np.cast['int64'](-1), natoms[0] * np.cast['int64'](self.ndescrpt)])        
         force \
             = op_module.prod_force_se_a (net_deriv_reshape,
                                           self.descrpt_deriv,

--- a/deepmd/fit/dipole.py
+++ b/deepmd/fit/dipole.py
@@ -123,20 +123,20 @@ class DipoleFittingSeA (Fitting) :
                 The atomic dipole.
         """
         start_index = 0
-        inputs = tf.reshape(input_d, [-1, self.dim_descrpt * natoms[0]])
-        rot_mat = tf.reshape(rot_mat, [-1, self.dim_rot_mat * natoms[0]])
+        inputs = tf.reshape(input_d, [-1, natoms[0], self.dim_descrpt])
+        rot_mat = tf.reshape(rot_mat, [-1, natoms[0], self.dim_rot_mat])
 
         count = 0
         outs_list = []
         for type_i in range(self.ntypes):
             # cut-out inputs
             inputs_i = tf.slice (inputs,
-                                 [ 0, start_index*      self.dim_descrpt],
-                                 [-1, natoms[2+type_i]* self.dim_descrpt] )
+                                 [ 0, start_index, 0],
+                                 [-1, natoms[2+type_i], -1] )
             inputs_i = tf.reshape(inputs_i, [-1, self.dim_descrpt])
             rot_mat_i = tf.slice (rot_mat,
-                                  [ 0, start_index*      self.dim_rot_mat],
-                                  [-1, natoms[2+type_i]* self.dim_rot_mat] )
+                                  [ 0, start_index, 0],
+                                  [-1, natoms[2+type_i], -1] )
             rot_mat_i = tf.reshape(rot_mat_i, [-1, self.dim_rot_mat_1, 3])
             start_index += natoms[2+type_i]
             if not type_i in self.sel_type :

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -277,7 +277,7 @@ class EnerFitting (Fitting):
         # cut-out inputs
         inputs_i = tf.slice (inputs,
                              [ 0, start_index, 0],
-                             [-1, natoms, self.dim_descrpt] )
+                             [-1, natoms, -1] )
         inputs_i = tf.reshape(inputs_i, [-1, self.dim_descrpt])
         layer = inputs_i
         if fparam is not None:

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -276,8 +276,8 @@ class EnerFitting (Fitting):
     ):
         # cut-out inputs
         inputs_i = tf.slice (inputs,
-                             [ 0, start_index*      self.dim_descrpt],
-                             [-1, natoms* self.dim_descrpt] )
+                             [ 0, start_index, 0],
+                             [-1, natoms, self.dim_descrpt] )
         inputs_i = tf.reshape(inputs_i, [-1, self.dim_descrpt])
         layer = inputs_i
         if fparam is not None:
@@ -419,13 +419,13 @@ class EnerFitting (Fitting):
                                                 trainable = False,
                                                 initializer = tf.constant_initializer(self.aparam_inv_std))
             
-        inputs = tf.reshape(inputs, [-1, self.dim_descrpt * natoms[0]])
+        inputs = tf.reshape(inputs, [-1, natoms[0], self.dim_descrpt])
         if len(self.atom_ener):
             # only for atom_ener
             nframes = input_dict.get('nframes')
             if nframes is not None:
                 # like inputs, but we don't want to add a dependency on inputs
-                inputs_zero = tf.zeros((nframes, self.dim_descrpt * natoms[0]), dtype=self.fitting_precision)
+                inputs_zero = tf.zeros((nframes, natoms[0], self.dim_descrpt), dtype=self.fitting_precision)
             else:
                 inputs_zero = tf.zeros_like(inputs, dtype=self.fitting_precision)
         
@@ -490,7 +490,7 @@ class EnerFitting (Fitting):
                 axis=1
             )
             self.dim_descrpt = self.dim_descrpt + type_shape[1]
-            inputs = tf.reshape(inputs, [-1, self.dim_descrpt * natoms[0]])
+            inputs = tf.reshape(inputs, [-1, natoms[0], self.dim_descrpt])
             final_layer = self._build_lower(
                 0, natoms[0], 
                 inputs, fparam, aparam, 

--- a/deepmd/fit/polar.py
+++ b/deepmd/fit/polar.py
@@ -56,7 +56,7 @@ class PolarFittingLocFrame () :
                reuse = None,
                suffix = '') :
         start_index = 0
-        inputs = tf.cast(tf.reshape(input_d, [-1, self.dim_descrpt * natoms[0]]), self.fitting_precision)
+        inputs = tf.cast(tf.reshape(input_d, [-1, natoms[0], self.dim_descrpt]), self.fitting_precision)
         rot_mat = tf.reshape(rot_mat, [-1, 9 * natoms[0]])
 
         count = 0
@@ -64,8 +64,8 @@ class PolarFittingLocFrame () :
         for type_i in range(self.ntypes):
             # cut-out inputs
             inputs_i = tf.slice (inputs,
-                                 [ 0, start_index*      self.dim_descrpt],
-                                 [-1, natoms[2+type_i]* self.dim_descrpt] )
+                                 [ 0, start_index, 0],
+                                 [-1, natoms[2+type_i], -1] )
             inputs_i = tf.reshape(inputs_i, [-1, self.dim_descrpt])
             rot_mat_i = tf.slice (rot_mat,
                                   [ 0, start_index*      9],

--- a/source/lib/include/device.h
+++ b/source/lib/include/device.h
@@ -6,6 +6,7 @@
 
 #define TPB 256
 #define SQRT_2_PI 0.7978845608028654 
+typedef long long int_64;
 typedef unsigned long long uint_64;
 
 #if GOOGLE_CUDA

--- a/source/lib/include/gelu.h
+++ b/source/lib/include/gelu.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "device.h"
 
 namespace deepmd{
 
@@ -6,14 +7,14 @@ template<typename FPTYPE>
 void gelu_cpu(
     FPTYPE * out, 
     const FPTYPE * xx, 
-    const int size);
+    const int_64 size);
 
 template<typename FPTYPE>
 void gelu_grad_cpu(
     FPTYPE * out, 
     const FPTYPE * xx,
     const FPTYPE * dy, 
-    const int size);
+    const int_64 size);
 
 template<typename FPTYPE>
 void gelu_grad_grad_cpu(
@@ -21,21 +22,21 @@ void gelu_grad_grad_cpu(
     const FPTYPE * xx,
     const FPTYPE * dy, 
     const FPTYPE * dy_2,
-    const int size);
+    const int_64 size);
 
 #if GOOGLE_CUDA
 template<typename FPTYPE>
 void gelu_gpu_cuda(
     FPTYPE * out, 
     const FPTYPE * xx, 
-    const int size);
+    const int_64 size);
 
 template<typename FPTYPE>
 void gelu_grad_gpu_cuda(
     FPTYPE * out, 
     const FPTYPE * xx,
     const FPTYPE * dy, 
-    const int size);
+    const int_64 size);
 
 template<typename FPTYPE>
 void gelu_grad_grad_gpu_cuda(
@@ -43,7 +44,7 @@ void gelu_grad_grad_gpu_cuda(
     const FPTYPE * xx,
     const FPTYPE * dy, 
     const FPTYPE * dy_2,
-    const int size);
+    const int_64 size);
 #endif // GOOGLE_CUDA
 
 #if TENSORFLOW_USE_ROCM
@@ -51,14 +52,14 @@ template<typename FPTYPE>
 void gelu_gpu_rocm(
     FPTYPE * out, 
     const FPTYPE * xx, 
-    const int size);
+    const int_64 size);
 
 template<typename FPTYPE>
 void gelu_grad_gpu_rocm(
     FPTYPE * out, 
     const FPTYPE * xx,
     const FPTYPE * dy, 
-    const int size);
+    const int_64 size);
 
 template<typename FPTYPE>
 void gelu_grad_grad_gpu_rocm(
@@ -66,7 +67,7 @@ void gelu_grad_grad_gpu_rocm(
     const FPTYPE * xx,
     const FPTYPE * dy, 
     const FPTYPE * dy_2,
-    const int size);
+    const int_64 size);
 
 #endif//TENSORFLOW_USE_ROCM
 }

--- a/source/lib/src/cuda/gelu.cu
+++ b/source/lib/src/cuda/gelu.cu
@@ -8,9 +8,9 @@ template <typename FPTYPE>
 __global__ void gelu(
     FPTYPE * out, 
     const FPTYPE * xx, 
-    int const size) 
+    const int_64 size) 
 {
-  int const idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int_64 idx = int_64(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= size) {
     return;
   }
@@ -22,9 +22,9 @@ __global__ void gelu_grad(
     FPTYPE * out, 
     const FPTYPE * xx, 
     const FPTYPE * dy, 
-    int const size) 
+    const int_64 size) 
 {
-  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int_64 idx = int_64(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= size) {
     return;
   }
@@ -39,9 +39,9 @@ __global__ void gelu_grad_grad(
     const FPTYPE * xx, 
     const FPTYPE * dy, 
     const FPTYPE * dy_2,
-    int const size) 
+    const int_64 size) 
 {
-  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int_64 idx = int_64(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= size) {
     return;
   }
@@ -56,7 +56,7 @@ template<typename FPTYPE>
 void gelu_gpu_cuda(
     FPTYPE * out, 
     const FPTYPE * xx, 
-    const int size)
+    const int_64 size)
 {
   if(size <= 0){
     return;
@@ -74,7 +74,7 @@ void gelu_grad_gpu_cuda(
     FPTYPE * out, 
     const FPTYPE * xx,
     const FPTYPE * dy, 
-    const int size)
+    const int_64 size)
 {
   if(size <= 0){
     return;
@@ -93,7 +93,7 @@ void gelu_grad_grad_gpu_cuda(
     const FPTYPE * xx,
     const FPTYPE * dy, 
     const FPTYPE * dy_2,
-    const int size)
+    const int_64 size)
 {
   if(size <= 0){
     return;
@@ -106,10 +106,10 @@ void gelu_grad_grad_gpu_cuda(
   DPErrcheck(cudaDeviceSynchronize());
 }
 
-template void gelu_gpu_cuda<float>(float * out, const float * x, const int size);
-template void gelu_gpu_cuda<double>(double * out, const double * x, const int size);
-template void gelu_grad_gpu_cuda<float>(float * out, const float * x, const float * dy, const int size);
-template void gelu_grad_gpu_cuda<double>(double * out, const double * x, const double * dy, const int size);
-template void gelu_grad_grad_gpu_cuda<float>(float * out, const float * x, const float * dy, const float * dy_2, const int size);
-template void gelu_grad_grad_gpu_cuda<double>(double * out, const double * x, const double * dy, const double * dy_2, const int size);
+template void gelu_gpu_cuda<float>(float * out, const float * x, const int_64 size);
+template void gelu_gpu_cuda<double>(double * out, const double * x, const int_64 size);
+template void gelu_grad_gpu_cuda<float>(float * out, const float * x, const float * dy, const int_64 size);
+template void gelu_grad_gpu_cuda<double>(double * out, const double * x, const double * dy, const int_64 size);
+template void gelu_grad_grad_gpu_cuda<float>(float * out, const float * x, const float * dy, const float * dy_2, const int_64 size);
+template void gelu_grad_grad_gpu_cuda<double>(double * out, const double * x, const double * dy, const double * dy_2, const int_64 size);
 }

--- a/source/lib/src/cuda/prod_env_mat.cu
+++ b/source/lib/src/cuda/prod_env_mat.cu
@@ -542,7 +542,7 @@ void format_nbor_list_gpu_cuda(
   int * nei_iter = array_int + sec.size(); // = new int[sec_size];
   int * i_idx = array_int + sec.size() + nloc * sec.size();
   uint_64 * key = array_longlong;
-  assert(max_nbor_size == 1024 || max_nbor_size == 2048 || max_nbor_size == 4096);
+  assert(max_nbor_size == 256 || max_nbor_size == 512 || max_nbor_size == 1024 || max_nbor_size == 2048 || max_nbor_size == 4096);
   DPErrcheck(cudaMemset(nlist, -1, sizeof(int) * int_64(nloc) * nnei));
   DPErrcheck(cudaMemset(key, 0xffffffff, sizeof(uint_64) * int_64(nloc) * max_nbor_size));
   DPErrcheck(cudaMemcpy(sec_dev, &sec[0], sizeof(int) * sec.size(), cudaMemcpyHostToDevice));   

--- a/source/lib/src/cuda/prod_env_mat.cu
+++ b/source/lib/src/cuda/prod_env_mat.cu
@@ -32,7 +32,7 @@ __global__ void BlockSortKernel(
   // Per-thread tile items
   Key items[ITEMS_PER_THREAD];
   // Our current block's offset
-  int block_offset = blockIdx.x * TILE_SIZE;
+  int_64 block_offset = (int_64)blockIdx.x * TILE_SIZE;
   // Load items into a blocked arrangement
   BlockLoadT(temp_storage.load).Load(d_in + block_offset, items);
   // Barrier for smem reuse
@@ -125,7 +125,7 @@ __global__ void format_nlist_fill_a(
     const int MAX_NBOR_SIZE)
 {   
   // <<<nloc, MAX_NBOR_SIZE>>>
-  const unsigned int idx = blockIdx.x;
+  const int_64 idx = blockIdx.x;
   const unsigned int idy = blockIdx.y * blockDim.y + threadIdx.y;
   
   const int nsize = numneigh[i_idx[idx]];
@@ -155,7 +155,7 @@ __global__ void fill_nei_iter(
     const int max_nbor_size,
     const int sec_size)
 {
-  int row = blockIdx.x;
+  int_64 row = blockIdx.x;
   int col = blockIdx.y * blockDim.x + threadIdx.x;
   const FPTYPE * key_out = key + nloc * max_nbor_size + row * max_nbor_size;
   int nei_type_cur = -1, nbor_idx_cur = 0;
@@ -181,7 +181,7 @@ __global__ void format_nlist_fill_b(
     int * nei_iter_dev,
     const int max_nbor_size)
 { 
-  int row = blockIdx.x;
+  int_64 row = blockIdx.x;
   int col = blockIdx.y * blockDim.x + threadIdx.x;
   int * nei_iter = nei_iter_dev + row * sec_size;
   FPTYPE * key_out = key + nloc * max_nbor_size + row * max_nbor_size;
@@ -215,6 +215,66 @@ __global__ void encoding_decoding_nbor_info(
   
   key[idx] = encoding_nbor_info(in_type[idx], in_dist[idx], in_index[idx]);
   decoding_nbor_info(out_type[idx], out_index[idx], key[idx]);
+}
+
+template<typename FPTYPE>
+void format_nbor_list_256 (
+    uint_64 * key,
+    const FPTYPE* coord,
+    const int* type,
+    const deepmd::InputNlist & gpu_inlist,
+    const int& nloc,       
+    const float& rcut, 
+    int * i_idx) 
+{   
+  const int LEN = 256;
+  const int MAX_NBOR_SIZE = 256;
+  const int nblock = (MAX_NBOR_SIZE + LEN - 1) / LEN;
+  dim3 block_grid(nloc, nblock);
+  dim3 thread_grid(1, LEN);
+  format_nlist_fill_a<<<block_grid, thread_grid>>> (
+      key,
+      coord, type, gpu_inlist.numneigh, gpu_inlist.firstneigh, rcut, i_idx, MAX_NBOR_SIZE);
+  DPErrcheck(cudaGetLastError());
+  DPErrcheck(cudaDeviceSynchronize());
+  const int ITEMS_PER_THREAD = 4;
+  const int BLOCK_THREADS = MAX_NBOR_SIZE / ITEMS_PER_THREAD;
+  // BlockSortKernel<NeighborInfo, BLOCK_THREADS, ITEMS_PER_THREAD><<<g_grid_size, BLOCK_THREADS>>> (
+  BlockSortKernel<uint_64, BLOCK_THREADS, ITEMS_PER_THREAD> <<<nloc, BLOCK_THREADS>>> (
+      key, 
+      key + nloc * MAX_NBOR_SIZE);
+  DPErrcheck(cudaGetLastError());
+  DPErrcheck(cudaDeviceSynchronize());
+}
+
+template<typename FPTYPE>
+void format_nbor_list_512 (
+    uint_64 * key,
+    const FPTYPE* coord,
+    const int* type,
+    const deepmd::InputNlist & gpu_inlist,
+    const int& nloc,       
+    const float& rcut, 
+    int * i_idx) 
+{   
+  const int LEN = 256;
+  const int MAX_NBOR_SIZE = 512;
+  const int nblock = (MAX_NBOR_SIZE + LEN - 1) / LEN;
+  dim3 block_grid(nloc, nblock);
+  dim3 thread_grid(1, LEN);
+  format_nlist_fill_a<<<block_grid, thread_grid>>> (
+      key,
+      coord, type, gpu_inlist.numneigh, gpu_inlist.firstneigh, rcut, i_idx, MAX_NBOR_SIZE);
+  DPErrcheck(cudaGetLastError());
+  DPErrcheck(cudaDeviceSynchronize());
+  const int ITEMS_PER_THREAD = 4;
+  const int BLOCK_THREADS = MAX_NBOR_SIZE / ITEMS_PER_THREAD;
+  // BlockSortKernel<NeighborInfo, BLOCK_THREADS, ITEMS_PER_THREAD><<<g_grid_size, BLOCK_THREADS>>> (
+  BlockSortKernel<uint_64, BLOCK_THREADS, ITEMS_PER_THREAD> <<<nloc, BLOCK_THREADS>>> (
+      key, 
+      key + nloc * MAX_NBOR_SIZE);
+  DPErrcheck(cudaGetLastError());
+  DPErrcheck(cudaDeviceSynchronize());
 }
 
 template<typename FPTYPE>
@@ -324,7 +384,7 @@ __global__ void compute_env_mat_a(
     const float rmax)
 {   
   // <<<nloc, TPB>>>
-  const unsigned int bid = blockIdx.x;
+  const int_64 bid = blockIdx.x;
   const unsigned int tid = threadIdx.x;
   if (tid >= nnei) {
     return;
@@ -410,7 +470,7 @@ __global__ void compute_env_mat_r(
     const float rmax)
 {
   // <<<nloc, TPB>>>
-  const unsigned int bid = blockIdx.x;
+  const int_64 bid = blockIdx.x;
   const unsigned int tid = threadIdx.x;
   if (tid >= nnei) {
     return;
@@ -483,8 +543,8 @@ void format_nbor_list_gpu_cuda(
   int * i_idx = array_int + sec.size() + nloc * sec.size();
   uint_64 * key = array_longlong;
   assert(max_nbor_size == 1024 || max_nbor_size == 2048 || max_nbor_size == 4096);
-  DPErrcheck(cudaMemset(nlist, -1, sizeof(int) * nloc * nnei));
-  DPErrcheck(cudaMemset(key, 0xffffffff, sizeof(uint_64) * nloc * max_nbor_size));
+  DPErrcheck(cudaMemset(nlist, -1, sizeof(int) * int_64(nloc) * nnei));
+  DPErrcheck(cudaMemset(key, 0xffffffff, sizeof(uint_64) * int_64(nloc) * max_nbor_size));
   DPErrcheck(cudaMemcpy(sec_dev, &sec[0], sizeof(int) * sec.size(), cudaMemcpyHostToDevice));   
 
   get_i_idx<<<nblock, LEN>>>(
@@ -493,7 +553,17 @@ void format_nbor_list_gpu_cuda(
   DPErrcheck(cudaGetLastError());
   DPErrcheck(cudaDeviceSynchronize());
 
-  if (max_nbor_size == 1024) {
+  if (max_nbor_size == 256) {
+    format_nbor_list_256 (
+        key,
+        coord, type, gpu_inlist, nloc, rcut, i_idx); 
+  }
+  else if (max_nbor_size == 512) {
+    format_nbor_list_512 (
+        key,
+        coord, type, gpu_inlist, nloc, rcut, i_idx); 
+  } 
+  else if (max_nbor_size == 1024) {
     format_nbor_list_1024 (
         key,
         coord, type, gpu_inlist, nloc, rcut, i_idx); 
@@ -542,9 +612,9 @@ void prod_env_mat_a_gpu_cuda(
 {
   const int nnei = sec.back();
   const int ndescrpt = nnei * 4;
-  DPErrcheck(cudaMemset(em, 0, sizeof(FPTYPE) * nloc * ndescrpt));
-  DPErrcheck(cudaMemset(em_deriv, 0, sizeof(FPTYPE) * nloc * ndescrpt * 3));
-  DPErrcheck(cudaMemset(rij, 0, sizeof(FPTYPE) * nloc * nnei * 3));
+  DPErrcheck(cudaMemset(em, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt));
+  DPErrcheck(cudaMemset(em_deriv, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt * 3));
+  DPErrcheck(cudaMemset(rij, 0, sizeof(FPTYPE) * int_64(nloc) * nnei * 3));
 
   format_nbor_list_gpu_cuda(
       nlist, 
@@ -581,9 +651,9 @@ void prod_env_mat_r_gpu_cuda(
 {
   const int nnei = sec.back();
   const int ndescrpt = nnei * 1;
-  DPErrcheck(cudaMemset(em, 0, sizeof(FPTYPE) * nloc * ndescrpt));
-  DPErrcheck(cudaMemset(em_deriv, 0, sizeof(FPTYPE) * nloc * ndescrpt * 3));
-  DPErrcheck(cudaMemset(rij, 0, sizeof(FPTYPE) * nloc * nnei * 3));
+  DPErrcheck(cudaMemset(em, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt));
+  DPErrcheck(cudaMemset(em_deriv, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt * 3));
+  DPErrcheck(cudaMemset(rij, 0, sizeof(FPTYPE) * int_64(nloc) * nnei * 3));
 
   format_nbor_list_gpu_cuda(
       nlist, 

--- a/source/lib/src/cuda/prod_force.cu
+++ b/source/lib/src/cuda/prod_force.cu
@@ -11,7 +11,7 @@ __global__ void force_deriv_wrt_center_atom(
     const int ndescrpt)
 {
   __shared__ FPTYPE data[THREADS_PER_BLOCK * 3];
-  unsigned int bid = blockIdx.x;
+  int_64 bid = blockIdx.x;
   unsigned int tid = threadIdx.x;
   for (int ii = tid; ii < THREADS_PER_BLOCK * 3; ii += THREADS_PER_BLOCK) {
     data[ii] = 0.f;
@@ -49,7 +49,7 @@ __global__ void force_deriv_wrt_neighbors_a(
     const int nnei)
 {  
     // idy -> nnei
-    const unsigned int idx = blockIdx.x;
+    const int_64 idx = blockIdx.x;
     const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
     const unsigned int idz = threadIdx.y;
     const int ndescrpt = nnei * 4;
@@ -78,7 +78,7 @@ __global__ void force_deriv_wrt_neighbors_r(
 		const int nnei)
 {  
     // idy -> nnei
-    const unsigned int idx = blockIdx.x;
+    const int_64 idx = blockIdx.x;
     const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
     const unsigned int idz = threadIdx.y;
     const int ndescrpt = nnei * 1;

--- a/source/lib/src/cuda/prod_force_grad.cu
+++ b/source/lib/src/cuda/prod_force_grad.cu
@@ -17,7 +17,7 @@ __global__ void force_grad_wrt_center_atom(
     const int ndescrpt)
 {
     __shared__ FPTYPE grad_one[3];
-    unsigned int center_idx = blockIdx.x;
+    int_64 center_idx = blockIdx.x;
     unsigned int tid = threadIdx.x;
     if(tid < 3){
         grad_one[tid] = grad[center_idx * 3 + tid];
@@ -39,7 +39,7 @@ __global__ void force_grad_wrt_neighbors_a(
     const int nnei)
 {
     // idy -> nnei
-    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int_64 idx = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int idy = blockIdx.y;
     const unsigned int idw = threadIdx.y;
     if (idx >= nloc) {
@@ -63,7 +63,7 @@ __global__ void force_grad_wrt_neighbors_r(
     const int nnei)
 {
     // idy -> nnei
-    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int_64 idx = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int idy = blockIdx.y;
     if (idx >= nloc) {
         return;

--- a/source/lib/src/cuda/prod_virial.cu
+++ b/source/lib/src/cuda/prod_virial.cu
@@ -44,7 +44,7 @@ __global__ void virial_deriv_wrt_neighbors_a(
   // idz = dd0 * 3 + dd1
   // dd0 = idz / 3
   // dd1 = idz % 3
-  const unsigned int idx = blockIdx.x;
+  const int_64 idx = blockIdx.x;
   const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
   const unsigned int idz = threadIdx.y;
   const int ndescrpt = nnei * 4;
@@ -81,7 +81,7 @@ __global__ void virial_deriv_wrt_neighbors_r(
     // idz = dd0 * 3 + dd1
     // dd0 = idz / 3
     // dd1 = idz % 3
-    const unsigned int idx = blockIdx.x;
+    const int_64 idx = blockIdx.x;
     const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
     const unsigned int idz = threadIdx.y;
     const int ndescrpt = nnei * 1;

--- a/source/lib/src/cuda/prod_virial_grad.cu
+++ b/source/lib/src/cuda/prod_virial_grad.cu
@@ -25,7 +25,7 @@ __global__ void virial_grad_wrt_neighbors_a(
 {
     // idy -> nnei
     const unsigned int tid = threadIdx.x;
-    const unsigned int idx = blockIdx.x * blockDim.x + tid;
+    const int_64 idx = blockIdx.x * blockDim.x + tid;
     const unsigned int idy = blockIdx.y;
     const unsigned int idw = threadIdx.y;
     const int ndescrpt = nnei * 4;
@@ -62,7 +62,7 @@ __global__ void virial_grad_wrt_neighbors_r(
 {
     // idy -> nnei
     const unsigned int tid = threadIdx.x;
-    const unsigned int idx = blockIdx.x * blockDim.x + tid;
+    const int_64 idx = blockIdx.x * blockDim.x + tid;
     const unsigned int idy = blockIdx.y;
     const int ndescrpt = nnei;
     __shared__ FPTYPE grad_one[9];

--- a/source/lib/src/cuda/tabulate.cu
+++ b/source/lib/src/cuda/tabulate.cu
@@ -157,7 +157,7 @@ __global__ void tabulate_fusion_se_a_fifth_order_polynomial(
     const int nnei, 
     const int last_layer_size) 
 {
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
   FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei + nnei - 1], 0);
   bool unloop = false;
@@ -210,7 +210,7 @@ __global__ void tabulate_fusion_se_a_grad_fifth_order_polynomial(
     const int last_layer_size) 
 {
   extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;  // nloc
+  const int_64 block_idx = blockIdx.x;  // nloc
   const int thread_idx = threadIdx.x; // KTILE * WARP_SIZE, usally 128 here~
   int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / WARP_SIZE, 0);
   int lane_idx = threadIdx.x % WARP_SIZE;
@@ -291,7 +291,7 @@ __global__ void tabulate_fusion_se_a_grad_grad_fifth_order_polynomial(
     const int last_layer_size)
 {
   extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
   FPTYPE ago = __shfl_sync(0xffffffff, em_x[block_idx * nnei + nnei - 1], 0);
   bool unloop = false;
@@ -349,7 +349,7 @@ __global__ void tabulate_fusion_se_t_fifth_order_polynomial(
     const int nnei_j, 
     const int last_layer_size) 
 {
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
 
   FPTYPE sum = (FPTYPE)0.;
@@ -402,7 +402,7 @@ __global__ void tabulate_fusion_se_t_grad_fifth_order_polynomial(
     const int last_layer_size) 
 {
   extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;  // nloc
+  const int_64 block_idx = blockIdx.x;  // nloc
   const int thread_idx = threadIdx.x; // KTILE * WARP_SIZE, usally 128 here~
   int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / WARP_SIZE, 0);
   int lane_idx = threadIdx.x % WARP_SIZE;
@@ -465,7 +465,7 @@ __global__ void tabulate_fusion_se_t_grad_grad_fifth_order_polynomial(
     const int nnei_j,
     const int last_layer_size)
 {
-  const int block_idx  = blockIdx.x;   // nloc
+  const int_64 block_idx  = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
 
   FPTYPE sum = (FPTYPE)0.;
@@ -515,7 +515,7 @@ __global__ void tabulate_fusion_se_r_fifth_order_polynomial(
     const int nnei, 
     const int last_layer_size) 
 {
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
 
   int mark_table_idx = -1;
@@ -550,7 +550,7 @@ __global__ void tabulate_fusion_se_r_grad_fifth_order_polynomial(
     const int last_layer_size) 
 {
   extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;  // nloc
+  const int_64 block_idx = blockIdx.x;  // nloc
   const int thread_idx = threadIdx.x; // KTILE * WARP_SIZE, usally 128 here~
   int warp_idx = __shfl_sync(0xffffffff, thread_idx / WARP_SIZE, 0);
   int lane_idx = thread_idx % WARP_SIZE;
@@ -595,7 +595,7 @@ __global__ void tabulate_fusion_se_r_grad_grad_fifth_order_polynomial(
     const int last_layer_size)
 {
   extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
   
   int mark_table_idx = -1;

--- a/source/lib/src/gelu.cc
+++ b/source/lib/src/gelu.cc
@@ -6,7 +6,7 @@ template<typename FPTYPE>
 void deepmd::gelu_cpu(
     FPTYPE * out, 
     const FPTYPE * xx, 
-    const int size)
+    const int_64 size)
 {
   for (int ii = 0; ii < size; ii++) {
     out[ii] = xx[ii] * (FPTYPE)0.5 * ((FPTYPE)1.0 + tanh((FPTYPE)SQRT_2_PI * (xx[ii] + (FPTYPE)0.044715 * xx[ii] * xx[ii] *xx[ii])));
@@ -18,7 +18,7 @@ void deepmd::gelu_grad_cpu(
     FPTYPE * out, 
     const FPTYPE * xx,
     const FPTYPE * dy, 
-    const int size)
+    const int_64 size)
 {
   for (int ii = 0; ii < size; ii++) {
     const FPTYPE var = tanh((FPTYPE)SQRT_2_PI * (xx[ii] + (FPTYPE)0.044715 * xx[ii] * xx[ii] * xx[ii]));
@@ -32,7 +32,7 @@ void deepmd::gelu_grad_grad_cpu(
     const FPTYPE * xx,
     const FPTYPE * dy, 
     const FPTYPE * dy_2,
-    const int size) 
+    const int_64 size) 
 {
   for (int ii = 0; ii < size; ii++) {
     const FPTYPE var1 = tanh((FPTYPE)SQRT_2_PI * (xx[ii] + (FPTYPE)0.044715 * xx[ii] * xx[ii] *xx[ii]));
@@ -41,9 +41,9 @@ void deepmd::gelu_grad_grad_cpu(
   }
 }
 
-template void deepmd::gelu_cpu<float>(float * out, const float * x, const int size);
-template void deepmd::gelu_cpu<double>(double * out, const double * x, const int size);
-template void deepmd::gelu_grad_cpu<float>(float * out, const float * x, const float * dy, const int size);
-template void deepmd::gelu_grad_cpu<double>(double * out, const double * x, const double * dy, const int size);
-template void deepmd::gelu_grad_grad_cpu<float>(float * out, const float * x, const float * dy, const float * dy_2, const int size);
-template void deepmd::gelu_grad_grad_cpu<double>(double * out, const double * x, const double * dy, const double * dy_2, const int size);
+template void deepmd::gelu_cpu<float>(float * out, const float * x, const int_64 size);
+template void deepmd::gelu_cpu<double>(double * out, const double * x, const int_64 size);
+template void deepmd::gelu_grad_cpu<float>(float * out, const float * x, const float * dy, const int_64 size);
+template void deepmd::gelu_grad_cpu<double>(double * out, const double * x, const double * dy, const int_64 size);
+template void deepmd::gelu_grad_grad_cpu<float>(float * out, const float * x, const float * dy, const float * dy_2, const int_64 size);
+template void deepmd::gelu_grad_grad_cpu<double>(double * out, const double * x, const double * dy, const double * dy_2, const int_64 size);

--- a/source/lib/src/prod_env_mat.cc
+++ b/source/lib/src/prod_env_mat.cc
@@ -284,7 +284,13 @@ void deepmd::env_mat_nbor_update(
     memcpy_host_to_device(gpu_inlist.ilist, inlist.ilist, inum);
     memcpy_host_to_device(gpu_inlist.numneigh, inlist.numneigh, inum);
     int _max_nbor_size = max_numneigh(inlist);
-    if (_max_nbor_size <= 1024) {
+    if (_max_nbor_size <= 256) {
+      _max_nbor_size = 256;
+    }
+    else if (_max_nbor_size <= 512) {
+      _max_nbor_size = 512;
+    }
+    else if (_max_nbor_size <= 1024) {
       _max_nbor_size = 1024;
     }
     else if (_max_nbor_size <= 2048) {

--- a/source/lib/src/rocm/gelu.hip.cu
+++ b/source/lib/src/rocm/gelu.hip.cu
@@ -8,9 +8,9 @@ template <typename FPTYPE>
 __global__ void gelu(
     FPTYPE * out, 
     const FPTYPE * xx, 
-    int const size) 
+    const int_64 size) 
 {
-  int const idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int_64 idx = int_64(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= size) {
     return;
   }
@@ -22,9 +22,9 @@ __global__ void gelu_grad(
     FPTYPE * out, 
     const FPTYPE * xx, 
     const FPTYPE * dy, 
-    int const size) 
+    const int_64 size) 
 {
-  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int_64 idx = int_64(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= size) {
     return;
   }
@@ -39,9 +39,9 @@ __global__ void gelu_grad_grad(
     const FPTYPE * xx, 
     const FPTYPE * dy, 
     const FPTYPE * dy_2,
-    int const size) 
+    const int_64 size) 
 {
-  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int_64 idx = int_64(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= size) {
     return;
   }
@@ -56,7 +56,7 @@ namespace deepmd {
   void gelu_gpu_rocm(
       FPTYPE * out, 
       const FPTYPE * xx, 
-      const int size)
+      const int_64 size)
   {
     if(size <= 0)
     {
@@ -75,7 +75,7 @@ namespace deepmd {
       FPTYPE * out, 
       const FPTYPE * xx,
       const FPTYPE * dy, 
-      const int size)
+      const int_64 size)
   {
     if(size <= 0)
     {
@@ -95,7 +95,7 @@ namespace deepmd {
       const FPTYPE * xx,
       const FPTYPE * dy, 
       const FPTYPE * dy_2,
-      const int size)
+      const int_64 size)
   {
     if(size <= 0)
     {
@@ -109,10 +109,10 @@ namespace deepmd {
     DPErrcheck(hipDeviceSynchronize());
   }
   
-  template void gelu_gpu_rocm<float>(float * out, const float * x, const int size);
-  template void gelu_gpu_rocm<double>(double * out, const double * x, const int size);
-  template void gelu_grad_gpu_rocm<float>(float * out, const float * x, const float * dy, const int size);
-  template void gelu_grad_gpu_rocm<double>(double * out, const double * x, const double * dy, const int size);
-  template void gelu_grad_grad_gpu_rocm<float>(float * out, const float * x, const float * dy, const float * dy_2, const int size);
-  template void gelu_grad_grad_gpu_rocm<double>(double * out, const double * x, const double * dy, const double * dy_2, const int size);
+  template void gelu_gpu_rocm<float>(float * out, const float * x, const int_64 size);
+  template void gelu_gpu_rocm<double>(double * out, const double * x, const int_64 size);
+  template void gelu_grad_gpu_rocm<float>(float * out, const float * x, const float * dy, const int_64 size);
+  template void gelu_grad_gpu_rocm<double>(double * out, const double * x, const double * dy, const int_64 size);
+  template void gelu_grad_grad_gpu_rocm<float>(float * out, const float * x, const float * dy, const float * dy_2, const int_64 size);
+  template void gelu_grad_grad_gpu_rocm<double>(double * out, const double * x, const double * dy, const double * dy_2, const int_64 size);
 }

--- a/source/lib/src/rocm/prod_env_mat.hip.cu
+++ b/source/lib/src/rocm/prod_env_mat.hip.cu
@@ -540,7 +540,7 @@ void format_nbor_list_gpu_rocm(
   int * nei_iter = array_int + sec.size(); // = new int[sec_size];
   int * i_idx = array_int + sec.size() + nloc * sec.size();
   uint_64 * key = array_longlong;
-  assert(max_nbor_size == 1024 || max_nbor_size == 2048 || max_nbor_size == 4096);
+  assert(max_nbor_size == 256 || max_nbor_size == 512 || 1024 || max_nbor_size == 2048 || max_nbor_size == 4096);
   DPErrcheck(hipMemset(nlist, -1, sizeof(int) * int_64(nloc) * nnei));
   DPErrcheck(hipMemset(key, 0xffffffff, sizeof(uint_64) * int_64(nloc) * max_nbor_size));
   DPErrcheck(hipMemcpy(sec_dev, &sec[0], sizeof(int) * sec.size(), hipMemcpyHostToDevice));   

--- a/source/lib/src/rocm/prod_env_mat.hip.cu
+++ b/source/lib/src/rocm/prod_env_mat.hip.cu
@@ -30,7 +30,7 @@ __global__ void BlockSortKernel(
   // Per-thread tile items
   Key items[ITEMS_PER_THREAD];
   // Our current block's offset
-  int block_offset = blockIdx.x * TILE_SIZE;
+  int_64 block_offset = (int_64)blockIdx.x * TILE_SIZE;
   // Load items into a blocked arrangement
   BlockLoadT(temp_storage.load).Load(d_in + block_offset, items);
   // Barrier for smem reuse
@@ -123,7 +123,7 @@ __global__ void format_nlist_fill_a(
     const int MAX_NBOR_SIZE)
 {   
   // <<<nloc, MAX_NBOR_SIZE>>>
-  const unsigned int idx = blockIdx.x;
+  const int_64 idx = blockIdx.x;
   const unsigned int idy = blockIdx.y * blockDim.y + threadIdx.y;
   
   const int nsize = numneigh[i_idx[idx]];
@@ -153,7 +153,7 @@ __global__ void fill_nei_iter(
     const int max_nbor_size,
     const int sec_size)
 {
-  int row = blockIdx.x;
+  int_64 row = blockIdx.x;
   int col = blockIdx.y * blockDim.x + threadIdx.x;
   const FPTYPE * key_out = key + nloc * max_nbor_size + row * max_nbor_size;
   int nei_type_cur = -1, nbor_idx_cur = 0;
@@ -179,7 +179,7 @@ __global__ void format_nlist_fill_b(
     int * nei_iter_dev,
     const int max_nbor_size)
 { 
-  int row = blockIdx.x;
+  int_64 row = blockIdx.x;
   int col = blockIdx.y * blockDim.x + threadIdx.x;
   int * nei_iter = nei_iter_dev + row * sec_size;
   FPTYPE * key_out = key + nloc * max_nbor_size + row * max_nbor_size;
@@ -213,6 +213,66 @@ __global__ void encoding_decoding_nbor_info(
   
   key[idx] = encoding_nbor_info(in_type[idx], in_dist[idx], in_index[idx]);
   decoding_nbor_info(out_type[idx], out_index[idx], key[idx]);
+}
+
+template<typename FPTYPE>
+void format_nbor_list_256 (
+    uint_64 * key,
+    const FPTYPE* coord,
+    const int* type,
+    const deepmd::InputNlist & gpu_inlist,
+    const int& nloc,       
+    const float& rcut, 
+    int * i_idx) 
+{   
+  const int LEN = 256;
+  const int MAX_NBOR_SIZE = 256;
+  const int nblock = (MAX_NBOR_SIZE + LEN - 1) / LEN;
+  dim3 block_grid(nloc, nblock);
+  dim3 thread_grid(1, LEN);
+  hipLaunchKernelGGL(format_nlist_fill_a, block_grid, thread_grid, 0, 0, 
+      key,
+      coord, type, gpu_inlist.numneigh, gpu_inlist.firstneigh, rcut, i_idx, MAX_NBOR_SIZE);
+  DPErrcheck(hipGetLastError());
+  DPErrcheck(hipDeviceSynchronize());
+  const int ITEMS_PER_THREAD = 4;
+  const int BLOCK_THREADS = MAX_NBOR_SIZE / ITEMS_PER_THREAD;
+  // hipLaunchKernelGGL(HIP_KERNEL_NAME(BlockSortKernel<NeighborInfo, BLOCK_THREADS, ITEMS_PER_THREAD>), g_grid_size, BLOCK_THREADS, 0, 0, 
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(BlockSortKernel<uint_64, BLOCK_THREADS, ITEMS_PER_THREAD>), nloc, BLOCK_THREADS, 0, 0, 
+      key, 
+      key + nloc * MAX_NBOR_SIZE);
+  DPErrcheck(hipGetLastError());
+  DPErrcheck(hipDeviceSynchronize());
+}
+
+template<typename FPTYPE>
+void format_nbor_list_512 (
+    uint_64 * key,
+    const FPTYPE* coord,
+    const int* type,
+    const deepmd::InputNlist & gpu_inlist,
+    const int& nloc,       
+    const float& rcut, 
+    int * i_idx) 
+{   
+  const int LEN = 256;
+  const int MAX_NBOR_SIZE = 512;
+  const int nblock = (MAX_NBOR_SIZE + LEN - 1) / LEN;
+  dim3 block_grid(nloc, nblock);
+  dim3 thread_grid(1, LEN);
+  hipLaunchKernelGGL(format_nlist_fill_a, block_grid, thread_grid, 0, 0, 
+      key,
+      coord, type, gpu_inlist.numneigh, gpu_inlist.firstneigh, rcut, i_idx, MAX_NBOR_SIZE);
+  DPErrcheck(hipGetLastError());
+  DPErrcheck(hipDeviceSynchronize());
+  const int ITEMS_PER_THREAD = 4;
+  const int BLOCK_THREADS = MAX_NBOR_SIZE / ITEMS_PER_THREAD;
+  // hipLaunchKernelGGL(HIP_KERNEL_NAME(BlockSortKernel<NeighborInfo, BLOCK_THREADS, ITEMS_PER_THREAD>), g_grid_size, BLOCK_THREADS, 0, 0, 
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(BlockSortKernel<uint_64, BLOCK_THREADS, ITEMS_PER_THREAD>), nloc, BLOCK_THREADS, 0, 0, 
+      key, 
+      key + nloc * MAX_NBOR_SIZE);
+  DPErrcheck(hipGetLastError());
+  DPErrcheck(hipDeviceSynchronize());
 }
 
 template<typename FPTYPE>
@@ -322,7 +382,7 @@ __global__ void compute_env_mat_a(
     const float rmax)
 {   
   // <<<nloc, TPB>>>
-  const unsigned int bid = blockIdx.x;
+  const int_64 bid = blockIdx.x;
   const unsigned int tid = threadIdx.x;
   if (tid >= nnei) {
     return;
@@ -408,7 +468,7 @@ __global__ void compute_env_mat_r(
     const float rmax)
 {
   // <<<nloc, TPB>>>
-  const unsigned int bid = blockIdx.x;
+  const int_64 bid = blockIdx.x;
   const unsigned int tid = threadIdx.x;
   if (tid >= nnei) {
     return;
@@ -481,8 +541,8 @@ void format_nbor_list_gpu_rocm(
   int * i_idx = array_int + sec.size() + nloc * sec.size();
   uint_64 * key = array_longlong;
   assert(max_nbor_size == 1024 || max_nbor_size == 2048 || max_nbor_size == 4096);
-  DPErrcheck(hipMemset(nlist, -1, sizeof(int) * nloc * nnei));
-  DPErrcheck(hipMemset(key, 0xffffffff, sizeof(uint_64) * nloc * max_nbor_size));
+  DPErrcheck(hipMemset(nlist, -1, sizeof(int) * int_64(nloc) * nnei));
+  DPErrcheck(hipMemset(key, 0xffffffff, sizeof(uint_64) * int_64(nloc) * max_nbor_size));
   DPErrcheck(hipMemcpy(sec_dev, &sec[0], sizeof(int) * sec.size(), hipMemcpyHostToDevice));   
 
   hipLaunchKernelGGL(get_i_idx, nblock, LEN, 0, 0, 
@@ -491,7 +551,17 @@ void format_nbor_list_gpu_rocm(
   DPErrcheck(hipGetLastError());
   DPErrcheck(hipDeviceSynchronize());
 
-  if (max_nbor_size == 1024) {
+  if (max_nbor_size == 256) {
+    format_nbor_list_256 (
+        key,
+        coord, type, gpu_inlist, nloc, rcut, i_idx); 
+  }
+  else if (max_nbor_size == 512) {
+    format_nbor_list_512 (
+        key,
+        coord, type, gpu_inlist, nloc, rcut, i_idx); 
+  } 
+  else if (max_nbor_size == 1024) {
     format_nbor_list_1024 (
         key,
         coord, type, gpu_inlist, nloc, rcut, i_idx); 
@@ -540,9 +610,9 @@ void prod_env_mat_a_gpu_rocm(
 {
   const int nnei = sec.back();
   const int ndescrpt = nnei * 4;
-  DPErrcheck(hipMemset(em, 0, sizeof(FPTYPE) * nloc * ndescrpt));
-  DPErrcheck(hipMemset(em_deriv, 0, sizeof(FPTYPE) * nloc * ndescrpt * 3));
-  DPErrcheck(hipMemset(rij, 0, sizeof(FPTYPE) * nloc * nnei * 3));
+  DPErrcheck(hipMemset(em, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt));
+  DPErrcheck(hipMemset(em_deriv, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt * 3));
+  DPErrcheck(hipMemset(rij, 0, sizeof(FPTYPE) * int_64(nloc) * nnei * 3));
 
   format_nbor_list_gpu_rocm(
       nlist, 
@@ -579,9 +649,9 @@ void prod_env_mat_r_gpu_rocm(
 {
   const int nnei = sec.back();
   const int ndescrpt = nnei * 1;
-  DPErrcheck(hipMemset(em, 0, sizeof(FPTYPE) * nloc * ndescrpt));
-  DPErrcheck(hipMemset(em_deriv, 0, sizeof(FPTYPE) * nloc * ndescrpt * 3));
-  DPErrcheck(hipMemset(rij, 0, sizeof(FPTYPE) * nloc * nnei * 3));
+  DPErrcheck(hipMemset(em, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt));
+  DPErrcheck(hipMemset(em_deriv, 0, sizeof(FPTYPE) * int_64(nloc) * ndescrpt * 3));
+  DPErrcheck(hipMemset(rij, 0, sizeof(FPTYPE) * int_64(nloc) * nnei * 3));
 
   format_nbor_list_gpu_rocm(
       nlist, 

--- a/source/lib/src/rocm/prod_force.hip.cu
+++ b/source/lib/src/rocm/prod_force.hip.cu
@@ -11,7 +11,7 @@ __global__ void force_deriv_wrt_center_atom(
     const int ndescrpt)
 {
   __shared__ FPTYPE data[THREADS_PER_BLOCK * 3];
-  unsigned int bid = blockIdx.x;
+  int_64 bid = blockIdx.x;
   unsigned int tid = threadIdx.x;
   for (int ii = tid; ii < THREADS_PER_BLOCK * 3; ii += THREADS_PER_BLOCK) {
     data[ii] = (FPTYPE)0.;
@@ -49,7 +49,7 @@ __global__ void force_deriv_wrt_neighbors_a(
     const int nnei)
 {  
     // idy -> nnei
-    const unsigned int idx = blockIdx.x;
+    const int_64 idx = blockIdx.x;
     const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
     const unsigned int idz = threadIdx.y;
     const int ndescrpt = nnei * 4;
@@ -78,7 +78,7 @@ __global__ void force_deriv_wrt_neighbors_r(
 		const int nnei)
 {  
     // idy -> nnei
-    const unsigned int idx = blockIdx.x;
+    const int_64 idx = blockIdx.x;
     const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
     const unsigned int idz = threadIdx.y;
     const int ndescrpt = nnei * 1;

--- a/source/lib/src/rocm/prod_force_grad.hip.cu
+++ b/source/lib/src/rocm/prod_force_grad.hip.cu
@@ -17,7 +17,7 @@ __global__ void force_grad_wrt_center_atom(
     const int ndescrpt)
 {
     __shared__ FPTYPE grad_one[3];
-    unsigned int center_idx = blockIdx.x;
+    int_64 center_idx = blockIdx.x;
     unsigned int tid = threadIdx.x;
     if(tid < 3){
         grad_one[tid] = grad[center_idx * 3 + tid];
@@ -39,7 +39,7 @@ __global__ void force_grad_wrt_neighbors_a(
     const int nnei)
 {
     // idy -> nnei
-    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int_64 idx = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int idy = blockIdx.y;
     const unsigned int idw = threadIdx.y;
     if (idx >= nloc) {
@@ -63,7 +63,7 @@ __global__ void force_grad_wrt_neighbors_r(
     const int nnei)
 {
     // idy -> nnei
-    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int_64 idx = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int idy = blockIdx.y;
     if (idx >= nloc) {
         return;

--- a/source/lib/src/rocm/prod_virial.hip.cu
+++ b/source/lib/src/rocm/prod_virial.hip.cu
@@ -44,7 +44,7 @@ __global__ void virial_deriv_wrt_neighbors_a(
   // idz = dd0 * 3 + dd1
   // dd0 = idz / 3
   // dd1 = idz % 3
-  const unsigned int idx = blockIdx.x;
+  const int_64 idx = blockIdx.x;
   const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
   const unsigned int idz = threadIdx.y;
   const int ndescrpt = nnei * 4;
@@ -78,7 +78,7 @@ __global__ void virial_deriv_wrt_neighbors_r(
     // idz = dd0 * 3 + dd1
     // dd0 = idz / 3
     // dd1 = idz % 3
-    const unsigned int idx = blockIdx.x;
+    const int_64 idx = blockIdx.x;
     const unsigned int idy = blockIdx.y * blockDim.x + threadIdx.x;
     const unsigned int idz = threadIdx.y;
     const int ndescrpt = nnei * 1;

--- a/source/lib/src/rocm/prod_virial_grad.hip.cu
+++ b/source/lib/src/rocm/prod_virial_grad.hip.cu
@@ -25,7 +25,7 @@ __global__ void virial_grad_wrt_neighbors_a(
 {
     // idy -> nnei
     const unsigned int tid = threadIdx.x;
-    const unsigned int idx = blockIdx.x * blockDim.x + tid;
+    const int_64 idx = blockIdx.x * blockDim.x + tid;
     const unsigned int idy = blockIdx.y;
     const unsigned int idw = threadIdx.y;
     const int ndescrpt = nnei * 4;
@@ -62,7 +62,7 @@ __global__ void virial_grad_wrt_neighbors_r(
 {
     // idy -> nnei
     const unsigned int tid = threadIdx.x;
-    const unsigned int idx = blockIdx.x * blockDim.x + tid;
+    const int_64 idx = blockIdx.x * blockDim.x + tid;
     const unsigned int idy = blockIdx.y;
     const int ndescrpt = nnei;
     __shared__ FPTYPE grad_one[9];

--- a/source/lib/src/rocm/tabulate.hip.cu
+++ b/source/lib/src/rocm/tabulate.hip.cu
@@ -110,7 +110,7 @@ __global__ void tabulate_fusion_se_a_fifth_order_polynomial(
     const int last_layer_size) 
 {
   HIP_DYNAMIC_SHARED( int, _data)
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
   FPTYPE ago = __shfl(em_x[block_idx * nnei + nnei - 1], 0);
   bool unloop = false;
@@ -167,7 +167,7 @@ __global__ void tabulate_fusion_se_a_grad_fifth_order_polynomial(
     const int last_layer_size) 
 {
   HIP_DYNAMIC_SHARED( int, _data)
-  const int block_idx = blockIdx.x;  // nloc
+  const int_64 block_idx = blockIdx.x;  // nloc
   const int thread_idx = threadIdx.x; // KTILE * WARP_SIZE, usally 128 here~
   int warp_idx = __shfl(threadIdx.x / 64, 0);
   int lane_idx = threadIdx.x % 64;
@@ -248,7 +248,7 @@ __global__ void tabulate_fusion_se_a_grad_grad_fifth_order_polynomial(
     const int last_layer_size)
 {
   extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
   FPTYPE ago = __shfl( em_x[block_idx * nnei + nnei - 1], 0);
   bool unloop = false;
@@ -307,7 +307,7 @@ __global__ void tabulate_fusion_se_t_fifth_order_polynomial(
     const int last_layer_size) 
 {
   HIP_DYNAMIC_SHARED( int, _data)
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
 
   FPTYPE sum = (FPTYPE)0.;
@@ -361,7 +361,7 @@ __global__ void tabulate_fusion_se_t_grad_fifth_order_polynomial(
     const int last_layer_size) 
 {
   HIP_DYNAMIC_SHARED( int, _data)
-  const int block_idx = blockIdx.x;  // nloc
+  const int_64 block_idx = blockIdx.x;  // nloc
   const int thread_idx = threadIdx.x; // KTILE * WARP_SIZE, usally 128 here~
   int warp_idx = __shfl(threadIdx.x / 64, 0);
   int lane_idx = threadIdx.x % 64;
@@ -430,7 +430,7 @@ __global__ void tabulate_fusion_se_t_grad_grad_fifth_order_polynomial(
     const int nnei_j,
     const int last_layer_size)
 {
-  const int block_idx  = blockIdx.x;   // nloc
+  const int_64 block_idx  = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
 
   FPTYPE sum = (FPTYPE)0.;
@@ -482,7 +482,7 @@ __global__ void tabulate_fusion_se_r_fifth_order_polynomial(
     const int last_layer_size) 
 {
   HIP_DYNAMIC_SHARED( int, _data)
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
   
   for (int ii = 0; ii < nnei; ii++) {
@@ -519,7 +519,7 @@ __global__ void tabulate_fusion_se_r_grad_fifth_order_polynomial(
     const int last_layer_size) 
 {
   HIP_DYNAMIC_SHARED( int, _data)
-  const int block_idx = blockIdx.x;  // nloc
+  const int_64 block_idx = blockIdx.x;  // nloc
   const int thread_idx = threadIdx.x; // KTILE * WARP_SIZE, usally 128 here~
   int warp_idx = __shfl(threadIdx.x / 64, 0);
   int lane_idx = threadIdx.x % 64;
@@ -569,7 +569,7 @@ __global__ void tabulate_fusion_se_r_grad_grad_fifth_order_polynomial(
     const int last_layer_size)
 {
   extern __shared__ int _data[];
-  const int block_idx = blockIdx.x;   // nloc
+  const int_64 block_idx = blockIdx.x;   // nloc
   const int thread_idx = threadIdx.x; // last_layer_size
 
   __syncthreads();

--- a/source/op/custom_op.h
+++ b/source/op/custom_op.h
@@ -1,6 +1,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include "device.h"
 
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"

--- a/source/op/gelu_multi_device.cc
+++ b/source/op/gelu_multi_device.cc
@@ -45,7 +45,7 @@ class GeluOp : public OpKernel {
     // flat the tensors
     FPTYPE * out = output_tensor->flat<FPTYPE>().data();
     const FPTYPE * x = x_tensor.flat<FPTYPE>().data();
-    const int size = static_cast<int>(output_tensor->NumElements());
+    const int_64 size = static_cast<int_64>(output_tensor->NumElements());
 
     if (device == "GPU") {
       #if GOOGLE_CUDA
@@ -98,7 +98,7 @@ class GeluGradOp : public OpKernel {
     FPTYPE * out = output_tensor->flat<FPTYPE>().data();
     const FPTYPE * x = x_tensor.flat<FPTYPE>().data();
     const FPTYPE * dy = dy_tensor.flat<FPTYPE>().data();
-    const int size = static_cast<int>(output_tensor->NumElements());
+    const int_64 size = static_cast<int_64>(output_tensor->NumElements());
 
     if (device == "GPU") {
       #if GOOGLE_CUDA
@@ -153,7 +153,7 @@ class GeluGradGradOp : public OpKernel {
     const FPTYPE * x = x_tensor.flat<FPTYPE>().data();
     const FPTYPE * dy = dy_tensor.flat<FPTYPE>().data();
     const FPTYPE * dy_2 = dy_2_tensor.flat<FPTYPE>().data();
-    const int size = static_cast<int>(output_tensor->NumElements());
+    const int_64 size = static_cast<int_64>(output_tensor->NumElements());
 
     if (device == "GPU") {
       #if GOOGLE_CUDA

--- a/source/op/prod_env_mat_multi_device.cc
+++ b/source/op/prod_env_mat_multi_device.cc
@@ -413,16 +413,16 @@ public:
     // Create output tensors
     TensorShape descrpt_shape ;
     descrpt_shape.AddDim (nsamples);
-    descrpt_shape.AddDim (nloc * ndescrpt);
+    descrpt_shape.AddDim (int_64(nloc) * ndescrpt);
     TensorShape descrpt_deriv_shape ;
     descrpt_deriv_shape.AddDim (nsamples);
-    descrpt_deriv_shape.AddDim (nloc * ndescrpt * 3);
+    descrpt_deriv_shape.AddDim (int_64(nloc) * ndescrpt * 3);
     TensorShape rij_shape ;
     rij_shape.AddDim (nsamples);
-    rij_shape.AddDim (nloc * nnei * 3);
+    rij_shape.AddDim (int_64(nloc) * nnei * 3);
     TensorShape nlist_shape ;
     nlist_shape.AddDim (nsamples);
-    nlist_shape.AddDim (nloc * nnei);
+    nlist_shape.AddDim (int_64(nloc) * nnei);
     // define output tensor
     int context_output_index = 0;
     Tensor* descrpt_tensor = NULL;
@@ -457,7 +457,7 @@ public:
     const int * p_type = type_tensor.flat<int>().data();
 
     // loop over samples
-    for(int ff = 0; ff < nsamples; ++ff){
+    for(int_64 ff = 0; ff < nsamples; ++ff){
       FPTYPE * em = p_em + ff*nloc*ndescrpt;
       FPTYPE * em_deriv = p_em_deriv + ff*nloc*ndescrpt*3;
       FPTYPE * rij = p_rij + ff*nloc*nnei*3;
@@ -488,11 +488,11 @@ public:
       // allocate temp memory, temp memory must not be used after this operation!
       Tensor int_temp;
       TensorShape int_shape;
-      int_shape.AddDim(sec_a.size() + nloc * sec_a.size() + nloc);
+      int_shape.AddDim(sec_a.size() + int_64(nloc) * sec_a.size() + nloc);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(nloc * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -526,11 +526,11 @@ public:
       // allocate temp memory, temp memory must not be used after this operation!
       Tensor int_temp;
       TensorShape int_shape;
-      int_shape.AddDim(sec_a.size() + nloc * sec_a.size() + nloc);
+      int_shape.AddDim(sec_a.size() + int_64(nloc) * sec_a.size() + nloc);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(nloc * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -677,16 +677,16 @@ public:
     // Create an output tensor
     TensorShape descrpt_shape ;
     descrpt_shape.AddDim (nsamples);
-    descrpt_shape.AddDim (nloc * ndescrpt);
+    descrpt_shape.AddDim (int_64(nloc) * ndescrpt);
     TensorShape descrpt_deriv_shape ;
     descrpt_deriv_shape.AddDim (nsamples);
-    descrpt_deriv_shape.AddDim (nloc * ndescrpt * 3);
+    descrpt_deriv_shape.AddDim (int_64(nloc) * ndescrpt * 3);
     TensorShape rij_shape ;
     rij_shape.AddDim (nsamples);
-    rij_shape.AddDim (nloc * nnei * 3);
+    rij_shape.AddDim (int_64(nloc) * nnei * 3);
     TensorShape nlist_shape ;
     nlist_shape.AddDim (nsamples);
-    nlist_shape.AddDim (nloc * nnei);
+    nlist_shape.AddDim (int_64(nloc) * nnei);
 
     int context_output_index = 0;
     Tensor* descrpt_tensor = NULL;
@@ -721,7 +721,7 @@ public:
     const int * p_type = type_tensor.flat<int>().data();
 
     // loop over samples
-    for(int ff = 0; ff < nsamples; ++ff){
+    for(int_64 ff = 0; ff < nsamples; ++ff){
       FPTYPE * em = p_em + ff*nloc*ndescrpt;
       FPTYPE * em_deriv = p_em_deriv + ff*nloc*ndescrpt*3;
       FPTYPE * rij = p_rij + ff*nloc*nnei*3;
@@ -752,11 +752,11 @@ public:
       // allocate temp memory, temp memory must not be used after this operation!
       Tensor int_temp;
       TensorShape int_shape;
-      int_shape.AddDim(sec.size() + nloc * sec.size() + nloc);
+      int_shape.AddDim(sec.size() + int_64(nloc) * sec.size() + nloc);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(nloc * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -791,11 +791,11 @@ public:
       // allocate temp memory, temp memory must not be used after this operation!
       Tensor int_temp;
       TensorShape int_shape;
-      int_shape.AddDim(sec.size() + nloc * sec.size() + nloc);
+      int_shape.AddDim(sec.size() + int_64(nloc) * sec.size() + nloc);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(nloc * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -935,8 +935,8 @@ _map_nlist_cpu(
     const int & nloc,
     const int & nnei)
 {
-  for (int ii = 0; ii < nloc; ++ii){
-    for (int jj = 0; jj < nnei; ++jj){
+  for (int_64 ii = 0; ii < nloc; ++ii){
+    for (int_64 jj = 0; jj < nnei; ++jj){
       int record = nlist[ii*nnei+jj];
       if (record >= 0) {		
 	nlist[ii*nnei+jj] = idx_mapping[record];	      
@@ -1112,11 +1112,11 @@ _build_nlist_gpu(
   int tt;
   for(tt = 0; tt < max_nnei_trial; ++tt){
     TensorShape jlist_shape;
-    jlist_shape.AddDim(3*nloc*mem_nnei);
+    jlist_shape.AddDim(3*int_64(nloc)*mem_nnei);
     context->allocate_temp(DT_INT32, jlist_shape, tensor_list+1);
     jlist = (*(tensor_list+1)).flat<int>().data();
     ind_data = jlist + nloc * mem_nnei;
-    for(int ii = 0; ii < nloc; ++ii){
+    for(int_64 ii = 0; ii < nloc; ++ii){
       firstneigh_host[ii] = jlist + ii * mem_nnei;
     }
     deepmd::memcpy_host_to_device(firstneigh, firstneigh_host);
@@ -1327,11 +1327,11 @@ _build_nlist_gpu_rocm(
   int tt;
   for(tt = 0; tt < max_nnei_trial; ++tt){
     TensorShape jlist_shape;
-    jlist_shape.AddDim(3*nloc*mem_nnei);
+    jlist_shape.AddDim(3*int_64(nloc)*mem_nnei);
     context->allocate_temp(DT_INT32, jlist_shape, tensor_list+1);
     jlist = (*(tensor_list+1)).flat<int>().data();
     ind_data = jlist + nloc * mem_nnei;
-    for(int ii = 0; ii < nloc; ++ii){
+    for(int_64 ii = 0; ii < nloc; ++ii){
       firstneigh_host[ii] = jlist + ii * mem_nnei;
     }
     deepmd::memcpy_host_to_device(firstneigh, firstneigh_host);

--- a/source/op/prod_env_mat_multi_device.cc
+++ b/source/op/prod_env_mat_multi_device.cc
@@ -492,7 +492,7 @@ public:
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * max_nbor_size * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -530,7 +530,7 @@ public:
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * max_nbor_size * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -756,7 +756,7 @@ public:
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * max_nbor_size * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -795,7 +795,7 @@ public:
       OP_REQUIRES_OK(context, context->allocate_temp(DT_INT32, int_shape, &int_temp));
       Tensor uint64_temp;
       TensorShape uint64_shape;
-      uint64_shape.AddDim(int_64(nloc) * GPU_MAX_NBOR_SIZE * 2);
+      uint64_shape.AddDim(int_64(nloc) * max_nbor_size * 2);
       OP_REQUIRES_OK(context, context->allocate_temp(DT_UINT64, uint64_shape, &uint64_temp));
       array_int = int_temp.flat<int>().data(); 
       array_longlong = uint64_temp.flat<unsigned long long>().data();
@@ -1210,7 +1210,7 @@ _prepare_coord_nlist_gpu(
     deepmd::env_mat_nbor_update(
         inlist_temp, inlist, max_nbor_size, nbor_list_dev,
         mesh_tensor_data, mesh_tensor_size);
-    OP_REQUIRES (context, (max_numneigh(inlist_temp) <= GPU_MAX_NBOR_SIZE), errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_numneigh(inlist_temp)) + " is larger than " + std::to_string(GPU_MAX_NBOR_SIZE) + ", which currently is not supported by deepmd-kit."));
+    OP_REQUIRES (context, (max_numneigh(inlist_temp) <= max_nbor_size), errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_numneigh(inlist_temp)) + " is larger than " + std::to_string(max_nbor_size) + ", which currently is not supported by deepmd-kit."));
   }
 }
 #endif  // GOOGLE_CUDA
@@ -1425,7 +1425,7 @@ _prepare_coord_nlist_gpu_rocm(
     deepmd::env_mat_nbor_update(
         inlist_temp, inlist, max_nbor_size, nbor_list_dev,
         mesh_tensor_data, mesh_tensor_size);
-    OP_REQUIRES (context, (max_numneigh(inlist_temp) <= GPU_MAX_NBOR_SIZE), errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_numneigh(inlist_temp)) + " is larger than " + std::to_string(GPU_MAX_NBOR_SIZE) + ", which currently is not supported by deepmd-kit."));
+    OP_REQUIRES (context, (max_numneigh(inlist_temp) <= max_nbor_size), errors::InvalidArgument ("Assert failed, max neighbor size of atom(lammps) " + std::to_string(max_numneigh(inlist_temp)) + " is larger than " + std::to_string(max_nbor_size) + ", which currently is not supported by deepmd-kit."));
   }
 }
 #endif  // TENSORFLOW_USE_ROCM

--- a/source/op/prod_force_grad_multi_device.cc
+++ b/source/op/prod_force_grad_multi_device.cc
@@ -69,13 +69,13 @@ public:
     OP_REQUIRES (context, (nframes == nlist_shape.dim_size(0)),		errors::InvalidArgument ("number of frames should match"));
     
     OP_REQUIRES (context, (nloc * 3 == grad_shape.dim_size(1)),		errors::InvalidArgument ("input grad shape should be 3 x natoms"));
-    OP_REQUIRES (context, (nloc * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
+    OP_REQUIRES (context, (int_64(nloc) * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
     OP_REQUIRES (context, (nnei == n_a_sel + n_r_sel),			errors::InvalidArgument ("number of neighbors should match"));
 
     // Create an output tensor
     TensorShape grad_net_shape ;
     grad_net_shape.AddDim (nframes);
-    grad_net_shape.AddDim (nloc * ndescrpt);
+    grad_net_shape.AddDim (int_64(nloc) * ndescrpt);
 
     // allocate the output tensor
     Tensor* grad_net_tensor = NULL;
@@ -106,7 +106,7 @@ public:
     const FPTYPE * p_in_deriv = in_deriv_tensor.flat<FPTYPE>().data();
     const int * p_nlist	= nlist_tensor.flat<int>().data();
 
-    for (int kk = 0; kk < nframes; ++kk){
+    for (int_64 kk = 0; kk < nframes; ++kk){
         FPTYPE * grad_net = p_grad_net + kk * nloc * ndescrpt;
         const FPTYPE * grad = p_grad + kk * nloc * 3;
         const FPTYPE * in_deriv = p_in_deriv + kk * nloc * ndescrpt * 3;
@@ -181,12 +181,12 @@ public:
     OP_REQUIRES (context, (nframes == nlist_shape.dim_size(0)),		errors::InvalidArgument ("number of frames should match"));
     
     OP_REQUIRES (context, (nloc * 3 == grad_shape.dim_size(1)),		errors::InvalidArgument ("input grad shape should be 3 x natoms"));
-    OP_REQUIRES (context, (nloc * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
+    OP_REQUIRES (context, (int_64(nloc) * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
 
     // Create an output tensor
     TensorShape grad_net_shape ;
     grad_net_shape.AddDim (nframes);
-    grad_net_shape.AddDim (nloc * ndescrpt);
+    grad_net_shape.AddDim (int_64(nloc) * ndescrpt);
 
     // allocate the output tensor
     Tensor* grad_net_tensor = NULL;
@@ -218,7 +218,7 @@ public:
     const int * p_nlist	= nlist_tensor.flat<int>().data();
 
     // loop over frames
-    for (int kk = 0; kk < nframes; ++kk){
+    for (int_64 kk = 0; kk < nframes; ++kk){
         FPTYPE * grad_net = p_grad_net + kk * nloc * ndescrpt;
         const FPTYPE * grad = p_grad + kk * nloc * 3;
         const FPTYPE * in_deriv = p_in_deriv + kk * nloc * ndescrpt * 3;

--- a/source/op/prod_force_multi_device.cc
+++ b/source/op/prod_force_multi_device.cc
@@ -80,7 +80,7 @@ public:
     // check the sizes
     OP_REQUIRES (context, (nframes == in_deriv_tensor.shape().dim_size(0)), errors::InvalidArgument ("number of samples should match"));
     OP_REQUIRES (context, (nframes == nlist_tensor.shape().dim_size(0)),    errors::InvalidArgument ("number of samples should match"));
-    OP_REQUIRES (context, (nloc * ndescrpt * 3 == in_deriv_tensor.shape().dim_size(1)), errors::InvalidArgument ("number of descriptors should match"));
+    OP_REQUIRES (context, (int_64(nloc) * ndescrpt * 3 == in_deriv_tensor.shape().dim_size(1)), errors::InvalidArgument ("number of descriptors should match"));
     // Create an output tensor
     TensorShape force_shape ;
     force_shape.AddDim (nframes);
@@ -124,7 +124,7 @@ public:
       nloc_loc = end_index - start_index;
     }
 
-    for(int kk = 0; kk < nframes; ++kk){
+    for(int_64 kk = 0; kk < nframes; ++kk){
       FPTYPE * force = p_force + kk * nall * 3;
       const FPTYPE * net_deriv = p_net_deriv + kk * nloc * ndescrpt;
       const FPTYPE * in_deriv = p_in_deriv + kk * nloc * ndescrpt * 3;
@@ -212,7 +212,7 @@ public:
     const FPTYPE * p_in_deriv = in_deriv_tensor.flat<FPTYPE>().data();
     const int * p_nlist = nlist_tensor.flat<int>().data();
 
-    for(int kk = 0; kk < nframes; ++kk){
+    for(int_64 kk = 0; kk < nframes; ++kk){
       FPTYPE * force = p_force + kk * nall * 3;
       const FPTYPE * net_deriv = p_net_deriv + kk * nloc * ndescrpt;
       const FPTYPE * in_deriv = p_in_deriv + kk * nloc * ndescrpt * 3;

--- a/source/op/prod_virial_grad_multi_device.cc
+++ b/source/op/prod_virial_grad_multi_device.cc
@@ -76,14 +76,14 @@ public:
     OP_REQUIRES (context, (nframes == nlist_shape.dim_size(0)),		errors::InvalidArgument ("number of frames should match"));
     
     OP_REQUIRES (context, (9 == grad_shape.dim_size(1)),		errors::InvalidArgument ("input grad shape should be 3 x natoms"));
-    OP_REQUIRES (context, (nloc * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
-    OP_REQUIRES (context, (nloc * nnei * 3 == rij_shape.dim_size(1)),	errors::InvalidArgument ("dim of rij should be  nnei * 3"));
+    OP_REQUIRES (context, (int_64(nloc) * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
+    OP_REQUIRES (context, (int_64(nloc) * nnei * 3 == rij_shape.dim_size(1)),	errors::InvalidArgument ("dim of rij should be  nnei * 3"));
     OP_REQUIRES (context, (nnei == n_a_sel + n_r_sel),			errors::InvalidArgument ("number of neighbors should match"));
 
     // Create an output tensor
     TensorShape grad_net_shape ;
     grad_net_shape.AddDim (nframes);
-    grad_net_shape.AddDim (nloc * ndescrpt);
+    grad_net_shape.AddDim (int_64(nloc) * ndescrpt);
 
     // allocate the output tensor
     Tensor* grad_net_tensor = NULL;
@@ -119,7 +119,7 @@ public:
     const int * p_nlist	= nlist_tensor.flat<int>().data();
 
     // loop over frames
-    for (int kk = 0; kk < nframes; ++kk){
+    for (int_64 kk = 0; kk < nframes; ++kk){
       FPTYPE * grad_net = p_grad_net + kk * nloc * ndescrpt;
       const FPTYPE * grad = p_grad + kk * 9;
       const FPTYPE * in_deriv = p_in_deriv + kk * nloc * ndescrpt * 3;
@@ -199,13 +199,13 @@ public:
     OP_REQUIRES (context, (nframes == nlist_shape.dim_size(0)),		errors::InvalidArgument ("number of frames should match"));
     
     OP_REQUIRES (context, (9 == grad_shape.dim_size(1)),		errors::InvalidArgument ("input grad shape should be 3 x natoms"));
-    OP_REQUIRES (context, (nloc * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
-    OP_REQUIRES (context, (nloc * nnei * 3 == rij_shape.dim_size(1)),	errors::InvalidArgument ("dim of rij should be  nnei * 3"));
+    OP_REQUIRES (context, (int_64(nloc) * ndescrpt * 3 == in_deriv_shape.dim_size(1)),errors::InvalidArgument ("number of descriptors should match"));
+    OP_REQUIRES (context, (int_64(nloc) * nnei * 3 == rij_shape.dim_size(1)),	errors::InvalidArgument ("dim of rij should be  nnei * 3"));
 
     // Create an output tensor
     TensorShape grad_net_shape ;
     grad_net_shape.AddDim (nframes);
-    grad_net_shape.AddDim (nloc * ndescrpt);
+    grad_net_shape.AddDim (int_64(nloc) * ndescrpt);
 
     // allocate the output tensor
     Tensor* grad_net_tensor = NULL;
@@ -241,7 +241,7 @@ public:
     const int * p_nlist	= nlist_tensor.flat<int>().data();
 
     // loop over frames
-    for (int kk = 0; kk < nframes; ++kk){
+    for (int_64 kk = 0; kk < nframes; ++kk){
       FPTYPE * grad_net = p_grad_net + kk * nloc * ndescrpt;
       const FPTYPE * grad = p_grad + kk * 9;
       const FPTYPE * in_deriv = p_in_deriv + kk * nloc * ndescrpt * 3;

--- a/source/op/prod_virial_multi_device.cc
+++ b/source/op/prod_virial_multi_device.cc
@@ -68,8 +68,8 @@ class ProdVirialSeAOp : public OpKernel {
     OP_REQUIRES (context, (nframes == in_deriv_tensor.shape().dim_size(0)), errors::InvalidArgument ("number of samples should match"));
     OP_REQUIRES (context, (nframes == rij_tensor.shape().dim_size(0)),      errors::InvalidArgument ("number of samples should match"));
     OP_REQUIRES (context, (nframes == nlist_tensor.shape().dim_size(0)),    errors::InvalidArgument ("number of samples should match"));
-    OP_REQUIRES (context, (nloc * ndescrpt * 3 == in_deriv_tensor.shape().dim_size(1)), errors::InvalidArgument ("number of descriptors should match"));
-    OP_REQUIRES (context, (nloc * nnei * 3 == rij_tensor.shape().dim_size(1)),  errors::InvalidArgument ("dim of rij should be nnei * 3"));
+    OP_REQUIRES (context, (int_64(nloc) * ndescrpt * 3 == in_deriv_tensor.shape().dim_size(1)), errors::InvalidArgument ("number of descriptors should match"));
+    OP_REQUIRES (context, (int_64(nloc) * nnei * 3 == rij_tensor.shape().dim_size(1)),  errors::InvalidArgument ("dim of rij should be nnei * 3"));
     // Create an output tensor
     TensorShape virial_shape ;
     virial_shape.AddDim (nframes);
@@ -100,7 +100,7 @@ class ProdVirialSeAOp : public OpKernel {
     const FPTYPE * p_rij = rij_tensor.flat<FPTYPE>().data();
     const int * p_nlist = nlist_tensor.flat<int>().data();
     
-    for(int kk = 0; kk < nframes; ++kk){
+    for(int_64 kk = 0; kk < nframes; ++kk){
       FPTYPE * virial = p_virial + kk * 9;
       FPTYPE * atom_virial = p_atom_virial + kk * nall * 9;
       const FPTYPE * net_deriv = p_net_deriv + kk * nloc * ndescrpt;
@@ -164,8 +164,8 @@ class ProdVirialSeROp : public OpKernel {
     OP_REQUIRES (context, (nframes == in_deriv_tensor.shape().dim_size(0)), errors::InvalidArgument ("number of samples should match"));
     OP_REQUIRES (context, (nframes == rij_tensor.shape().dim_size(0)),      errors::InvalidArgument ("number of samples should match"));
     OP_REQUIRES (context, (nframes == nlist_tensor.shape().dim_size(0)),    errors::InvalidArgument ("number of samples should match"));
-    OP_REQUIRES (context, (nloc * ndescrpt * 3 == in_deriv_tensor.shape().dim_size(1)), errors::InvalidArgument ("number of descriptors should match"));
-    OP_REQUIRES (context, (nloc * nnei * 3 == rij_tensor.shape().dim_size(1)),  errors::InvalidArgument ("dim of rij should be nnei * 3"));
+    OP_REQUIRES (context, (int_64(nloc) * ndescrpt * 3 == in_deriv_tensor.shape().dim_size(1)), errors::InvalidArgument ("number of descriptors should match"));
+    OP_REQUIRES (context, (int_64(nloc) * nnei * 3 == rij_tensor.shape().dim_size(1)),  errors::InvalidArgument ("dim of rij should be nnei * 3"));
     // Create an output tensor
     TensorShape virial_shape ;
     virial_shape.AddDim (nframes);
@@ -196,7 +196,7 @@ class ProdVirialSeROp : public OpKernel {
     const FPTYPE * p_rij = rij_tensor.flat<FPTYPE>().data();
     const int * p_nlist = nlist_tensor.flat<int>().data();
     
-    for(int kk = 0; kk < nframes; ++kk){
+    for(int_64 kk = 0; kk < nframes; ++kk){
       FPTYPE * virial = p_virial + kk * 9;
       FPTYPE * atom_virial = p_atom_virial + kk * nall * 9;
       const FPTYPE * net_deriv = p_net_deriv + kk * nloc * ndescrpt;


### PR DESCRIPTION
We use int32 to store the size or shape of tensors in the graph. And the multiplication of two large integers is often used as a memory allocation parameter, which is very dangerous as the number of atoms grows. Currently, a single GPU with 32 GiB or more device memory can process up to 240,000 atoms and may cause a potential waste of device resources.

To solve this problem, I have modified the code as follows:

1. Replace some `int` with `int64` within the `*_multi_device.cc` files to avoid memory allocation failure.
2. Change the related CUDA and ROCm implementations.
3. Avoid possible out-of-bounds reshape operations within the `deepmd/fit/ener.py` file.
4. The CPU part remains unchanged, simply because a single CPU core cannot handle such a large system.

After these changes, I tested using the 80 GiB A100 GPU with the example water system. 

Double precision, compressed model, max number of atoms: 835,584
```
Step PotEng KinEng TotEng Temp Press Volume 
       0 -1.3031679e+08    35642.501 -1.3028114e+08          330    4889.2972    8387686.3 
      10 -1.3031618e+08    35032.193 -1.3028114e+08    324.34939   -750.61864    8387686.3 
Loop time of 9.2185 on 1 procs for 10 steps with 835584 atoms

Performance: 0.047 ns/day, 512.139 hours/ns, 1.085 timesteps/s
100.5% CPU use with 1 MPI tasks x no OpenMP threads
```


Single precision, compressed model, max number of atoms: 1,951,488
```
Step PotEng KinEng TotEng Temp Press Volume 
       0 -3.0430224e+08    83242.333 -3.0421899e+08          330    21683.542     19589256 
      10 -3.043003e+08      81313.6 -3.0421899e+08    322.35387    16440.116     19589256 
Loop time of 11.1804 on 1 procs for 10 steps with 1951488 atoms

Performance: 0.039 ns/day, 621.135 hours/ns, 0.894 timesteps/s
97.8% CPU use with 1 MPI tasks x no OpenMP threads
```


