### PR TITLE
fix DeprecationWarning of imp

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -5,7 +5,7 @@ import os
 import re
 import platform
 from configparser import ConfigParser
-from imp import reload
+from importlib import reload
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from packaging.version import Version


### PR DESCRIPTION
> deepmd/env.py:8: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses

See also https://docs.python.org/3/library/imp.html#imp.reload
