### PR TITLE
lmp: throw errors when 6-element atomic virial requested

### DIFF
--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -310,7 +310,7 @@ void PairDeepMD::compute(int eflag, int vflag)
 {
   if (numb_models == 0) return;
   if (eflag || vflag) ev_setup(eflag,vflag);
-  if (vflag_atom) error->all(FLERR, "6-element virial is not supported. Use compute centroid/stress/atom command for 9-element virial.");
+  if (vflag_atom) error->all(FLERR, "6-element atomic virial is not supported. Use compute centroid/stress/atom command for 9-element atomic virial.");
   bool do_ghost = true;
   
   double **x = atom->x;

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -310,6 +310,7 @@ void PairDeepMD::compute(int eflag, int vflag)
 {
   if (numb_models == 0) return;
   if (eflag || vflag) ev_setup(eflag,vflag);
+  if (vflag_atom) error->all(FLERR, "6-element virial is not supported. Use compute centroid/stress/atom command for 9-element virial.");
   bool do_ghost = true;
   
   double **x = atom->x;


### PR DESCRIPTION
Otherwise it returns zero atomic virials.