### PR TITLE
improve building wheel workflow

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -2,10 +2,6 @@ name: Build and upload to PyPI
 
 on:
   push:
-    branches:
-      - master
-    tags:
-      - v*
   pull_request:
 
 jobs:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -2,63 +2,106 @@ name: Build and upload to PyPI
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - v*
   pull_request:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels for cp${{ matrix.python }}-${{ matrix.platform_id }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-18.04]  #, windows-latest, macos-latest]
-
+        include:
+          # linux-64
+          - os: ubuntu-latest
+            python: 37
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 39
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_x86_64
+          # macos-x86-64
+          - os: macos-latest
+            python: 37
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 38
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 39
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 310
+            platform_id: macosx_x86_64
+          # macos-arm64
+          - os: macos-latest
+            bitness: 64
+            python: 38
+            platform_id: macosx_arm64
+          - os: macos-latest
+            bitness: 64
+            python: 39
+            platform_id: macosx_arm64
+          - os: macos-latest
+            bitness: 64
+            python: 310
+            platform_id: macosx_arm64
     steps:
-      - name: work around permission issue
-        run: git config --global --add safe.directory /__w/deepmd-kit/deepmd-kit
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions/setup-python@v2
         name: Install Python
         with:
           python-version: '3.8'
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
-
+      - run: python -m pip install cibuildwheel==2.11.2
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_ARCHS: all
+          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
-      - run: pip install -U scikit-build tensorflow setuptools_scm
+          python-version: '3.10'
+      - run: python -m pip install build
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
-
       - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -25,32 +25,6 @@ jobs:
           - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
-          # macos-x86-64
-          - os: macos-latest
-            python: 37
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python: 38
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python: 39
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python: 310
-            platform_id: macosx_x86_64
-          # macos-arm64
-          - os: macos-latest
-            bitness: 64
-            python: 38
-            platform_id: macosx_arm64
-          - os: macos-latest
-            bitness: 64
-            python: 39
-            platform_id: macosx_arm64
-          - os: macos-latest
-            bitness: 64
-            python: 310
-            platform_id: macosx_arm64
     steps:
       - uses: actions/checkout@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 
 [tool.cibuildwheel.linux]
-repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 libtensorflow_framework.so.1 libtensorflow_framework.so -w {dest_dir} {wheel}"
+repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so -w {dest_dir} {wheel}"
 environment-pass = ["CIBW_BUILD"]
 
 # selectively turn of lintner warnings, always include reasoning why any warning should

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test-command = "dp -h"
 test-requires = "tensorflow"
 build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
-manylinux-x86_64-image = "manylinux_2_28_x86_64"
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 libtensorflow_framework.so.1 libtensorflow_framework.so -w {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,13 @@ write_to = "deepmd/_version.py"
 [tool.cibuildwheel]
 test-command = "dp -h"
 test-requires = "tensorflow"
-build = ["cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*"]
+build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
-manylinux-x86_64-image = "ghcr.io/deepmodeling/manylinux_2_28_x86_64_tensorflow"
+manylinux-x86_64-image = "manylinux_2_28_x86_64"
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 libtensorflow_framework.so.1 libtensorflow_framework.so -w {dest_dir} {wheel}"
+environment-pass = ["CIBW_BUILD"]
 
 # selectively turn of lintner warnings, always include reasoning why any warning should
 # be silenced

--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -244,10 +244,7 @@ if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.4 AND MSVC)
 endif()
 
 # auto op_cxx_abi
-if(MSVC OR APPLE)
-  # skip on windows or osx
-  set(OP_CXX_ABI 0)
-elseif (NOT DEFINED OP_CXX_ABI)
+if (NOT DEFINED OP_CXX_ABI)
   if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.9)
     # TF 2.9 removes the tf_cxx11_abi_flag function, which is really bad...
     # try compiling with both 0 and 1, and see which one works

--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -244,7 +244,10 @@ if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.4 AND MSVC)
 endif()
 
 # auto op_cxx_abi
-if (NOT DEFINED OP_CXX_ABI)
+if(MSVC OR APPLE)
+  # skip on windows or osx
+  set(OP_CXX_ABI 0)
+elseif (NOT DEFINED OP_CXX_ABI)
   if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.9)
     # TF 2.9 removes the tf_cxx11_abi_flag function, which is really bad...
     # try compiling with both 0 and 1, and see which one works


### PR DESCRIPTION
This patch includes the following improvements about building wheels:
- drop Python 3.6 support;
- split a single job into multiple jobs
- use auditwheel's new option `--exclude`, so we do not need to patch `policy.json` any more
- use `build` to build sdist and include submodules in the sdist