### PR TITLE
load libcublasLt before libcublas

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -40,8 +40,8 @@ def dlopen_library(module: str, filename: str):
 # dlopen pip cuda library before tensorflow
 if platform.system() == "Linux":
     dlopen_library("nvidia.cuda_runtime.lib", "libcudart.so*")
-    dlopen_library("nvidia.cublas.lib", "libcublas.so*")
     dlopen_library("nvidia.cublas.lib", "libcublasLt.so*")
+    dlopen_library("nvidia.cublas.lib", "libcublas.so*")
     dlopen_library("nvidia.cufft.lib", "libcufft.so*")
     dlopen_library("nvidia.curand.lib", "libcurand.so*")
     dlopen_library("nvidia.cusolver.lib", "libcusolver.so*")


### PR DESCRIPTION
This fixes an error:
```
OSError: /home/jz748/anaconda3/envs/tf/lib/python3.10/site-packages/nvidia/cublas/lib/libcublas.so.11: symbol cublasLtHSHMatmulAlgoInit, version libcublasLt.so.11 not defined in file libcublasLt.so.11 with link time reference
```
