### PR TITLE
store energy bias with interface precision

### DIFF
--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -170,7 +170,7 @@ class EnerModel(Model) :
                 suffix = suffix,
             )
             input_dict['type_embedding'] = type_embedding
-            input_dict['atype'] = atype_
+        input_dict['atype'] = atype_
 
         if frz_model == None:
             dout \

--- a/deepmd/model/multi.py
+++ b/deepmd/model/multi.py
@@ -195,7 +195,7 @@ class MultiModel(Model):
                 suffix=suffix,
             )
             input_dict['type_embedding'] = type_embedding
-            input_dict['atype'] = atype_
+        input_dict['atype'] = atype_
 
         dout \
             = self.descrpt.build(coord_,

--- a/source/tests/test_model_se_a.py
+++ b/source/tests/test_model_se_a.py
@@ -69,7 +69,7 @@ class TestModel(tf.test.TestCase):
                       'default_mesh' : [test_data['default_mesh']]
         }
         model._compute_input_stat(input_data)
-        model.descrpt.bias_atom_e = data.compute_energy_shift()
+        model.fitting.bias_atom_e = np.array(set_atom_ener)
 
         t_prop_c           = tf.placeholder(tf.float32, [5],    name='t_prop_c')
         t_energy           = tf.placeholder(GLOBAL_ENER_FLOAT_PRECISION, [None], name='t_energy')


### PR DESCRIPTION
This PR moves energy biases out of NN for all situations and stores them with interface precision.

When using the double precision interface and float precision NN, this patch can improve the accuracy of the atomic energy when it has a large absolute value. For example, when the atomic energy is 11451.41234567 eV, the float value is 11451.412 eV (places=3); but if we have a double bias of 11450.000000 eV, the NN only needs to fit 1.41234567 eV, and the float value is 1.4123456 eV (places=7).