### PR TITLE
fix TF compile warnings about Status::OK

### DIFF
--- a/source/op/optimizer/parallel.cc
+++ b/source/op/optimizer/parallel.cc
@@ -60,13 +60,13 @@ Status ParallelProdForce(RemapperContext *ctx, int node_index,
                          std::vector<bool> *nodes_to_delete) {
   // skip on GPUs
   if (GetNumAvailableGPUs() > 0)
-    return Status::OK();
+    return Status();
 
   const NodeDef *ori_node = ctx->graph_view.GetNode(node_index)->node();
   auto &src_attr = ori_node->attr();
   TF_INT64 tot = GetNThreads();
   if (tot <= 1)
-    return Status::OK();
+    return Status();
 
   NodeDef sum_node;
   sum_node.set_name(ori_node->name());
@@ -104,7 +104,7 @@ Status ParallelProdForce(RemapperContext *ctx, int node_index,
   TF_RETURN_IF_ERROR(mutation->Apply());
   (*invalidated_nodes)[node_index] = true;
 
-  return Status::OK();
+  return Status();
 }
 
 Status DPParallel::Optimize(Cluster *cluster, const GrapplerItem &item,
@@ -153,7 +153,7 @@ Status DPParallel::Optimize(Cluster *cluster, const GrapplerItem &item,
 
   *optimized_graph = std::move(mutable_item.graph);
 
-  return Status::OK();
+  return Status();
 }
 
 REGISTER_GRAPH_OPTIMIZER_AS(DPParallel, "dpparallel");

--- a/source/op/optimizer/parallel.h
+++ b/source/op/optimizer/parallel.h
@@ -10,7 +10,7 @@ class DPParallel : public CustomGraphOptimizer {
  public:
   Status Init(
       const tensorflow::RewriterConfig_CustomGraphOptimizer* config) override {
-    return Status::OK();
+    return Status();
   }
   std::string name() const override { return "dpparallel"; };
   bool UsesFunctionLibrary() const override { return false; }


### PR DESCRIPTION
Fix the following warning

> warning: ‘static tsl::Status tsl::Status::OK()’ is deprecated: Use `OkStatus()` (preferred) or `Status()` (which is backward compatible with TF v2.9 and lower) instead. [-Wdeprecated-declarations]