### PR TITLE
c++: add clang tests and fix clang errors

### DIFF
--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -12,6 +12,7 @@ jobs:
         include:
         - variant: cpu
         - variant: cuda
+        - variant: clang
     steps:
     - name: work around permission issue
       run: git config --global --add safe.directory /__w/deepmd-kit/deepmd-kit
@@ -22,10 +23,20 @@ jobs:
       if: matrix.variant == 'cpu'
     - run: apt-get update && apt-get install -y nvidia-cuda-toolkit
       if: matrix.variant == 'cuda'
+    - run: apt-get update && apt-get install -y clang
+      if: matrix.variant == 'clang'  
     - run: source/install/build_cc.sh
       env:
         DP_VARIANT: ${{ matrix.variant }}
         DOWNLOAD_TENSORFLOW: "FALSE"
+      if: matrix.variant != 'clang'
+    - run: source/install/build_cc.sh
+      env:
+        DP_VARIANT: cpu
+        DOWNLOAD_TENSORFLOW: "FALSE"
+        CC: clang
+        CXX: clang++
+      if: matrix.variant == 'clang'
     # test lammps
     - run: source/install/build_lammps.sh
       if: matrix.variant == 'cpu'

--- a/source/api_cc/src/AtomMap.cc
+++ b/source/api_cc/src/AtomMap.cc
@@ -65,6 +65,6 @@ backward (typename std::vector<VALUETYPE >::iterator out,
   }
 }
 
-template class AtomMap<float>;
-template class AtomMap<double>;
+template class deepmd::AtomMap<float>;
+template class deepmd::AtomMap<double>;
 


### PR DESCRIPTION
Clang is the default compiler for macos. For errors see also https://docwiki.embarcadero.com/RADStudio/Sydney/en/Explicit_instantiation_of_%27namespace::templated_class%27_must_occur_in_namespace_%27namespace%27_(C%2B%2B)