### PR TITLE
do not apply automatic batch size on CPUs

### DIFF
--- a/deepmd/utils/batch_size.py
+++ b/deepmd/utils/batch_size.py
@@ -46,6 +46,7 @@ class AutoBatchSize:
         self.current_batch_size = initial_batch_size
         DP_INFER_BATCH_SIZE = int(os.environ.get('DP_INFER_BATCH_SIZE', 0))
         if DP_INFER_BATCH_SIZE > 0:
+            self.current_batch_size = DP_INFER_BATCH_SIZE
             self.maximum_working_batch_size = DP_INFER_BATCH_SIZE
             self.minimal_not_working_batch_size = self.maximum_working_batch_size + 1
         else:

--- a/source/tests/test_auto_batch_size.py
+++ b/source/tests/test_auto_batch_size.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 
@@ -11,7 +12,9 @@ class TestAutoBatchSize(unittest.TestCase):
             raise OutOfMemoryError
         return batch_size, np.zeros((batch_size, 2))
 
-    def test_execute_oom(self):
+    @unittest.mock.patch('tensorflow.compat.v1.test.is_gpu_available')
+    def test_execute_oom_gpu(self, mock_is_gpu_available):
+        mock_is_gpu_available.return_value = True
         # initial batch size 256 = 128 * 2
         auto_batch_size = AutoBatchSize(256, 2.)
         # no error - 128
@@ -34,7 +37,48 @@ class TestAutoBatchSize(unittest.TestCase):
         nb, result = auto_batch_size.execute(self.oom, 1, 2)
         self.assertEqual(nb, 256)
         self.assertEqual(result.shape, (256, 2))
-    
+
+    @unittest.mock.patch('tensorflow.compat.v1.test.is_gpu_available')
+    def test_execute_oom_cpu(self, mock_is_gpu_available):
+        mock_is_gpu_available.return_value = False
+        # initial batch size 256 = 128 * 2, nb is always 128
+        auto_batch_size = AutoBatchSize(256, 2.)
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+
+    @unittest.mock.patch.dict(os.environ, {"DP_INFER_BATCH_SIZE": "256"}, clear=True)
+    def test_execute_oom_environment_variables(self):
+        # DP_INFER_BATCH_SIZE = 256 = 128 * 2, nb is always 128
+        auto_batch_size = AutoBatchSize(999, 2.)
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+        nb, result = auto_batch_size.execute(self.oom, 1, 2)
+        self.assertEqual(nb, 128)
+        self.assertEqual(result.shape, (128, 2))
+
     def test_execute_all(self):
         dd1 = np.zeros((10000, 2, 1))
         auto_batch_size = AutoBatchSize(256, 2.)


### PR DESCRIPTION
On CPUs, the batch size will not be increased anymore.

This PR also introduces an environment variable `DP_INFER_BATCH_SIZE`. It can be used to override the initial batch size.

To clarify: higher batch size also has better performance on CPUs.