### PR TITLE
bump minimal dargs version to 0.2.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     'numpy',
     'scipy',
     'pyyaml',
-    'dargs >= 0.2.6',
+    'dargs >= 0.2.9',
     'python-hostlist >= 1.21',
     'typing_extensions; python_version < "3.7"',
     'importlib_metadata>=1.4; python_version < "3.8"',


### PR DESCRIPTION
0.2.8 does not pass the tests. See https://github.com/njzjz/deepmd-kit/actions/runs/3890065119/jobs/6638845358. See also https://github.com/deepmodeling/dargs/pull/8.