### PR TITLE
enable gcov for Python tests

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -69,5 +69,6 @@ jobs:
         CXX: g++-${{ matrix.gcc }}
         TENSORFLOW_VERSION: ${{ matrix.tf }}
         SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
+        DP_BUILD_TESTING: 1
     - run: dp --version
     - run: pytest --cov=deepmd source/tests && codecov

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ elif dp_variant == "rocm":
 else:
     raise RuntimeError("Unsupported DP_VARIANT option: %s" % dp_variant)
 
+if os.environ.get("DP_BUILD_TESTING", "0") == "1":
+    cmake_args.append("-DBUILD_TESTING:BOOL=TRUE")
+
 # get tensorflow spec
 tf_spec = find_spec("tensorflow")
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.12)
 project(DeePMD)
 
+option(BUILD_TESTING "Enable converage" OFF)
+if(BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(${CMAKE_SOURCE_DIR}/cmake/coverage_config coverage_config)
+endif()
+
 # build cpp or python interfaces
 if (NOT DEFINED BUILD_CPP_IF) 
   set(BUILD_CPP_IF TRUE)

--- a/source/op/CMakeLists.txt
+++ b/source/op/CMakeLists.txt
@@ -58,6 +58,10 @@ if (BUILD_PY_IF)
     INSTALL_RPATH $ORIGIN
     )
   endif ()
+  if (CMAKE_TESTING_ENABLED)
+    target_link_libraries(op_abi PRIVATE coverage_config)
+    target_link_libraries(op_grads PRIVATE coverage_config)
+  endif()
 endif (BUILD_PY_IF)
 
 if (BUILD_CPP_IF)


### PR DESCRIPTION
Coverage for C++ libraries will be counted when testing Python. It's expected to see the codecov coverage increases.