### PR TITLE
fix typo in hip assert error message

### DIFF
--- a/source/lib/include/gpu_rocm.h
+++ b/source/lib/include/gpu_rocm.h
@@ -13,7 +13,7 @@
 inline void DPAssert(hipError_t code, const char *file, int line, bool abort=true) {
     if (code != hipSuccess) {
         fprintf(stderr,"hip assert: %s %s %d\n", hipGetErrorString(code), file, line);
-        if (abort) throw deepmd::deepmd_exception("CUDA Assert");
+        if (abort) throw deepmd::deepmd_exception("HIP Assert");
     }
 }
 
@@ -21,7 +21,7 @@ inline void DPAssert(hipError_t code, const char *file, int line, bool abort=tru
 inline void nborAssert(hipError_t code, const char *file, int line, bool abort=true) {
     if (code != hipSuccess) {
         fprintf(stderr,"hip assert: %s %s %d\n", "DeePMD-kit:\tillegal nbor list sorting", file, line);
-        if (abort) throw deepmd::deepmd_exception("CUDA Assert");
+        if (abort) throw deepmd::deepmd_exception("HIP Assert: illegal nbor list sorting");
     }
 }
 


### PR DESCRIPTION
Wrongly written as "cuda assert" (#1801).