### PR TITLE
support the custom training times for each frame

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -122,6 +122,7 @@ def add_data_requirement(
     type_sel: Optional[bool] = None,
     repeat: int = 1,
     default: float = 0.,
+    dtype: Optional[np.dtype] = None,
 ):
     """Specify data requirements for training.
 
@@ -145,6 +146,8 @@ def add_data_requirement(
         if specify repaeat data `repeat` times, by default 1
     default : float, optional, default=0.
         default value of data
+    dtype : np.dtype, optional
+        the dtype of data, overwrites `high_prec` if provided
     """
     data_requirement[key] = {
         "ndof": ndof,
@@ -154,6 +157,7 @@ def add_data_requirement(
         "type_sel": type_sel,
         "repeat": repeat,
         "default": default,
+        "dtype": dtype,
     }
 
 

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -431,7 +431,7 @@ class DeepmdData() :
         nframes = data['coord'].shape[0]
         idx = np.arange (nframes)
         # probability (frequency, the number of visiting) of each frame
-        idx = np.repeat(idx, data['prob'])
+        idx = np.repeat(idx, np.reshape(data['prob'], (nframes,)))
         dp_random.shuffle(idx)
         for kk in data :
             if type(data[kk]) == np.ndarray and \

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -98,8 +98,8 @@ class DeepmdData() :
         # add box and coord
         self.add('box', 9, must = self.pbc)
         self.add('coord', 3, atomic = True, must = True)
-        # probability (frequency) of each frame
-        self.add('prob', 1, must=False, default=1, dtype=int)
+        # the training times of each frame
+        self.add('numb_copy', 1, must=False, default=1, dtype=int)
         # set counters
         self.set_count = 0
         self.iterator = 0
@@ -430,8 +430,8 @@ class DeepmdData() :
         ret = {}
         nframes = data['coord'].shape[0]
         idx = np.arange (nframes)
-        # probability (frequency, the number of visiting) of each frame
-        idx = np.repeat(idx, np.reshape(data['prob'], (nframes,)))
+        # the training times of each frame
+        idx = np.repeat(idx, np.reshape(data['numb_copy'], (nframes,)))
         dp_random.shuffle(idx)
         for kk in data :
             if type(data[kk]) == np.ndarray and \

--- a/doc/data/system.md
+++ b/doc/data/system.md
@@ -18,8 +18,9 @@ coord    | Atomic coordinates      | coord.raw      | Å    | Required          
 box      | Boxes                   | box.raw        | Å    | Required if periodic | Nframes \* 3 \* 3        | in the order `XX XY XZ YX YY YZ ZX ZY ZZ`
 fparam   | Extra frame parameters  | fparam.raw     | Any  | Optional             | Nframes \* Any           |
 aparam   | Extra atomic parameters | aparam.raw     | Any  | Optional             | Nframes \* aparam \* Any |
+prob     | Probability of each frame | prob.raw     | 1    | Optional             | Nframes                  | Integer; Default is 1 for all frames
 
-The labeled frame properties is listed as follows, all of which will be used for training if and only if the loss function contains such property:
+The labeled frame properties are listed as follows, all of which will be used for training if and only if the loss function contains such property:
 
 ID                     | Property                 | Raw file                 | Unit   | Shape                    | Description
 ---------------------- | -----------------------  | ------------------------ | ----   | -----------------------  | -----------

--- a/doc/data/system.md
+++ b/doc/data/system.md
@@ -18,7 +18,7 @@ coord    | Atomic coordinates      | coord.raw      | Å    | Required          
 box      | Boxes                   | box.raw        | Å    | Required if periodic | Nframes \* 3 \* 3        | in the order `XX XY XZ YX YY YZ ZX ZY ZZ`
 fparam   | Extra frame parameters  | fparam.raw     | Any  | Optional             | Nframes \* Any           |
 aparam   | Extra atomic parameters | aparam.raw     | Any  | Optional             | Nframes \* aparam \* Any |
-prob     | Probability of each frame | prob.raw     | 1    | Optional             | Nframes                  | Integer; Default is 1 for all frames
+numb_copy     | The training times of each frame | prob.raw     | 1    | Optional             | Nframes                  | Integer; Default is 1 for all frames
 
 The labeled frame properties are listed as follows, all of which will be used for training if and only if the loss function contains such property:
 

--- a/doc/data/system.md
+++ b/doc/data/system.md
@@ -18,7 +18,7 @@ coord    | Atomic coordinates      | coord.raw      | Å    | Required          
 box      | Boxes                   | box.raw        | Å    | Required if periodic | Nframes \* 3 \* 3        | in the order `XX XY XZ YX YY YZ ZX ZY ZZ`
 fparam   | Extra frame parameters  | fparam.raw     | Any  | Optional             | Nframes \* Any           |
 aparam   | Extra atomic parameters | aparam.raw     | Any  | Optional             | Nframes \* aparam \* Any |
-numb_copy     | The training times of each frame | prob.raw     | 1    | Optional             | Nframes                  | Integer; Default is 1 for all frames
+numb_copy     | Each frame is copied by the `numb_copy` (int) times | prob.raw     | 1    | Optional             | Nframes                  | Integer; Default is 1 for all frames
 
 The labeled frame properties are listed as follows, all of which will be used for training if and only if the loss function contains such property:
 

--- a/source/tests/test_deepmd_data.py
+++ b/source/tests/test_deepmd_data.py
@@ -191,7 +191,7 @@ class TestData (unittest.TestCase) :
         data = dd._load_set(os.path.join(self.data_name, 'set.foo'))
         data_bk = copy.deepcopy(data)
         data, idx = dd._shuffle_data(data)
-        assert idx.size == prob.size
+        assert idx.size == np.sum(prob)
         self._comp_np_mat2(data_bk['coord'][idx,:], 
                            data['coord'])
         self._comp_np_mat2(data_bk['test_atomic'][idx,:], 

--- a/source/tests/test_deepmd_data.py
+++ b/source/tests/test_deepmd_data.py
@@ -181,8 +181,8 @@ class TestData (unittest.TestCase) :
         self._comp_np_mat2(data_bk['test_frame'][idx,:], 
                            data['test_frame'])
 
-    def test_shuffle_with_prob(self):
-        path = os.path.join(self.data_name, 'set.foo', 'prob.npy')
+    def test_shuffle_with_numb_copy(self):
+        path = os.path.join(self.data_name, 'set.foo', 'numb_copy.npy')
         prob = np.arange(self.nframes)
         np.save(path, prob)
         dd = DeepmdData(self.data_name)\

--- a/source/tests/test_deepmd_data.py
+++ b/source/tests/test_deepmd_data.py
@@ -181,6 +181,24 @@ class TestData (unittest.TestCase) :
         self._comp_np_mat2(data_bk['test_frame'][idx,:], 
                            data['test_frame'])
 
+    def test_shuffle_with_prob(self):
+        path = os.path.join(self.data_name, 'set.foo', 'prob.npy')
+        prob = np.arange(self.nframes)
+        np.save(path, prob)
+        dd = DeepmdData(self.data_name)\
+             .add('test_atomic', 7, atomic=True, must=True)\
+             .add('test_frame', 5, atomic=False, must=True)
+        data = dd._load_set(os.path.join(self.data_name, 'set.foo'))
+        data_bk = copy.deepcopy(data)
+        data, idx = dd._shuffle_data(data)
+        assert idx.size == prob.size
+        self._comp_np_mat2(data_bk['coord'][idx,:], 
+                           data['coord'])
+        self._comp_np_mat2(data_bk['test_atomic'][idx,:], 
+                           data['test_atomic'])
+        self._comp_np_mat2(data_bk['test_frame'][idx,:], 
+                           data['test_frame'])
+
     def test_reduce(self) :
         dd = DeepmdData(self.data_name)\
              .add('test_atomic', 7, atomic=True, must=True)


### PR DESCRIPTION
Before, `sys_probs` only specifies the probability of each system. This patch allows `numb_copy.npy` (`int`) to specify each frame is copied by the "numb_copy" (int) times. The default is 1 for all frames, which keeps the same behavior as before.