### PR TITLE
error if LAMMPS_VERSION_NUMBER is not defined

### DIFF
--- a/source/lmp/pair_deepmd.h.in
+++ b/source/lmp/pair_deepmd.h.in
@@ -1,3 +1,7 @@
+#ifndef LAMMPS_VERSION_NUMBER
+#error Please define LAMMPS_VERSION_NUMBER to yyyymmdd
+#endif
+
 #ifdef PAIR_CLASS
 
 PairStyle(deepmd,PairDeepMD)


### PR DESCRIPTION
Throw an error if some one (like @Yi-FanLi) compiles LAMMPS with USER-DEEPMD using CMAKE and does not define `LAMMPS_VERSION_NUMBER`.

