### PR TITLE
avoid unnecessary std::endl

### DIFF
--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -331,22 +331,22 @@ void
 DeepPot::
 print_summary(const std::string &pre) const
 {
-  std::cout << pre << "installed to:       " + global_install_prefix << std::endl;
-  std::cout << pre << "source:             " + global_git_summ << std::endl;
-  std::cout << pre << "source branch:       " + global_git_branch << std::endl;
-  std::cout << pre << "source commit:      " + global_git_hash << std::endl;
-  std::cout << pre << "source commit at:   " + global_git_date << std::endl;
-  std::cout << pre << "surpport model ver.:" + global_model_version << std::endl;
+  std::cout << pre << "installed to:       " + global_install_prefix << "\n";
+  std::cout << pre << "source:             " + global_git_summ << "\n";
+  std::cout << pre << "source branch:       " + global_git_branch << "\n";
+  std::cout << pre << "source commit:      " + global_git_hash << "\n";
+  std::cout << pre << "source commit at:   " + global_git_date << "\n";
+  std::cout << pre << "surpport model ver.:" + global_model_version << "\n";
 #if defined(GOOGLE_CUDA)
-  std::cout << pre << "build variant:      cuda" << std::endl;
+  std::cout << pre << "build variant:      cuda" << "\n";
 #elif defined(TENSORFLOW_USE_ROCM)
-  std::cout << pre << "build variant:      rocm" << std::endl;
+  std::cout << pre << "build variant:      rocm" << "\n";
 #else
-  std::cout << pre << "build variant:      cpu" << std::endl;
+  std::cout << pre << "build variant:      cpu" << "\n";
 #endif
-  std::cout << pre << "build with tf inc:  " + global_tf_include_dir << std::endl;
-  std::cout << pre << "build with tf lib:  " + global_tf_lib << std::endl;
-  std::cout << pre << "set tf intra_op_parallelism_threads: " <<  num_intra_nthreads << std::endl;
+  std::cout << pre << "build with tf inc:  " + global_tf_include_dir << "\n";
+  std::cout << pre << "build with tf lib:  " + global_tf_lib << "\n";
+  std::cout << pre << "set tf intra_op_parallelism_threads: " <<  num_intra_nthreads << "\n";
   std::cout << pre << "set tf inter_op_parallelism_threads: " <<  num_inter_nthreads << std::endl;
 }
 

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -68,15 +68,15 @@ void
 DeepTensor::
 print_summary(const std::string &pre) const
 {
-  std::cout << pre << "installed to:       " + global_install_prefix << std::endl;
-  std::cout << pre << "source:             " + global_git_summ << std::endl;
-  std::cout << pre << "source branch:      " + global_git_branch << std::endl;
-  std::cout << pre << "source commit:      " + global_git_hash << std::endl;
-  std::cout << pre << "source commit at:   " + global_git_date << std::endl;
-  std::cout << pre << "surpport model ver.:" + global_model_version << std::endl;
-  std::cout << pre << "build with tf inc:  " + global_tf_include_dir << std::endl;
-  std::cout << pre << "build with tf lib:  " + global_tf_lib << std::endl;
-  std::cout << pre << "set tf intra_op_parallelism_threads: " <<  num_intra_nthreads << std::endl;
+  std::cout << pre << "installed to:       " + global_install_prefix << "\n";
+  std::cout << pre << "source:             " + global_git_summ << "\n";
+  std::cout << pre << "source branch:      " + global_git_branch << "\n";
+  std::cout << pre << "source commit:      " + global_git_hash << "\n";
+  std::cout << pre << "source commit at:   " + global_git_date << "\n";
+  std::cout << pre << "surpport model ver.:" + global_model_version << "\n";
+  std::cout << pre << "build with tf inc:  " + global_tf_include_dir << "\n";
+  std::cout << pre << "build with tf lib:  " + global_tf_lib << "\n";
+  std::cout << pre << "set tf intra_op_parallelism_threads: " <<  num_intra_nthreads << "\n";
   std::cout << pre << "set tf inter_op_parallelism_threads: " <<  num_inter_nthreads << std::endl;
 }
 

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -280,17 +280,17 @@ PairDeepMD::print_summary(const string pre) const
     std::streambuf *sbuf = std::cout.rdbuf();
     std::cout.rdbuf(buffer.rdbuf());
 
-    cout << "Summary of lammps deepmd module ..." << endl;
-    cout << pre << ">>> Info of deepmd-kit:" << endl;
+    cout << "Summary of lammps deepmd module ..." << "\n";
+    cout << pre << ">>> Info of deepmd-kit:" << "\n";
     deep_pot.print_summary(pre);
-    cout << pre << ">>> Info of lammps module:" << endl;
-    cout << pre << "use deepmd-kit at:  " << STR_DEEPMD_ROOT << endl;
-    cout << pre << "source:             " << STR_GIT_SUMM << endl;
-    cout << pre << "source branch:      " << STR_GIT_BRANCH << endl;
-    cout << pre << "source commit:      " << STR_GIT_HASH << endl;
-    cout << pre << "source commit at:   " << STR_GIT_DATE << endl;
-    cout << pre << "build float prec:   " << STR_FLOAT_PREC << endl;
-    cout << pre << "build with tf inc:  " << STR_TensorFlow_INCLUDE_DIRS << endl;
+    cout << pre << ">>> Info of lammps module:" << "\n";
+    cout << pre << "use deepmd-kit at:  " << STR_DEEPMD_ROOT << "\n";
+    cout << pre << "source:             " << STR_GIT_SUMM << "\n";
+    cout << pre << "source branch:      " << STR_GIT_BRANCH << "\n";
+    cout << pre << "source commit:      " << STR_GIT_HASH << "\n";
+    cout << pre << "source commit at:   " << STR_GIT_DATE << "\n";
+    cout << pre << "build float prec:   " << STR_FLOAT_PREC << "\n";
+    cout << pre << "build with tf inc:  " << STR_TensorFlow_INCLUDE_DIRS << "\n";
     cout << pre << "build with tf lib:  " << STR_TensorFlow_LIBRARY << endl;
 
     std::cout.rdbuf(sbuf);
@@ -713,7 +713,7 @@ void PairDeepMD::compute(int eflag, int vflag)
 	  }
 	}
 	if (rank == 0) {
-	  fp << endl;
+	  fp << "\n";
 	}
       }
     }
@@ -962,14 +962,14 @@ void PairDeepMD::settings(int narg, char **arg)
 	 << setw(18+1) << "max_devi_f"
 	 << setw(18+1) << "min_devi_f"
 	 << setw(18+1) << "avg_devi_f"
-	 << endl;
+	 << "\n";
       } else {
         fp.open (out_file, std::ofstream::out | std::ofstream::app);
         fp << scientific;
       }
     }
     string pre = "  ";
-    cout << pre << ">>> Info of model(s):" << endl
+    cout << pre << ">>> Info of model(s):" << "\n"
 	 << pre << "using " << setw(3) << numb_models << " model(s): ";
     if (narg == 1) {
       cout << arg[0] << " ";
@@ -979,9 +979,9 @@ void PairDeepMD::settings(int narg, char **arg)
       	cout << models[ii] << " ";
       }
     }
-    cout << endl
-	 << pre << "rcut in model:      " << cutoff << endl
-	 << pre << "ntypes in model:    " << numb_types << endl;
+    cout << "\n"
+	 << pre << "rcut in model:      " << cutoff << "\n"
+	 << pre << "ntypes in model:    " << numb_types << "\n";
     if (dim_fparam > 0) {
       cout << pre << "using fparam(s):    " ;
       for (int ii = 0; ii < dim_fparam; ++ii){

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1003,6 +1003,11 @@ void PairDeepMD::settings(int narg, char **arg)
   all_force.resize(numb_models);
 }
 
+void PairDeepMD::finish()
+{
+  if(fp) fp << std::flush;
+}
+
 void PairDeepMD::read_restart(FILE *)
 {
   is_restart = true;

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -987,15 +987,16 @@ void PairDeepMD::settings(int narg, char **arg)
       for (int ii = 0; ii < dim_fparam; ++ii){
 	cout << fparam[ii] << "  " ;
       }
-      cout << endl;
+      cout << "\n";
     }
     if (aparam.size() > 0) {
       cout << pre << "using aparam(s):    " ;
       for (int ii = 0; ii < aparam.size(); ++ii){
 	cout << aparam[ii] << "  " ;
       }
-      cout << endl;
+      cout << "\n";
     }
+    cout << std::flush;
   }
   
   comm_reverse = numb_models * 3;

--- a/source/lmp/pair_deepmd.h.in
+++ b/source/lmp/pair_deepmd.h.in
@@ -51,6 +51,7 @@ class PairDeepMD : public Pair {
   ~PairDeepMD() override;
   void compute(int, int) override;
   void *extract(const char *, int &) override;
+  void finish() override;
   void settings(int, char **) override;
   void coeff(int, char **) override;
   void init_style() override;


### PR DESCRIPTION
`std::endl` = `\n` + `flush`, and in these situations, it is not required to flush every line:
1. multiple lines into stdout and stderr. Only the last line is required to flush;
2. frequently writing to a file. In the DeePMD-kit, model_devi.out was flushed every line, but usually, one does not need to monitor it.

See also:
https://en.cppreference.com/w/cpp/io/manip/endl
https://stackoverflow.com/a/17468264/9567349
