### PR TITLE
Fix compatibility with ROCm>=3.5.1; fix typo in hip neighbor_list

### DIFF
--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -12,6 +12,7 @@ jobs:
         include:
         - variant: cpu
         - variant: cuda
+        - variant: rocm
         - variant: clang
     steps:
     - name: work around permission issue
@@ -23,6 +24,14 @@ jobs:
       if: matrix.variant == 'cpu'
     - run: apt-get update && apt-get install -y nvidia-cuda-toolkit
       if: matrix.variant == 'cuda'
+    - run: |
+         apt-get update && apt-get install -y gnupg2 \
+         && echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/5.3/ jammy main' | tee /etc/apt/sources.list.d/rocm.list \
+         && printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | tee /etc/apt/preferences.d/rocm-pin-600 \
+         && curl -s https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
+         && apt-get update \
+         && apt-get install -y rocm-dev hipcub-dev
+      if: matrix.variant == 'rocm'
     - run: apt-get update && apt-get install -y clang
       if: matrix.variant == 'clang'  
     - run: source/install/build_cc.sh

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -177,7 +177,7 @@ One may add the following arguments to `cmake`:
 | -DUSE_CUDA_TOOLKIT=&lt;value&gt; | `TRUE` or `FALSE` | `FALSE`       | If `TRUE`, Build GPU support with CUDA toolkit. |
 | -DCUDA_TOOLKIT_ROOT_DIR=&lt;value&gt; | Path         | Detected automatically | The path to the CUDA toolkit directory. CUDA 7.0 or later is supported. NVCC is required. |
 | -DUSE_ROCM_TOOLKIT=&lt;value&gt; | `TRUE` or `FALSE` | `FALSE`       | If `TRUE`, Build GPU support with ROCM toolkit. |
-| -DROCM_ROOT=&lt;value&gt; | Path         | Detected automatically | The path to the ROCM toolkit directory. |
+| -DCMAKE_HIP_COMPILER_ROCM_ROOT=&lt;value&gt; | Path         | Detected automatically | The path to the ROCM toolkit directory. |
 | -DLAMMPS_SOURCE_ROOT=&lt;value&gt; | Path         | - | Only neccessary for LAMMPS plugin mode. The path to the [LAMMPS source code](install-lammps.md). LAMMPS 8Apr2021 or later is supported. If not assigned, the plugin mode will not be enabled. |
 | -DUSE_TF_PYTHON_LIBS=&lt;value&gt; | `TRUE` or `FALSE` | `FALSE`       | If `TRUE`, Build C++ interface with TensorFlow's Python libraries(TensorFlow's Python Interface is required). And there's no need for building TensorFlow's C++ interface.|
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ elif dp_variant == "rocm":
     cmake_args.append("-DUSE_ROCM_TOOLKIT:BOOL=TRUE")
     rocm_root = os.environ.get("ROCM_ROOT")
     if rocm_root:
-        cmake_args.append(f"-DROCM_ROOT:STRING={rocm_root}")
+        cmake_args.append(f"-DCMAKE_HIP_COMPILER_ROCM_ROOT:STRING={rocm_root}")
 else:
     raise RuntimeError("Unsupported DP_VARIANT option: %s" % dp_variant)
 

--- a/source/cmake/FindROCM.cmake
+++ b/source/cmake/FindROCM.cmake
@@ -7,10 +7,9 @@
 # ROCM_LIBRARIES
 
 # define the search path
-list(APPEND ROCM_search_PATHS ${ROCM_ROOT})
-list(APPEND ROCM_search_PATHS $ENV{ROCM_PATH})
-list(APPEND ROCM_search_PATHS "/opt/rocm/")
-
+cmake_minimum_required(VERSION 3.21)
+include(CMakeDetermineHIPCompiler)
+set(ROCM_search_PATHS ${CMAKE_HIP_COMPILER_ROCM_ROOT})
 
 # includes
 find_path (ROCM_INCLUDE_DIRS

--- a/source/cmake/FindROCM.cmake
+++ b/source/cmake/FindROCM.cmake
@@ -9,6 +9,7 @@
 # define the search path
 cmake_minimum_required(VERSION 3.21)
 include(CMakeDetermineHIPCompiler)
+set(ROCM_PATH ${CMAKE_HIP_COMPILER_ROCM_ROOT})
 set(ROCM_search_PATHS ${CMAKE_HIP_COMPILER_ROCM_ROOT})
 
 # includes

--- a/source/install/build_cc.sh
+++ b/source/install/build_cc.sh
@@ -1,8 +1,11 @@
 set -e
 
-if [ "$DP_VARIANT" == "cuda" ]
+if [ "$DP_VARIANT" = "cuda" ]
 then
   CUDA_ARGS="-DUSE_CUDA_TOOLKIT=TRUE"
+elif [ "$DP_VARIANT" = "rocm" ]
+then
+  CUDA_ARGS="-DUSE_ROCM_TOOLKIT=TRUE"
 fi
 #------------------
 

--- a/source/lib/src/rocm/CMakeLists.txt
+++ b/source/lib/src/rocm/CMakeLists.txt
@@ -1,18 +1,21 @@
 # required cmake version
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.21)
 # project name
 project(deepmd_op_rocm)
 set(CMAKE_LINK_WHAT_YOU_USE TRUE)
 
 # set c++ version c++11
-SET(CMAKE_CXX_STANDARD 11)
-SET(CMAKE_HIP_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_HIP_STANDARD 14)
 add_definitions("-DCUB_IGNORE_DEPRECATED_CPP_DIALECT")
 add_definitions("-DCUB_IGNORE_DEPRECATED_CPP_DIALECT")
 
 message(STATUS "HIP major version is " ${HIP_VERSION_MAJOR})
 
-set (HIP_HIPCC_FLAGS -hc; -fno-gpu-rdc; --amdgpu-target=gfx906; -fPIC; -O3; --std=c++11)
+set (HIP_HIPCC_FLAGS -fno-gpu-rdc; -fPIC --std=c++14) # --amdgpu-target=gfx906
+if (HIP_VERSION VERSION_LESS 3.5.1)
+  set (HIP_HIPCC_FLAGS -hc; ${HIP_HIPCC_FLAGS})
+endif()
 
 file (GLOB SOURCE_FILES "*.hip.cu" )
 

--- a/source/lib/src/rocm/neighbor_list.hip.cu
+++ b/source/lib/src/rocm/neighbor_list.hip.cu
@@ -288,7 +288,7 @@ void use_nei_info_gpu_rocm(
     dim3 block_grid(nloc, nblock);
     dim3 thread_grid(1, TPB);
     DPErrcheck(hipMemset(ntype, 0, sizeof(int) * nloc * nnei));
-    DPErrcheck(hipMemset(nmask, 0, sizeof(FPTYPE) * nloc * nnei));
+    DPErrcheck(hipMemset(nmask, 0, sizeof(bool) * nloc * nnei));
     if (b_nlist_map){
         hipLaunchKernelGGL(map_nei_info, block_grid, thread_grid, 0, 0, nlist, ntype, nmask, type, nlist_map, nloc, nnei, ntypes);
     }


### PR DESCRIPTION
Fixes #1400. Fixes #2009.

1. Uses cmake native module `CMakeDetermineHIPCompiler` to find the search path;
2. for ROCm>=3.5.1, `hip-hcc hiprtc` is replaced by `amd_comgr amdhip64`, per https://github.com/RadeonOpenCompute/ROCm/issues/1200. (I am not sure about the situation of `amd_comgr`?)
3. Removes `-hc` from the flag for ROCm>=3.5.1.
4. Bumps from C++11 to C++14 as C++ 14 required by `amd_comgr`.
5. Removes `--amdgpu-target=gfx906`. I don't see the reason why it is in the flag.
6. Fixes a typo in #1866.