### PR TITLE
fix deprecated bare `pair_coeff`

### DIFF
--- a/doc/third-party/lammps-command.md
+++ b/doc/third-party/lammps-command.md
@@ -96,7 +96,7 @@ dump            1 all custom 100 water.dump id type c_dipole[1] c_dipole[2] c_di
 The reciprocal space part of the long-range interaction can be calculated by LAMMPS command `kspace_style`. To use it with DeePMD-kit, one writes 
 ```bash
 pair_style	deepmd graph.pb
-pair_coeff
+pair_coeff  * *
 kspace_style	pppm 1.0e-5
 kspace_modify	gewald 0.45
 ```

--- a/examples/fparam/lmp/in.lammps
+++ b/examples/fparam/lmp/in.lammps
@@ -12,7 +12,7 @@ mass 		1 16
 
 # pair_style	deepmd frozen_model.pb fparam 0.68938740
 pair_style	deepmd frozen_model.pb fparam 0.25852028
-pair_coeff	
+pair_coeff	* *
 
 velocity        all create 2000 23456789
 


### PR DESCRIPTION
Bare `pair_coeff` is not allowed in the recent versions of LAMMPS.