### PR TITLE
enable CUDA for linux-64 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so -w {dest_dir} {wheel}"
 environment-pass = ["CIBW_BUILD"]
+environment = { DP_VARIANT="cuda" }
+before-all = "dnf install -y cuda-toolkit-11"
 
 # selectively turn of lintner warnings, always include reasoning why any warning should
 # be silenced

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so -w {dest_dir} {wheel}"
 environment-pass = ["CIBW_BUILD"]
 environment = { DP_VARIANT="cuda" }
-before-all = "yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && yum install -y cuda-11-2"
+before-all = "yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && yum install -y cuda-11-8"
 
 # selectively turn of lintner warnings, always include reasoning why any warning should
 # be silenced

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so -w {dest_dir} {wheel}"
 environment-pass = ["CIBW_BUILD"]
 environment = { DP_VARIANT="cuda" }
-before-all = "yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && yum install -y cuda"
+before-all = "yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && yum install -y cuda-11-2"
 
 # selectively turn of lintner warnings, always include reasoning why any warning should
 # be silenced

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so -w {dest_dir} {wheel}"
 environment-pass = ["CIBW_BUILD"]
 environment = { DP_VARIANT="cuda" }
-before-all = "dnf install -y cuda-toolkit-11"
+before-all = "yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && yum install -y cuda"
 
 # selectively turn of lintner warnings, always include reasoning why any warning should
 # be silenced


### PR DESCRIPTION
Builds linux-64 wheels against CUDA 11.8, but per [NVIDIA documentation](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#default-to-minor-version) it should work if the driver version >= 450.80.02. If GPU is not available, it should be able to fall back to CPUs.
The wheel size increases to about 3 MB, but is still not too big.