### PR TITLE
revert prod_force OMP in #1360

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -62,7 +62,7 @@ jobs:
           ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - run: python -m pip install -U pip>=21.3.1
+    #- run: python -m pip install -U pip>=21.3.1
     - run: pip install -e .[cpu,test] codecov
       env:
         CC: gcc-${{ matrix.gcc }}

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -62,11 +62,12 @@ jobs:
           ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    #- run: python -m pip install -U pip>=21.3.1
+    - run: python -m pip install -U pip>=21.3.1
     - run: pip install -e .[cpu,test] codecov
       env:
         CC: gcc-${{ matrix.gcc }}
         CXX: g++-${{ matrix.gcc }}
         TENSORFLOW_VERSION: ${{ matrix.tf }}
+        SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
     - run: dp --version
     - run: pytest --cov=deepmd source/tests && codecov

--- a/source/lib/src/prod_force.cc
+++ b/source/lib/src/prod_force.cc
@@ -37,17 +37,14 @@ prod_force_a_cpu(
 
   memset(force, 0, sizeof(FPTYPE) * nall * 3);
   // compute force of a frame
-  #pragma omp parallel
   for (int i_idx = start_index; i_idx < start_index + nloc; ++i_idx) {
     // deriv wrt center atom
-    #pragma omp single
     for (int aa = 0; aa < ndescrpt; ++aa) {
       force[i_idx * 3 + 0] -= net_deriv[i_idx * ndescrpt + aa] * env_deriv[i_idx * ndescrpt * 3 + aa * 3 + 0];
       force[i_idx * 3 + 1] -= net_deriv[i_idx * ndescrpt + aa] * env_deriv[i_idx * ndescrpt * 3 + aa * 3 + 1];
       force[i_idx * 3 + 2] -= net_deriv[i_idx * ndescrpt + aa] * env_deriv[i_idx * ndescrpt * 3 + aa * 3 + 2];
     }
     // deriv wrt neighbors
-    #pragma omp for
     for (int jj = 0; jj < nnei; ++jj) {
       int j_idx = nlist[i_idx * nnei + jj];
       if (j_idx < 0) continue;
@@ -111,18 +108,15 @@ prod_force_r_cpu(
   }
 
   // compute force of a frame
-  #pragma omp parallel
   for (int ii = 0; ii < nloc; ++ii){
     int i_idx = ii;	
     // deriv wrt center atom
-    #pragma omp single
     for (int aa = 0; aa < ndescrpt; ++aa){
       force[i_idx * 3 + 0] -= net_deriv[i_idx * ndescrpt + aa] * env_deriv[i_idx * ndescrpt * 3 + aa * 3 + 0];
       force[i_idx * 3 + 1] -= net_deriv[i_idx * ndescrpt + aa] * env_deriv[i_idx * ndescrpt * 3 + aa * 3 + 1];
       force[i_idx * 3 + 2] -= net_deriv[i_idx * ndescrpt + aa] * env_deriv[i_idx * ndescrpt * 3 + aa * 3 + 2];
     }
     // deriv wrt neighbors
-    #pragma omp for
     for (int jj = 0; jj < nnei; ++jj){
       int j_idx = nlist[i_idx * nnei + jj];
       // if (j_idx > nloc) j_idx = j_idx % nloc;


### PR DESCRIPTION
Sometimes when the box is quite small (i.e. box size < 2 * rcut), the same atom may repeat to appear in the neighbor list built by DP. This cause inaccurate results when using OMP.