### PR TITLE
resolve macos clang errors

### DIFF
--- a/source/api_cc/CMakeLists.txt
+++ b/source/api_cc/CMakeLists.txt
@@ -20,6 +20,10 @@ target_link_libraries (${libname} PUBLIC ${LIB_DEEPMD}	${TensorFlow_LIBRARY} ${T
 target_include_directories(${libname} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(${libname} PRIVATE ${TensorFlow_INCLUDE_DIRS})
 
+if(Protobuf_LIBRARY)
+  target_link_libraries(op_abi PRIVATE ${Protobuf_LIBRARY})
+endif()
+
 # link: libpython3.x.so
 if (USE_TF_PYTHON_LIBS)
   target_link_libraries (${libname} PUBLIC ${Python_LIBRARIES})

--- a/source/api_cc/CMakeLists.txt
+++ b/source/api_cc/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(${libname} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
 target_include_directories(${libname} PRIVATE ${TensorFlow_INCLUDE_DIRS})
 
 if(Protobuf_LIBRARY)
-  target_link_libraries(op_abi PRIVATE ${Protobuf_LIBRARY})
+  target_link_libraries(${libname} PRIVATE ${Protobuf_LIBRARY})
 endif()
 
 # link: libpython3.x.so

--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -149,8 +149,6 @@ find_path(TensorFlow_INCLUDE_DIRS_GOOGLE
   PATH_SUFFIXES "/include"
   NO_DEFAULT_PATH
   )
-if (NOT TensorFlow_INCLUDE_DIRS_GOOGLE)
-  message(STATUS "Protobuf headers are not found in the directory of TensorFlow, assuming external protobuf was used to build TensorFlow")
   # try to find from ldd list of TF library
   # a warning is threw here, just ignore it
   # https://stackoverflow.com/a/49738486/9567349
@@ -172,6 +170,8 @@ if (NOT TensorFlow_INCLUDE_DIRS_GOOGLE)
         break()
       endif()
   endforeach()
+if (NOT TensorFlow_INCLUDE_DIRS_GOOGLE)
+  message(STATUS "Protobuf headers are not found in the directory of TensorFlow, assuming external protobuf was used to build TensorFlow")
   if (NOT Protobuf_LIBRARY)
     message(FATAL_ERROR "TensorFlow is not linked to protobuf")
   endif()

--- a/source/ipi/CMakeLists.txt
+++ b/source/ipi/CMakeLists.txt
@@ -16,6 +16,14 @@ add_executable(${ipiname} ${DRIVER_SOURCE_FILES})
 target_link_libraries(${ipiname} PRIVATE ${libipiname} ${LIB_DEEPMD_CC}${variant_name})
 target_include_directories(${ipiname} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/)
 
+if (APPLE)
+  set_target_properties(
+    ${ipiname}
+    PROPERTIES
+    INSTALL_RPATH "@loader_path/../lib:${TensorFlow_LIBRARY_PATH}"
+    COMPILE_DEFINITIONS ${prec_def}
+  )
+else()
 set_target_properties(
   ${ipiname}
   PROPERTIES
@@ -23,6 +31,7 @@ set_target_properties(
   INSTALL_RPATH "$ORIGIN/../lib:${TensorFlow_LIBRARY_PATH}"
   COMPILE_DEFINITIONS ${prec_def}
 )
+endif()
 
 install(
   TARGETS	${libipiname}

--- a/source/lmp/plugin/CMakeLists.txt
+++ b/source/lmp/plugin/CMakeLists.txt
@@ -64,6 +64,9 @@ if (DEFINED LAMMPS_SOURCE_ROOT OR DEFINED LAMMPS_VERSION)
     ${LAMMPS_SOURCE_ROOT}/src/KSPACE
     ${LAMMPS_SOURCE_ROOT}/src
   )
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set_target_properties(${libname} PROPERTIES LINK_FLAGS "-Wl,-undefined,dynamic_lookup")
+  endif()
 
   set_target_properties(
     ${libname} 

--- a/source/op/CMakeLists.txt
+++ b/source/op/CMakeLists.txt
@@ -33,6 +33,9 @@ if (BUILD_PY_IF)
   target_link_libraries(
     op_grads PRIVATE ${TensorFlowFramework_LIBRARY}
     )
+  if(Protobuf_LIBRARY)
+    target_link_libraries(op_abi PRIVATE ${Protobuf_LIBRARY})
+  endif()
   target_include_directories(op_abi PUBLIC ${TensorFlow_INCLUDE_DIRS})
   target_include_directories(op_grads PUBLIC ${TensorFlow_INCLUDE_DIRS})
   if (APPLE)


### PR DESCRIPTION
This is also aimed at resolving macos clang errors:
1. link to protobuf if it's used and separated;
2. add link flags to lmp lib.
3. set rpath; remove gnu specific flags;