### PR TITLE
refactor enable_compression

### DIFF
--- a/deepmd/descriptor/descriptor.py
+++ b/deepmd/descriptor/descriptor.py
@@ -227,7 +227,8 @@ class Descriptor(PluginVariant):
 
     def enable_compression(self,
                            min_nbor_dist: float,
-                           model_file: str = 'frozon_model.pb',
+                           graph: tf.Graph,
+                           graph_def: tf.GraphDef,
                            table_extrapolate: float = 5.,
                            table_stride_1: float = 0.01,
                            table_stride_2: float = 0.1,
@@ -242,8 +243,10 @@ class Descriptor(PluginVariant):
         ----------
         min_nbor_dist : float
                 The nearest distance between atoms
-        model_file : str, default: 'frozon_model.pb'
-                The original frozen model, which will be compressed by the program
+        graph : tf.Graph
+                The graph of the model
+        graph_def : tf.GraphDef
+                The graph definition of the model
         table_extrapolate : float, default: 5.
                 The scale of model extrapolation
         table_stride_1 : float, default: 0.01

--- a/deepmd/descriptor/hybrid.py
+++ b/deepmd/descriptor/hybrid.py
@@ -254,6 +254,7 @@ class DescrptHybrid (Descriptor):
     def enable_compression(self,
                            min_nbor_dist: float,
                            graph: tf.Graph,
+                           graph_def: tf.GraphDef,
                            table_extrapolate: float = 5.,
                            table_stride_1: float = 0.01,
                            table_stride_2: float = 0.1,
@@ -270,6 +271,8 @@ class DescrptHybrid (Descriptor):
                 The nearest distance between atoms
         graph : tf.Graph
                 The graph of the model
+        graph_def : tf.GraphDef
+                The graph_def of the model
         table_extrapolate : float, default: 5.
                 The scale of model extrapolation
         table_stride_1 : float, default: 0.01
@@ -282,7 +285,7 @@ class DescrptHybrid (Descriptor):
                 The suffix of the scope
         """
         for idx, ii in enumerate(self.descrpt_list):
-            ii.enable_compression(min_nbor_dist, graph, table_extrapolate, table_stride_1, table_stride_2, check_frequency, suffix=f"{suffix}_{idx}")
+            ii.enable_compression(min_nbor_dist, graph, graph_def, table_extrapolate, table_stride_1, table_stride_2, check_frequency, suffix=f"{suffix}_{idx}")
 
 
     def enable_mixed_precision(self, mixed_prec : dict = None) -> None:

--- a/deepmd/descriptor/hybrid.py
+++ b/deepmd/descriptor/hybrid.py
@@ -253,7 +253,7 @@ class DescrptHybrid (Descriptor):
 
     def enable_compression(self,
                            min_nbor_dist: float,
-                           model_file: str = 'frozon_model.pb',
+                           graph: tf.Graph,
                            table_extrapolate: float = 5.,
                            table_stride_1: float = 0.01,
                            table_stride_2: float = 0.1,
@@ -268,8 +268,8 @@ class DescrptHybrid (Descriptor):
         ----------
         min_nbor_dist : float
                 The nearest distance between atoms
-        model_file : str, default: 'frozon_model.pb'
-                The original frozen model, which will be compressed by the program
+        graph : tf.Graph
+                The graph of the model
         table_extrapolate : float, default: 5.
                 The scale of model extrapolation
         table_stride_1 : float, default: 0.01
@@ -282,7 +282,7 @@ class DescrptHybrid (Descriptor):
                 The suffix of the scope
         """
         for idx, ii in enumerate(self.descrpt_list):
-            ii.enable_compression(min_nbor_dist, model_file, table_extrapolate, table_stride_1, table_stride_2, check_frequency, suffix=f"{suffix}_{idx}")
+            ii.enable_compression(min_nbor_dist, graph, table_extrapolate, table_stride_1, table_stride_2, check_frequency, suffix=f"{suffix}_{idx}")
 
 
     def enable_mixed_precision(self, mixed_prec : dict = None) -> None:

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -330,7 +330,8 @@ class DescrptSeA (DescrptSe):
 
     def enable_compression(self,
                            min_nbor_dist : float,
-                           model_file : str = 'frozon_model.pb',
+                           graph: tf.Graph,
+                           graph_def: tf.GraphDef,
                            table_extrapolate : float = 5,
                            table_stride_1 : float = 0.01,
                            table_stride_2 : float = 0.1,
@@ -344,8 +345,10 @@ class DescrptSeA (DescrptSe):
         ----------
         min_nbor_dist
                 The nearest distance between atoms
-        model_file
-                The original frozen model, which will be compressed by the program
+        grapf : tf.Graph
+                The graph of the model
+        graph_def : tf.GraphDef
+                The graph_def of the model
         table_extrapolate
                 The scale of model extrapolation
         table_stride_1
@@ -377,7 +380,7 @@ class DescrptSeA (DescrptSe):
 
         self.compress = True
         self.table = DPTabulate(
-            self, self.filter_neuron, model_file, self.type_one_side, self.exclude_types, self.compress_activation_fn, suffix=suffix)
+            self, self.filter_neuron, graph, graph_def, self.type_one_side, self.exclude_types, self.compress_activation_fn, suffix=suffix)
         self.table_config = [table_extrapolate, table_stride_1, table_stride_2, check_frequency]
         self.lower, self.upper \
             = self.table.build(min_nbor_dist, 
@@ -385,7 +388,6 @@ class DescrptSeA (DescrptSe):
                                table_stride_1, 
                                table_stride_2)
         
-        graph, _ = load_graph_def(model_file)
         self.davg = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_avg' % suffix)
         self.dstd = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_std' % suffix)
 

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -244,7 +244,8 @@ class DescrptSeR (DescrptSe):
 
     def enable_compression(self,
                            min_nbor_dist : float,
-                           model_file : str = 'frozon_model.pb',
+                           graph: tf.Graph,
+                           graph_def: tf.GraphDef,
                            table_extrapolate : float = 5,
                            table_stride_1 : float = 0.01,
                            table_stride_2 : float = 0.1,
@@ -258,8 +259,10 @@ class DescrptSeR (DescrptSe):
         ----------
         min_nbor_dist
                 The nearest distance between atoms
-        model_file
-                The original frozen model, which will be compressed by the program
+        grapf : tf.Graph
+                The graph of the model
+        graph_def : tf.GraphDef
+                The graph_def of the model
         table_extrapolate
                 The scale of model extrapolation
         table_stride_1
@@ -285,7 +288,7 @@ class DescrptSeR (DescrptSe):
 
         self.compress = True
         self.table = DPTabulate(
-            self, self.filter_neuron, model_file, activation_fn = self.filter_activation_fn, suffix=suffix)
+            self, self.filter_neuron, graph, graph_def, activation_fn = self.filter_activation_fn, suffix=suffix)
         self.table_config = [table_extrapolate, table_stride_1, table_stride_2, check_frequency]
         self.lower, self.upper \
             = self.table.build(min_nbor_dist, 
@@ -293,7 +296,6 @@ class DescrptSeR (DescrptSe):
                                table_stride_1, 
                                table_stride_2)
         
-        graph, _ = load_graph_def(model_file)
         self.davg = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_avg' % suffix)
         self.dstd = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_std' % suffix)
 

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -260,7 +260,8 @@ class DescrptSeT (DescrptSe):
 
     def enable_compression(self,
                            min_nbor_dist : float,
-                           model_file : str = 'frozon_model.pb',
+                           graph: tf.Graph,
+                           graph_def: tf.GraphDef,
                            table_extrapolate : float = 5,
                            table_stride_1 : float = 0.01,
                            table_stride_2 : float = 0.1,
@@ -274,8 +275,10 @@ class DescrptSeT (DescrptSe):
         ----------
         min_nbor_dist
                 The nearest distance between atoms
-        model_file
-                The original frozen model, which will be compressed by the program
+        grapf : tf.Graph
+                The graph of the model
+        graph_def : tf.GraphDef
+                The graph_def of the model
         table_extrapolate
                 The scale of model extrapolation
         table_stride_1
@@ -301,7 +304,7 @@ class DescrptSeT (DescrptSe):
 
         self.compress = True
         self.table = DPTabulate(
-            self, self.filter_neuron, model_file, activation_fn = self.filter_activation_fn, suffix=suffix)
+            self, self.filter_neuron, graph, graph_def, activation_fn = self.filter_activation_fn, suffix=suffix)
         self.table_config = [table_extrapolate, table_stride_1 * 10, table_stride_2 * 10, check_frequency]
         self.lower, self.upper \
             = self.table.build(min_nbor_dist, 
@@ -309,7 +312,6 @@ class DescrptSeT (DescrptSe):
                                table_stride_1 * 10, 
                                table_stride_2 * 10)
         
-        graph, _ = load_graph_def(model_file)
         self.davg = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_avg' % suffix)
         self.dstd = get_tensor_by_name_from_graph(graph, 'descrpt_attr%s/t_std' % suffix)
 

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -661,31 +661,7 @@ class EnerFitting (Fitting):
             raise RuntimeError('Unknown bias_shift mode: ' + bias_shift)
         log.info("Change energy bias of {} from {} to {}.".format(str(origin_type_map), str(old_bias),
                                                                          str(self.bias_atom_e[idx_type_map])))
-
-    def enable_compression(self,
-                           model_file: str,
-                           suffix: str = ""
-    ) -> None:
-        """
-        Set the fitting net attributes from the frozen model_file when fparam or aparam is not zero
-
-        Parameters
-        ----------
-        model_file : str
-            The input frozen model file
-        suffix : str, optional
-                The suffix of the scope
-        """
-        if self.numb_fparam > 0 or self.numb_aparam > 0:
-            graph, _ = load_graph_def(model_file)
-        if self.numb_fparam > 0:
-            self.fparam_avg = get_tensor_by_name_from_graph(graph, 'fitting_attr%s/t_fparam_avg' % suffix)
-            self.fparam_inv_std = get_tensor_by_name_from_graph(graph, 'fitting_attr%s/t_fparam_istd' % suffix)
-        if self.numb_aparam > 0:
-            self.aparam_avg = get_tensor_by_name_from_graph(graph, 'fitting_attr%s/t_aparam_avg' % suffix)
-            self.aparam_inv_std = get_tensor_by_name_from_graph(graph, 'fitting_attr%s/t_aparam_istd' % suffix)
  
-
     def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:
         """
         Reveive the mixed precision setting.

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -424,11 +424,9 @@ class DPTrainer (object):
             #       architecture to call neighbor stat
         else :
             graph, graph_def = load_graph_def(self.model_param['compress']['model_file'])
-            self.descrpt.enable_compression(self.model_param['compress']["min_nbor_dist"], self.model_param['compress']['model_file'], self.model_param['compress']['table_config'][0], self.model_param['compress']['table_config'][1], self.model_param['compress']['table_config'][2], self.model_param['compress']['table_config'][3])
-            self.fitting.init_variables(graph, graph_def)
+            self.descrpt.enable_compression(self.model_param['compress']["min_nbor_dist"], graph, graph_def, self.model_param['compress']['table_config'][0], self.model_param['compress']['table_config'][1], self.model_param['compress']['table_config'][2], self.model_param['compress']['table_config'][3])
             # for fparam or aparam settings in 'ener' type fitting net
-            if self.fitting_type == 'ener':
-                self.fitting.enable_compression(self.model_param['compress']['model_file'])
+            self.fitting.init_variables(graph, graph_def)
         
         if self.is_compress or self.model_type == 'compressed_model':
             tf.constant("compressed_model", name = 'model_type', dtype = tf.string)

--- a/deepmd/utils/tabulate.py
+++ b/deepmd/utils/tabulate.py
@@ -8,7 +8,7 @@ from scipy.special import comb
 from deepmd.env import tf
 from deepmd.env import op_module
 from deepmd.common import ACTIVATION_FN_DICT
-from deepmd.utils.graph import get_tensor_by_name_from_graph, load_graph_def 
+from deepmd.utils.graph import get_tensor_by_name_from_graph 
 from deepmd.utils.graph import get_embedding_net_nodes_from_graph_def
 from deepmd.descriptor import Descriptor
 
@@ -28,8 +28,10 @@ class DPTabulate():
             Descriptor of the original model
     neuron
             Number of neurons in each hidden layers of the embedding net :math:`\\mathcal{N}`
-    model_file
-            The frozen model
+    graph : tf.Graph
+            The graph of the original model
+    graph_def : tf.GraphDef
+            The graph_def of the original model
     type_one_side
             Try to build N_types tables. Otherwise, building N_types^2 tables
     exclude_types : List[List[int]]
@@ -43,7 +45,8 @@ class DPTabulate():
     def __init__(self,
                  descrpt : Descriptor,
                  neuron : List[int],
-                 model_file : str,
+                 graph: tf.Graph,
+                 graph_def: tf.GraphDef,
                  type_one_side : bool = False,
                  exclude_types : List[List[int]] = [],
                  activation_fn : Callable[[tf.Tensor], tf.Tensor] = tf.nn.tanh,
@@ -54,7 +57,8 @@ class DPTabulate():
         """
         self.descrpt = descrpt
         self.neuron = neuron
-        self.model_file = model_file
+        self.graph = graph
+        self.graph_def = graph_def
         self.type_one_side = type_one_side
         self.exclude_types = exclude_types
         self.suffix = suffix
@@ -76,7 +80,6 @@ class DPTabulate():
             raise RuntimeError("Unknown actication function type!")
         self.activation_fn = activation_fn
 
-        self.graph, self.graph_def = load_graph_def(self.model_file)
         #self.sess = tf.Session(graph = self.graph)
 
         self.sub_graph, self.sub_graph_def = self._load_sub_graph()


### PR DESCRIPTION
1. pass `graph` and `graph_def` instead of `model_name` so the model will be read from the disk only once;
2. remove `Fitting.enable_compression` as it is duplicated as `Fitting.init_variables`.