### PR TITLE
retag wheels to `py37-none-<platform>`

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -14,40 +14,13 @@ jobs:
         include:
           # linux-64
           - os: ubuntu-latest
-            python: 37
-            platform_id: manylinux_x86_64
-          - os: ubuntu-latest
-            python: 38
-            platform_id: manylinux_x86_64
-          - os: ubuntu-latest
-            python: 39
-            platform_id: manylinux_x86_64
-          - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
           # macos-x86-64
           - os: macos-latest
-            python: 37
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python: 38
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python: 39
-            platform_id: macosx_x86_64
-          - os: macos-latest
             python: 310
             platform_id: macosx_x86_64
           # win-64
-          - os: windows-2019
-            python: 37
-            platform_id: win_amd64
-          - os: windows-2019
-            python: 38
-            platform_id: win_amd64
-          - os: windows-2019
-            python: 39
-            platform_id: win_amd64
           - os: windows-2019
             python: 310
             platform_id: win_amd64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ repository = "https://github.com/deepmodeling/deepmd-kit"
 [tool.setuptools_scm]
 write_to = "deepmd/_version.py"
 
-[tool.distutils.bdist_wheel]
-python-tag = "py3"
-
 [tool.cibuildwheel]
 test-command = "dp -h"
 test-requires = "tensorflow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,13 @@ repository = "https://github.com/deepmodeling/deepmd-kit"
 [tool.setuptools_scm]
 write_to = "deepmd/_version.py"
 
+[tool.distutils.bdist_wheel]
+universal = true
+
 [tool.cibuildwheel]
 test-command = "dp -h"
 test-requires = "tensorflow"
-build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
+build = ["cp310-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
 # TODO: bump to "latest" tag when CUDA supports GCC 12
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:2022-11-19-1b19e81"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ repository = "https://github.com/deepmodeling/deepmd-kit"
 write_to = "deepmd/_version.py"
 
 [tool.distutils.bdist_wheel]
-universal = true
+python-tag = "py3"
 
 [tool.cibuildwheel]
 test-command = "dp -h"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self):
         python, abi, plat = super().get_tag()
         if python.startswith("cp"):
-            return "cp37", "none", plat
+            return "py37", "none", plat
         return python, abi, plat
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from skbuild import setup
+from wheel.bdist_wheel import bdist_wheel
 
 topdir = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(topdir, 'backend'))
@@ -36,6 +37,14 @@ if os.environ.get("DP_ENABLE_NATIVE_OPTIMIZATION", "0") == "1":
 
 tf_install_dir, _ = find_tensorflow()
 tf_version = get_tf_version(tf_install_dir)
+
+
+class bdist_wheel_abi3(bdist_wheel):
+    def get_tag(self):
+        python, abi, plat = super().get_tag()
+        if python.startswith("cp"):
+            return "cp37", "none", plat
+        return python, abi, plat
 
 
 # TODO: migrate packages and entry_points to pyproject.toml after scikit-build supports it
@@ -89,4 +98,7 @@ setup(
         **get_tf_requirement(tf_version),
     },
     entry_points={"console_scripts": ["dp = deepmd.entrypoints.main:main"]},
+    cmdclass = {
+        "bdist_wheel": bdist_wheel_abi3,
+    },
 )


### PR DESCRIPTION
Our wheels do not link against any Python ABIs. The libraries only link against TensorFlow ABIs. So it's safe to retag them to `py37-none-<platform>` but keep the platform tag. We only need to build the wheel once for a platform to reduce the CI time, and the wheel should work for all Python versions.

References: [PEP 425](https://peps.python.org/pep-0425/)