### PR TITLE
LAMMPS: Use of “override” instead of “virtual”

### DIFF
--- a/source/lmp/compute_deeptensor_atom.h
+++ b/source/lmp/compute_deeptensor_atom.h
@@ -20,11 +20,11 @@ namespace LAMMPS_NS {
 class ComputeDeeptensorAtom : public Compute {
  public:
   ComputeDeeptensorAtom(class LAMMPS *, int, char **);
-  ~ComputeDeeptensorAtom();
-  void init();
-  void compute_peratom();
-  double memory_usage();
-  void init_list(int, class NeighList *);
+  ~ComputeDeeptensorAtom() override;
+  void init() override;
+  void compute_peratom() override;
+  double memory_usage() override;
+  void init_list(int, class NeighList *) override;
 
  private:
   int nmax;

--- a/source/lmp/fix_dplr.h
+++ b/source/lmp/fix_dplr.h
@@ -29,17 +29,17 @@ namespace LAMMPS_NS {
   class FixDPLR : public Fix {
 public:
     FixDPLR(class LAMMPS *, int, char **);
-    virtual ~FixDPLR() {};
-    int setmask();
-    void init();
-    void setup(int);
-    void post_integrate();
-    void pre_force(int);
-    void post_force(int);
-    int pack_reverse_comm(int, int, double *);
-    void unpack_reverse_comm(int, int *, double *);
-    double compute_scalar(void);
-    double compute_vector(int);
+    ~FixDPLR() {} override;
+    int setmask() override;
+    void init() override;
+    void setup(int) override;
+    void post_integrate() override;
+    void pre_force(int) override;
+    void post_force(int) override;
+    int pack_reverse_comm(int, int, double *) override;
+    void unpack_reverse_comm(int, int *, double *) override;
+    double compute_scalar(void) override;
+    double compute_vector(int) override;
 private:
     PairDeepMD * pair_deepmd;
     deepmd::DeepTensor dpt;

--- a/source/lmp/fix_dplr.h
+++ b/source/lmp/fix_dplr.h
@@ -29,7 +29,7 @@ namespace LAMMPS_NS {
   class FixDPLR : public Fix {
 public:
     FixDPLR(class LAMMPS *, int, char **);
-    ~FixDPLR() {} override;
+    ~FixDPLR() override {};
     int setmask() override;
     void init() override;
     void setup(int) override;

--- a/source/lmp/pair_deepmd.h.in
+++ b/source/lmp/pair_deepmd.h.in
@@ -48,17 +48,17 @@ namespace LAMMPS_NS {
 class PairDeepMD : public Pair {
  public:
   PairDeepMD(class LAMMPS *);
-  virtual ~PairDeepMD();
-  virtual void compute(int, int);
-  virtual void *extract(const char *, int &);
-  void settings(int, char **);
-  virtual void coeff(int, char **);
-  void init_style();
-  virtual void write_restart(FILE *);
-  virtual void read_restart(FILE *);
-  double init_one(int i, int j);
-  int pack_reverse_comm(int, int, double *);
-  void unpack_reverse_comm(int, int *, double *);
+  ~PairDeepMD() override;
+  void compute(int, int) override;
+  void *extract(const char *, int &) override;
+  void settings(int, char **) override;
+  void coeff(int, char **) override;
+  void init_style() override;
+  void write_restart(FILE *) override;
+  void read_restart(FILE *) override;
+  double init_one(int i, int j) override;
+  int pack_reverse_comm(int, int, double *) override;
+  void unpack_reverse_comm(int, int *, double *) override;
   void print_summary(const std::string pre) const;
   int get_node_rank();
   std::string get_file_content(const std::string & model);

--- a/source/lmp/pppm_dplr.h
+++ b/source/lmp/pppm_dplr.h
@@ -27,9 +27,9 @@ public:
 #else
     PPPMDPLR(class LAMMPS *);
 #endif
-    ~PPPMDPLR () {} override;
+    ~PPPMDPLR () override {};
     void init() override;
-    const std::vector<double > & get_fele() const {return fele;} override;
+    const std::vector<double > & get_fele() const {return fele;};
 protected:
     void compute(int, int) override;
     void fieldforce_ik() override;

--- a/source/lmp/pppm_dplr.h
+++ b/source/lmp/pppm_dplr.h
@@ -27,13 +27,13 @@ public:
 #else
     PPPMDPLR(class LAMMPS *);
 #endif
-    virtual ~PPPMDPLR () {};
-    void init();
-    const std::vector<double > & get_fele() const {return fele;};
+    ~PPPMDPLR () {} override;
+    void init() override;
+    const std::vector<double > & get_fele() const {return fele;} override;
 protected:
-    virtual void compute(int, int);
-    virtual void fieldforce_ik();
-    virtual void fieldforce_ad();    
+    void compute(int, int) override;
+    void fieldforce_ik() override;
+    void fieldforce_ad() override;
 private:
     std::vector<double > fele;
   };


### PR DESCRIPTION
fix #1855.