### PR TITLE
assign type map for LAMMPS `pair_style deepmd`

### DIFF
--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -457,7 +457,7 @@ def model_compression_type_args():
 
 
 def model_args ():    
-    doc_type_map = 'A list of strings. Give the name to each type of atoms. It is noted that the number of atom type of training system must be less than 128 in a GPU environment.'
+    doc_type_map = 'A list of strings. Give the name to each type of atoms. It is noted that the number of atom type of training system must be less than 128 in a GPU environment. If not given, type.raw in each system should use the same type indexes, and type_map.raw will take no effect.'
     doc_data_stat_nbatch = 'The model determines the normalization from the statistics of the data. This key specifies the number of `frames` in each `system` used for statistics.'
     doc_data_stat_protect = 'Protect parameter for atomic energy regression.'
     doc_data_bias_nsample = 'The number of training samples in a system to compute and change the energy bias.'

--- a/doc/data/system.md
+++ b/doc/data/system.md
@@ -6,8 +6,8 @@ A system should contain system properties, input frame properties, and labeled f
 
 ID       | Property                | Raw file     | Required/Optional    | Shape                    | Description
 -------- | ----------------------  | ------------ | -------------------- | -----------------------  | -----------
-type     | Atom type indexes       | type.raw     | Required             | Natoms                   | Integers that start with 0
-type_map | Atom type names         | type_map.raw | Optional             | Ntypes                   | Atom names that map to atom type, which is unnecessart to be contained in the periodic table
+type     | Atom type indexes       | type.raw     | Required             | Natoms                   | Integers that start with 0. If the training parameter {ref}`type_map <model/type_map>` is set and `type_map.raw` is provided, type indexes map to `type_map.raw`; otherwise, the system type indexes map to model type indexes (whether {ref}`type_map <model/type_map>` is set or not)
+type_map | Atom type names         | type_map.raw | Optional             | Ntypes                   | Atom names that map to atom type, which is unnecessary to be contained in the periodic table. Only works when the training parameter {ref}`type_map <model/type_map>` is set
 nopbc    | Non-periodic system     | nopbc        | Optional             | 1                        | If True, this system is non-periodic; otherwise it's periodic
 
 The input frame properties contain the following property, the first axis of which is the number of frames:

--- a/doc/data/system.md
+++ b/doc/data/system.md
@@ -6,7 +6,7 @@ A system should contain system properties, input frame properties, and labeled f
 
 ID       | Property                | Raw file     | Required/Optional    | Shape                    | Description
 -------- | ----------------------  | ------------ | -------------------- | -----------------------  | -----------
-type     | Atom type indexes       | type.raw     | Required             | Natoms                   | Integers that start with 0. If the training parameter {ref}`type_map <model/type_map>` is set and `type_map.raw` is provided, type indexes map to `type_map.raw`; otherwise, the system type indexes map to model type indexes (whether {ref}`type_map <model/type_map>` is set or not)
+type     | Atom type indexes       | type.raw     | Required             | Natoms                   | Integers that start with 0. If both the training parameter {ref}`type_map <model/type_map>` is set and `type_map.raw` is provided, the system atom type should be mapped to `type_map.raw` in `type.raw` and will be mapped to the model atom type when training; otherwise, the system atom type will be always mapped to the model atom type (whether {ref}`type_map <model/type_map>` is set or not)
 type_map | Atom type names         | type_map.raw | Optional             | Ntypes                   | Atom names that map to atom type, which is unnecessary to be contained in the periodic table. Only works when the training parameter {ref}`type_map <model/type_map>` is set
 nopbc    | Non-periodic system     | nopbc        | Optional             | 1                        | If True, this system is non-periodic; otherwise it's periodic
 

--- a/doc/model/dplr.md
+++ b/doc/model/dplr.md
@@ -143,6 +143,7 @@ fix		0 all dplr model ener.pb type_associate 1 3 bond_type 1
 fix_modify	0 virial yes
 ```
 The fix command `dplr` calculates the position of WCs by the DW model and back-propagates the long-range interaction on virtual atoms to real toms. 
+At this time, the training parameter {ref}`type_map <model/type_map>` will be used to map with LAMMPS atom types.
 
 ```lammps
 # compute the temperature of real atoms, excluding virtual atom contribution

--- a/doc/model/dplr.md
+++ b/doc/model/dplr.md
@@ -143,7 +143,7 @@ fix		0 all dplr model ener.pb type_associate 1 3 bond_type 1
 fix_modify	0 virial yes
 ```
 The fix command `dplr` calculates the position of WCs by the DW model and back-propagates the long-range interaction on virtual atoms to real toms. 
-At this time, the training parameter {ref}`type_map <model/type_map>` will be used to map with LAMMPS atom types.
+At this time, the training parameter {ref}`type_map <model/type_map>` will be mapped to LAMMPS atom types.
 
 ```lammps
 # compute the temperature of real atoms, excluding virtual atom contribution

--- a/doc/third-party/lammps-command.md
+++ b/doc/third-party/lammps-command.md
@@ -29,10 +29,8 @@ pair_style deepmd models ... keyword value ...
 - models = frozen model(s) to compute the interaction. 
 If multiple models are provided, then only the first model serves to provide energy and force prediction for each timestep of molecular dynamics, 
 and the model deviation will be computed among all models every `out_freq` timesteps.
-- keyword = *type_map* or *out_file* or *out_freq* or *fparam* or *atomic* or *relative* or *relative_v* or *aparam* or *ttm*
+- keyword = *out_file* or *out_freq* or *fparam* or *atomic* or *relative* or *relative_v* or *aparam* or *ttm*
 <pre>
-    <i>type_map</i> value = types
-        types = Atom names that map to LAMMPS atom type. Default follows the type map of the model
     <i>out_file</i> value = filename
         filename = The file name for the model deviation output. Default is model_devi.out
     <i>out_freq</i> value = freq
@@ -56,16 +54,13 @@ and the model deviation will be computed among all models every `out_freq` times
 pair_style deepmd graph.pb
 pair_style deepmd graph.pb fparam 1.2
 pair_style deepmd graph_0.pb graph_1.pb graph_2.pb out_file md.out out_freq 10 atomic relative 1.0
+pair_coeff * * O H
 ```
 
 ### Description
 Evaluate the interaction of the system by using [Deep Potential][DP] or [Deep Potential Smooth Edition][DP-SE]. It is noticed that deep potential is not a "pairwise" interaction, but a multi-body interaction. 
 
 This pair style takes the deep potential defined in a model file that usually has the .pb extension. The model can be trained and frozen by package [DeePMD-kit](https://github.com/deepmodeling/deepmd-kit).
-
-`type_map` maps atom names with LAMMPS atom types (integers from 1 to Ntypes).
-If the `pair_style` argument `type_map` is not set, the training parameter {ref}`type_map <model/type_map>` will be used by default.
-If the training parameter {ref}`type_map <model/type_map>` is not set, the `pair_style` argument `type_map` cannot be used. In this case, atom type indexes in [`type.raw`](../data/system.md) (integers from 0 to Ntypes-1) will map with LAMMPS atom types.
 
 The model deviation evalulates the consistency of the force predictions from multiple models. By default, only the maximal, minimal and average model deviations are output. If the key `atomic` is set, then the model deviation of force prediction of each atom will be output.
 
@@ -81,6 +76,10 @@ $$E_{v_i}=\frac{\left|D_{v_i}\right|}{\left|v_i\right|+l}$$
 If the keyword `fparam` is set, the given frame parameter(s) will be fed to the model.
 If the keyword `aparam` is set, the given atomic parameter(s) will be fed to the model, where each atom is assumed to have the same atomic parameter(s). 
 If the keyword `ttm` is set, electronic temperatures from [fix ttm command](https://docs.lammps.org/fix_ttm.html) will be fed to the model as the atomic parameters.
+
+Only a single `pair_coeff` command is used with the deepmd style which specifies atom names. These are mapped to LAMMPS atom types (integers from 1 to Ntypes) by specifying Ntypes additional arguments after `* *` in the `pair_coeff` command.
+If atom names are not set in the `pair_coeff` command, the training parameter {ref}`type_map <model/type_map>` will be used by default.
+If the training parameter {ref}`type_map <model/type_map>` is not set, atom names in the `pair_coeff` command cannot be set. In this case, atom type indexes in [`type.raw`](../data/system.md) (integers from 0 to Ntypes-1) will map to LAMMPS atom types.
 
 ### Restrictions
 - The `deepmd` pair style is provided in the USER-DEEPMD package, which is compiled from the DeePMD-kit, visit the [DeePMD-kit website](https://github.com/deepmodeling/deepmd-kit) for more information.
@@ -98,7 +97,7 @@ compute ID group-ID deeptensor/atom model_file
 - deeptensor/atom: the style of this compute
 - model_file: the name of the binary model file.
 
-At this time, the training parameter {ref}`type_map <model/type_map>` will be used to map with LAMMPS atom types.
+At this time, the training parameter {ref}`type_map <model/type_map>` will be mapped to LAMMPS atom types.
 
 ### Examples
 ```lammps

--- a/doc/third-party/lammps-command.md
+++ b/doc/third-party/lammps-command.md
@@ -29,8 +29,10 @@ pair_style deepmd models ... keyword value ...
 - models = frozen model(s) to compute the interaction. 
 If multiple models are provided, then only the first model serves to provide energy and force prediction for each timestep of molecular dynamics, 
 and the model deviation will be computed among all models every `out_freq` timesteps.
-- keyword = *out_file* or *out_freq* or *fparam* or *atomic* or *relative* or *relative_v* or *aparam* or *ttm*
+- keyword = *type_map* or *out_file* or *out_freq* or *fparam* or *atomic* or *relative* or *relative_v* or *aparam* or *ttm*
 <pre>
+    <i>type_map</i> value = types
+        types = Atom names that map to LAMMPS atom type. Default follows the type map of the model
     <i>out_file</i> value = filename
         filename = The file name for the model deviation output. Default is model_devi.out
     <i>out_freq</i> value = freq
@@ -60,6 +62,10 @@ pair_style deepmd graph_0.pb graph_1.pb graph_2.pb out_file md.out out_freq 10 a
 Evaluate the interaction of the system by using [Deep Potential][DP] or [Deep Potential Smooth Edition][DP-SE]. It is noticed that deep potential is not a "pairwise" interaction, but a multi-body interaction. 
 
 This pair style takes the deep potential defined in a model file that usually has the .pb extension. The model can be trained and frozen by package [DeePMD-kit](https://github.com/deepmodeling/deepmd-kit).
+
+`type_map` maps atom names with LAMMPS atom types (integers from 1 to Ntypes).
+If the `pair_style` argument `type_map` is not set, the training parameter {ref}`type_map <model/type_map>` will be used by default.
+If the training parameter {ref}`type_map <model/type_map>` is not set, the `pair_style` argument `type_map` cannot be used. In this case, atom type indexes in [`type.raw`](../data/system.md) (integers from 0 to Ntypes-1) will map with LAMMPS atom types.
 
 The model deviation evalulates the consistency of the force predictions from multiple models. By default, only the maximal, minimal and average model deviations are output. If the key `atomic` is set, then the model deviation of force prediction of each atom will be output.
 
@@ -91,6 +97,8 @@ compute ID group-ID deeptensor/atom model_file
 - group-ID: ID of the group of atoms to compute
 - deeptensor/atom: the style of this compute
 - model_file: the name of the binary model file.
+
+At this time, the training parameter {ref}`type_map <model/type_map>` will be used to map with LAMMPS atom types.
 
 ### Examples
 ```lammps

--- a/doc/third-party/lammps.md
+++ b/doc/third-party/lammps.md
@@ -3,7 +3,7 @@
 Running an MD simulation with LAMMPS is simpler. In the LAMMPS input file, one needs to specify the pair style as follows
 
 ```lammps
-pair_style     deepmd graph.pb type_map O H
-pair_coeff     * *
+pair_style     deepmd graph.pb
+pair_coeff     * * O H
 ```
-where `graph.pb` is the file name of the frozen model. `type_map` maps atom names with LAMMPS atom types (integers from 1 to Ntypes).
+where `graph.pb` is the file name of the frozen model. `pair_coeff` maps atom names (`O H`) with LAMMPS atom types (integers from 1 to Ntypes, i.e. `1 2`).

--- a/doc/third-party/lammps.md
+++ b/doc/third-party/lammps.md
@@ -3,7 +3,7 @@
 Running an MD simulation with LAMMPS is simpler. In the LAMMPS input file, one needs to specify the pair style as follows
 
 ```lammps
-pair_style     deepmd graph.pb
+pair_style     deepmd graph.pb type_map O H
 pair_coeff     * *
 ```
-where `graph.pb` is the file name of the frozen model. It should be noted that LAMMPS counts atom types starting from 1, therefore, all LAMMPS atom types will be firstly subtracted by 1, and then passed into the DeePMD-kit engine to compute the interactions. 
+where `graph.pb` is the file name of the frozen model. `type_map` maps atom names with LAMMPS atom types (integers from 1 to Ntypes).

--- a/examples/water/lmp/in.lammps
+++ b/examples/water/lmp/in.lammps
@@ -11,7 +11,7 @@ read_data	water.lmp
 mass 		1 16
 mass		2 2
 
-pair_style	deepmd frozen_model.pb
+pair_style	deepmd frozen_model.pb type_map O H
 pair_coeff  * *	
 
 velocity        all create 330.0 23456789

--- a/examples/water/lmp/in.lammps
+++ b/examples/water/lmp/in.lammps
@@ -11,8 +11,8 @@ read_data	water.lmp
 mass 		1 16
 mass		2 2
 
-pair_style	deepmd frozen_model.pb type_map O H
-pair_coeff  * *	
+pair_style	deepmd frozen_model.pb
+pair_coeff  * *	O H
 
 velocity        all create 330.0 23456789
 

--- a/examples/water/lmp/in.plugin.lammps
+++ b/examples/water/lmp/in.plugin.lammps
@@ -14,8 +14,8 @@ mass		2 2
 # load the deepmd plugin
 plugin load libdeepmd_lmp.so
 
-pair_style	deepmd frozen_model.pb type_map O H
-pair_coeff  * *	
+pair_style	deepmd frozen_model.pb
+pair_coeff  * *	O H
 
 velocity        all create 330.0 23456789
 

--- a/examples/water/lmp/in.plugin.lammps
+++ b/examples/water/lmp/in.plugin.lammps
@@ -14,7 +14,7 @@ mass		2 2
 # load the deepmd plugin
 plugin load libdeepmd_lmp.so
 
-pair_style	deepmd frozen_model.pb
+pair_style	deepmd frozen_model.pb type_map O H
 pair_coeff  * *	
 
 velocity        all create 330.0 23456789

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -978,6 +978,7 @@ void PairDeepMD::settings(int narg, char **arg)
           error->all(FLERR, "type_map: element " + type_name + " not found in the model");
         }
       }
+      iarg += 1;
     }
   }
   if (out_freq < 0) error->all(FLERR,"Illegal out_freq, should be >= 0");

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1057,8 +1057,7 @@ void PairDeepMD::coeff(int narg, char **arg)
     }
 
     type_idx_map.clear();
-    while (iarg+1 < narg && !is_key(arg[iarg+1])) {
-      iarg += 1;
+    while (iarg < narg) {
       std::string type_name = arg[iarg];
       bool found_element = false;
       for (int ii = 0; ii < type_map.size(); ++ii) {
@@ -1071,6 +1070,7 @@ void PairDeepMD::coeff(int narg, char **arg)
       if (!found_element) {
         error->all(FLERR, "pair_coeff: element " + type_name + " not found in the model");
       }
+      iarg += 1;
     }
     numb_types = type_idx_map.size();
   }

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -328,7 +328,7 @@ void PairDeepMD::compute(int eflag, int vflag)
 
   vector<int > dtype (nall);
   for (int ii = 0; ii < nall; ++ii){
-    dtype[ii] = type[ii] - 1;
+    dtype[ii] = type_idx_map[type[ii] - 1];
   }  
 
   double dener (0);
@@ -810,6 +810,7 @@ is_key (const string& input)
   keys.push_back("atomic");
   keys.push_back("relative");
   keys.push_back("relative_v");
+  keys.push_back("type_map");
 
   for (int ii = 0; ii < keys.size(); ++ii){
     if (input == keys[ii]) {
@@ -862,6 +863,10 @@ void PairDeepMD::settings(int narg, char **arg)
     assert(numb_types == deep_pot.numb_types());
     assert(dim_fparam == deep_pot.dim_fparam());
     assert(dim_aparam == deep_pot.dim_aparam());
+  }
+  type_idx_map.resize(numb_types);
+  for (int ii = 0; ii < numb_types; ++ii){
+    type_idx_map[ii] = ii;
   }
 
   out_freq = 100;
@@ -942,6 +947,37 @@ void PairDeepMD::settings(int narg, char **arg)
       eps_v = strtof(arg[iarg+1], NULL);
 #endif
       iarg += 2;
+    }
+    else if (string(arg[iarg]) == string("type_map")) {
+      // type_map is a list of strings with undetermined length
+      // note: although we have numb_types from the model, we do not require
+      // the number of types in the system matches that in the model
+      std::vector<std::string> type_map;
+      std::string type_map_str;
+      deep_pot.get_type_map(type_map_str);
+      // convert the string to a vector of strings
+      std::istringstream iss(type_map_str);
+      std::string type_name;
+      while (iss >> type_name) {
+        type_map.push_back(type_name);
+      }
+
+      type_idx_map.clear();
+      while (iarg+1 < narg && !is_key(arg[iarg+1])) {
+        iarg += 1;
+        std::string type_name = arg[iarg];
+        bool found_element = false;
+        for (int ii = 0; ii < type_map.size(); ++ii) {
+          if (type_map[ii] == type_name) {
+            type_idx_map.push_back(ii);
+            found_element = true;
+            break;
+          }
+        }
+        if (!found_element) {
+          error->all(FLERR, "type_map: element " + type_name + " not found in the model");
+        }
+      }
     }
   }
   if (out_freq < 0) error->all(FLERR,"Illegal out_freq, should be >= 0");

--- a/source/lmp/pair_deepmd.h.in
+++ b/source/lmp/pair_deepmd.h.in
@@ -109,6 +109,7 @@ private:
   int *counts,*displacements;
   tagint *tagsend, *tagrecv;
   double *stdfsend, *stdfrecv;
+  std::vector<int> type_idx_map;
 };
 
 }

--- a/source/lmp/tests/data_type_map.lmp
+++ b/source/lmp/tests/data_type_map.lmp
@@ -1,0 +1,16 @@
+# the first line must be comment
+6 atoms
+2 atom types
+0.0 13.0 xlo xhi
+0.0 13.0 ylo yhi
+0.0 13.0 zlo zhi
+0.0 0.0 0.0 xy xz yz
+
+Atoms
+
+1	2	12.83	2.56	2.18
+2	1	12.09	2.87	2.74
+3	1	0.25	3.32	1.68
+4	2	3.36	3.00	1.81
+5	1	3.51	2.51	2.60
+6	1	4.27	3.22	1.56 

--- a/source/lmp/tests/test_lammps.py
+++ b/source/lmp/tests/test_lammps.py
@@ -90,6 +90,7 @@ def lammps(data_file=data_file) -> PyLammps:
     yield lammps
 
 
+@pytest.fixture
 def lammps_type_map():
     lammps(data_file=data_type_map_file)
 

--- a/source/lmp/tests/test_lammps.py
+++ b/source/lmp/tests/test_lammps.py
@@ -85,7 +85,7 @@ def _lammps(data_file) -> PyLammps:
     lammps.mass("2 2")
     lammps.timestep(0.0005)
     lammps.fix("1 all nve")
-    yield lammps
+    return lammps
 
 
 @pytest.fixture

--- a/source/lmp/tests/test_lammps.py
+++ b/source/lmp/tests/test_lammps.py
@@ -94,7 +94,7 @@ def lammps():
 
 @pytest.fixture
 def lammps_type_map():
-    yield lammps(data_file=data_type_map_file)
+    yield _lammps(data_file=data_type_map_file)
 
 
 def test_pair_deepmd(lammps):

--- a/source/lmp/tests/test_lammps.py
+++ b/source/lmp/tests/test_lammps.py
@@ -73,9 +73,7 @@ sp.check_output("{} -m deepmd convert-from pbtxt -i {} -o {}".format(
     ).split())
 
 
-
-@pytest.fixture
-def lammps(data_file=data_file) -> PyLammps:
+def _lammps(data_file) -> PyLammps:
     lammps = PyLammps()
     lammps.units("metal")
     lammps.boundary("p p p")
@@ -91,8 +89,12 @@ def lammps(data_file=data_file) -> PyLammps:
 
 
 @pytest.fixture
+def lammps():
+    yield _lammps(data_file=data_file)
+
+@pytest.fixture
 def lammps_type_map():
-    lammps(data_file=data_type_map_file)
+    yield lammps(data_file=data_type_map_file)
 
 
 def test_pair_deepmd(lammps):

--- a/source/lmp/tests/test_lammps.py
+++ b/source/lmp/tests/test_lammps.py
@@ -215,8 +215,8 @@ def test_pair_deepmd_model_devi_atomic_relative_v(lammps):
     assert md[3] == pytest.approx(np.sqrt(np.mean(np.square(expected_md_v))))
 
 def test_pair_deepmd_type_map(lammps_type_map):
-    lammps_type_map.pair_style("deepmd {} type_map H O".format(pb_file.resolve()))
-    lammps_type_map.pair_coeff("* *")
+    lammps_type_map.pair_style("deepmd {}".format(pb_file.resolve()))
+    lammps_type_map.pair_coeff("* * H O")
     lammps_type_map.run(0)
     assert lammps_type_map.eval("pe") == pytest.approx(expected_e)
     for ii in range(6):


### PR DESCRIPTION
Fix #2237. Use the LAMMPS `pair_coeff` command to set `type_map`, like ReaxFF, EAM, etc.
Add and improve the documentation about `type_map`. From now on, setting `type_map` explicitly is encouraged (but not necessary).