### PR TITLE
pin manylinux image to a specific tag for GCC 11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ test-command = "dp -h"
 test-requires = "tensorflow"
 build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
-manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
+# TODO: bump to "latest" tag when CUDA supports GCC 12
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:2022-11-19-1b19e81"
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"


### PR DESCRIPTION
Today manylinux_2_28 bumps the GCC version to 12 in https://github.com/pypa/manylinux/pull/1415. However, at present, CUDA only supports GCC 11.

TODO: when CUDA supports GCC 12, revert this change and bump the CUDA version.