### PR TITLE
remove white space from train_attr/training_script

### DIFF
--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -97,7 +97,8 @@ def train(
         json.dump(jdata, fp, indent=4)
 
     # save the training script into the graph
-    tf.constant(json.dumps(jdata), name='train_attr/training_script', dtype=tf.string)
+    # remove white spaces as it is not compressed
+    tf.constant(json.dumps(jdata, separators=(',', ':')), name='train_attr/training_script', dtype=tf.string)
 
     for message in WELCOME + CITATION + BUILD:
         log.info(message)


### PR DESCRIPTION
#921 discussed that the tensors are compressed in the graph file. But it looks no... So at least we remove white space.

When any graph file is opened, it is clear that `train_attr/training_script` is stored as raw text.
![image](https://user-images.githubusercontent.com/9496702/185806085-add75aa0-c712-4d02-a1ab-b88f4521c3f5.png)
