### PR TITLE
skip checking `_GLIBCXX_USE_CXX11_ABI` on windows or osx 

### DIFF
--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -244,8 +244,8 @@ if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.4 AND MSVC)
 endif()
 
 # auto op_cxx_abi
-if(MSVC OR APPLE)
-  # skip on windows or osx
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  # skip if the compiler is not gcc or icc
   set(OP_CXX_ABI 0)
 elseif (NOT DEFINED OP_CXX_ABI)
   if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.9)

--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -244,7 +244,10 @@ if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.4 AND MSVC)
 endif()
 
 # auto op_cxx_abi
-if (NOT DEFINED OP_CXX_ABI)
+if(MSVC OR APPLE)
+  # skip on windows or osx
+  set(OP_CXX_ABI 0)
+elseif (NOT DEFINED OP_CXX_ABI)
   if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.9)
     # TF 2.9 removes the tf_cxx11_abi_flag function, which is really bad...
     # try compiling with both 0 and 1, and see which one works

--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -244,8 +244,8 @@ if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.4 AND MSVC)
 endif()
 
 # auto op_cxx_abi
-if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  # skip if the compiler is not gcc or icc
+if(MSVC OR APPLE)
+  # skip on windows or osx
   set(OP_CXX_ABI 0)
 elseif (NOT DEFINED OP_CXX_ABI)
   if (TENSORFLOW_VERSION VERSION_GREATER_EQUAL 2.9)


### PR DESCRIPTION
This patch skips detecting `_GLIBCXX_USE_CXX11_ABI` on windows and osx. These platforms do not have GNU C++ library.