### PR TITLE
add `enable_atom_ener_coeff` option for energy loss

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -95,6 +95,7 @@ def add_data_requirement(
     high_prec: bool = False,
     type_sel: bool = None,
     repeat: int = 1,
+    default: float = 0.,
 ):
     """Specify data requirements for training.
 
@@ -116,6 +117,8 @@ def add_data_requirement(
         select only certain type of atoms, by default None
     repeat : int, optional
         if specify repaeat data `repeat` times, by default 1
+    default : float, optional, default=0.
+        default value of data
     """
     data_requirement[key] = {
         "ndof": ndof,
@@ -124,6 +127,7 @@ def add_data_requirement(
         "high_prec": high_prec,
         "type_sel": type_sel,
         "repeat": repeat,
+        "default": default,
     }
 
 

--- a/deepmd/loss/ener.py
+++ b/deepmd/loss/ener.py
@@ -90,6 +90,7 @@ class EnerStdLoss (Loss) :
             # E = - E(A) - E(B) + E(C) + E(D)
             # A, B, C, D could be put far away from each other
             atom_ener_coeff = label_dict['atom_ener_coeff']
+            atom_ener_coeff = tf.reshape(atom_ener_coeff, tf.shape(atom_ener))
             energy = tf.reduce_sum(atom_ener_coeff * atom_ener, 1)
         l2_ener_loss = tf.reduce_mean( tf.square(energy - energy_hat), name='l2_'+suffix)
 

--- a/deepmd/loss/ener.py
+++ b/deepmd/loss/ener.py
@@ -11,6 +11,11 @@ from .loss import Loss
 class EnerStdLoss (Loss) :
     """
     Standard loss function for DP models
+
+    Parameters
+    ----------
+    enable_atom_ener_coeff : bool
+        if true, the energy will be computed as \sum_i c_i E_i
     """
     def __init__ (self, 
                   starter_learning_rate : float, 
@@ -24,7 +29,8 @@ class EnerStdLoss (Loss) :
                   limit_pref_ae : float = 0.0,
                   start_pref_pf : float = 0.0,
                   limit_pref_pf : float = 0.0,
-                  relative_f : float = None 
+                  relative_f : float = None,
+                  enable_atom_ener_coeff: bool=False,
     ) -> None:
         self.starter_learning_rate = starter_learning_rate
         self.start_pref_e = start_pref_e
@@ -38,6 +44,7 @@ class EnerStdLoss (Loss) :
         self.start_pref_pf = start_pref_pf
         self.limit_pref_pf = limit_pref_pf
         self.relative_f = relative_f
+        self.enable_atom_ener_coeff = enable_atom_ener_coeff
         self.has_e = (self.start_pref_e != 0.0 or self.limit_pref_e != 0.0)
         self.has_f = (self.start_pref_f != 0.0 or self.limit_pref_f != 0.0)
         self.has_v = (self.start_pref_v != 0.0 or self.limit_pref_v != 0.0)
@@ -49,7 +56,8 @@ class EnerStdLoss (Loss) :
         add_data_requirement('virial', 9, atomic=False, must=False, high_prec=False)
         add_data_requirement('atom_ener', 1, atomic=True, must=False, high_prec=False)
         add_data_requirement('atom_pref', 1, atomic=True, must=False, high_prec=False, repeat=3)
-        add_data_requirement('atom_ener_coeff', 1, atomic=True, must=False, high_prec=False)
+        if self.enable_atom_ener_coeff:
+            add_data_requirement('atom_ener_coeff', 1, atomic=True, must=False, high_prec=False, default=1.)
 
     def build (self, 
                learning_rate,
@@ -72,7 +80,7 @@ class EnerStdLoss (Loss) :
         find_atom_ener = label_dict['find_atom_ener']                
         find_atom_pref = label_dict['find_atom_pref']                
 
-        if 'atom_ener_coeff' in label_dict:
+        if self.enable_atom_ener_coeff:
             # when ener_coeff (\nu) is defined, the energy is defined as 
             # E = \sum_i \nu_i E_i
             # instead of the sum of atomic energies.
@@ -80,9 +88,10 @@ class EnerStdLoss (Loss) :
             # A case is that we want to train reaction energy
             # A + B -> C + D
             # E = - E(A) - E(B) + E(C) + E(D)
-            # A, B, C, D could be put far away from each otehr
+            # A, B, C, D could be put far away from each other
             atom_ener_coeff = label_dict['atom_ener_coeff']
-            energy = tf.reduce_sum(weighted_atom_ener * atom_ener, 1)
+            energy = tf.reduce_sum(atom_ener_coeff * atom_ener, 1)
+        l2_ener_loss = tf.reduce_mean( tf.square(energy - energy_hat), name='l2_'+suffix)
 
         force_reshape = tf.reshape (force, [-1])
         force_hat_reshape = tf.reshape (force_hat, [-1])

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -479,6 +479,7 @@ def loss_ener():
     doc_start_pref_pf = start_pref('atom_pref')
     doc_limit_pref_pf = limit_pref('atom_pref')
     doc_relative_f = 'If provided, relative force error will be used in the loss. The difference of force will be normalized by the magnitude of the force in the label with a shift given by `relative_f`, i.e. DF_i / ( || F || + relative_f ) with DF denoting the difference between prediction and label and || F || denoting the L2 norm of the label.'
+    doc_enable_atom_ener_coeff = "If true, the energy will be computed as \sum_i c_i E_i. c_i should be provided by file atom_ener_coeff.npy in each data system, otherwise it's 1."
     return [
         Argument("start_pref_e", [float,int], optional = True, default = 0.02, doc = doc_start_pref_e),
         Argument("limit_pref_e", [float,int], optional = True, default = 1.00, doc = doc_limit_pref_e),
@@ -490,7 +491,8 @@ def loss_ener():
         Argument("limit_pref_ae", [float,int], optional = True, default = 0.00, doc = doc_limit_pref_ae),
         Argument("start_pref_pf", [float,int], optional = True, default = 0.00, doc = doc_start_pref_pf),
         Argument("limit_pref_pf", [float,int], optional = True, default = 0.00, doc = doc_limit_pref_pf),
-        Argument("relative_f", [float,None], optional = True, doc = doc_relative_f)
+        Argument("relative_f", [float,None], optional = True, doc = doc_relative_f),
+        Argument("enable_atom_ener_coeff", [bool], optional=True, default=False, doc=doc_enable_atom_ener_coeff),
     ]
 
 # YWolfeee: Modified to support tensor type of loss args.

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -491,9 +491,9 @@ class DeepmdData() :
             raise RuntimeError("%s not found!" % path)
         else:
             if high_prec :
-                data = np.full([nframes,ndof], default).astype(GLOBAL_ENER_FLOAT_PRECISION)                
+                data = np.full([nframes, ndof], default, dtype=GLOBAL_ENER_FLOAT_PRECISION)                
             else :
-                data = np.full([nframes,ndof], default).astype(GLOBAL_NP_FLOAT_PRECISION)
+                data = np.full([nframes, ndof], default, dtype=GLOBAL_NP_FLOAT_PRECISION)
             if repeat != 1:
                 data = np.repeat(data, repeat).reshape([nframes, -1])
             return np.float32(0.0), data

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -92,7 +92,8 @@ class DeepmdData() :
             must : bool = False, 
             high_prec : bool = False,
             type_sel : List[int] = None,
-            repeat : int = 1
+            repeat : int = 1,
+            default: bool=True,
     ) :
         """
         Add a data item that to be loaded
@@ -124,6 +125,7 @@ class DeepmdData() :
                                'type_sel': type_sel,
                                'repeat': repeat,
                                'reduce': None,
+                               'default': default,
         }
         return self
 
@@ -438,7 +440,9 @@ class DeepmdData() :
                                       high_prec = self.data_dict[kk]['high_prec'],
                                       must = self.data_dict[kk]['must'], 
                                       type_sel = self.data_dict[kk]['type_sel'],
-                                      repeat = self.data_dict[kk]['repeat'])
+                                      repeat = self.data_dict[kk]['repeat'],
+                                      default=self.data_dict[kk]['default'],
+                                      )
         for kk in self.data_dict.keys():
             if self.data_dict[kk]['reduce'] is not None :
                 k_in = self.data_dict[kk]['reduce']
@@ -450,7 +454,7 @@ class DeepmdData() :
         return data
 
 
-    def _load_data(self, set_name, key, nframes, ndof_, atomic = False, must = True, repeat = 1, high_prec = False, type_sel = None):
+    def _load_data(self, set_name, key, nframes, ndof_, atomic = False, must = True, repeat = 1, high_prec = False, type_sel = None, default: float=0.):
         if atomic:
             natoms = self.natoms
             idx_map = self.idx_map
@@ -487,9 +491,9 @@ class DeepmdData() :
             raise RuntimeError("%s not found!" % path)
         else:
             if high_prec :
-                data = np.zeros([nframes,ndof]).astype(GLOBAL_ENER_FLOAT_PRECISION)                
+                data = np.full([nframes,ndof], default).astype(GLOBAL_ENER_FLOAT_PRECISION)                
             else :
-                data = np.zeros([nframes,ndof]).astype(GLOBAL_NP_FLOAT_PRECISION)
+                data = np.full([nframes,ndof], default).astype(GLOBAL_NP_FLOAT_PRECISION)
             if repeat != 1:
                 data = np.repeat(data, repeat).reshape([nframes, -1])
             return np.float32(0.0), data

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -222,7 +222,9 @@ class DeepmdDataSystem() :
                      must=adict[kk]['must'], 
                      high_prec=adict[kk]['high_prec'], 
                      type_sel=adict[kk]['type_sel'], 
-                     repeat=adict[kk]['repeat'])
+                     repeat=adict[kk]['repeat'],
+                     default=adict[kk]['default'],
+                     )
 
     def add(self, 
             key : str, 
@@ -231,7 +233,8 @@ class DeepmdDataSystem() :
             must : bool = False, 
             high_prec : bool = False,
             type_sel : List[int] = None,
-            repeat : int = 1
+            repeat : int = 1,
+            default: float=0.,
     ) :
         """
         Add a data item that to be loaded
@@ -255,9 +258,11 @@ class DeepmdDataSystem() :
                 Select certain type of atoms
         repeat
                 The data will be repeated `repeat` times.
+        default, default=0.
+                Default value of data
         """
         for ii in self.data_systems:
-            ii.add(key, ndof, atomic=atomic, must=must, high_prec=high_prec, repeat=repeat, type_sel=type_sel)
+            ii.add(key, ndof, atomic=atomic, must=must, high_prec=high_prec, repeat=repeat, type_sel=type_sel, default=default)
 
     def reduce(self, key_out, key_in):
         """

--- a/source/tests/test_data_requirement.py
+++ b/source/tests/test_data_requirement.py
@@ -11,3 +11,4 @@ class TestDataRequirement(unittest.TestCase):
         self.assertEqual(data_requirement['test']['must'], False)
         self.assertEqual(data_requirement['test']['high_prec'], False)
         self.assertEqual(data_requirement['test']['repeat'], 1)
+        self.assertEqual(data_requirement['test']['default'], 0.)

--- a/source/tests/test_deepmd_data_sys.py
+++ b/source/tests/test_deepmd_data_sys.py
@@ -82,6 +82,7 @@ class TestDataSystem (unittest.TestCase) :
         ds = DeepmdDataSystem(self.sys_name, batch_size, test_size, 2.0)
         ds.add('test', self.test_ndof, atomic = True, must = True)
         ds.add('null', self.test_ndof, atomic = True, must = False)
+        ds.add('ones', self.test_ndof, atomic = True, must = False, default=1.)
         sys_idx = 0
         data = ds.get_test(sys_idx=sys_idx)
         self.assertEqual(list(data['type'][0]), list(np.sort(self.atom_type[sys_idx])))
@@ -97,6 +98,11 @@ class TestDataSystem (unittest.TestCase) :
                                                         self.natoms[sys_idx]*self.test_ndof])
                                               -
                                               data['null']
+        ), 0.0)
+        self.assertAlmostEqual(np.linalg.norm(np.ones([self.nframes[sys_idx]+2,
+                                                self.natoms[sys_idx]*self.test_ndof])
+                                        -
+                                        data['ones']
         ), 0.0)
 
         sys_idx = 2


### PR DESCRIPTION
Usually, the model energy is given by

$$ E = \sum_i E_i $$

By enabling this option, when training the model, the energy will be given by

$$ E = \sum_i c_i E_i $$

$c_i$ is provided by `atom_ener_coeff.npy` (default is 1.).

By this feature, we could train the reaction energy $\Delta E_\text{rnx}$ for $\ce{A + B -> C + D}$. Just put A, B, C, and D into the same box.
