### PR TITLE
perceive LAMMPS version for built-in mode

### DIFF
--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -178,7 +178,6 @@ One may add the following arguments to `cmake`:
 | -DCUDA_TOOLKIT_ROOT_DIR=&lt;value&gt; | Path         | Detected automatically | The path to the CUDA toolkit directory. CUDA 7.0 or later is supported. NVCC is required. |
 | -DUSE_ROCM_TOOLKIT=&lt;value&gt; | `TRUE` or `FALSE` | `FALSE`       | If `TRUE`, Build GPU support with ROCM toolkit. |
 | -DROCM_ROOT=&lt;value&gt; | Path         | Detected automatically | The path to the ROCM toolkit directory. |
-| -DLAMMPS_VERSION_NUMBER=&lt;value&gt; | Number         | `20220723` | Only neccessary for LAMMPS built-in mode. The version number of LAMMPS (yyyymmdd). LAMMPS 29Oct2020 (20201029) or later is supported. |
 | -DLAMMPS_SOURCE_ROOT=&lt;value&gt; | Path         | - | Only neccessary for LAMMPS plugin mode. The path to the [LAMMPS source code](install-lammps.md). LAMMPS 8Apr2021 or later is supported. If not assigned, the plugin mode will not be enabled. |
 | -DUSE_TF_PYTHON_LIBS=&lt;value&gt; | `TRUE` or `FALSE` | `FALSE`       | If `TRUE`, Build C++ interface with TensorFlow's Python libraries(TensorFlow's Python Interface is required). And there's no need for building TensorFlow's C++ interface.|
 

--- a/doc/install/install-lammps.md
+++ b/doc/install/install-lammps.md
@@ -11,7 +11,7 @@ DeePMD-kit provides a module for running MD simulation with LAMMPS. Now make the
 cd $deepmd_source_dir/source/build
 make lammps
 ```
-DeePMD-kit will generate a module called `USER-DEEPMD` in the `build` directory. If you need the low precision version, move `env_low.sh` to `env.sh` in the directory. Now download the LAMMPS code, and uncompress it. The LAMMPS version should be the same as what is specified as the CMAKE argument `LAMMPS_VERSION_NUMBER`.
+DeePMD-kit will generate a module called `USER-DEEPMD` in the `build` directory. If you need the low precision version, move `env_low.sh` to `env.sh` in the directory. Now download the LAMMPS code, and uncompress it.
 ```bash
 cd /some/workspace
 wget https://github.com/lammps/lammps/archive/stable_23Jun2022_update1.tar.gz

--- a/source/lmp/CMakeLists.txt
+++ b/source/lmp/CMakeLists.txt
@@ -1,9 +1,4 @@
 add_subdirectory(plugin)
-if (NOT DEFINED LAMMPS_VERSION_NUMBER)
-    # set the default to stable_23Jun2022_update1
-    set(LAMMPS_VERSION_NUMBER 20220623)
-endif()
-message(STATUS "LAMMPS version is ${LAMMPS_VERSION_NUMBER}")
 
 file(GLOB LMP_HEADER *.h)
 file(GLOB LMP_SRC *.cpp)

--- a/source/lmp/env.sh.in
+++ b/source/lmp/env.sh.in
@@ -6,6 +6,6 @@ TF_INCLUDE_DIRS=`echo $TENSORFLOW_INCLUDE_DIRS | sed "s/;/ -I/g"`
 TF_LIBRARY_PATH=`echo $TENSORFLOW_LIBRARY_PATH | sed "s/;/ -L/g"`
 TF_RPATH=`echo $TENSORFLOW_LIBRARY_PATH | sed "s/;/ -Wl,-rpath=/g"`
 
-NNP_INC=" -std=c++@CMAKE_CXX_STANDARD@ -D@prec_def@ @TTM_DEF@ -DLAMMPS_VERSION_NUMBER=@LAMMPS_VERSION_NUMBER@ -I$DEEPMD_ROOT/include/ "
+NNP_INC=" -std=c++@CMAKE_CXX_STANDARD@ -D@prec_def@ @TTM_DEF@ -DLAMMPS_VERSION_NUMBER=$(./lmp_version.sh) -I$DEEPMD_ROOT/include/ "
 NNP_PATH=" -L$TF_LIBRARY_PATH -L$DEEPMD_ROOT/lib"
 NNP_LIB=" -Wl,--no-as-needed -l@LIB_DEEPMD_CC@@variant_name@ -ltensorflow_cc -ltensorflow_framework -Wl,-rpath=$TF_RPATH -Wl,-rpath=$DEEPMD_ROOT/lib"

--- a/source/lmp/env_py.sh.in
+++ b/source/lmp/env_py.sh.in
@@ -8,6 +8,6 @@ TF_LIBRARY_PATH=`echo $TENSORFLOW_LIBRARY_PATH | sed "s/;/ -L/g"`
 TF_RPATH=`echo $TENSORFLOW_LIBRARY_PATH | sed "s/;/ -Wl,-rpath=/g"`
 PYTHON_RPATH=`echo $PYTHON_LIBRARY_PATH | sed "s/;/ -Wl,-rpath=/g"`
 
-NNP_INC=" -D_GLIBCXX_USE_CXX11_ABI=@OP_CXX_ABI@ -std=c++@CMAKE_CXX_STANDARD@ -D@prec_def@ @TTM_DEF@ -DLAMMPS_VERSION_NUMBER=@LAMMPS_VERSION_NUMBER@ -I$TF_INCLUDE_DIRS -I$DEEPMD_ROOT/include/ "
+NNP_INC=" -D_GLIBCXX_USE_CXX11_ABI=@OP_CXX_ABI@ -std=c++@CMAKE_CXX_STANDARD@ -D@prec_def@ @TTM_DEF@ -DLAMMPS_VERSION_NUMBER=$(./lmp_version.sh) -I$TF_INCLUDE_DIRS -I$DEEPMD_ROOT/include/ "
 NNP_PATH=" -L$TF_LIBRARY_PATH -L$DEEPMD_ROOT/lib"
 NNP_LIB=" -Wl,--no-as-needed -l@LIB_DEEPMD_CC@@variant_name@ -ltensorflow_cc -ltensorflow_framework -lpython@Python_VERSION_MAJOR@.@Python_VERSION_MINOR@ -Wl,-rpath=$TF_RPATH -Wl,-rpath=$DEEPMD_ROOT/lib -Wl,-rpath=$PYTHON_RPATH "

--- a/source/lmp/lmp_version.sh
+++ b/source/lmp/lmp_version.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+# Read LAMMPS version from version.h
+version_line=$(grep LAMMPS_VERSION ../version.h)
+# extract version
+tmp=${version_line#*\"}   # remove prefix ending in "
+version=${tmp%\"*}   # remove suffix starting with "
+# string to int
+date --date="$(printf $version)" +"%Y%m%d"

--- a/source/lmp/plugin/CMakeLists.txt
+++ b/source/lmp/plugin/CMakeLists.txt
@@ -33,6 +33,7 @@ if (DEFINED LAMMPS_SOURCE_ROOT OR DEFINED LAMMPS_VERSION)
   include(${LAMMPS_SOURCE_ROOT}/cmake/Modules/LAMMPSUtils.cmake)
   get_lammps_version(${LAMMPS_HEADER_DIR}/version.h LAMMPS_VERSION_NUMBER)
   set(LAMMPS_VERSION_NUMBER ${LAMMPS_VERSION_NUMBER} PARENT_SCOPE)
+  message(STATUS "LAMMPS version is ${LAMMPS_VERSION_NUMBER}")
 
   configure_file("../pair_deepmd.h.in" "${CMAKE_CURRENT_BINARY_DIR}/pair_deepmd.h" @ONLY)
 


### PR DESCRIPTION
Set `LAMMPS_VERSION_NUMBER` during `make yes-user-deepmd`. Fixes #1947. The corresponding CMake argument is deprecated.