### PR TITLE
add an option to enable native compilation optimization

### DIFF
--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -77,6 +77,7 @@ One may set the following environment variables before executing `pip`:
 | CUDA_TOOLKIT_ROOT_DIR | Path                   | Detected automatically | The path to the CUDA toolkit directory. CUDA 7.0 or later is supported. NVCC is required. |
 | ROCM_ROOT             | Path                   | Detected automatically | The path to the ROCM toolkit directory. |
 | TENSORFLOW_ROOT       | Path                   | Detected automatically | The path to TensorFlow Python library. By default the installer only finds TensorFlow under user site-package directory (`site.getusersitepackages()`) or system site-package directory (`sysconfig.get_path("purelib")`) due to limitation of [PEP-517](https://peps.python.org/pep-0517/). If not found, the latest TensorFlow (or the environment variable `TENSORFLOW_VERSION` if given) from PyPI will be built against.|
+| DP_ENABLE_NATIVE_OPTIMIZATION | 0, 1           | 0             | Enable compilation optimization for the native machine's CPU type. Do not enable it if generated code will run on different CPUs. |
 
 To test the installation, one should first jump out of the source directory
 ```
@@ -181,7 +182,7 @@ One may add the following arguments to `cmake`:
 | -DCMAKE_HIP_COMPILER_ROCM_ROOT=&lt;value&gt; | Path         | Detected automatically | The path to the ROCM toolkit directory. |
 | -DLAMMPS_SOURCE_ROOT=&lt;value&gt; | Path         | - | Only neccessary for LAMMPS plugin mode. The path to the [LAMMPS source code](install-lammps.md). LAMMPS 8Apr2021 or later is supported. If not assigned, the plugin mode will not be enabled. |
 | -DUSE_TF_PYTHON_LIBS=&lt;value&gt; | `TRUE` or `FALSE` | `FALSE`       | If `TRUE`, Build C++ interface with TensorFlow's Python libraries(TensorFlow's Python Interface is required). And there's no need for building TensorFlow's C++ interface.|
-
+| -DENABLE_NATIVE_OPTIMIZATION       | `TRUE` or `FALSE` | `FALSE`       | Enable compilation optimization for the native machine's CPU type. Do not enable it if generated code will run on different CPUs. |
 
 If the CMake has been executed successfully, then run the following make commands to build the package:  
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ else:
 
 if os.environ.get("DP_BUILD_TESTING", "0") == "1":
     cmake_args.append("-DBUILD_TESTING:BOOL=TRUE")
+if os.environ.get("DP_ENABLE_NATIVE_OPTIMIZATION", "0") == "1":
+    cmake_args.append("-DENABLE_NATIVE_OPTIMIZATION:BOOL=TRUE")
 
 tf_install_dir, _ = find_tensorflow()
 tf_version = get_tf_version(tf_install_dir)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -140,6 +140,13 @@ if (OPENMP_FOUND)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
+# optimize flags
+option(ENABLE_NATIVE_OPTIMIZATION "Enable native optimization" OFF)
+if (ENABLE_NATIVE_OPTIMIZATION)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native -mtune=native")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mtune=native")
+endif()
+
 # define names of libs
 set (LIB_DEEPMD		"deepmd")
 if (BUILD_CPP_IF)


### PR DESCRIPTION
After I enable it, I can observe speedup in some cases. For `examples/water/se_e2_a`, compress training FP32 networks:
```sh
CUDA_VISIBLE_DEVICES= OMP_NUM_THREADS=8 TF_INTRA_OP_PARALLELISM_THREADS=8 TF_INTER_OP_PARALLELISM_THREADS=2 dp train input.json -f frozen_model_compressed.pb
```

Before enabling it,
```
DEEPMD INFO    batch     100 training time 1.67 s, testing time 0.03 s
DEEPMD INFO    batch     200 training time 1.25 s, testing time 0.03 s
DEEPMD INFO    batch     300 training time 1.23 s, testing time 0.03 s
DEEPMD INFO    batch     400 training time 1.24 s, testing time 0.03 s
DEEPMD INFO    batch     500 training time 1.24 s, testing time 0.03 s
DEEPMD INFO    batch     600 training time 1.23 s, testing time 0.03 s
DEEPMD INFO    batch     700 training time 1.24 s, testing time 0.03 s
DEEPMD INFO    batch     800 training time 1.24 s, testing time 0.03 s
DEEPMD INFO    batch     900 training time 1.24 s, testing time 0.03 s
DEEPMD INFO    batch    1000 training time 1.24 s, testing time 0.03 s
```
After enabling it,
```
DEEPMD INFO    batch     100 training time 1.60 s, testing time 0.03 s
DEEPMD INFO    batch     200 training time 1.10 s, testing time 0.03 s
DEEPMD INFO    batch     300 training time 1.10 s, testing time 0.03 s
DEEPMD INFO    batch     400 training time 1.10 s, testing time 0.03 s
DEEPMD INFO    batch     500 training time 1.11 s, testing time 0.03 s
DEEPMD INFO    batch     600 training time 1.11 s, testing time 0.03 s
DEEPMD INFO    batch     700 training time 1.10 s, testing time 0.03 s
DEEPMD INFO    batch     800 training time 1.10 s, testing time 0.03 s
DEEPMD INFO    batch     900 training time 1.10 s, testing time 0.03 s
DEEPMD INFO    batch    1000 training time 1.13 s, testing time 0.03 s
```
About 10% improvement.
