### PR TITLE
c: add DipoleChargeModifier 

### DIFF
--- a/source/api_c/include/c_api.h
+++ b/source/api_c/include/c_api.h
@@ -39,11 +39,11 @@ extern DP_DeepPot* DP_NewDeepPot(const char* c_model);
  * 
  * @param c_model The name of the frozen model file.
  * @param gpu_rank The rank of the GPU.
- * @param c_name_scope The name scope.
+ * @param c_file_content The content of the model file.
  * @return DP_DeepPot* A pointer to the deep potential.
  */
 extern DP_DeepPot* DP_NewDeepPotWithParam(
-        const char* c_model, const int gpu_rank, const char* c_name_scope);
+        const char* c_model, const int gpu_rank, const char* c_file_content);
 
 /**
 * @brief Evaluate the energy, force and virial by using a DP. (double version)

--- a/source/api_c/include/c_api.h
+++ b/source/api_c/include/c_api.h
@@ -526,6 +526,109 @@ int* DP_DeepTensorGetSelTypes(DP_DeepTensor* dt);
 int DP_DeepTensorGetNumbSelTypes(DP_DeepTensor* dt);
 
 /**
+* @brief The dipole charge modifier.
+**/
+typedef struct DP_DipoleChargeModifier DP_DipoleChargeModifier;
+
+/**
+* @brief Dipole charge modifier constructor with initialization.
+* @param[in] c_model The name of the frozen model file.
+* @returns A pointer to the dipole charge modifier.
+**/
+extern DP_DipoleChargeModifier* DP_NewDipoleChargeModifier(const char* c_model);
+
+/**
+* @brief Evaluate the force and virial correction by using a dipole charge modifier with the neighbor list. (double version)
+* @param[in] dcm The dipole charge modifier to use.
+* @param[in] natoms The number of atoms.
+* @param[in] coord The coordinates of atoms. The array should be of size natoms x 3.
+* @param[in] atype The atom types. The array should contain natoms ints.
+* @param[in] cell The cell of the region. The array should be of size 9. Pass NULL if pbc is not used.
+* @param[in] pairs The pairs of atoms. The list should contain npairs pairs of ints.
+* @param[in] npairs The number of pairs.
+* @param[in] delef_ The electric field on each atom. The array should be of size nframes x natoms x 3.
+* @param[in] nghost The number of ghost atoms.
+* @param[in] nlist The neighbor list.
+* @param[out] dfcorr_ Output force correction. The array should be of size natoms x 3.
+* @param[out] dvcorr_ Output virial correction. The array should be of size 9.
+* @warning The output arrays should be allocated before calling this function. Pass NULL if not required.
+  **/
+extern void DP_DipoleChargeModifierComputeNList (
+  DP_DipoleChargeModifier* dcm,
+  const int natom,
+  const double* coord,
+  const int* atype,
+  const double* cell,
+  const int* pairs,
+  const int npairs,
+  const double* delef_,
+  const int nghost,
+  const DP_Nlist* nlist,
+  double* dfcorr_,
+  double* dvcorr_
+  );
+
+
+/**
+* @brief Evaluate the force and virial correction by using a dipole charge modifier with the neighbor list. (float version)
+* @param[in] dcm The dipole charge modifier to use.
+* @param[in] natoms The number of atoms.
+* @param[in] coord The coordinates of atoms. The array should be of size natoms x 3.
+* @param[in] atype The atom types. The array should contain natoms ints.
+* @param[in] cell The cell of the region. The array should be of size 9. Pass NULL if pbc is not used.
+* @param[in] pairs The pairs of atoms. The list should contain npairs pairs of ints.
+* @param[in] npairs The number of pairs.
+* @param[in] delef_ The electric field on each atom. The array should be of size nframes x natoms x 3.
+* @param[in] nghost The number of ghost atoms.
+* @param[in] nlist The neighbor list.
+* @param[out] dfcorr_ Output force correction. The array should be of size natoms x 3.
+* @param[out] dvcorr_ Output virial correction. The array should be of size 9.
+* @warning The output arrays should be allocated before calling this function. Pass NULL if not required.
+  **/
+extern void DP_DipoleChargeModifierComputeNListf (
+  DP_DipoleChargeModifier* dcm,
+  const int natom,
+  const float* coord,
+  const int* atype,
+  const float* cell,
+  const int* pairs,
+  const int npairs,
+  const float* delef_,
+  const int nghost,
+  const DP_Nlist* nlist,
+  float* dfcorr_,
+  float* dvcorr_
+  );
+
+/**
+ * @brief Get the type map of a DipoleChargeModifier.
+ * @param[in] dcm The DipoleChargeModifier to use.
+ * @return The cutoff radius.
+*/
+double DP_DipoleChargeModifierGetCutoff(DP_DipoleChargeModifier* dt);
+
+/**
+ * @brief Get the type map of a DipoleChargeModifier.
+ * @param[in] dcm The DipoleChargeModifier to use.
+ * @return The number of types of the DipoleChargeModifier.
+*/
+int DP_DipoleChargeModifierGetNumbTypes(DP_DipoleChargeModifier* dt);
+
+/**
+ * @brief Get sel types of a DipoleChargeModifier.
+ * @param[in] dcm The DipoleChargeModifier to use.
+ * @return The sel types
+*/
+int* DP_DipoleChargeModifierGetSelTypes(DP_DipoleChargeModifier* dt);
+
+/**
+ * @brief Get the number of sel types of a DipoleChargeModifier.
+ * @param[in] dcm The DipoleChargeModifier to use.
+ * @return The number of sel types
+*/
+int DP_DipoleChargeModifierGetNumbSelTypes(DP_DipoleChargeModifier* dt);
+
+/**
 * @brief Convert PBtxt to PB.
 * @param[in] c_pbtxt The name of the PBtxt file.
 * @param[in] c_pb The name of the PB file.

--- a/source/api_c/include/c_api.h
+++ b/source/api_c/include/c_api.h
@@ -35,6 +35,17 @@ typedef struct DP_DeepPot DP_DeepPot;
 extern DP_DeepPot* DP_NewDeepPot(const char* c_model);
 
 /**
+ * @brief DP constructor with initialization.
+ * 
+ * @param c_model The name of the frozen model file.
+ * @param gpu_rank The rank of the GPU.
+ * @param c_name_scope The name scope.
+ * @return DP_DeepPot* A pointer to the deep potential.
+ */
+extern DP_DeepPot* DP_NewDeepPotWithParam(
+        const char* c_model, const int gpu_rank, const char* c_name_scope);
+
+/**
 * @brief Evaluate the energy, force and virial by using a DP. (double version)
 * @param[in] dp The DP to use.
 * @param[in] natoms The number of atoms.
@@ -278,6 +289,17 @@ typedef struct DP_DeepTensor DP_DeepTensor;
 * @returns A pointer to the deep tensor.
 **/
 extern DP_DeepTensor* DP_NewDeepTensor(const char* c_model);
+
+/**
+ * @brief Deep Tensor constructor with initialization.
+ * 
+ * @param c_model The name of the frozen model file.
+ * @param gpu_rank The rank of the GPU.
+ * @param c_name_scope The name scope.
+ * @return DP_DeepTensor* A pointer to the deep tensor.
+ */
+extern DP_DeepTensor* DP_NewDeepTensorWithParam(
+        const char* c_model, const int gpu_rank, const char* c_name_scope);
 
 /**
 * @brief Evaluate the tensor by using a DP. (double version)
@@ -536,6 +558,17 @@ typedef struct DP_DipoleChargeModifier DP_DipoleChargeModifier;
 * @returns A pointer to the dipole charge modifier.
 **/
 extern DP_DipoleChargeModifier* DP_NewDipoleChargeModifier(const char* c_model);
+
+/**
+ * @brief Dipole charge modifier constructor with initialization.
+ * 
+ * @param c_model The name of the frozen model file.
+ * @param gpu_rank The rank of the GPU.
+ * @param c_name_scope The name scope.
+ * @return DP_DipoleChargeModifier* A pointer to the dipole charge modifier.
+ */
+extern DP_DipoleChargeModifier* DP_NewDipoleChargeModifierWithParam(
+        const char* c_model, const int gpu_rank, const char* c_name_scope);
 
 /**
 * @brief Evaluate the force and virial correction by using a dipole charge modifier with the neighbor list. (double version)

--- a/source/api_c/include/c_api_internal.h
+++ b/source/api_c/include/c_api_internal.h
@@ -1,6 +1,7 @@
 #include "neighbor_list.h"
 #include "DeepPot.h"
 #include "DeepTensor.h"
+#include "DataModifier.h"
 
 struct DP_Nlist {
   DP_Nlist(deepmd::InputNlist& nl);
@@ -24,4 +25,10 @@ struct DP_DeepTensor {
   DP_DeepTensor(deepmd::DeepTensor& dt);
 
   deepmd::DeepTensor dt;
+};
+
+struct DP_DipoleChargeModifier {
+  DP_DipoleChargeModifier(deepmd::DipoleChargeModifier& dcm);
+
+  deepmd::DipoleChargeModifier dcm;
 };

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -1020,7 +1020,7 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-                const int odim = output_dim();
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1060,7 +1060,7 @@ namespace deepmd
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
                 
-                const int odim = output_dim();
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1112,7 +1112,7 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-                const int odim = output_dim();
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1157,7 +1157,7 @@ namespace deepmd
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
 
-                const int odim = output_dim();
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -486,22 +486,22 @@ namespace deepmd
              * @brief DP constructor with initialization.
              * @param[in] model The name of the frozen model file.
              **/
-            DeepPot(const std::string &model) : dp(nullptr)
+            DeepPot(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "") : dp(nullptr)
             {
-                init(model);
+                init(model, gpu_rank, name_scope);
             };
             /**
              * @brief Initialize the DP.
              * @param[in] model The name of the frozen model file.
              **/
-            void init(const std::string &model)
+            void init(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "")
             {
                 if (dp)
                 {
                     std::cerr << "WARNING: deepmd-kit should not be initialized twice, do nothing at the second call of initializer" << std::endl;
                     return;
                 }
-                dp = DP_NewDeepPot(model.c_str());
+                dp = DP_NewDeepPotWithParam(model.c_str(), gpu_rank, name_scope.c_str());
             };
 
             /**
@@ -903,22 +903,22 @@ namespace deepmd
              * @brief DeepTensor constructor with initialization.
              * @param[in] model The name of the frozen model file.
              **/
-            DeepTensor(const std::string &model) : dt(nullptr)
+            DeepTensor(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "") : dt(nullptr)
             {
-                init(model);
+                init(model, gpu_rank, name_scope);
             };
             /**
              * @brief Initialize the DeepTensor.
              * @param[in] model The name of the frozen model file.
              **/
-            void init(const std::string &model)
+            void init(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "")
             {
                 if (dt)
                 {
                     std::cerr << "WARNING: deepmd-kit should not be initialized twice, do nothing at the second call of initializer" << std::endl;
                     return;
                 }
-                dt = DP_NewDeepTensor(model.c_str());
+                dt = DP_NewDeepTensorWithParam(model.c_str(), gpu_rank, name_scope.c_str());
                 odim = output_dim();
                 nsel_types = DP_DeepTensorGetNumbSelTypes(dt);
             };
@@ -1227,23 +1227,27 @@ namespace deepmd
             /**
              * @brief DipoleChargeModifier constructor with initialization.
              * @param[in] model The name of the frozen model file.
+             * @param[in] gpu_rank The rank of the GPU to be used.
+             * @param[in] name_scope The name scope of the model.
              **/
-            DipoleChargeModifier(const std::string &model) : dcm(nullptr)
+            DipoleChargeModifier(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "") : dcm(nullptr)
             {
-                init(model);
+                init(model, gpu_rank, name_scope);
             };
             /**
              * @brief Initialize the DipoleChargeModifier.
              * @param[in] model The name of the frozen model file.
+             * @param[in] gpu_rank The rank of the GPU to be used.
+             * @param[in] name_scope The name scope of the model.
              **/
-            void init(const std::string &model)
+            void init(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "")
             {
                 if (dcm)
                 {
                     std::cerr << "WARNING: deepmd-kit should not be initialized twice, do nothing at the second call of initializer" << std::endl;
                     return;
                 }
-                dcm = DP_NewDipoleChargeModifier(model.c_str());
+                dcm = DP_NewDipoleChargeModifierWithParam(model.c_str(), gpu_rank, name_scope.c_str());
                 nsel_types = DP_DipoleChargeModifierGetNumbSelTypes(dcm);
             };
             /**
@@ -1287,7 +1291,7 @@ namespace deepmd
                 VALUETYPE *dfcorr = &dfcorr_[0];
                 VALUETYPE *dvcorr = &dvcorr_[0];
 
-                _DP_DipoleChargeModifierComputeNList<VALUETYPE>(dcm, natoms, dcoord, datype, dbox_, npairs, dpairs, delef, nghost, lmp_list.nl, dfcorr, dvcorr);
+                _DP_DipoleChargeModifierComputeNList<VALUETYPE>(dcm, natoms, dcoord, datype, dbox_, dpairs, npairs, delef, nghost, lmp_list.nl, dfcorr, dvcorr);
             };
             /**
              * @brief Get the cutoff radius.

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -348,7 +348,7 @@ inline void _DP_DeepTensorComputeNList<float>(
 }
 
 template <typename FPTYPE>
-inline void _DP_DipoleChargeModifierCompute(
+inline void _DP_DipoleChargeModifierComputeNList(
     DP_DipoleChargeModifier* dcm,
     const int natom,
     const FPTYPE* coord,
@@ -361,10 +361,10 @@ inline void _DP_DipoleChargeModifierCompute(
     const DP_Nlist* nlist,
     FPTYPE* dfcorr_,
     FPTYPE* dvcorr_
-)
+);
 
 template <>
-inline void _DP_DipoleChargeModifierCompute<double>(
+inline void _DP_DipoleChargeModifierComputeNList<double>(
     DP_DipoleChargeModifier* dcm,
     const int natom,
     const double* coord,
@@ -379,11 +379,11 @@ inline void _DP_DipoleChargeModifierCompute<double>(
     double* dvcorr_
 )
 {
-    DP_DipoleChargeModifierCompute(dcm, natom, coord, atype, cell, pairs, npairs, delef_, nghost, nlist, dfcorr_, dvcorr_);
+    DP_DipoleChargeModifierComputeNList(dcm, natom, coord, atype, cell, pairs, npairs, delef_, nghost, nlist, dfcorr_, dvcorr_);
 }
 
 template <>
-inline void _DP_DipoleChargeModifierCompute<float>(
+inline void _DP_DipoleChargeModifierComputeNList<float>(
     DP_DipoleChargeModifier* dcm,
     const int natom,
     const float* coord,
@@ -398,7 +398,7 @@ inline void _DP_DipoleChargeModifierCompute<float>(
     float* dvcorr_
 )
 {
-    DP_DipoleChargeModifierComputef(dcm, natom, coord, atype, cell, pairs, npairs, delef_, nghost, nlist, dfcorr_, dvcorr_);
+    DP_DipoleChargeModifierComputeNListf(dcm, natom, coord, atype, cell, pairs, npairs, delef_, nghost, nlist, dfcorr_, dvcorr_);
 }
 
 namespace deepmd
@@ -1228,7 +1228,7 @@ namespace deepmd
              * @brief DipoleChargeModifier constructor with initialization.
              * @param[in] model The name of the frozen model file.
              **/
-            DipoleChargeModifier(const std::string &model) : dt(nullptr)
+            DipoleChargeModifier(const std::string &model) : dcm(nullptr)
             {
                 init(model);
             };
@@ -1287,7 +1287,7 @@ namespace deepmd
                 VALUETYPE *dfcorr = &dfcorr_[0];
                 VALUETYPE *dvcorr = &dvcorr_[0];
 
-                _DP_DipoleChargeModifierCompute<VALUETYPE>(dcm, natoms, dcoord, datype, dbox_, npairs, dpairs, delef, nghost, lmp_list.nl, dfcorr, dvcorr);
+                _DP_DipoleChargeModifierComputeNList<VALUETYPE>(dcm, natoms, dcoord, datype, dbox_, npairs, dpairs, delef, nghost, lmp_list.nl, dfcorr, dvcorr);
             };
             /**
              * @brief Get the cutoff radius.
@@ -1310,12 +1310,13 @@ namespace deepmd
 
             std::vector<int> sel_types() const
             {
-                int* sel_types_arr = DP_DipoleChargeModifierGetSelTypes(dt);
+                int* sel_types_arr = DP_DipoleChargeModifierGetSelTypes(dcm);
                 std::vector<int> sel_types_vec = std::vector<int>(sel_types_arr, sel_types_arr + nsel_types);
                 return sel_types_vec;
             }
         private:
             DP_DipoleChargeModifier *dcm;
+            int nsel_types;
         };
     }
 }

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -1020,7 +1020,7 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-                odim = output_dim();
+                const int odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1060,7 +1060,7 @@ namespace deepmd
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
                 
-                odim = output_dim();
+                const int odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1112,7 +1112,7 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-                odim = output_dim();
+                const int odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1157,7 +1157,7 @@ namespace deepmd
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
 
-                odim = output_dim();
+                const int odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -919,6 +919,7 @@ namespace deepmd
                     return;
                 }
                 dt = DP_NewDeepTensorWithParam(model.c_str(), gpu_rank, name_scope.c_str());
+                odim = output_dim();
                 nsel_types = DP_DeepTensorGetNumbSelTypes(dt);
             };
 
@@ -1020,7 +1021,6 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1059,8 +1059,7 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-                
-                odim = output_dim();
+
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1112,7 +1111,6 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1157,7 +1155,6 @@ namespace deepmd
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
 
-                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1215,6 +1212,7 @@ namespace deepmd
 
         private:
             DP_DeepTensor *dt;
+            int odim;
             int nsel_types;
         };
 

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -919,7 +919,6 @@ namespace deepmd
                     return;
                 }
                 dt = DP_NewDeepTensorWithParam(model.c_str(), gpu_rank, name_scope.c_str());
-                odim = output_dim();
                 nsel_types = DP_DeepTensorGetNumbSelTypes(dt);
             };
 
@@ -1021,6 +1020,7 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1059,7 +1059,8 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
-
+                
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1111,6 +1112,7 @@ namespace deepmd
                 const VALUETYPE *coord_ = &coord[0];
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1155,6 +1157,7 @@ namespace deepmd
                 const VALUETYPE *box_ = !box.empty() ? &box[0] : nullptr;
                 const int *atype_ = &atype[0];
 
+                odim = output_dim();
                 global_tensor.resize(odim);
                 force.resize(odim * natoms * 3);
                 virial.resize(odim * 9);
@@ -1212,7 +1215,6 @@ namespace deepmd
 
         private:
             DP_DeepTensor *dt;
-            int odim;
             int nsel_types;
         };
 

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -485,23 +485,27 @@ namespace deepmd
             /**
              * @brief DP constructor with initialization.
              * @param[in] model The name of the frozen model file.
+             * @param[in] gpu_rank The GPU rank.
+             * @param[in] file_content The content of the frozen model file.
              **/
-            DeepPot(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "") : dp(nullptr)
+            DeepPot(const std::string &model, const int &gpu_rank = 0, const std::string &file_content = "") : dp(nullptr)
             {
-                init(model, gpu_rank, name_scope);
+                init(model, gpu_rank, file_content);
             };
             /**
              * @brief Initialize the DP.
              * @param[in] model The name of the frozen model file.
+             * @param[in] gpu_rank The GPU rank.
+             * @param[in] file_content The content of the frozen model file.
              **/
-            void init(const std::string &model, const int &gpu_rank = 0, const std::string &name_scope = "")
+            void init(const std::string &model, const int &gpu_rank = 0, const std::string &file_content = "")
             {
                 if (dp)
                 {
                     std::cerr << "WARNING: deepmd-kit should not be initialized twice, do nothing at the second call of initializer" << std::endl;
                     return;
                 }
-                dp = DP_NewDeepPotWithParam(model.c_str(), gpu_rank, name_scope.c_str());
+                dp = DP_NewDeepPotWithParam(model.c_str(), gpu_rank, file_content.c_str());
             };
 
             /**

--- a/source/api_c/src/c_api.cc
+++ b/source/api_c/src/c_api.cc
@@ -56,7 +56,7 @@ DP_DeepTensor* DP_NewDeepTensor(const char* c_model) {
 DP_DipoleChargeModifier::DP_DipoleChargeModifier(deepmd::DipoleChargeModifier& dcm)
     : dcm(dcm) {}
 
-DP_DipoleChargeModifier* DP_DipoleChargeModifier(const char* c_model) {
+DP_DipoleChargeModifier* DP_NewDipoleChargeModifier(const char* c_model) {
     std::string model(c_model);
     deepmd::DipoleChargeModifier dcm(model);
     DP_DipoleChargeModifier* new_dcm = new DP_DipoleChargeModifier(dcm);

--- a/source/api_c/src/c_api.cc
+++ b/source/api_c/src/c_api.cc
@@ -54,7 +54,7 @@ DP_DeepTensor* DP_NewDeepTensor(const char* c_model) {
 }
 
 DP_DipoleChargeModifier::DP_DipoleChargeModifier(deepmd::DipoleChargeModifier& dcm)
-    : dt(dt) {}
+    : dcm(dcm) {}
 
 DP_DipoleChargeModifier* DP_DipoleChargeModifier(const char* c_model) {
     std::string model(c_model);
@@ -551,7 +551,7 @@ template <typename VALUETYPE>
 inline
 void DP_DipoleChargeModifierComputeNList_variant (
   DP_DipoleChargeModifier* dcm,
-  const int natom,
+  const int natoms,
   const VALUETYPE* coord,
   const int* atype,
   const VALUETYPE* cell,
@@ -588,7 +588,7 @@ void DP_DipoleChargeModifierComputeNList_variant (
 template
 void DP_DipoleChargeModifierComputeNList_variant <double> (
   DP_DipoleChargeModifier* dcm,
-  const int natom,
+  const int natoms,
   const double* coord,
   const int* atype,
   const double* cell,
@@ -604,7 +604,7 @@ void DP_DipoleChargeModifierComputeNList_variant <double> (
 template
 void DP_DipoleChargeModifierComputeNList_variant <float> (
   DP_DipoleChargeModifier* dcm,
-  const int natom,
+  const int natoms,
   const float* coord,
   const int* atype,
   const float* cell,

--- a/source/api_c/src/c_api.cc
+++ b/source/api_c/src/c_api.cc
@@ -34,10 +34,10 @@ DP_DeepPot* DP_NewDeepPot(const char* c_model) {
 }
 
 DP_DeepPot* DP_NewDeepPotWithParam(
-        const char* c_model, const int gpu_rank, const char* c_name_scope) {
+        const char* c_model, const int gpu_rank, const char* c_file_content) {
     std::string model(c_model);
-    std::string name_scope(c_name_scope);
-    deepmd::DeepPot dp(model, gpu_rank, name_scope);
+    std::string file_content(c_file_content);
+    deepmd::DeepPot dp(model, gpu_rank, file_content);
     DP_DeepPot* new_dp = new DP_DeepPot(dp);
     return new_dp;
 }

--- a/source/api_c/src/c_api.cc
+++ b/source/api_c/src/c_api.cc
@@ -33,6 +33,15 @@ DP_DeepPot* DP_NewDeepPot(const char* c_model) {
     return new_dp;
 }
 
+DP_DeepPot* DP_NewDeepPotWithParam(
+        const char* c_model, const int gpu_rank, const char* c_name_scope) {
+    std::string model(c_model);
+    std::string name_scope(c_name_scope);
+    deepmd::DeepPot dp(model, gpu_rank, name_scope);
+    DP_DeepPot* new_dp = new DP_DeepPot(dp);
+    return new_dp;
+}
+
 DP_DeepPotModelDevi::DP_DeepPotModelDevi(deepmd::DeepPotModelDevi& dp)
     : dp(dp) {}
 
@@ -53,12 +62,30 @@ DP_DeepTensor* DP_NewDeepTensor(const char* c_model) {
     return new_dt;
 }
 
+DP_DeepTensor* DP_NewDeepTensorWithParam(
+        const char* c_model, const int gpu_rank, const char* c_name_scope) {
+    std::string model(c_model);
+    std::string name_scope(c_name_scope);
+    deepmd::DeepTensor dt(model, gpu_rank, name_scope);
+    DP_DeepTensor* new_dt = new DP_DeepTensor(dt);
+    return new_dt;
+}
+
 DP_DipoleChargeModifier::DP_DipoleChargeModifier(deepmd::DipoleChargeModifier& dcm)
     : dcm(dcm) {}
 
 DP_DipoleChargeModifier* DP_NewDipoleChargeModifier(const char* c_model) {
     std::string model(c_model);
     deepmd::DipoleChargeModifier dcm(model);
+    DP_DipoleChargeModifier* new_dcm = new DP_DipoleChargeModifier(dcm);
+    return new_dcm;
+}
+
+DP_DipoleChargeModifier* DP_NewDipoleChargeModifierWithParam(
+        const char* c_model, const int gpu_rank, const char* c_name_scope) {
+    std::string model(c_model);
+    std::string name_scope(c_name_scope);
+    deepmd::DipoleChargeModifier dcm(model, gpu_rank, name_scope);
     DP_DipoleChargeModifier* new_dcm = new DP_DipoleChargeModifier(dcm);
     return new_dcm;
 }

--- a/source/api_c/tests/CMakeLists.txt
+++ b/source/api_c/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ set_target_properties(
 
 add_executable( runUnitTests_c ${TEST_SRC} )
 target_link_libraries(runUnitTests_c PRIVATE GTest::gtest_main ${LIB_DEEPMD_C} rt coverage_config)
-target_link_libraries(runUnitTests_c PRIVATE ${LIB_DEEPMD})
+target_link_libraries(runUnitTests_c PRIVATE ${LIB_DEEPMD} ${LIB_DEEPMD_CC})
 target_precompile_headers(runUnitTests_c PRIVATE test_utils.h [["deepmd.hpp"]])
 add_test( runUnitTests_c runUnitTests_c )
 set_target_properties(

--- a/source/api_c/tests/test_dipolecharge.cc
+++ b/source/api_c/tests/test_dipolecharge.cc
@@ -5,6 +5,8 @@
 #include <vector>
 #include "deepmd.hpp"
 #include "test_utils.h"
+#include "ewald.h"
+#include "region.h"
 
 template <class VALUETYPE>
 class TestDipoleCharge : public ::testing::Test
@@ -124,11 +126,11 @@ TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
   std::vector<int> sel_types = dp.sel_types();
   std::vector<int> sel_fwd, sel_bwd;
   int sel_nghost;
-  deepmd::hpp::select_by_type(sel_fwd, sel_bwd, sel_nghost, coord_cpy, atype_cpy, nghost, sel_types);
+  deepmd::select_by_type(sel_fwd, sel_bwd, sel_nghost, coord_cpy, atype_cpy, nghost, sel_types);
   int sel_nall = sel_bwd.size();
   int sel_nloc = sel_nall - sel_nghost;
   std::vector<int> sel_atype(sel_bwd.size());
-  deepmd::hpp::select_map<int>(sel_atype, atype, sel_fwd, 1);
+  deepmd::select_map<int>(sel_atype, atype, sel_fwd, 1);
   // Yixiao: because the deeptensor already return the correct order, the following map is no longer needed
   // deepmd::AtomMap<double> nnp_map(sel_atype.begin(), sel_atype.begin() + sel_nloc);
   // const std::vector<int> & sort_fwd_map(nnp_map.get_fwd_map());
@@ -173,9 +175,9 @@ TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
   // compute the recp part of the ele interaction
   VALUETYPE eener;
   std::vector<VALUETYPE> eforce, evirial;
-  deepmd::hpp::Region<VALUETYPE> region;
+  deepmd::Region<VALUETYPE> region;
   init_region_cpu(region, &box[0]);
-  deepmd::hpp::EwaldParameters<VALUETYPE> eparam;
+  deepmd::EwaldParameters<VALUETYPE> eparam;
   eparam.beta = 0.2;
   eparam.spacing = 4;
   ewald_recp(eener, eforce, evirial, coord, charge, region, eparam);

--- a/source/api_c/tests/test_dipolecharge.cc
+++ b/source/api_c/tests/test_dipolecharge.cc
@@ -5,6 +5,7 @@
 #include <vector>
 #include "deepmd.hpp"
 #include "test_utils.h"
+#include "common.h"
 #include "ewald.h"
 #include "region.h"
 

--- a/source/api_c/tests/test_dipolecharge.cc
+++ b/source/api_c/tests/test_dipolecharge.cc
@@ -1,0 +1,239 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <algorithm>
+#include <fstream>
+#include <vector>
+#include "deepmd.hpp"
+#include "test_utils.h"
+
+template <class VALUETYPE>
+class TestDipoleCharge : public ::testing::Test
+{  
+protected:  
+  std::vector<VALUETYPE> coord = {
+    4.6067455554,    8.8719311819,    6.3886531197,
+    4.0044515745,    4.2449530507,    7.7902855220,
+    2.6453069446,    0.8772647726,    1.2804446790,
+    1.1445332290,    0.0067366438,    1.8606485070,
+    7.1002867706,    5.0325506787,    3.1805888348,
+    4.5352891138,    7.7389683929,    9.4260970128,
+    2.1833238914,    9.0916071034,    7.2299906064,
+    4.1040157820,    1.0496745045,    5.4748315591,
+  };
+  std::vector<int> atype = {
+    0,3,2,1,3,4,1,4
+  };
+  std::vector<VALUETYPE> box = {
+    10., 0., 0., 0., 10., 0., 0., 0., 10.
+  };
+  std::vector<double> expected_e = {
+    3.671081837126222158e+00
+  };
+  std::vector<VALUETYPE> expected_f = {
+    8.786854427753210128e-01,-1.590752486903602159e-01,-2.709225006303785932e-01,-4.449513960033193438e-01,-1.564291540964127813e-01,2.139031741772115178e-02,1.219699614140521193e+00,-5.580358618499958734e-02,-3.878662478349682585e-01,-1.286685244990778854e+00,1.886475802950296488e-01,3.904450515493615437e-01,1.605017382138404849e-02,2.138016869742287995e-01,-2.617514921203008965e-02,2.877081057057793712e-01,-3.846449683844421763e-01,3.048855616906603894e-02,-9.075632811311897807e-01,-6.509653472431625731e-03,2.302010972126376787e-01,2.370565856822822726e-01,3.600133435593881881e-01,1.243887532859055609e-02
+  };
+  std::vector<VALUETYPE> expected_v = {
+    3.714071471995848417e-01,6.957130186032146613e-01,-1.158289779017217302e+00,6.957130186032139951e-01,-1.400130091653774933e+01,-3.631620234653316626e-01,-1.158289779017217302e+00,-3.631620234653316626e-01,3.805077486043773050e+00
+  };
+  std::vector<VALUETYPE> charge_map = {
+    1., 1., 1., 1., 1., -1., -3.
+  };
+  int natoms;
+  int ntypes;
+  std::vector<int> type_asso;
+  double expected_tot_e;
+  std::vector<VALUETYPE>expected_tot_v;
+
+  deepmd::hpp::DeepTensor dp;
+  deepmd::hpp::DipoleChargeModifier dm;
+
+  void SetUp() override {
+    std::string file_name = "../../tests/infer/dipolecharge_e.pbtxt";
+    std::string model = "dipolecharge_e.pb";
+    deepmd::hpp::convert_pbtxt_to_pb(file_name, model);
+    dp.init(model, 0, "dipole_charge");
+    dm.init(model, 0, "dipole_charge");
+
+    natoms = atype.size();
+    ntypes = 5;
+    type_asso.resize(ntypes, -1);
+    type_asso[1] = 5;
+    type_asso[3] = 6;
+
+    EXPECT_EQ(natoms * 3, expected_f.size());
+    EXPECT_EQ(9, expected_v.size());
+  };
+
+  void TearDown() override {
+    remove( "dipolecharge_e.pb" ) ;
+  };
+};
+
+static bool
+_in_vec(const int & value,
+	const std::vector<int> & vec)
+{
+  // naive impl.
+  for(int ii = 0; ii < vec.size(); ++ii){
+    if(value == vec[ii]) return true;
+  }
+  return false;
+}
+
+TYPED_TEST_SUITE(TestDipoleCharge, ValueTypes);
+
+TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
+{
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<double>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  std::vector<VALUETYPE>& charge_map = this->charge_map;
+  int& natoms = this->natoms;
+  int& ntypes = this->ntypes;
+  std::vector<int>& type_asso = this->type_asso;
+  double& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>&expected_tot_v = this->expected_tot_v;
+  deepmd::hpp::DeepTensor& dp = this->dp;
+  deepmd::hpp::DipoleChargeModifier& dm = this->dm;
+  // build nlist
+  // float rc = dp.cutoff();
+  float rc = 4.0;
+  int nloc = coord.size() / 3;  
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;  
+  std::vector<std::vector<int > > nlist_data;
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+  	       coord, atype, box, rc);
+  int nall = coord_cpy.size() / 3;
+  int nghost = nall - nloc;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::hpp::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_data);  
+
+  // evaluate dipole
+  std::vector<VALUETYPE> dipole, dipole_recd(nloc*3, 0.0);
+  dp.compute(dipole, coord_cpy, atype_cpy, box, nall-nloc, inlist);
+
+  // add virtual atoms to the system
+  // // a lot of mappings
+  std::vector<int> sel_types = dp.sel_types();
+  std::vector<int> sel_fwd, sel_bwd;
+  int sel_nghost;
+  deepmd::hpp::select_by_type(sel_fwd, sel_bwd, sel_nghost, coord_cpy, atype_cpy, nghost, sel_types);
+  int sel_nall = sel_bwd.size();
+  int sel_nloc = sel_nall - sel_nghost;
+  std::vector<int> sel_atype(sel_bwd.size());
+  deepmd::hpp::select_map<int>(sel_atype, atype, sel_fwd, 1);
+  // Yixiao: because the deeptensor already return the correct order, the following map is no longer needed
+  // deepmd::AtomMap<double> nnp_map(sel_atype.begin(), sel_atype.begin() + sel_nloc);
+  // const std::vector<int> & sort_fwd_map(nnp_map.get_fwd_map());
+
+  // // add coords
+  std::vector<VALUETYPE > add_coord;
+  std::vector<int > add_atype;
+  std::vector<std::pair<int,int>> pairs;
+  for(int ii = 0; ii < nloc; ++ii){
+    if(_in_vec(atype[ii], sel_types)){
+      // Yixiao: the sort map is no longer needed
+      // int res_idx = sort_fwd_map[sel_fwd[ii]];
+      int res_idx = sel_fwd[ii];
+      std::vector<VALUETYPE > tmp_coord(3);
+      for(int dd = 0; dd < 3; ++dd){
+	tmp_coord[dd] = coord[ii*3+dd] + dipole[res_idx*3+dd];
+	dipole_recd[ii*3+dd] = dipole[res_idx*3+dd];
+      }
+      pairs.push_back(std::pair<int,int>(ii, add_atype.size()+atype.size()));
+      // std::cout << ii <<  " " 
+      // 		<< atype[ii] << " " 
+      // 		<< res_idx << " " 
+      // 		<< type_asso[atype[ii]] << " " 
+      // 		<< " pair "  
+      // 		<< pairs.back().first << " " << pairs.back().second << " "
+      // 		<< std::endl;
+      add_coord.insert(add_coord.end(), tmp_coord.begin(), tmp_coord.end());
+      add_atype.push_back(type_asso[atype[ii]]);      
+    }
+  }
+  coord.insert(coord.end(), add_coord.begin(), add_coord.end());
+  atype.insert(atype.end(), add_atype.begin(), add_atype.end());
+  nloc = atype.size();
+  EXPECT_EQ(atype.size()*3, coord.size());
+
+  // get charge value
+  std::vector<VALUETYPE> charge(nloc);
+  for(int ii = 0; ii < nloc; ++ii){
+    charge[ii] = charge_map[atype[ii]];
+  }
+  
+  // compute the recp part of the ele interaction
+  VALUETYPE eener;
+  std::vector<VALUETYPE> eforce, evirial;
+  deepmd::hpp::Region<VALUETYPE> region;
+  init_region_cpu(region, &box[0]);
+  deepmd::hpp::EwaldParameters<VALUETYPE> eparam;
+  eparam.beta = 0.2;
+  eparam.spacing = 4;
+  ewald_recp(eener, eforce, evirial, coord, charge, region, eparam);
+  
+  EXPECT_LT(fabs(eener - expected_e[0]), 1e-6);
+  EXPECT_EQ(eforce.size(), coord.size());
+  EXPECT_EQ(evirial.size(), 9);  
+
+  // extend the system with virtual atoms, and build nlist
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+  	       coord, atype, box, rc);
+  nall = coord_cpy.size() / 3;
+  nghost = nall - nloc;
+  ilist.resize(nloc);
+  numneigh.resize(nloc);
+  firstneigh.resize(nloc);
+  inlist.inum = nloc;
+  inlist.ilist = &ilist[0];
+  inlist.numneigh = &numneigh[0];
+  inlist.firstneigh = &firstneigh[0];
+  convert_nlist(inlist, nlist_data);
+
+  // compute force and virial
+  std::vector<VALUETYPE > force_, force, virial;
+  dm.compute(force_, virial, coord_cpy, atype_cpy, box, pairs, eforce, nghost, inlist);
+  // for(int ii = 0; ii < force_.size(); ++ii){
+  //   std::cout << force_[ii] << " " ;
+  // }
+  // std::cout << std::endl;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  // compare force
+  EXPECT_EQ(force.size(), nloc*3);
+  // note nloc > expected_f.size(), because nloc contains virtual atoms.
+  for(int ii = 0; ii < expected_f.size(); ++ii){
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), 1e-6);
+  }
+
+  // add recp virial and viral corr to virial
+  // virial = virial_recp + virial_dipolecharge + virial_corr
+  for (int dd0 = 0; dd0 < 3; ++dd0){
+    for (int dd1 = 0; dd1 < 3; ++dd1){
+      virial[dd0*3+dd1] += evirial[dd0*3+dd1];
+    }
+  }    
+  for(int ii = 0; ii < pairs.size(); ++ii){
+    int idx0 = pairs[ii].first;
+    int idx1 = pairs[ii].second;
+    for (int dd0 = 0; dd0 < 3; ++dd0){
+      for (int dd1 = 0; dd1 < 3; ++dd1){
+	virial[dd0*3+dd1] -= eforce[idx1*3+dd0] * dipole_recd[idx0*3+dd1];
+      }
+    }    
+  }
+  // compare virial
+  EXPECT_EQ(virial.size(), 3*3);
+  for(int ii = 0; ii < expected_v.size(); ++ii){
+    EXPECT_LT(fabs(virial[ii] - expected_v[ii]), 1e-5);
+  }
+}
+

--- a/source/api_cc/include/DataModifier.h
+++ b/source/api_cc/include/DataModifier.h
@@ -17,7 +17,7 @@ public:
   * @brief Dipole charge modifier without initialization.
   * @param[in] model The name of the frozen model file.
   * @param[in] gpu_rank The GPU rank. Default is 0.
-  * @param[in] file_content The content of the model file. If it is not empty, DP will read from the string instead of the file.
+  * @param[in] name_scope The name scope.
   **/
   DipoleChargeModifier(const std::string & model, 
 	       const int & gpu_rank = 0, 
@@ -27,7 +27,7 @@ public:
   * @brief Initialize the dipole charge modifier.
   * @param[in] model The name of the frozen model file.
   * @param[in] gpu_rank The GPU rank. Default is 0.
-  * @param[in] file_content The content of the model file. If it is not empty, DP will read from the string instead of the file.
+  * @param[in] name_scope The name scope.
   **/
   void init (const std::string & model, 
 	     const int & gpu_rank = 0, 

--- a/source/api_cc/include/DataModifier.h
+++ b/source/api_cc/include/DataModifier.h
@@ -3,19 +3,53 @@
 #include "DeepPot.h"
 
 namespace deepmd{
+/**
+* @brief Dipole charge modifier.
+**/
 class DipoleChargeModifier
 {
 public:
+  /**
+  * @brief Dipole charge modifier without initialization.
+  **/
   DipoleChargeModifier();
+  /**
+  * @brief Dipole charge modifier without initialization.
+  * @param[in] model The name of the frozen model file.
+  * @param[in] gpu_rank The GPU rank. Default is 0.
+  * @param[in] file_content The content of the model file. If it is not empty, DP will read from the string instead of the file.
+  **/
   DipoleChargeModifier(const std::string & model, 
 	       const int & gpu_rank = 0, 
 	       const std::string & name_scope = "");
   ~DipoleChargeModifier ();
+  /**
+  * @brief Initialize the dipole charge modifier.
+  * @param[in] model The name of the frozen model file.
+  * @param[in] gpu_rank The GPU rank. Default is 0.
+  * @param[in] file_content The content of the model file. If it is not empty, DP will read from the string instead of the file.
+  **/
   void init (const std::string & model, 
 	     const int & gpu_rank = 0, 
 	     const std::string & name_scope = "");
+  /**
+  * @brief Print the DP summary to the screen.
+  * @param[in] pre The prefix to each line.
+  **/
   void print_summary(const std::string &pre) const;
 public:
+  /**
+  * @brief Evaluate the force and virial correction by using this dipole charge modifier.
+  * @param[out] dfcorr_ The force correction on each atom.
+  * @param[out] dvcorr_ The virial correction.
+  * @param[in] dcoord_ The coordinates of atoms. The array should be of size natoms x 3.
+  * @param[in] datype_ The atom types. The list should contain natoms ints.
+  * @param[in] dbox The cell of the region. The array should be of size 9.
+  * @param[in] pairs The pairs of atoms. The list should contain npairs pairs of ints.
+  * @param[in] delef_ The electric field on each atom. The array should be of size natoms x 3.
+  * @param[in] nghost The number of ghost atoms.
+  * @param[in] lmp_list The neighbor list.
+  **/
   template<typename VALUETYPE>
   void compute (std::vector<VALUETYPE> &		dfcorr_,
 		std::vector<VALUETYPE> &		dvcorr_,
@@ -26,8 +60,20 @@ public:
 		const std::vector<VALUETYPE> &	delef_, 
 		const int			nghost,
 		const InputNlist &	lmp_list);
+  /**
+   * @brief Get cutoff radius.
+   * @return double cutoff radius.
+   */
   double cutoff () const {assert(inited); return rcut;};
+  /**
+   * @brief Get the number of atom types.
+   * @return int number of atom types.
+   */
   int numb_types () const {assert(inited); return ntypes;};
+  /**
+   * @brief Get the list of sel types.
+   * @return The list of sel types.
+   */
   std::vector<int> sel_types () const {assert(inited); return sel_type;};
 private:
   tensorflow::Session* session;

--- a/source/api_cc/include/DeepTensor.h
+++ b/source/api_cc/include/DeepTensor.h
@@ -162,6 +162,10 @@ public:
   * @return The output dimension.
   **/
   int output_dim () const {assert(inited); return odim;};
+  /**
+   * @brief Get the list of sel types.
+   * @return The list of sel types.
+   */
   const std::vector<int> & sel_types () const {assert(inited); return sel_type;};
 private:
   tensorflow::Session* session;

--- a/source/api_cc/src/DataModifier.cc
+++ b/source/api_cc/src/DataModifier.cc
@@ -17,7 +17,7 @@ DipoleChargeModifier(const std::string & model,
     : inited (false), name_scope(name_scope_),
       graph_def(new GraphDef())
 {
-  init(model, gpu_rank);  
+  init(model, gpu_rank, name_scope_);  
 }
 
 DipoleChargeModifier::

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -17,7 +17,7 @@ DeepTensor(const std::string & model,
     : inited (false), name_scope(name_scope_),
       graph_def(new GraphDef())
 {
-  init(model, gpu_rank);  
+  init(model, gpu_rank, name_scope_);  
 }
 
 DeepTensor::~DeepTensor() {


### PR DESCRIPTION
Add `DipoleChargeModifier` to C API.

In addition, this patch also contains the following changes:
* fix bugs in `deepmd::DeepTensor::DeepTensor` and `deepmd::DipoleChargeModifier::DipoleChargeModifier`
* add comments to `deepmd::DipoleChargeModifier`
* support `gpu_rank` and other parameters for `deepmd::hpp::DeepPot` and `deepmd::hpp::DeepTensor`