### PR TITLE
docs: fix emoji in PDF

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -255,3 +255,12 @@ mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-mml
 myst_enable_extensions = [
     'dollarmath',
 ]
+# fix emoji issue in pdf
+latex_engine = "xelatex"
+latex_elements = {
+    'fontpkg': r'''
+\usepackage{fontspec}
+\setmainfont{Symbola}
+''',
+}
+


### PR DESCRIPTION
by changing the main font to Symbola.

This font has been installed in the RTD image. But if one wants to build locally, first install the font:
```sh
apt-get install fonts-symbola
```