### PR TITLE
fix Findtensorflow when LD_LIBRARY_PATH is empty

### DIFF
--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -160,7 +160,7 @@ find_path(TensorFlow_INCLUDE_DIRS_GOOGLE
     UNRESOLVED_DEPENDENCIES_VAR TensorFlow_LINKED_LIBRARIES_UNRESOLVED
     LIBRARIES ${TensorFlowFramework_LIBRARY}
     POST_INCLUDE_REGEXES "^.+protobuf\..+$"
-    DIRECTORIES ${_LD_LIBRARY_DIRS}
+    DIRECTORIES "${_LD_LIBRARY_DIRS}"
   )
   # search protobuf from linked libraries
   foreach(_lib ${TensorFlow_LINKED_LIBRARIES})


### PR DESCRIPTION
Just add quotes for cmake empty variables. See https://stackoverflow.com/a/52481212/9567349