### PR TITLE
support restarting from compressed checkpoints

### DIFF
--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -129,6 +129,7 @@ class EnerModel(Model) :
                mesh,
                input_dict,
                frz_model = None,
+               ckpt_meta = None,
                suffix = '', 
                reuse = None):
  
@@ -172,7 +173,7 @@ class EnerModel(Model) :
             input_dict['type_embedding'] = type_embedding
         input_dict['atype'] = atype_
 
-        if frz_model == None:
+        if frz_model is None and ckpt_meta is None:
             dout \
                 = self.descrpt.build(coord_,
                                      atype_,
@@ -192,8 +193,14 @@ class EnerModel(Model) :
                 dtype = tf.int32)
             feed_dict = self.descrpt.get_feed_dict(coord_, atype_, natoms, box, mesh)
             return_elements = [*self.descrpt.get_tensor_names(), 'o_descriptor:0']
-            imported_tensors \
-                = self._import_graph_def_from_frz_model(frz_model, feed_dict, return_elements)
+            if frz_model is not None:
+                imported_tensors \
+                    = self._import_graph_def_from_frz_model(frz_model, feed_dict, return_elements)
+            elif ckpt_meta is not None:
+                imported_tensors \
+                    = self._import_graph_def_from_ckpt_meta(ckpt_meta, feed_dict, return_elements)
+            else:
+                raise RuntimeError("should not reach here")  # pragma: no cover
             dout = imported_tensors[-1]
             self.descrpt.pass_tensors_from_frz_model(*imported_tensors[:-1])
 
@@ -288,8 +295,18 @@ class EnerModel(Model) :
         return model_dict
 
     def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
+        return_nodes = [x[:-2] for x in return_elements]
         graph, graph_def = load_graph_def(frz_model)
-        return tf.import_graph_def(graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
+        sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
+        return tf.import_graph_def(sub_graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
+
+    def _import_graph_def_from_ckpt_meta(self, ckpt_meta: str, feed_dict: dict, return_elements: List[str]):
+        return_nodes = [x[:-2] for x in return_elements]
+        with tf.Graph().as_default() as graph:
+            tf.train.import_meta_graph(f"{ckpt_meta}.meta", clear_devices=True)
+            graph_def = graph.as_graph_def()
+            sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
+        return tf.import_graph_def(sub_graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
 
     def init_variables(self,
                        graph : tf.Graph,

--- a/deepmd/model/ener.py
+++ b/deepmd/model/ener.py
@@ -1,10 +1,8 @@
 import numpy as np
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 from deepmd.env import tf
 from deepmd.utils.pair_tab import PairTab
-from deepmd.utils.graph import load_graph_def, get_tensor_by_name_from_graph
-from deepmd.utils.errors import GraphWithoutTensorError
 from deepmd.env import global_cvt_2_ener_float, MODEL_VERSION, GLOBAL_TF_FLOAT_PRECISION
 from deepmd.env import op_module
 from .model import Model
@@ -129,7 +127,7 @@ class EnerModel(Model) :
                mesh,
                input_dict,
                frz_model = None,
-               ckpt_meta = None,
+               ckpt_meta: Optional[str] = None,
                suffix = '', 
                reuse = None):
  
@@ -173,37 +171,12 @@ class EnerModel(Model) :
             input_dict['type_embedding'] = type_embedding
         input_dict['atype'] = atype_
 
-        if frz_model is None and ckpt_meta is None:
-            dout \
-                = self.descrpt.build(coord_,
-                                     atype_,
-                                     natoms,
-                                     box,
-                                     mesh,
-                                     input_dict,
-                                     suffix = suffix,
-                                     reuse = reuse)
-            dout = tf.identity(dout, name='o_descriptor')
-        else:
-            tf.constant(self.rcut,
-                name = 'descrpt_attr/rcut',
-                dtype = GLOBAL_TF_FLOAT_PRECISION)
-            tf.constant(self.ntypes,
-                name = 'descrpt_attr/ntypes',
-                dtype = tf.int32)
-            feed_dict = self.descrpt.get_feed_dict(coord_, atype_, natoms, box, mesh)
-            return_elements = [*self.descrpt.get_tensor_names(), 'o_descriptor:0']
-            if frz_model is not None:
-                imported_tensors \
-                    = self._import_graph_def_from_frz_model(frz_model, feed_dict, return_elements)
-            elif ckpt_meta is not None:
-                imported_tensors \
-                    = self._import_graph_def_from_ckpt_meta(ckpt_meta, feed_dict, return_elements)
-            else:
-                raise RuntimeError("should not reach here")  # pragma: no cover
-            dout = imported_tensors[-1]
-            self.descrpt.pass_tensors_from_frz_model(*imported_tensors[:-1])
-
+        dout = self.build_descrpt(
+            coord, atype, natoms, box, mesh, input_dict,
+            frz_model=frz_model,
+            ckpt_meta=ckpt_meta,
+            suffix=suffix,
+            reuse=reuse)
 
         if self.srtab is not None :
             nlist, rij, sel_a, sel_r = self.descrpt.get_nlist()
@@ -293,20 +266,6 @@ class EnerModel(Model) :
         model_dict['atype'] = atype
         
         return model_dict
-
-    def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
-        return_nodes = [x[:-2] for x in return_elements]
-        graph, graph_def = load_graph_def(frz_model)
-        sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
-        return tf.import_graph_def(sub_graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
-
-    def _import_graph_def_from_ckpt_meta(self, ckpt_meta: str, feed_dict: dict, return_elements: List[str]):
-        return_nodes = [x[:-2] for x in return_elements]
-        with tf.Graph().as_default() as graph:
-            tf.train.import_meta_graph(f"{ckpt_meta}.meta", clear_devices=True)
-            graph_def = graph.as_graph_def()
-            sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
-        return tf.import_graph_def(sub_graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
 
     def init_variables(self,
                        graph : tf.Graph,

--- a/deepmd/model/model.py
+++ b/deepmd/model/model.py
@@ -1,7 +1,55 @@
-from deepmd.env import tf
+from typing import Optional, Union
+from abc import ABC, abstractmethod
 
+from deepmd.env import tf, GLOBAL_TF_FLOAT_PRECISION
+from deepmd.utils.graph import load_graph_def
 
-class Model:
+class Model(ABC):
+    @abstractmethod
+    def build (
+        self,
+        coord_: tf.Tensor,
+        atype_: tf.Tensor,
+        natoms: tf.Tensor,
+        box: tf.Tensor,
+        mesh: tf.Tensor,
+        input_dict: dict,
+        frz_model: Optional[str] = None,
+        ckpt_meta: Optional[str] = None,
+        suffix: str = '', 
+        reuse: Optional[Union[bool, tf.AUTO_REUSE]] = None
+    ):
+        """Build the model.
+
+        Parameters
+        ----------
+        coord_ : tf.Tensor
+            The coordinates of atoms
+        atype_ : tf.Tensor
+            The atom types of atoms
+        natoms : tf.Tensor
+            The number of atoms
+        box : tf.Tensor
+            The box vectors
+        mesh : tf.Tensor
+            The mesh vectors
+        input_dict : dict
+            The input dict
+        frz_model : str, optional
+            The path to the frozen model
+        ckpt_meta : str, optional
+            The path to the checkpoint and meta file
+        suffix : str, optional
+            The suffix of the scope
+        reuse : bool or tf.AUTO_REUSE, optional
+            Whether to reuse the variables
+
+        Returns
+        -------
+        dict
+            The output dict
+        """
+
     def init_variables(self,
                        graph : tf.Graph,
                        graph_def : tf.GraphDef,
@@ -23,3 +71,92 @@ class Model:
             suffix to name scope
         """
         raise RuntimeError("The 'dp train init-frz-model' command do not support this model!")
+
+    def build_descrpt(
+            self,
+            coord_: tf.Tensor,
+            atype_: tf.Tensor,
+            natoms: tf.Tensor,
+            box: tf.Tensor,
+            mesh: tf.Tensor,
+            input_dict: dict,
+            frz_model: Optional[str] = None,
+            ckpt_meta: Optional[str] = None,
+            suffix: str = '', 
+            reuse: Optional[Union[bool, tf.AUTO_REUSE]] = None
+        ):
+        """Build the descriptor part of the model.
+
+        Parameters
+        ----------
+        coord_ : tf.Tensor
+            The coordinates of atoms
+        atype_ : tf.Tensor
+            The atom types of atoms
+        natoms : tf.Tensor
+            The number of atoms
+        box : tf.Tensor
+            The box vectors
+        mesh : tf.Tensor
+            The mesh vectors
+        input_dict : dict
+            The input dict
+        frz_model : str, optional
+            The path to the frozen model
+        ckpt_meta : str, optional
+            The path to the checkpoint and meta file
+        suffix : str, optional
+            The suffix of the scope
+        reuse : bool or tf.AUTO_REUSE, optional
+            Whether to reuse the variables
+
+        Returns
+        -------
+        tf.Tensor
+            The descriptor tensor
+        """
+        if frz_model is None and ckpt_meta is None:
+            dout \
+                = self.descrpt.build(coord_,
+                                     atype_,
+                                     natoms,
+                                     box,
+                                     mesh,
+                                     input_dict,
+                                     suffix = suffix,
+                                     reuse = reuse)
+            dout = tf.identity(dout, name='o_descriptor')
+        else:
+            tf.constant(self.rcut,
+                name = 'descrpt_attr/rcut',
+                dtype = GLOBAL_TF_FLOAT_PRECISION)
+            tf.constant(self.ntypes,
+                name = 'descrpt_attr/ntypes',
+                dtype = tf.int32)
+            feed_dict = self.descrpt.get_feed_dict(coord_, atype_, natoms, box, mesh)
+            return_elements = [*self.descrpt.get_tensor_names(), 'o_descriptor:0']
+            if frz_model is not None:
+                imported_tensors \
+                    = self._import_graph_def_from_frz_model(frz_model, feed_dict, return_elements)
+            elif ckpt_meta is not None:
+                imported_tensors \
+                    = self._import_graph_def_from_ckpt_meta(ckpt_meta, feed_dict, return_elements)
+            else:
+                raise RuntimeError("should not reach here")  # pragma: no cover
+            dout = imported_tensors[-1]
+            self.descrpt.pass_tensors_from_frz_model(*imported_tensors[:-1])
+        return dout
+
+    def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
+        return_nodes = [x[:-2] for x in return_elements]
+        graph, graph_def = load_graph_def(frz_model)
+        sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
+        return tf.import_graph_def(sub_graph_def, input_map = feed_dict, return_elements = return_elements, name = "")
+
+    def _import_graph_def_from_ckpt_meta(self, ckpt_meta: str, feed_dict: dict, return_elements: List[str]):
+        return_nodes = [x[:-2] for x in return_elements]
+        with tf.Graph().as_default() as graph:
+            tf.train.import_meta_graph(f"{ckpt_meta}.meta", clear_devices=True)
+            graph_def = graph.as_graph_def()
+            sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
+        return tf.import_graph_def(sub_graph_def, input_map = feed_dict, return_elements = return_elements, name = "")

--- a/deepmd/model/model.py
+++ b/deepmd/model/model.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, List
 from abc import ABC, abstractmethod
 from enum import Enum
 

--- a/deepmd/model/model.py
+++ b/deepmd/model/model.py
@@ -148,7 +148,7 @@ class Model(ABC):
             self.descrpt.pass_tensors_from_frz_model(*imported_tensors[:-1])
         return dout
 
-    def _import_graph_def_from_frz_model(self, frz_model, feed_dict, return_elements):
+    def _import_graph_def_from_frz_model(self, frz_model: str, feed_dict: dict, return_elements: List[str]):
         return_nodes = [x[:-2] for x in return_elements]
         graph, graph_def = load_graph_def(frz_model)
         sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
@@ -159,5 +159,5 @@ class Model(ABC):
         with tf.Graph().as_default() as graph:
             tf.train.import_meta_graph(f"{ckpt_meta}.meta", clear_devices=True)
             graph_def = graph.as_graph_def()
-            sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
+        sub_graph_def = tf.graph_util.extract_sub_graph(graph_def, return_nodes)
         return tf.import_graph_def(sub_graph_def, input_map = feed_dict, return_elements = return_elements, name = "")

--- a/deepmd/model/model.py
+++ b/deepmd/model/model.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union
 from abc import ABC, abstractmethod
+from enum import Enum
 
 from deepmd.env import tf, GLOBAL_TF_FLOAT_PRECISION
 from deepmd.utils.graph import load_graph_def
@@ -17,7 +18,7 @@ class Model(ABC):
         frz_model: Optional[str] = None,
         ckpt_meta: Optional[str] = None,
         suffix: str = '', 
-        reuse: Optional[Union[bool, tf.AUTO_REUSE]] = None
+        reuse: Optional[Union[bool, Enum]] = None
     ):
         """Build the model.
 
@@ -83,7 +84,7 @@ class Model(ABC):
             frz_model: Optional[str] = None,
             ckpt_meta: Optional[str] = None,
             suffix: str = '', 
-            reuse: Optional[Union[bool, tf.AUTO_REUSE]] = None
+            reuse: Optional[Union[bool, Enum]] = None
         ):
         """Build the descriptor part of the model.
 

--- a/deepmd/model/multi.py
+++ b/deepmd/model/multi.py
@@ -140,6 +140,7 @@ class MultiModel(Model):
               mesh,
               input_dict,
               frz_model=None,
+              ckpt_meta: Optional[str] = None,
               suffix='',
               reuse=None):
 
@@ -199,15 +200,12 @@ class MultiModel(Model):
             input_dict['type_embedding'] = type_embedding
         input_dict['atype'] = atype_
 
-        dout \
-            = self.descrpt.build(coord_,
-                                 atype_,
-                                 natoms,
-                                 box,
-                                 mesh,
-                                 input_dict,
-                                 suffix=suffix,
-                                 reuse=reuse)
+        dout = self.build_descrpt(
+            coord, atype, natoms, box, mesh, input_dict,
+            frz_model=frz_model,
+            ckpt_meta=ckpt_meta,
+            suffix=suffix,
+            reuse=reuse)
         dout = tf.identity(dout, name='o_descriptor')
 
         if self.srtab is not None:

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -344,6 +344,7 @@ class DPTrainer (object):
 
         # if init the graph with the frozen model
         self.frz_model = None
+        self.ckpt_meta = None
         self.model_type = None
 
 
@@ -415,8 +416,11 @@ class DPTrainer (object):
             # config the init_frz_model command
             if self.run_opt.init_mode == 'init_from_frz_model':
                 self._init_from_frz_model()
-
-            if self.run_opt.init_mode == 'finetune':
+            elif self.run_opt.init_mode == 'init_model':
+                self.ckpt_meta = self.run_opt.init_model
+            elif self.run_opt.init_mode == 'restart':
+                self.ckpt_meta = self.run_opt.restart
+            elif self.run_opt.init_mode == 'finetune':
                 self._init_from_pretrained_model(data=data, origin_type_map=origin_type_map)
 
             # neighbor_stat is moved to train.py as duplicated
@@ -475,7 +479,8 @@ class DPTrainer (object):
                                 self.place_holders['box'], 
                                 self.place_holders['default_mesh'],
                                 self.place_holders,
-                                self.frz_model,
+                                frz_model = self.frz_model,
+                                ckpt_meta = self.ckpt_meta,
                                 suffix = suffix,
                                 reuse = False)
 


### PR DESCRIPTION
Fix #1700. Fix #1936.

* Supports restarting from compressed checkpoints.
* When initializing from a frozen compressed model, only import a sub graph_def. This is critical, as #1700 will make it fail to restart.
* Merge methods in `EnerModel` and `TensorModel` to `Model`.