### PR TITLE
build_tf.py: mirror fixes

### DIFF
--- a/source/install/build_tf.py
+++ b/source/install/build_tf.py
@@ -575,7 +575,7 @@ class BuildTensorFlow(Build):
         with set_directory(src):
             # configure -- need bazelisk in PATH
             call([str(src / "configure")], env={
-                "PATH": list2env([PREFIX / "bin", "/usr/bin"]),
+                "PATH": list2env([PREFIX / "bin", "/usr/bin", "/bin"]),
                 **self._environments,
             })
             # bazel build
@@ -586,7 +586,7 @@ class BuildTensorFlow(Build):
                 *self._build_opts,
                 *self._build_targets,
             ], env={
-                "PATH": list2env(["/usr/bin"]),
+                "PATH": list2env(["/usr/bin", "/bin"]),
                 "HOME": os.environ.get("HOME"),
                 "TEST_TMPDIR": str(PACKAGE_DIR / "bazelcache"),
                 # for libstdc++

--- a/source/install/build_tf.py
+++ b/source/install/build_tf.py
@@ -590,7 +590,7 @@ class BuildTensorFlow(Build):
                 "HOME": os.environ.get("HOME"),
                 "TEST_TMPDIR": str(PACKAGE_DIR / "bazelcache"),
                 # for libstdc++
-                "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH"),
+                "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
                 "CC": str(Path(GCC).resolve()),
                 "CXX": str(Path(GXX).resolve()),
             })


### PR DESCRIPTION
- fix error when LD_LIBRARY_PATH is not set
- add `/bin` to `PATH` considering `/bin` is not a symbolic link to `/usr/bin` on some systems