### PR TITLE
move run_config.ini into the root directory

### DIFF
--- a/deepmd/.gitignore
+++ b/deepmd/.gitignore
@@ -1,3 +1,4 @@
 op/_*.py
 pkg_config
+run_config.ini
 !op/__init__.py

--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -327,14 +327,14 @@ def get_module(module_name: str) -> "ModuleType":
 
 
 def _get_package_constants(
-    config_file: Path = Path(__file__).parent / "pkg_config/run_config.ini",
+    config_file: Path = Path(__file__).parent / "run_config.ini",
 ) -> Dict[str, str]:
     """Read package constants set at compile time by CMake to dictionary.
 
     Parameters
     ----------
     config_file : str, optional
-        path to CONFIG file, by default "pkg_config/run_config.ini"
+        path to CONFIG file, by default "run_config.ini"
 
     Returns
     -------

--- a/source/config/CMakeLists.txt
+++ b/source/config/CMakeLists.txt
@@ -4,5 +4,5 @@ configure_file("run_config.ini" "${CMAKE_CURRENT_BINARY_DIR}/run_config.ini" @ON
 
 install(
   FILES		${CMAKE_CURRENT_BINARY_DIR}/run_config.ini
-  DESTINATION	deepmd/pkg_config
+  DESTINATION	deepmd
 )


### PR DESCRIPTION
This fixes a warning during installation:
```
         !!
  
  
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'deepmd.pkg_config' as an importable package,
        but it is not listed in the `packages` configuration of setuptools.
  
        'deepmd.pkg_config' has been automatically added to the distribution only
        because it may contain data files, but this behavior is likely to change
        in future versions of setuptools (and therefore is considered deprecated).
  
        Please make sure that 'deepmd.pkg_config' is included as a package by using
        the `packages` configuration field or the proper discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).
  
        You can read more about "package discovery" and "data files" on setuptools
        documentation page.
  
  
    !!
```

It's a bit hard to dismiss this warning, but it's easy to just move `run_config.ini`.