### PR TITLE
add shuffle_exclude_empty to DeepPot.compute(nlist, atomic)

### DIFF
--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -710,7 +710,7 @@ compute (ENERGYTYPE &			dener,
     assert (nloc_real == atommap.get_type().size());
 
         nlist_data.copy_from_nlist(lmp_list);
-        nlist_data.shuffle_exclude_empty(atommap);
+        nlist_data.shuffle_exclude_empty(fwd_map);
 	nlist_data.make_inlist(nlist);
     }
 

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -697,11 +697,9 @@ compute (ENERGYTYPE &			dener,
   int nloc_real = nall_real - nghost_real;
   dcoord.resize(nall_real * 3);
   datype.resize(nall_real);
-  datom_energy.resize(nall_real);
   // fwd map
   select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3);
   select_map<int>(datype, datype_, fwd_map, 1);
-  select_map<VALUETYPE>(datom_energy, datom_energy_, fwd_map, 1);
   // aparam
   if (daparam > 0){
     aparam.resize(nloc_real);

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -711,6 +711,7 @@ compute (ENERGYTYPE &			dener,
 
         nlist_data.copy_from_nlist(lmp_list);
         nlist_data.shuffle_exclude_empty(fwd_map);
+	nlist_data.shuffle(atommap);
 	nlist_data.make_inlist(nlist);
     }
 

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -706,7 +706,7 @@ compute (ENERGYTYPE &			dener,
     select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam);
   }
     if (ago == 0) {
-    atommap = AtomMap (datype.begin(), datype.begin() + nloc_real);
+    atommap = deepmd::AtomMap (datype.begin(), datype.begin() + nloc_real);
     assert (nloc_real == atommap.get_type().size());
 
         nlist_data.copy_from_nlist(lmp_list);

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -711,7 +711,7 @@ compute (ENERGYTYPE &			dener,
 
         nlist_data.copy_from_nlist(lmp_list);
         nlist_data.shuffle_exclude_empty(fwd_map);
-	nlist_data.shuffle(atommap);
+        nlist_data.shuffle(atommap);
 	nlist_data.make_inlist(nlist);
     }
 

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -710,7 +710,7 @@ compute (ENERGYTYPE &			dener,
     assert (nloc_real == atommap.get_type().size());
 
         nlist_data.copy_from_nlist(lmp_list);
-        nlist_data.shuffle(atommap);
+        nlist_data.shuffle_exclude_empty(atommap);
 	nlist_data.make_inlist(nlist);
     }
 

--- a/source/api_cc/tests/test_deeppot_a.cc
+++ b/source/api_cc/tests/test_deeppot_a.cc
@@ -447,7 +447,7 @@ TYPED_TEST(TestInferDeepPotA, cpu_lmp_nlist_type_sel)
 
   // dp compute
   double ener;
-  std::vector<VALUETYPE> force_(nall*3, 0.0), virial(9, 0.0), atomic_energy(nall, 0.0), atomic_virial(nall*9, 0.0);
+  std::vector<VALUETYPE> force_(nall*3, 0.0), virial(9, 0.0), atomic_energy, atomic_virial;
   dp.compute(ener, force_, virial, atomic_energy, atomic_virial, coord_cpy, atype_cpy, box, nall-nloc, inlist, 0);
   // fold back
   std::vector<VALUETYPE> force;

--- a/source/api_cc/tests/test_deeppot_a.cc
+++ b/source/api_cc/tests/test_deeppot_a.cc
@@ -447,6 +447,68 @@ TYPED_TEST(TestInferDeepPotA, cpu_lmp_nlist_type_sel)
 
   // dp compute
   double ener;
+  std::vector<VALUETYPE> force_(nall*3, 0.0), virial(9, 0.0);
+  dp.compute(ener, force_, virial, coord_cpy, atype_cpy, box, nall-nloc, inlist, 0);
+  // fold back
+  std::vector<VALUETYPE> force;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(force.size(), natoms*3);
+  EXPECT_EQ(virial.size(), 9);
+
+  EXPECT_LT(fabs(ener - expected_tot_e), EPSILON);
+  for(int ii = 0; ii < natoms*3; ++ii){
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);    
+  }
+  for(int ii = 0; ii < 3*3; ++ii){
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
+
+TYPED_TEST(TestInferDeepPotA, cpu_lmp_nlist_type_sel_atomic)
+{
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  double& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>&expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+
+  // add vir atoms
+  int nvir = 2;
+  std::vector<VALUETYPE> coord_vir(nvir*3);
+  std::vector<int> atype_vir(nvir, 2);
+  for(int ii = 0; ii < nvir; ++ii){
+    coord_vir[ii] = coord[ii];
+  }  
+  coord.insert(coord.begin(), coord_vir.begin(), coord_vir.end());
+  atype.insert(atype.begin(), atype_vir.begin(), atype_vir.end());
+  natoms += nvir;
+  std::vector<VALUETYPE> expected_f_vir(nvir*3, 0.0);
+  expected_f.insert(expected_f.begin(), expected_f_vir.begin(), expected_f_vir.end());
+
+  // build nlist
+  int nloc = coord.size() / 3;  
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;  
+  std::vector<std::vector<int > > nlist_data;
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+	       coord, atype, box, rc);
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_data);  
+
+  // dp compute
+  double ener;
   std::vector<VALUETYPE> force_(nall*3, 0.0), virial(9, 0.0), atomic_energy, atomic_virial;
   dp.compute(ener, force_, virial, atomic_energy, atomic_virial, coord_cpy, atype_cpy, box, nall-nloc, inlist, 0);
   // fold back

--- a/source/api_cc/tests/test_deeppot_a.cc
+++ b/source/api_cc/tests/test_deeppot_a.cc
@@ -447,8 +447,8 @@ TYPED_TEST(TestInferDeepPotA, cpu_lmp_nlist_type_sel)
 
   // dp compute
   double ener;
-  std::vector<VALUETYPE> force_(nall*3, 0.0), virial(9, 0.0);
-  dp.compute(ener, force_, virial, coord_cpy, atype_cpy, box, nall-nloc, inlist, 0);
+  std::vector<VALUETYPE> force_(nall*3, 0.0), virial(9, 0.0), atomic_energy(nall, 0.0), atomic_virial(nall*9, 0.0);
+  dp.compute(ener, force_, virial, atomic_energy, atomic_virial, coord_cpy, atype_cpy, box, nall-nloc, inlist, 0);
   // fold back
   std::vector<VALUETYPE> force;
   _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);


### PR DESCRIPTION
Fixes #2105.
