### PR TITLE
Fix version 0.12 model conversion

### DIFF
--- a/deepmd/infer/deep_pot.py
+++ b/deepmd/infer/deep_pot.py
@@ -357,21 +357,21 @@ class DeepPot(DeepEval):
         feed_dict_test = {}
         feed_dict_test[self.t_natoms] = natoms_vec
         if mixed_type:
-            feed_dict_test[self.t_type] = np.reshape(atom_types, [-1])
+            feed_dict_test[self.t_type] = atom_types.reshape([-1])
         else:
-            feed_dict_test[self.t_type] = (np.tile(atom_types, [nframes, 1])).reshape([-1])
-        feed_dict_test[self.t_coord] = coords.reshape([-1])
+            feed_dict_test[self.t_type] = np.tile(atom_types, [nframes, 1]).reshape([-1])
+        feed_dict_test[self.t_coord] = np.reshape(coords, [-1])
         feed_dict_test[self.t_box  ] = cells
         if self.has_efield:
-            feed_dict_test[self.t_efield]= efield
+            feed_dict_test[self.t_efield]= np.reshape(efield, [-1])
         if pbc:
             feed_dict_test[self.t_mesh ] = make_default_mesh(cells)
         else:
             feed_dict_test[self.t_mesh ] = np.array([], dtype = np.int32)
         if self.has_fparam:
-            feed_dict_test[self.t_fparam] = fparam
+            feed_dict_test[self.t_fparam] = np.reshape(fparam, [-1])
         if self.has_aparam:
-            feed_dict_test[self.t_aparam] = aparam
+            feed_dict_test[self.t_aparam] = np.reshape(aparam, [-1])
         return feed_dict_test, imap
 
     def _eval_inner(

--- a/deepmd/infer/deep_pot.py
+++ b/deepmd/infer/deep_pot.py
@@ -123,7 +123,11 @@ class DeepPot(DeepEval):
 
         # now load tensors to object attributes
         for attr_name, tensor_name in self.tensors.items():
-            self._get_tensor(tensor_name, attr_name)
+            try:
+                self._get_tensor(tensor_name, attr_name)
+            except KeyError:
+                if attr_name != "t_descriptor":
+                    raise
 
         self._run_default_sess()
         self.tmap = self.tmap.decode('UTF-8').split()        
@@ -353,21 +357,21 @@ class DeepPot(DeepEval):
         feed_dict_test = {}
         feed_dict_test[self.t_natoms] = natoms_vec
         if mixed_type:
-            feed_dict_test[self.t_type] = atom_types.reshape([-1])
+            feed_dict_test[self.t_type] = np.reshape(atom_types, [-1])
         else:
-            feed_dict_test[self.t_type] = np.tile(atom_types, [nframes, 1]).reshape([-1])
-        feed_dict_test[self.t_coord] = np.reshape(coords, [-1])
-        feed_dict_test[self.t_box  ] = np.reshape(cells , [-1])
+            feed_dict_test[self.t_type] = (np.tile(atom_types, [nframes, 1])).reshape([-1])
+        feed_dict_test[self.t_coord] = coords.reshape([-1])
+        feed_dict_test[self.t_box  ] = cells
         if self.has_efield:
-            feed_dict_test[self.t_efield]= np.reshape(efield, [-1])
+            feed_dict_test[self.t_efield]= efield
         if pbc:
             feed_dict_test[self.t_mesh ] = make_default_mesh(cells)
         else:
             feed_dict_test[self.t_mesh ] = np.array([], dtype = np.int32)
         if self.has_fparam:
-            feed_dict_test[self.t_fparam] = np.reshape(fparam, [-1])
+            feed_dict_test[self.t_fparam] = fparam
         if self.has_aparam:
-            feed_dict_test[self.t_aparam] = np.reshape(aparam, [-1])
+            feed_dict_test[self.t_aparam] = aparam
         return feed_dict_test, imap
 
     def _eval_inner(

--- a/deepmd/infer/deep_pot.py
+++ b/deepmd/infer/deep_pot.py
@@ -361,7 +361,13 @@ class DeepPot(DeepEval):
         else:
             feed_dict_test[self.t_type] = np.tile(atom_types, [nframes, 1]).reshape([-1])
         feed_dict_test[self.t_coord] = np.reshape(coords, [-1])
-        feed_dict_test[self.t_box  ] = cells
+        
+        if len(self.t_box.shape) == 1:
+            feed_dict_test[self.t_box  ] = np.reshape(cells , [-1])
+        elif len(self.t_box.shape) == 2:
+            feed_dict_test[self.t_box  ] = cells
+        else:
+            raise RuntimeError
         if self.has_efield:
             feed_dict_test[self.t_efield]= np.reshape(efield, [-1])
         if pbc:

--- a/deepmd/utils/convert.py
+++ b/deepmd/utils/convert.py
@@ -138,7 +138,7 @@ def convert_pbtxt_to_pb(pbtxtfile: str, pbfile: str):
 
 
 def convert_dp012_to_dp10(file: str):
-    """Convert DP 1.0 graph text to 1.1 graph text.
+    """Convert DP 0.12 graph text to 1.0 graph text.
     
     Parameters
     ----------
@@ -205,6 +205,29 @@ def convert_dp012_to_dp10(file: str):
           }
         }
       }
+      """)
+    file_content += textwrap.dedent("""\
+      node {
+        name: "model_attr/tmap"
+        op: "Const"
+        attr {
+          key: "dtype"
+          value {
+            type: DT_STRING
+          }
+        }
+        attr {
+          key: "value"
+          value {
+            tensor {
+              dtype: DT_STRING
+              tensor_shape {
+              }
+              string_val: ""
+            }
+          }
+        }
+      }      
       """)
     with open(file, 'w') as fp:
         fp.write(file_content)


### PR DESCRIPTION
- Added model_attr/tmap to the convert_dp012_to_dp10 function of deepmd/utils/convert.py.
- Changed the reshape behavior of the feed_dict_test elements in the _prepare_feed_dict function of deepmd/infer/deep_pot.py.

After these modifications, the v0.12 model can be successfully converted to a model compatible with DeePMD-kit v2.1.5.