### PR TITLE
fix `dp freeze` for multi-task when `atom_ener` is set

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -166,6 +166,8 @@ REMOVE_SUFFIX_DICT = {
     "model_attr/sel_type_{}": "model_attr/sel_type",
     "model_attr/output_dim_{}": "model_attr/output_dim",
     "_{}/": "/",
+    # when atom_ener is set
+    "_{}_1/": "_1/",
     "o_energy_{}": "o_energy",
     "o_force_{}": "o_force",
     "o_virial_{}": "o_virial",


### PR DESCRIPTION
When `atom_ener` is set, there will be variables named `layer_xx_suffix_1/MatMul` (the automatic name when  `layer_xx_suffix/MatMul` has been used).