### PR TITLE
speed up test_neighbor_stat

### DIFF
--- a/source/tests/test_neighbor_stat.py
+++ b/source/tests/test_neighbor_stat.py
@@ -8,15 +8,15 @@ from deepmd.entrypoints.neighbor_stat import neighbor_stat
 def gen_sys(nframes):
     natoms = 1000
     data = {}
-    X, Y, Z = np.mgrid[0:9:10j, 0:9:10j, 0:9:10j]
+    X, Y, Z = np.mgrid[0:2:3j, 0:2:3j, 0:2:3j]
     positions = np.vstack([X.ravel(), Y.ravel(), Z.ravel()]).T #+ 0.1
     data['coords'] = np.repeat(positions[np.newaxis, :, :], nframes, axis=0)
     data['forces'] = np.random.random([nframes, natoms, 3])
-    data['cells'] = np.array([10., 0., 0., 0., 10., 0., 0., 0., 10.]).reshape(1,3,3)
+    data['cells'] = np.array([3., 0., 0., 0., 3., 0., 0., 0., 3.]).reshape(1,3,3)
     data['energies'] = np.random.random([nframes, 1])
     data['atom_names'] = ['TYPE']
-    data['atom_numbs'] = [1000]
-    data['atom_types'] = np.repeat(0, 1000)
+    data['atom_numbs'] = [27]
+    data['atom_types'] = np.repeat(0, 27)
     return data
 
 
@@ -25,7 +25,7 @@ class TestNeighborStat(unittest.TestCase):
         data0 = gen_sys(1)
         sys0 = dpdata.LabeledSystem()
         sys0.data = data0
-        sys0.to_deepmd_npy('system_0', set_size = 10)
+        sys0.to_deepmd_npy('system_0', set_size = 1)
         
     def tearDown(self):
         shutil.rmtree('system_0')
@@ -33,7 +33,7 @@ class TestNeighborStat(unittest.TestCase):
     def test_neighbor_stat(self):
         # set rcut to 0. will cause a core dumped
         # TODO: check what is wrong
-        for rcut in (3., 6., 11.):
+        for rcut in (1., 2., 4.):
             with self.subTest():
                 rcut += 1e-3 # prevent numerical errors
                 min_nbor_dist, max_nbor_size = neighbor_stat(system="system_0", rcut=rcut, type_map=["TYPE"])


### PR DESCRIPTION
In #2117, we found that `test_neighbor_stat` is too slow, which takes over one minute. This PR uses a minor system and fewer frames to speed up `test_neighbor_stat`, so it only takes <0.2 s now.
