### PR TITLE
build, package, and release C library

### DIFF
--- a/.github/workflows/package_c.yml
+++ b/.github/workflows/package_c.yml
@@ -1,0 +1,26 @@
+name: Build C library
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_c:
+    name: Build C library
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Package C library
+        run: ./source/install/docker_package_c.sh
+      - name: Test C library
+        run: ./source/install/docker_test_package_c.sh
+      # for download and debug
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: ./libdeepmd_c.tar.gz
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: libdeepmd_c.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,11 @@ dp/
 dp_test/
 dp_test_cc/
 dp_test_c/
+dp_c/
 build_lammps/
 .idea/
 build_tests/
 build_cc_tests
 build_c_tests
+build_c/
+libdeepmd_c/

--- a/examples/infer_water/.gitignore
+++ b/examples/infer_water/.gitignore
@@ -4,3 +4,5 @@ CMakeCache.txt
 CMakeFiles
 infer_water_cc
 infer_water_c
+infer_water
+graph.pb

--- a/source/api_c/CMakeLists.txt
+++ b/source/api_c/CMakeLists.txt
@@ -39,7 +39,7 @@ if (PACKAGE_C)
   # follow pypa/auditwheel convention
   install(CODE [[
     file(GET_RUNTIME_DEPENDENCIES
-      LIBRARIES $<TARGET_FILE:deepmd_c>
+      LIBRARIES $<TARGET_FILE:deepmd_c> $<TARGET_FILE:deepmd_op>
       RESOLVED_DEPENDENCIES_VAR _r_deps
       PRE_EXCLUDE_REGEXES "libgcc_s\\.so.*"
                           "libstdc\\+\\+\\.so.*"

--- a/source/api_c/CMakeLists.txt
+++ b/source/api_c/CMakeLists.txt
@@ -33,3 +33,42 @@ install(
   FILES		${INC_SRC}
   DESTINATION	include/deepmd
 )
+
+if (PACKAGE_C)
+  MESSAGE(STATUS "Packaging C API library")
+  # follow pypa/auditwheel convention
+  install(CODE [[
+    file(GET_RUNTIME_DEPENDENCIES
+      LIBRARIES $<TARGET_FILE:deepmd_c>
+      RESOLVED_DEPENDENCIES_VAR _r_deps
+      PRE_EXCLUDE_REGEXES "libgcc_s\\.so.*"
+                          "libstdc\\+\\+\\.so.*"
+                          "libm\\.so.*"
+                          "libdl\\.so.*"
+                          "librt\\.so.*"
+                          "libc\\.so.*"
+                          "libpthread\\.so.*"
+                          "ld-.*\\.so.*"
+                          "libgomp\\.so.*"
+      )
+    message(STATUS "Runtime dependencies: ${_r_deps}")
+    foreach(_file ${_r_deps})
+      file(INSTALL ${_file} DESTINATION libdeepmd_c/lib
+        FOLLOW_SYMLINK_CHAIN
+      )
+    endforeach()
+    ]]
+  )
+  install(
+    FILES ${INC_SRC}
+    DESTINATION	${CMAKE_BINARY_DIR}/libdeepmd_c/include/deepmd
+  )
+  install(
+    TARGETS ${libname}
+    DESTINATION	${CMAKE_BINARY_DIR}/libdeepmd_c/lib
+  )
+  install(
+    TARGETS ${LIB_DEEPMD_OP}
+    DESTINATION	${CMAKE_BINARY_DIR}/libdeepmd_c/lib
+  )
+endif()

--- a/source/install/docker_package_c.sh
+++ b/source/install/docker_package_c.sh
@@ -1,0 +1,9 @@
+set -e
+
+SCRIPT_PATH=$(dirname $(realpath -s $0))
+
+docker run --rm -v ${SCRIPT_PATH}/../..:/root/deepmd-kit -w /root/deepmd-kit \
+       ghcr.io/deepmodeling/libtensorflow_cc:2.9.2_cuda11.6_centos7_cmake \
+       /bin/sh -c "source /opt/rh/devtoolset-10/enable \
+            && cd /root/deepmd-kit/source/install \
+            && /bin/sh package_c.sh"

--- a/source/install/docker_test_package_c.sh
+++ b/source/install/docker_test_package_c.sh
@@ -1,0 +1,15 @@
+# test libdeepmd_c.tar.gz works with gcc 4.9.0, glibc 2.19
+set -e
+
+SCRIPT_PATH=$(dirname $(realpath -s $0))
+
+# assume libdeepmd_c.tar.gz has been created
+
+wget "https://drive.google.com/uc?export=download&id=1xldLhzm4uSkq6iPohSycNWAsWqKAenKX" -O ${SCRIPT_PATH}/../../examples/infer_water/"graph.pb"
+
+docker run --rm -v ${SCRIPT_PATH}/../..:/root/deepmd-kit -w /root/deepmd-kit \
+       gcc:4.9 \
+       /bin/sh -c "tar vxzf libdeepmd_c.tar.gz \
+            && cd examples/infer_water \
+            && gcc infer_water.c -std=c99 -L ../../libdeepmd_c/lib -I ../../libdeepmd_c/include -Wl,--no-as-needed -ldeepmd_c -Wl,-rpath=../../libdeepmd_c/lib -o infer_water \
+            && ./infer_water"

--- a/source/install/package_c.sh
+++ b/source/install/package_c.sh
@@ -1,0 +1,29 @@
+# package C library into a tarball
+
+set -e
+
+SCRIPT_PATH=$(dirname $(realpath -s $0))
+if [ -z "$INSTALL_PREFIX" ]
+then
+  INSTALL_PREFIX=$(realpath -s ${SCRIPT_PATH}/../../dp_c)
+fi
+mkdir -p ${INSTALL_PREFIX}
+echo "Installing DeePMD-kit to ${INSTALL_PREFIX}"
+NPROC=$(nproc --all)
+
+#------------------
+
+BUILD_TMP_DIR=${SCRIPT_PATH}/../build_c
+mkdir -p ${BUILD_TMP_DIR}
+cd ${BUILD_TMP_DIR}
+cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+      -DUSE_CUDA_TOOLKIT=TRUE \
+      -DOP_CXX_ABI=0 \
+      -DPACKAGE_C=TRUE \
+      ..
+make -j${NPROC}
+make install
+
+#------------------
+
+tar vczf ${SCRIPT_PATH}/../../libdeepmd_c.tar.gz -C ${BUILD_TMP_DIR} libdeepmd_c


### PR DESCRIPTION
Fix #2058.

This patch builds DeePMD-kit C library against TensorFlow 2.9.2 C++ library with CUDA support on CentOS 7 and then packages DeePMD-kit C library along with TensorFlow libraries. Then it is tested with GCC 4.9.0 and GLIBC 2.19. Finally, the package is uploaded and released. GitHub Actions and Docker drive all these things.
The minimum GLIBC requirement is 2.17, and the minimum GLIBCXX requirement is 3.4.19. It should work with any version of GCC.
Note that one still needs to install CUDA Toolkit 11 and cuDNN 8 manually for GPUs, otherwise TF falls back to CPUs.