### PR TITLE
skip `get_gpus` subprocess when TF is cpu only

### DIFF
--- a/deepmd/cluster/local.py
+++ b/deepmd/cluster/local.py
@@ -21,6 +21,10 @@ def get_gpus():
     Optional[List[int]]
         List of available GPU IDs. Otherwise, None.
     """
+    if (not tf.test.is_built_with_cuda() and 
+        not (hasattr(tf.test, 'is_built_with_rocm') and tf.test.is_built_with_rocm())):
+        # TF is built with CPU only, skip expensive subprocess call
+        return None
     test_cmd = 'from tensorflow.python.client import device_lib; ' \
                'devices = device_lib.list_local_devices(); ' \
                'gpus = [d.name for d in devices if d.device_type == "GPU"]; ' \

--- a/source/tests/test_cluster.py
+++ b/source/tests/test_cluster.py
@@ -23,24 +23,36 @@ class FakePopen(object):
 
 class TestGPU(unittest.TestCase):
     @mock.patch('subprocess.Popen')
-    def test_none(self, mock_Popen):
+    @mock.patch('tf.test.is_built_with_cuda')
+    def test_none(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = FakePopen(b'0', b'')
+        mock_is_built_with_cuda.return_value = True
         gpus = local.get_gpus()
         self.assertIsNone(gpus)
 
     @mock.patch('subprocess.Popen')
-    def test_valid(self, mock_Popen):
+    @mock.patch('tf.test.is_built_with_cuda')
+    def test_valid(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = FakePopen(b'2', b'')
+        mock_is_built_with_cuda.return_value = True
         gpus = local.get_gpus()
         self.assertEqual(gpus, [0, 1])
 
     @mock.patch('subprocess.Popen')
-    def test_error(self, mock_Popen):
+    @mock.patch('tf.test.is_built_with_cuda')
+    def test_error(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = \
             FakePopen(stderr=b'!', returncode=1)
+        mock_is_built_with_cuda.return_value = True
         with self.assertRaises(RuntimeError) as cm:
             _ = local.get_gpus()
             self.assertIn('Failed to detect', str(cm.exception))
+
+    @mock.patch('tf.test.is_built_with_cuda')
+    def test_cpu(self, mock_is_built_with_cuda):
+        mock_is_built_with_cuda.return_value = False
+        gpus = local.get_gpus()
+        self.assertIsNone(gpus)
 
 
 class TestLocal(unittest.TestCase):

--- a/source/tests/test_cluster.py
+++ b/source/tests/test_cluster.py
@@ -23,24 +23,24 @@ class FakePopen(object):
 
 
 class TestGPU(unittest.TestCase):
-    @mock.patch('subprocess.Popen')
     @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
+    @mock.patch('subprocess.Popen')
     def test_none(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = FakePopen(b'0', b'')
         mock_is_built_with_cuda.return_value = True
         gpus = local.get_gpus()
         self.assertIsNone(gpus)
 
-    @mock.patch('subprocess.Popen')
     @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
+    @mock.patch('subprocess.Popen')
     def test_valid(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = FakePopen(b'2', b'')
         mock_is_built_with_cuda.return_value = True
         gpus = local.get_gpus()
         self.assertEqual(gpus, [0, 1])
 
-    @mock.patch('subprocess.Popen')
     @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
+    @mock.patch('subprocess.Popen')
     def test_error(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = \
             FakePopen(stderr=b'!', returncode=1)

--- a/source/tests/test_cluster.py
+++ b/source/tests/test_cluster.py
@@ -1,6 +1,7 @@
 import unittest
 
 from deepmd.cluster import local, slurm
+from deepmd.env import tf
 from unittest import mock
 
 
@@ -23,7 +24,7 @@ class FakePopen(object):
 
 class TestGPU(unittest.TestCase):
     @mock.patch('subprocess.Popen')
-    @mock.patch('tf.test.is_built_with_cuda')
+    @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
     def test_none(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = FakePopen(b'0', b'')
         mock_is_built_with_cuda.return_value = True
@@ -31,7 +32,7 @@ class TestGPU(unittest.TestCase):
         self.assertIsNone(gpus)
 
     @mock.patch('subprocess.Popen')
-    @mock.patch('tf.test.is_built_with_cuda')
+    @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
     def test_valid(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = FakePopen(b'2', b'')
         mock_is_built_with_cuda.return_value = True
@@ -39,7 +40,7 @@ class TestGPU(unittest.TestCase):
         self.assertEqual(gpus, [0, 1])
 
     @mock.patch('subprocess.Popen')
-    @mock.patch('tf.test.is_built_with_cuda')
+    @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
     def test_error(self, mock_Popen, mock_is_built_with_cuda):
         mock_Popen.return_value.__enter__.return_value = \
             FakePopen(stderr=b'!', returncode=1)
@@ -48,7 +49,7 @@ class TestGPU(unittest.TestCase):
             _ = local.get_gpus()
             self.assertIn('Failed to detect', str(cm.exception))
 
-    @mock.patch('tf.test.is_built_with_cuda')
+    @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
     def test_cpu(self, mock_is_built_with_cuda):
         mock_is_built_with_cuda.return_value = False
         gpus = local.get_gpus()

--- a/source/tests/test_cluster.py
+++ b/source/tests/test_cluster.py
@@ -49,9 +49,11 @@ class TestGPU(unittest.TestCase):
             _ = local.get_gpus()
             self.assertIn('Failed to detect', str(cm.exception))
 
+    @mock.patch('tensorflow.compat.v1.test.is_built_with_rocm', create=True)
     @mock.patch('tensorflow.compat.v1.test.is_built_with_cuda')
-    def test_cpu(self, mock_is_built_with_cuda):
+    def test_cpu(self, mock_is_built_with_cuda, mock_is_built_with_rocm):
         mock_is_built_with_cuda.return_value = False
+        mock_is_built_with_rocm.return_value = False
         gpus = local.get_gpus()
         self.assertIsNone(gpus)
 


### PR DESCRIPTION
When I benchmark deepmd-kit on my machine, I found `get_gpus` takes about 2s and is quite slow. In #905, a subprocess was added to get available GPUs. As benchmarked in #2121, it's quite slow to import tensorflow.

I don't have better ideas not to call a subprocess, but we can skip this process when TensorFlow is not built against GPUs. The tests on the GitHub Actions will also benefit.

Attached is the selected profiling:
>  ncalls  tottime  percall  cumtime  percall filename:lineno(function)
> 1    0.000    0.000    2.141    2.141 local.py:15(get_gpus)
> 1    0.000    0.000    2.133    2.133 subprocess.py:1090(communicate)