### PR TITLE
merge print_summary and add it to C API

### DIFF
--- a/source/api_c/include/c_api.h
+++ b/source/api_c/include/c_api.h
@@ -671,6 +671,14 @@ extern void DP_ConvertPbtxtToPb(
   const char* c_pb
   );
 
+/**
+ * @brief Print the summary of DeePMD-kit, including the version and the build information.
+ * @param[in] c_pre The prefix to each line.
+ */
+extern void DP_PrintSummary(
+  const char* c_pre
+  );
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -701,6 +701,14 @@ namespace deepmd
                 type_map.assign(type_map_c);
                 delete[] type_map_c;
             };
+            /**
+             * @brief Print the summary of DeePMD-kit, including the version and the build information.
+             * @param[in] pre The prefix to each line.
+             */
+            void print_summary(const std::string &pre) const
+            {
+                DP_PrintSummary(pre.c_str());
+            }
 
         private:
             DP_DeepPot *dp;
@@ -1213,6 +1221,14 @@ namespace deepmd
                 std::vector<int> sel_types_vec = std::vector<int>(sel_types_arr, sel_types_arr + nsel_types);
                 return sel_types_vec;
             }
+            /**
+             * @brief Print the summary of DeePMD-kit, including the version and the build information.
+             * @param[in] pre The prefix to each line.
+             */
+            void print_summary(const std::string &pre) const
+            {
+                DP_PrintSummary(pre.c_str());
+            }
 
         private:
             DP_DeepTensor *dt;
@@ -1321,6 +1337,15 @@ namespace deepmd
                 int* sel_types_arr = DP_DipoleChargeModifierGetSelTypes(dcm);
                 std::vector<int> sel_types_vec = std::vector<int>(sel_types_arr, sel_types_arr + nsel_types);
                 return sel_types_vec;
+            }
+
+            /**
+             * @brief Print the summary of DeePMD-kit, including the version and the build information.
+             * @param[in] pre The prefix to each line.
+             */
+            void print_summary(const std::string &pre) const
+            {
+                DP_PrintSummary(pre.c_str());
             }
         private:
             DP_DipoleChargeModifier *dcm;

--- a/source/api_c/src/c_api.cc
+++ b/source/api_c/src/c_api.cc
@@ -1004,4 +1004,11 @@ void DP_ConvertPbtxtToPb(
     deepmd::convert_pbtxt_to_pb(pbtxt, pb);
 }
 
+void DP_PrintSummary(
+    const char* c_pre
+    ) {
+    std::string pre(c_pre);
+    deepmd::print_summary(pre);
+}
+
 } // extern "C"

--- a/source/api_c/tests/test_deeppolar_hpp.cc
+++ b/source/api_c/tests/test_deeppolar_hpp.cc
@@ -336,5 +336,5 @@ TYPED_TEST(TestInferDeepPolarNew, cpu_lmp_nlist)
 TYPED_TEST(TestInferDeepPolarNew, print_summary)
 {
   deepmd::DeepTensor& dp = this->dp;
-  dp.print_summary();
+  dp.print_summary("");
 }

--- a/source/api_c/tests/test_deeppolar_hpp.cc
+++ b/source/api_c/tests/test_deeppolar_hpp.cc
@@ -333,3 +333,8 @@ TYPED_TEST(TestInferDeepPolarNew, cpu_lmp_nlist)
   }
 }
 
+TYPED_TEST(TestInferDeepPolarNew, print_summary)
+{
+  deepmd::DeepTensor& dp = this->dp;
+  dp.print_summary();
+}

--- a/source/api_c/tests/test_deeppolar_hpp.cc
+++ b/source/api_c/tests/test_deeppolar_hpp.cc
@@ -335,6 +335,6 @@ TYPED_TEST(TestInferDeepPolarNew, cpu_lmp_nlist)
 
 TYPED_TEST(TestInferDeepPolarNew, print_summary)
 {
-  deepmd::DeepTensor& dp = this->dp;
+  deepmd::hpp::DeepTensor& dp = this->dp;
   dp.print_summary("");
 }

--- a/source/api_c/tests/test_deeppot_a_hpp.cc
+++ b/source/api_c/tests/test_deeppot_a_hpp.cc
@@ -462,7 +462,7 @@ TYPED_TEST(TestInferDeepPotAHPP, cpu_lmp_nlist_type_sel)
 
 TYPED_TEST(TestInferDeepPotAHPP, print_summary)
 {
-  deepmd::DeepPot& dp = this->dp;
+  deepmd::hpp::DeepPot& dp = this->dp;
   dp.print_summary("");
 }
 

--- a/source/api_c/tests/test_deeppot_a_hpp.cc
+++ b/source/api_c/tests/test_deeppot_a_hpp.cc
@@ -460,6 +460,12 @@ TYPED_TEST(TestInferDeepPotAHPP, cpu_lmp_nlist_type_sel)
   }
 }
 
+TYPED_TEST(TestInferDeepPotAHPP, print_summary)
+{
+  deepmd::DeepPot& dp = this->dp;
+  dp.print_summary();
+}
+
 
 template <class VALUETYPE>
 class TestInferDeepPotANoPbcHPP : public ::testing::Test

--- a/source/api_c/tests/test_deeppot_a_hpp.cc
+++ b/source/api_c/tests/test_deeppot_a_hpp.cc
@@ -463,7 +463,7 @@ TYPED_TEST(TestInferDeepPotAHPP, cpu_lmp_nlist_type_sel)
 TYPED_TEST(TestInferDeepPotAHPP, print_summary)
 {
   deepmd::DeepPot& dp = this->dp;
-  dp.print_summary();
+  dp.print_summary("");
 }
 
 

--- a/source/api_c/tests/test_dipolecharge.cc
+++ b/source/api_c/tests/test_dipolecharge.cc
@@ -242,6 +242,6 @@ TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
 
 TYPED_TEST(TestDipoleCharge, print_summary)
 {
-  deepmd::DipoleChargeModifier& dm = this->dm;
+  deepmd::hpp::DipoleChargeModifier& dm = this->dm;
   dm.print_summary("");
 }

--- a/source/api_c/tests/test_dipolecharge.cc
+++ b/source/api_c/tests/test_dipolecharge.cc
@@ -240,3 +240,8 @@ TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
   }
 }
 
+TYPED_TEST(TestDipoleCharge, print_summary)
+{
+  deepmd::DipoleChargeModifier& dm = this->dm;
+  dm.print_summary();
+}

--- a/source/api_c/tests/test_dipolecharge.cc
+++ b/source/api_c/tests/test_dipolecharge.cc
@@ -243,5 +243,5 @@ TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
 TYPED_TEST(TestDipoleCharge, print_summary)
 {
   deepmd::DipoleChargeModifier& dm = this->dm;
-  dm.print_summary();
+  dm.print_summary("");
 }

--- a/source/api_cc/include/common.h
+++ b/source/api_cc/include/common.h
@@ -249,5 +249,12 @@ read_file_to_string(std::string model, std::string & file_content);
 **/
 void
 convert_pbtxt_to_pb(std::string fn_pb_txt, std::string fn_pb);
+
+/**
+ * @brief Print the summary of DeePMD-kit, including the version and the build information.
+ * @param[in] pre The prefix to each line.
+ */
+void
+print_summary(const std::string &pre);
 }
 

--- a/source/api_cc/src/DataModifier.cc
+++ b/source/api_cc/src/DataModifier.cc
@@ -343,3 +343,10 @@ compute <float> (std::vector<float> &		dfcorr_,
 	 const std::vector<float> &		delef_, 
 	 const int				nghost,
 	 const InputNlist &		lmp_list);
+
+void 
+DipoleChargeModifier::
+print_summary(const std::string &pre) const
+{
+  deepmd::print_summary(pre);
+}

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -331,23 +331,7 @@ void
 DeepPot::
 print_summary(const std::string &pre) const
 {
-  std::cout << pre << "installed to:       " + global_install_prefix << std::endl;
-  std::cout << pre << "source:             " + global_git_summ << std::endl;
-  std::cout << pre << "source branch:       " + global_git_branch << std::endl;
-  std::cout << pre << "source commit:      " + global_git_hash << std::endl;
-  std::cout << pre << "source commit at:   " + global_git_date << std::endl;
-  std::cout << pre << "surpport model ver.:" + global_model_version << std::endl;
-#if defined(GOOGLE_CUDA)
-  std::cout << pre << "build variant:      cuda" << std::endl;
-#elif defined(TENSORFLOW_USE_ROCM)
-  std::cout << pre << "build variant:      rocm" << std::endl;
-#else
-  std::cout << pre << "build variant:      cpu" << std::endl;
-#endif
-  std::cout << pre << "build with tf inc:  " + global_tf_include_dir << std::endl;
-  std::cout << pre << "build with tf lib:  " + global_tf_lib << std::endl;
-  std::cout << pre << "set tf intra_op_parallelism_threads: " <<  num_intra_nthreads << std::endl;
-  std::cout << pre << "set tf inter_op_parallelism_threads: " <<  num_inter_nthreads << std::endl;
+  deepmd::print_summary(pre);
 }
 
 template<class VT>

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -68,16 +68,7 @@ void
 DeepTensor::
 print_summary(const std::string &pre) const
 {
-  std::cout << pre << "installed to:       " + global_install_prefix << std::endl;
-  std::cout << pre << "source:             " + global_git_summ << std::endl;
-  std::cout << pre << "source branch:      " + global_git_branch << std::endl;
-  std::cout << pre << "source commit:      " + global_git_hash << std::endl;
-  std::cout << pre << "source commit at:   " + global_git_date << std::endl;
-  std::cout << pre << "surpport model ver.:" + global_model_version << std::endl;
-  std::cout << pre << "build with tf inc:  " + global_tf_include_dir << std::endl;
-  std::cout << pre << "build with tf lib:  " + global_tf_lib << std::endl;
-  std::cout << pre << "set tf intra_op_parallelism_threads: " <<  num_intra_nthreads << std::endl;
-  std::cout << pre << "set tf inter_op_parallelism_threads: " <<  num_inter_nthreads << std::endl;
+  deepmd::print_summary(pre);
 }
 
 template<class VT>

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -1090,7 +1090,7 @@ session_input_tensors<float, float> (std::vector<std::pair<std::string, tensorfl
 
 void
 deepmd::
-print_summary(const std::string &pre) const
+print_summary(const std::string &pre)
 {
   int num_intra_nthreads, num_inter_nthreads;
   deepmd::get_env_nthreads(num_intra_nthreads, num_inter_nthreads);

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -1092,6 +1092,8 @@ void
 deepmd::
 print_summary(const std::string &pre) const
 {
+  int num_intra_nthreads, num_inter_nthreads;
+  deepmd::get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
   std::cout << pre << "installed to:       " + global_install_prefix << "\n";
   std::cout << pre << "source:             " + global_git_summ << "\n";
   std::cout << pre << "source branch:       " + global_git_branch << "\n";

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -1087,3 +1087,26 @@ session_input_tensors<float, float> (std::vector<std::pair<std::string, tensorfl
 		       const int			nghost,
 		       const int			ago,
 		       const std::string		scope);
+
+void
+deepmd::
+print_summary(const std::string &pre) const
+{
+  std::cout << pre << "installed to:       " + global_install_prefix << "\n";
+  std::cout << pre << "source:             " + global_git_summ << "\n";
+  std::cout << pre << "source branch:       " + global_git_branch << "\n";
+  std::cout << pre << "source commit:      " + global_git_hash << "\n";
+  std::cout << pre << "source commit at:   " + global_git_date << "\n";
+  std::cout << pre << "surpport model ver.:" + global_model_version << "\n";
+#if defined(GOOGLE_CUDA)
+  std::cout << pre << "build variant:      cuda" << "\n";
+#elif defined(TENSORFLOW_USE_ROCM)
+  std::cout << pre << "build variant:      rocm" << "\n";
+#else
+  std::cout << pre << "build variant:      cpu" << "\n";
+#endif
+  std::cout << pre << "build with tf inc:  " + global_tf_include_dir << "\n";
+  std::cout << pre << "build with tf lib:  " + global_tf_lib << "\n";
+  std::cout << pre << "set tf intra_op_parallelism_threads: " <<  num_intra_nthreads << "\n";
+  std::cout << pre << "set tf inter_op_parallelism_threads: " <<  num_inter_nthreads << std::endl;
+}

--- a/source/api_cc/tests/test_deeppolar.cc
+++ b/source/api_cc/tests/test_deeppolar.cc
@@ -341,5 +341,5 @@ TYPED_TEST(TestInferDeepPolarNew, cpu_lmp_nlist)
 TYPED_TEST(TestInferDeepPolarNew, print_summary)
 {
   deepmd::DeepTensor& dp = this->dp;
-  dp.print_summary();
+  dp.print_summary("");
 }

--- a/source/api_cc/tests/test_deeppolar.cc
+++ b/source/api_cc/tests/test_deeppolar.cc
@@ -338,3 +338,8 @@ TYPED_TEST(TestInferDeepPolarNew, cpu_lmp_nlist)
   }
 }
 
+TYPED_TEST(TestInferDeepPolarNew, print_summary)
+{
+  deepmd::DeepTensor& dp = this->dp;
+  dp.print_summary();
+}

--- a/source/api_cc/tests/test_deeppot_a.cc
+++ b/source/api_cc/tests/test_deeppot_a.cc
@@ -527,6 +527,12 @@ TYPED_TEST(TestInferDeepPotA, cpu_lmp_nlist_type_sel_atomic)
   }
 }
 
+TYPED_TEST(TestInferDeepPotA, print_summary)
+{
+  deepmd::DeepPot& dp = this->dp;
+  dp.print_summary();
+}
+
 
 template <class VALUETYPE>
 class TestInferDeepPotANoPbc : public ::testing::Test

--- a/source/api_cc/tests/test_deeppot_a.cc
+++ b/source/api_cc/tests/test_deeppot_a.cc
@@ -530,7 +530,7 @@ TYPED_TEST(TestInferDeepPotA, cpu_lmp_nlist_type_sel_atomic)
 TYPED_TEST(TestInferDeepPotA, print_summary)
 {
   deepmd::DeepPot& dp = this->dp;
-  dp.print_summary();
+  dp.print_summary("");
 }
 
 

--- a/source/api_cc/tests/test_dipolecharge.cc
+++ b/source/api_cc/tests/test_dipolecharge.cc
@@ -245,3 +245,8 @@ TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
   }
 }
 
+TYPED_TEST(TestDipoleCharge, print_summary)
+{
+  deepmd::DipoleChargeModifier& dm = this->dm;
+  dm.print_summary();
+}

--- a/source/api_cc/tests/test_dipolecharge.cc
+++ b/source/api_cc/tests/test_dipolecharge.cc
@@ -248,5 +248,5 @@ TYPED_TEST(TestDipoleCharge, cpu_lmp_nlist)
 TYPED_TEST(TestDipoleCharge, print_summary)
 {
   deepmd::DipoleChargeModifier& dm = this->dm;
-  dm.print_summary();
+  dm.print_summary("");
 }


### PR DESCRIPTION
* merge the implementation of `deepmd::DeepPot::print_summary` and `deepmd::DeepTensor::print_summary` to `deepmd::print_summary`
* add the implementation of `deepmd::DipoleChargeModifier::print_summary`
* add `DP_PrintSummary`, `deepmd::hpp::DeepPot::print_summary`, `deepmd::hpp::DeepTensor::print_summary`, and `deepmd::hpp::DipoleChargeModifier::print_summary`
* add tests for above
