### PR TITLE
add Optional to type hints when default is None

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -119,7 +119,7 @@ def add_data_requirement(
     atomic: bool = False,
     must: bool = False,
     high_prec: bool = False,
-    type_sel: bool = None,
+    type_sel: Optional[bool] = None,
     repeat: int = 1,
     default: float = 0.,
 ):
@@ -237,7 +237,7 @@ class ClassArg:
         key: str,
         types_: Union[type, List[type]],
         alias: Optional[Union[str, List[str]]] = None,
-        default: Any = None,
+        default: Optional[Any] = None,
         must: bool = False,
     ) -> "ClassArg":
         """Add key to be parsed.

--- a/deepmd/descriptor/descriptor.py
+++ b/deepmd/descriptor/descriptor.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Tuple
+from typing import Optional, Any, Dict, List, Tuple
 
 import numpy as np
 from deepmd.env import tf
@@ -185,7 +185,7 @@ class Descriptor(PluginVariant):
               box_: tf.Tensor,
               mesh: tf.Tensor,
               input_dict: Dict[str, Any],
-              reuse: bool = None,
+              reuse: Optional[bool] = None,
               suffix: str = '',
               ) -> tf.Tensor:
         """
@@ -262,7 +262,7 @@ class Descriptor(PluginVariant):
         raise NotImplementedError(
             "Descriptor %s doesn't support compression!" % type(self).__name__)
 
-    def enable_mixed_precision(self, mixed_prec: dict = None) -> None:
+    def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:
         """
         Reveive the mixed precision setting.
 

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-from typing import Tuple, List, Dict, Any
+from typing import Optional, Tuple, List, Dict, Any
 
 from deepmd.env import tf
 from deepmd.common import get_activation_func, get_precision, cast_precision
@@ -113,7 +113,7 @@ class DescrptSeA (DescrptSe):
                   axis_neuron: int = 8,
                   resnet_dt: bool = False,
                   trainable: bool = True,
-                  seed: int = None,
+                  seed: Optional[int] = None,
                   type_one_side: bool = True,
                   exclude_types: List[List[int]] = [],
                   set_davg_zero: bool = False,

--- a/deepmd/descriptor/se_a_ebd.py
+++ b/deepmd/descriptor/se_a_ebd.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.common import ClassArg, get_activation_func, get_precision, add_data_requirement
@@ -62,7 +62,7 @@ class DescrptSeAEbd (DescrptSeA):
                   axis_neuron: int = 8,
                   resnet_dt: bool = False,
                   trainable: bool = True,
-                  seed: int = None,
+                  seed: Optional[int] = None,
                   type_one_side: bool = True,
                   type_nchanl : int = 2,
                   type_nlayer : int = 1,

--- a/deepmd/descriptor/se_a_ef.py
+++ b/deepmd/descriptor/se_a_ef.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.common import add_data_requirement
@@ -56,7 +56,7 @@ class DescrptSeAEf (Descriptor):
                  axis_neuron: int = 8,
                  resnet_dt: bool = False,
                  trainable: bool = True,
-                 seed: int = None,
+                 seed: Optional[int] = None,
                  type_one_side: bool = True,
                  exclude_types: List[List[int]] = [],
                  set_davg_zero: bool = False,
@@ -284,7 +284,7 @@ class DescrptSeAEfLower (DescrptSeA):
                   axis_neuron: int = 8,
                   resnet_dt: bool = False,
                   trainable: bool = True,
-                  seed: int = None,
+                  seed: Optional[int] = None,
                   type_one_side: bool = True,
                   exclude_types: List[List[int]] = [],
                   set_davg_zero: bool = False,

--- a/deepmd/descriptor/se_atten.py
+++ b/deepmd/descriptor/se_atten.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-from typing import Tuple, List, Dict, Any
+from typing import Optional, Tuple, List, Dict, Any
 from packaging.version import Version
 
 from deepmd.env import tf
@@ -77,7 +77,7 @@ class DescrptSeAtten(DescrptSeA):
                  axis_neuron: int = 8,
                  resnet_dt: bool = False,
                  trainable: bool = True,
-                 seed: int = None,
+                 seed: Optional[int] = None,
                  type_one_side: bool = True,
                  exclude_types: List[List[int]] = [],
                  set_davg_zero: bool = False,
@@ -157,7 +157,7 @@ class DescrptSeAtten(DescrptSeA):
                             mesh: list,
                             input_dict: dict,
                             mixed_type: bool = False,
-                            real_natoms_vec: list = None
+                            real_natoms_vec: Optional[list] = None
                             ) -> None:
         """
         Compute the statisitcs (avg and std) of the training data. The input will be normalized by the statistics.
@@ -227,7 +227,7 @@ class DescrptSeAtten(DescrptSeA):
               box_: tf.Tensor,
               mesh: tf.Tensor,
               input_dict: dict,
-              reuse: bool = None,
+              reuse: Optional[bool] = None,
               suffix: str = ''
               ) -> tf.Tensor:
         """

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.common import get_activation_func, get_precision, cast_precision
@@ -58,7 +58,7 @@ class DescrptSeR (DescrptSe):
                   neuron: List[int] = [24,48,96],
                   resnet_dt: bool = False,
                   trainable: bool = True,
-                  seed: int = None,
+                  seed: Optional[int] = None,
                   type_one_side: bool = True,
                   exclude_types: List[List[int]] = [],
                   set_davg_zero: bool = False,

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.common import get_activation_func, get_precision, cast_precision
@@ -56,7 +56,7 @@ class DescrptSeT (DescrptSe):
                   neuron: List[int] = [24,48,96],
                   resnet_dt: bool = False,
                   trainable: bool = True,
-                  seed: int = None,
+                  seed: Optional[int] = None,
                   set_davg_zero: bool = False,
                   activation_function: str = 'tanh',
                   precision: str = 'default',

--- a/deepmd/fit/dipole.py
+++ b/deepmd/fit/dipole.py
@@ -1,6 +1,6 @@
 import warnings
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.common import add_data_requirement, get_activation_func, get_precision, cast_precision
@@ -139,7 +139,7 @@ class DipoleFittingSeA (Fitting) :
                input_d : tf.Tensor,
                rot_mat : tf.Tensor,
                natoms : tf.Tensor,
-               input_dict: dict = None,
+               input_dict: Optional[dict] = None,
                reuse : bool = None,
                suffix : str = '') -> tf.Tensor:
         """

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 from packaging.version import Version
 
 from deepmd.env import tf
@@ -686,7 +686,7 @@ class EnerFitting (Fitting):
             self.aparam_inv_std = get_tensor_by_name_from_graph(graph, 'fitting_attr%s/t_aparam_istd' % suffix)
  
 
-    def enable_mixed_precision(self, mixed_prec: dict = None) -> None:
+    def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:
         """
         Reveive the mixed precision setting.
 

--- a/deepmd/fit/polar.py
+++ b/deepmd/fit/polar.py
@@ -1,6 +1,6 @@
 import warnings
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.common import add_data_requirement, cast_precision, get_activation_func, get_precision
@@ -349,7 +349,7 @@ class PolarFittingSeA (Fitting) :
                input_d : tf.Tensor,
                rot_mat : tf.Tensor,
                natoms : tf.Tensor,
-               input_dict: dict = None,
+               input_dict: Optional[dict] = None,
                reuse : bool = None,
                suffix : str = '') :
         """
@@ -558,7 +558,7 @@ class GlobalPolarFittingSeA () :
                input_d,
                rot_mat,
                natoms,
-               input_dict: dict = None,
+               input_dict: Optional[dict] = None,
                reuse = None,
                suffix = '') -> tf.Tensor:
         """

--- a/deepmd/model/multi.py
+++ b/deepmd/model/multi.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.utils.pair_tab import PairTab
@@ -47,13 +47,13 @@ class MultiModel(Model):
             fitting_dict,
             fitting_type_dict,
             typeebd=None,
-            type_map: List[str] = None,
+            type_map: Optional[List[str]] = None,
             data_stat_nbatch: int = 10,
             data_stat_protect: float = 1e-2,
-            use_srtab: str = None,  # all the ener fitting will do this
-            smin_alpha: float = None,
-            sw_rmin: float = None,
-            sw_rmax: float = None
+            use_srtab: Optional[str] = None,  # all the ener fitting will do this
+            smin_alpha: Optional[float] = None,
+            sw_rmin: Optional[float] = None,
+            sw_rmax: Optional[float] = None
     ) -> None:
         """
         Constructor

--- a/deepmd/utils/parallel_op.py
+++ b/deepmd/utils/parallel_op.py
@@ -1,4 +1,4 @@
-from typing import Callable, Generator, Tuple, Dict, Any
+from typing import Optional, Callable, Generator, Tuple, Dict, Any
 
 from deepmd.env import tf
 from deepmd.utils.sess import run_sess
@@ -32,7 +32,7 @@ class ParallelOp:
     >>> print(*p.generate(tf.Session(), feed()))
     [1] [2] [3] [4] [5] [6] [7] [8] [9] [10]
     """
-    def __init__(self, builder: Callable[..., Tuple[Dict[str, tf.Tensor], Tuple[tf.Tensor]]], nthreads: int = None, config: tf.ConfigProto = None) -> None:
+    def __init__(self, builder: Callable[..., Tuple[Dict[str, tf.Tensor], Tuple[tf.Tensor]]], nthreads: Optional[int] = None, config: Optional[tf.ConfigProto] = None) -> None:
         if nthreads is not None:
             self.nthreads = nthreads
         elif config is not None:

--- a/deepmd/utils/path.py
+++ b/deepmd/utils/path.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Optional, List
 from pathlib import Path
 from functools import lru_cache
 
@@ -246,7 +246,7 @@ class DPH5Path(DPPath):
         """
         return self.root[self.name][:]
     
-    def load_txt(self, dtype: np.dtype = None, **kwargs) -> np.ndarray:
+    def load_txt(self, dtype: Optional[np.dtype] = None, **kwargs) -> np.ndarray:
         """Load NumPy array from text.
         
         Returns

--- a/deepmd/utils/random.py
+++ b/deepmd/utils/random.py
@@ -1,10 +1,12 @@
+from typing import Optional
+
 import numpy as np
 
 
 _RANDOM_GENERATOR = np.random.RandomState()
 
 
-def choice(a: np.ndarray, p: np.ndarray = None):
+def choice(a: np.ndarray, p: Optional[np.ndarray] = None):
     """Generates a random sample from a given 1-D array.
 
     Parameters
@@ -38,7 +40,7 @@ def random(size=None):
     return _RANDOM_GENERATOR.random_sample(size)
 
 
-def seed(val: int = None):
+def seed(val: Optional[int] = None):
     """Seed the generator.
 
     Parameters

--- a/deepmd/utils/type_embed.py
+++ b/deepmd/utils/type_embed.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Tuple, List, Union
+from typing import Optional, Tuple, List, Union
 
 from deepmd.env import tf
 from deepmd.utils.network import one_layer
@@ -82,7 +82,7 @@ class TypeEmbedNet():
             activation_function: Union[str, None] = 'tanh',
             precision: str = 'default',
             trainable: bool = True,
-            seed: int = None,
+            seed: Optional[int] = None,
             uniform_seed: bool = False,
             padding: bool = False,
     )->None:


### PR DESCRIPTION
script:

```py
from glob import glob
import re

regex = re.compile(r"([^,\(\)= ]+):[ ]*((?!Optional)[^,\(\)= ]+)[ ]*=[ ]*None")

for ii in glob("deepmd/**/*.py", recursive=True):
    with open(ii, 'r') as ff:
        content = ff.read()        
    has_optional = "Optional" in content
    has_typing = "from typing" in content
        
    content, nsub = regex.subn(r"\1: Optional[\2] = None", content)
    if nsub > 0:
        if not has_optional:
            if has_typing:
                content = content.replace("from typing import", "from typing import Optional,")
            else:
                content = "from typing import Optional\n" + content
            
        with open(ii, 'w') as ff:
            ff.write(content)
```