### PR TITLE
support multiple frames with C++ DeepPot

### DIFF
--- a/source/api_cc/include/AtomMap.h
+++ b/source/api_cc/include/AtomMap.h
@@ -13,11 +13,15 @@ class AtomMap {
   template <typename VALUETYPE>
   void forward(typename std::vector<VALUETYPE>::iterator out,
                const typename std::vector<VALUETYPE>::const_iterator in,
-               const int stride = 1) const;
+               const int stride = 1,
+               const int nframes = 1,
+               const int nall = 0) const;
   template <typename VALUETYPE>
   void backward(typename std::vector<VALUETYPE>::iterator out,
                 const typename std::vector<VALUETYPE>::const_iterator in,
-                const int stride = 1) const;
+                const int stride = 1,
+                const int nframes = 1,
+                const int nall = 0) const;
   const std::vector<int>& get_type() const { return atype; }
   const std::vector<int>& get_fwd_map() const { return fwd_idx_map; }
   const std::vector<int>& get_bkw_map() const { return idx_map; }

--- a/source/api_cc/include/DeepPot.h
+++ b/source/api_cc/include/DeepPot.h
@@ -40,7 +40,6 @@ class DeepPot {
    **/
   void print_summary(const std::string& pre) const;
 
- public:
   /**
    * @brief Evaluate the energy, force and virial by using this DP.
    * @param[out] ener The system energy.
@@ -61,8 +60,8 @@ class DeepPot {
    *same aparam. dim_aparam. Then all frames and atoms are provided with the
    *same aparam.
    **/
-  template <typename VALUETYPE>
-  void compute(ENERGYTYPE& ener,
+  template <typename VALUETYPE, typename ENERGYVTYPE>
+  void compute(ENERGYVTYPE& ener,
                std::vector<VALUETYPE>& force,
                std::vector<VALUETYPE>& virial,
                const std::vector<VALUETYPE>& coord,
@@ -93,8 +92,8 @@ class DeepPot {
    *same aparam. dim_aparam. Then all frames and atoms are provided with the
    *same aparam.
    **/
-  template <typename VALUETYPE>
-  void compute(ENERGYTYPE& ener,
+  template <typename VALUETYPE, typename ENERGYVTYPE>
+  void compute(ENERGYVTYPE& ener,
                std::vector<VALUETYPE>& force,
                std::vector<VALUETYPE>& virial,
                const std::vector<VALUETYPE>& coord,
@@ -128,8 +127,8 @@ class DeepPot {
    *same aparam. dim_aparam. Then all frames and atoms are provided with the
    *same aparam.
    **/
-  template <typename VALUETYPE>
-  void compute(ENERGYTYPE& ener,
+  template <typename VALUETYPE, typename ENERGYVTYPE>
+  void compute(ENERGYVTYPE& ener,
                std::vector<VALUETYPE>& force,
                std::vector<VALUETYPE>& virial,
                std::vector<VALUETYPE>& atom_energy,
@@ -165,8 +164,8 @@ class DeepPot {
    *same aparam. dim_aparam. Then all frames and atoms are provided with the
    *same aparam.
    **/
-  template <typename VALUETYPE>
-  void compute(ENERGYTYPE& ener,
+  template <typename VALUETYPE, typename ENERGYVTYPE>
+  void compute(ENERGYVTYPE& ener,
                std::vector<VALUETYPE>& force,
                std::vector<VALUETYPE>& virial,
                std::vector<VALUETYPE>& atom_energy,
@@ -238,9 +237,9 @@ class DeepPot {
   void validate_fparam_aparam(const int& nloc,
                               const std::vector<VALUETYPE>& fparam,
                               const std::vector<VALUETYPE>& aparam) const;
-  template <typename VALUETYPE>
+  template <typename VALUETYPE, typename ENERGYVTYPE>
   void compute_inner(
-      ENERGYTYPE& ener,
+      ENERGYVTYPE& ener,
       std::vector<VALUETYPE>& force,
       std::vector<VALUETYPE>& virial,
       const std::vector<VALUETYPE>& coord,
@@ -292,7 +291,6 @@ class DeepPotModelDevi {
             const std::vector<std::string>& file_contents =
                 std::vector<std::string>());
 
- public:
   /**
    * @brief Evaluate the energy, force and virial by using these DP models.
    * @param[out] all_ener The system energies of all models.

--- a/source/api_cc/include/common.h
+++ b/source/api_cc/include/common.h
@@ -66,13 +66,18 @@ template <typename VT>
 void select_map(std::vector<VT>& out,
                 const std::vector<VT>& in,
                 const std::vector<int>& fwd_map,
-                const int& stride);
+                const int& stride,
+                const int& nframes = 1,
+                // nall will not take effect if nframes is 1
+                const int& nall = 0);
 
 template <typename VT>
 void select_map(typename std::vector<VT>::iterator out,
                 const typename std::vector<VT>::const_iterator in,
                 const std::vector<int>& fwd_map,
-                const int& stride);
+                const int& stride,
+                const int& nframes = 1,
+                const int& nall = 0);
 
 template <typename VT>
 void select_map_inv(std::vector<VT>& out,

--- a/source/api_cc/include/common.h
+++ b/source/api_cc/include/common.h
@@ -69,7 +69,8 @@ void select_map(std::vector<VT>& out,
                 const int& stride,
                 const int& nframes = 1,
                 // nall will not take effect if nframes is 1
-                const int& nall = 0);
+                const int& nall1 = 0,
+                const int& nall2 = 0);
 
 template <typename VT>
 void select_map(typename std::vector<VT>::iterator out,
@@ -77,7 +78,8 @@ void select_map(typename std::vector<VT>::iterator out,
                 const std::vector<int>& fwd_map,
                 const int& stride,
                 const int& nframes = 1,
-                const int& nall = 0);
+                const int& nall1 = 0,
+                const int& nall2 = 0);
 
 template <typename VT>
 void select_map_inv(std::vector<VT>& out,

--- a/source/api_cc/src/AtomMap.cc
+++ b/source/api_cc/src/AtomMap.cc
@@ -29,13 +29,18 @@ AtomMap::AtomMap(const std::vector<int>::const_iterator in_begin,
 template <typename VALUETYPE>
 void AtomMap::forward(typename std::vector<VALUETYPE>::iterator out,
                       const typename std::vector<VALUETYPE>::const_iterator in,
-                      const int stride) const {
+                      const int stride,
+                      const int nframes,
+                      const int nall) const {
   int natoms = idx_map.size();
-  for (int ii = 0; ii < natoms; ++ii) {
-    int gro_i = idx_map[ii];
-    for (int dd = 0; dd < stride; ++dd) {
-      // out[ii*stride+dd] = in[gro_i*stride+dd];
-      *(out + ii * stride + dd) = *(in + gro_i * stride + dd);
+  for (int kk = 0; kk < nframes; ++kk) {
+    for (int ii = 0; ii < natoms; ++ii) {
+      int gro_i = idx_map[ii];
+      for (int dd = 0; dd < stride; ++dd) {
+        // out[ii*stride+dd] = in[gro_i*stride+dd];
+        *(out + kk * nall * stride + ii * stride + dd) =
+            *(in + kk * nall * stride + gro_i * stride + dd);
+      }
     }
   }
 }
@@ -43,13 +48,18 @@ void AtomMap::forward(typename std::vector<VALUETYPE>::iterator out,
 template <typename VALUETYPE>
 void AtomMap::backward(typename std::vector<VALUETYPE>::iterator out,
                        const typename std::vector<VALUETYPE>::const_iterator in,
-                       const int stride) const {
+                       const int stride,
+                       const int nframes,
+                       const int nall) const {
   int natoms = idx_map.size();
-  for (int ii = 0; ii < natoms; ++ii) {
-    int gro_i = idx_map[ii];
-    for (int dd = 0; dd < stride; ++dd) {
-      // out[gro_i*stride+dd] = in[ii*stride+dd];
-      *(out + gro_i * stride + dd) = *(in + ii * stride + dd);
+  for (int kk = 0; kk < nframes; ++kk) {
+    for (int ii = 0; ii < natoms; ++ii) {
+      int gro_i = idx_map[ii];
+      for (int dd = 0; dd < stride; ++dd) {
+        // out[gro_i*stride+dd] = in[ii*stride+dd];
+        *(out + kk * nall * stride + gro_i * stride + dd) =
+            *(in + kk * nall * stride + ii * stride + dd);
+      }
     }
   }
 }
@@ -57,19 +67,27 @@ void AtomMap::backward(typename std::vector<VALUETYPE>::iterator out,
 template void AtomMap::forward<double>(
     typename std::vector<double>::iterator out,
     const typename std::vector<double>::const_iterator in,
-    const int stride) const;
+    const int stride,
+    const int nframes,
+    const int nall) const;
 
 template void AtomMap::forward<float>(
     typename std::vector<float>::iterator out,
     const typename std::vector<float>::const_iterator in,
-    const int stride) const;
+    const int stride,
+    const int nframes,
+    const int nall) const;
 
 template void AtomMap::backward<double>(
     typename std::vector<double>::iterator out,
     const typename std::vector<double>::const_iterator in,
-    const int stride) const;
+    const int stride,
+    const int nframes,
+    const int nall) const;
 
 template void AtomMap::backward<float>(
     typename std::vector<float>::iterator out,
     const typename std::vector<float>::const_iterator in,
-    const int stride) const;
+    const int stride,
+    const int nframes,
+    const int nall) const;

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -663,12 +663,14 @@ void DeepPot::compute(ENERGYVTYPE& dener,
   dcoord.resize(nframes * bkw_map.size() * 3);
   datype.resize(bkw_map.size());
   // fwd map
-  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3, nframes, nall);
-  select_map<int>(datype, datype_, fwd_map, 1, nframes, nall);
+  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3, nframes, bkw_map.size(),
+                        nall);
+  select_map<int>(datype, datype_, fwd_map, 1);
   // aparam
   if (daparam > 0) {
     aparam.resize(nframes * (bkw_map.size() - nghost_real));
-    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam, nframes, nall);
+    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam, nframes,
+                          bkw_map.size() - nghost_real, nall);
   }
   // internal nlist
   if (ago == 0) {
@@ -679,7 +681,8 @@ void DeepPot::compute(ENERGYVTYPE& dener,
                 fparam, aparam);
   // bkw map
   dforce_.resize(nframes * fwd_map.size() * 3);
-  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3, nframes, nall);
+  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3, nframes, fwd_map.size(),
+                        bkw_map.size());
 }
 
 template void DeepPot::compute<double, ENERGYTYPE>(
@@ -935,12 +938,13 @@ void DeepPot::compute(ENERGYVTYPE& dener,
   dcoord.resize(nframes * nall_real * 3);
   datype.resize(nall_real);
   // fwd map
-  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3, nframes, nall);
-  select_map<int>(datype, datype_, fwd_map, 1, nframes, nall);
+  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3, nframes, nall_real, nall);
+  select_map<int>(datype, datype_, fwd_map, 1);
   // aparam
   if (daparam > 0) {
     aparam.resize(nframes * nloc_real);
-    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam, nframes, nall);
+    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam, nframes, nloc_real,
+                          nall);
   }
   if (ago == 0) {
     atommap = deepmd::AtomMap(datype.begin(), datype.begin() + nloc_real);
@@ -972,9 +976,12 @@ void DeepPot::compute(ENERGYVTYPE& dener,
   dforce_.resize(nframes * fwd_map.size() * 3);
   datom_energy_.resize(nframes * fwd_map.size());
   datom_virial_.resize(nframes * fwd_map.size() * 9);
-  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3, nframes, nall);
-  select_map<VALUETYPE>(datom_energy_, datom_energy, bkw_map, 1, nframes, nall);
-  select_map<VALUETYPE>(datom_virial_, datom_virial, bkw_map, 9, nframes, nall);
+  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3, nframes, fwd_map.size(),
+                        nall_real);
+  select_map<VALUETYPE>(datom_energy_, datom_energy, bkw_map, 1, nframes,
+                        fwd_map.size(), nall_real);
+  select_map<VALUETYPE>(datom_virial_, datom_virial, bkw_map, 9, nframes,
+                        fwd_map.size(), nall_real);
 }
 
 template void DeepPot::compute<double, ENERGYTYPE>(

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -182,7 +182,7 @@ static void run_model(
   for (int ii = 0; ii < nframes * nall * 3; ++ii) {
     dforce[ii] = of(ii);
   }
-  for (int ii = 0; ii < nframes * nloc; ++ii) {
+  for (int ii = 0; ii < nframes * nall; ++ii) {
     datom_energy[ii] = oae(ii);
   }
   for (int ii = 0; ii < nframes * nall * 9; ++ii) {

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -182,8 +182,10 @@ static void run_model(
   for (int ii = 0; ii < nframes * nall * 3; ++ii) {
     dforce[ii] = of(ii);
   }
-  for (int ii = 0; ii < nframes * nall; ++ii) {
-    datom_energy[ii] = oae(ii);
+  for (int ii = 0; ii < nframes; ++ii) {
+    for (int jj = 0; jj < nloc; ++jj) {
+      datom_energy[ii * nall + jj] = oae(ii * nloc + jj);
+    }
   }
   for (int ii = 0; ii < nframes * nall * 9; ++ii) {
     datom_virial[ii] = oav(ii);

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -18,25 +18,28 @@ static std::vector<int> cum_sum(const std::vector<int32>& n_sel) {
   return sec;
 }
 
+// start multiple frames
+
 template <typename MODELTYPE, typename VALUETYPE>
 static void run_model(
-    ENERGYTYPE& dener,
+    std::vector<ENERGYTYPE>& dener,
     std::vector<VALUETYPE>& dforce_,
     std::vector<VALUETYPE>& dvirial,
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const AtomMap& atommap,
+    const int nframes,
     const int nghost = 0) {
   unsigned nloc = atommap.get_type().size();
   unsigned nall = nloc + nghost;
+  dener.resize(nframes);
   if (nloc == 0) {
-    dener = 0;
     // no backward map needed
     // dforce of size nall * 3
-    dforce_.resize(nall * 3);
+    dforce_.resize(nframes * nall * 3);
     fill(dforce_.begin(), dforce_.end(), (VALUETYPE)0.0);
     // dvirial of size 9
-    dvirial.resize(9);
+    dvirial.resize(nframes * 9);
     fill(dvirial.begin(), dvirial.end(), (VALUETYPE)0.0);
     return;
   }
@@ -54,68 +57,77 @@ static void run_model(
   auto of = output_f.flat<MODELTYPE>();
   auto oav = output_av.flat<MODELTYPE>();
 
-  dener = oe(0);
-  std::vector<VALUETYPE> dforce(3 * nall);
-  dvirial.resize(9);
-  for (unsigned ii = 0; ii < nall * 3; ++ii) {
+  std::vector<VALUETYPE> dforce(nframes * 3 * nall);
+  dvirial.resize(nframes * 9);
+  for (int ii = 0; ii < nframes; ++ii) {
+    dener[ii] = oe(ii);
+  }
+  for (unsigned ii = 0; ii < nframes * nall * 3; ++ii) {
     dforce[ii] = of(ii);
   }
   // set dvirial to zero, prevent input vector is not zero (#1123)
   std::fill(dvirial.begin(), dvirial.end(), (VALUETYPE)0.);
-  for (int ii = 0; ii < nall; ++ii) {
-    dvirial[0] += (VALUETYPE)1.0 * oav(9 * ii + 0);
-    dvirial[1] += (VALUETYPE)1.0 * oav(9 * ii + 1);
-    dvirial[2] += (VALUETYPE)1.0 * oav(9 * ii + 2);
-    dvirial[3] += (VALUETYPE)1.0 * oav(9 * ii + 3);
-    dvirial[4] += (VALUETYPE)1.0 * oav(9 * ii + 4);
-    dvirial[5] += (VALUETYPE)1.0 * oav(9 * ii + 5);
-    dvirial[6] += (VALUETYPE)1.0 * oav(9 * ii + 6);
-    dvirial[7] += (VALUETYPE)1.0 * oav(9 * ii + 7);
-    dvirial[8] += (VALUETYPE)1.0 * oav(9 * ii + 8);
+  for (int kk = 0; kk < nframes; ++kk) {
+    for (int ii = 0; ii < nall; ++ii) {
+      dvirial[kk * 9 + 0] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 0);
+      dvirial[kk * 9 + 1] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 1);
+      dvirial[kk * 9 + 2] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 2);
+      dvirial[kk * 9 + 3] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 3);
+      dvirial[kk * 9 + 4] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 4);
+      dvirial[kk * 9 + 5] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 5);
+      dvirial[kk * 9 + 6] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 6);
+      dvirial[kk * 9 + 7] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 7);
+      dvirial[kk * 9 + 8] += (VALUETYPE)1.0 * oav(kk * nall * 9 + 9 * ii + 8);
+    }
   }
   dforce_ = dforce;
-  atommap.backward<VALUETYPE>(dforce_.begin(), dforce.begin(), 3);
+  atommap.backward<VALUETYPE>(dforce_.begin(), dforce.begin(), 3, nframes,
+                              nall);
 }
 
 template void run_model<double, double>(
-    ENERGYTYPE& dener,
+    std::vector<ENERGYTYPE>& dener,
     std::vector<double>& dforce_,
     std::vector<double>& dvirial,
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const AtomMap& atommap,
+    const int nframes,
     const int nghost);
 
 template void run_model<double, float>(
-    ENERGYTYPE& dener,
+    std::vector<ENERGYTYPE>& dener,
     std::vector<float>& dforce_,
     std::vector<float>& dvirial,
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const AtomMap& atommap,
+    const int nframes,
     const int nghost);
 
 template void run_model<float, double>(
-    ENERGYTYPE& dener,
+    std::vector<ENERGYTYPE>& dener,
     std::vector<double>& dforce_,
     std::vector<double>& dvirial,
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const AtomMap& atommap,
+    const int nframes,
     const int nghost);
 
 template void run_model<float, float>(
-    ENERGYTYPE& dener,
+    std::vector<ENERGYTYPE>& dener,
     std::vector<float>& dforce_,
     std::vector<float>& dvirial,
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const AtomMap& atommap,
+    const int nframes,
     const int nghost);
 
 template <typename MODELTYPE, typename VALUETYPE>
 static void run_model(
-    ENERGYTYPE& dener,
+    std::vector<ENERGYTYPE>& dener,
     std::vector<VALUETYPE>& dforce_,
     std::vector<VALUETYPE>& dvirial,
     std::vector<VALUETYPE>& datom_energy_,
@@ -123,23 +135,24 @@ static void run_model(
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const deepmd::AtomMap& atommap,
+    const int& nframes,
     const int& nghost = 0) {
   unsigned nloc = atommap.get_type().size();
   unsigned nall = nloc + nghost;
+  dener.resize(nframes);
   if (nloc == 0) {
-    dener = 0;
     // no backward map needed
     // dforce of size nall * 3
-    dforce_.resize(nall * 3);
+    dforce_.resize(nframes * nall * 3);
     fill(dforce_.begin(), dforce_.end(), (VALUETYPE)0.0);
     // dvirial of size 9
-    dvirial.resize(9);
+    dvirial.resize(nframes * 9);
     fill(dvirial.begin(), dvirial.end(), (VALUETYPE)0.0);
     // datom_energy_ of size nall
-    datom_energy_.resize(nall);
+    datom_energy_.resize(nframes * nall);
     fill(datom_energy_.begin(), datom_energy_.end(), (VALUETYPE)0.0);
     // datom_virial_ of size nall * 9
-    datom_virial_.resize(nall * 9);
+    datom_virial_.resize(nframes * nall * 9);
     fill(datom_virial_.begin(), datom_virial_.end(), (VALUETYPE)0.0);
     return;
   }
@@ -159,39 +172,186 @@ static void run_model(
   auto oae = output_ae.flat<MODELTYPE>();
   auto oav = output_av.flat<MODELTYPE>();
 
-  dener = oe(0);
-  std::vector<VALUETYPE> dforce(3 * nall);
-  std::vector<VALUETYPE> datom_energy(nall, 0);
-  std::vector<VALUETYPE> datom_virial(9 * nall);
-  dvirial.resize(9);
-  for (int ii = 0; ii < nall * 3; ++ii) {
+  std::vector<VALUETYPE> dforce(nframes * 3 * nall);
+  std::vector<VALUETYPE> datom_energy(nframes * nall, 0);
+  std::vector<VALUETYPE> datom_virial(nframes * 9 * nall);
+  dvirial.resize(nframes * 9);
+  for (int ii = 0; ii < nframes; ++ii) {
+    dener[ii] = oe(ii);
+  }
+  for (int ii = 0; ii < nframes * nall * 3; ++ii) {
     dforce[ii] = of(ii);
   }
-  for (int ii = 0; ii < nloc; ++ii) {
+  for (int ii = 0; ii < nframes * nloc; ++ii) {
     datom_energy[ii] = oae(ii);
   }
-  for (int ii = 0; ii < nall * 9; ++ii) {
+  for (int ii = 0; ii < nframes * nall * 9; ++ii) {
     datom_virial[ii] = oav(ii);
   }
   // set dvirial to zero, prevent input vector is not zero (#1123)
   std::fill(dvirial.begin(), dvirial.end(), (VALUETYPE)0.);
-  for (int ii = 0; ii < nall; ++ii) {
-    dvirial[0] += (VALUETYPE)1.0 * datom_virial[9 * ii + 0];
-    dvirial[1] += (VALUETYPE)1.0 * datom_virial[9 * ii + 1];
-    dvirial[2] += (VALUETYPE)1.0 * datom_virial[9 * ii + 2];
-    dvirial[3] += (VALUETYPE)1.0 * datom_virial[9 * ii + 3];
-    dvirial[4] += (VALUETYPE)1.0 * datom_virial[9 * ii + 4];
-    dvirial[5] += (VALUETYPE)1.0 * datom_virial[9 * ii + 5];
-    dvirial[6] += (VALUETYPE)1.0 * datom_virial[9 * ii + 6];
-    dvirial[7] += (VALUETYPE)1.0 * datom_virial[9 * ii + 7];
-    dvirial[8] += (VALUETYPE)1.0 * datom_virial[9 * ii + 8];
+  for (int kk = 0; kk < nframes; ++kk) {
+    for (int ii = 0; ii < nall; ++ii) {
+      dvirial[kk * 9 + 0] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 0];
+      dvirial[kk * 9 + 1] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 1];
+      dvirial[kk * 9 + 2] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 2];
+      dvirial[kk * 9 + 3] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 3];
+      dvirial[kk * 9 + 4] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 4];
+      dvirial[kk * 9 + 5] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 5];
+      dvirial[kk * 9 + 6] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 6];
+      dvirial[kk * 9 + 7] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 7];
+      dvirial[kk * 9 + 8] +=
+          (VALUETYPE)1.0 * datom_virial[kk * nall * 9 + 9 * ii + 8];
+    }
   }
   dforce_ = dforce;
   datom_energy_ = datom_energy;
   datom_virial_ = datom_virial;
-  atommap.backward<VALUETYPE>(dforce_.begin(), dforce.begin(), 3);
-  atommap.backward<VALUETYPE>(datom_energy_.begin(), datom_energy.begin(), 1);
-  atommap.backward<VALUETYPE>(datom_virial_.begin(), datom_virial.begin(), 9);
+  atommap.backward<VALUETYPE>(dforce_.begin(), dforce.begin(), 3, nframes,
+                              nall);
+  atommap.backward<VALUETYPE>(datom_energy_.begin(), datom_energy.begin(), 1,
+                              nframes, nall);
+  atommap.backward<VALUETYPE>(datom_virial_.begin(), datom_virial.begin(), 9,
+                              nframes, nall);
+}
+
+template void run_model<double, double>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    std::vector<double>& datom_energy_,
+    std::vector<double>& datom_virial_,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const deepmd::AtomMap& atommap,
+    const int& nframes,
+    const int& nghost);
+
+template void run_model<double, float>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    std::vector<float>& datom_energy_,
+    std::vector<float>& datom_virial_,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const deepmd::AtomMap& atommap,
+    const int& nframes,
+    const int& nghost);
+
+template void run_model<float, double>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    std::vector<double>& datom_energy_,
+    std::vector<double>& datom_virial_,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const deepmd::AtomMap& atommap,
+    const int& nframes,
+    const int& nghost);
+
+template void run_model<float, float>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    std::vector<float>& datom_energy_,
+    std::vector<float>& datom_virial_,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const deepmd::AtomMap& atommap,
+    const int& nframes,
+    const int& nghost);
+
+// end multiple frames
+
+// start single frame
+
+template <typename MODELTYPE, typename VALUETYPE>
+static void run_model(
+    ENERGYTYPE& dener,
+    std::vector<VALUETYPE>& dforce_,
+    std::vector<VALUETYPE>& dvirial,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const AtomMap& atommap,
+    const int nframes = 1,
+    const int nghost = 0) {
+  assert(nframes == 1);
+  std::vector<ENERGYTYPE> dener_(1);
+  // call multi-frame version
+  run_model<MODELTYPE, VALUETYPE>(dener_, dforce_, dvirial, session,
+                                  input_tensors, atommap, nframes, nghost);
+  dener = dener_[0];
+}
+
+template void run_model<double, double>(
+    ENERGYTYPE& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const AtomMap& atommap,
+    const int nframes,
+    const int nghost);
+
+template void run_model<double, float>(
+    ENERGYTYPE& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const AtomMap& atommap,
+    const int nframes,
+    const int nghost);
+
+template void run_model<float, double>(
+    ENERGYTYPE& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const AtomMap& atommap,
+    const int nframes,
+    const int nghost);
+
+template void run_model<float, float>(
+    ENERGYTYPE& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const AtomMap& atommap,
+    const int nframes,
+    const int nghost);
+
+template <typename MODELTYPE, typename VALUETYPE>
+static void run_model(
+    ENERGYTYPE& dener,
+    std::vector<VALUETYPE>& dforce_,
+    std::vector<VALUETYPE>& dvirial,
+    std::vector<VALUETYPE>& datom_energy_,
+    std::vector<VALUETYPE>& datom_virial_,
+    Session* session,
+    const std::vector<std::pair<std::string, Tensor>>& input_tensors,
+    const deepmd::AtomMap& atommap,
+    const int& nframes = 1,
+    const int& nghost = 0) {
+  assert(nframes == 1);
+  std::vector<ENERGYTYPE> dener_(1);
+  // call multi-frame version
+  run_model<MODELTYPE, VALUETYPE>(dener_, dforce_, dvirial, datom_energy_,
+                                  datom_virial_, session, input_tensors,
+                                  atommap, nframes, nghost);
+  dener = dener_[0];
 }
 
 template void run_model<double, double>(
@@ -203,6 +363,7 @@ template void run_model<double, double>(
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const deepmd::AtomMap& atommap,
+    const int& nframes,
     const int& nghost);
 
 template void run_model<double, float>(
@@ -214,6 +375,7 @@ template void run_model<double, float>(
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const deepmd::AtomMap& atommap,
+    const int& nframes,
     const int& nghost);
 
 template void run_model<float, double>(
@@ -225,6 +387,7 @@ template void run_model<float, double>(
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const deepmd::AtomMap& atommap,
+    const int& nframes,
     const int& nghost);
 
 template void run_model<float, float>(
@@ -236,7 +399,10 @@ template void run_model<float, float>(
     Session* session,
     const std::vector<std::pair<std::string, Tensor>>& input_tensors,
     const deepmd::AtomMap& atommap,
+    const int& nframes,
     const int& nghost);
+
+// end single frame
 
 DeepPot::DeepPot()
     : inited(false), init_nbor(false), graph_def(new GraphDef()) {}
@@ -397,8 +563,10 @@ template void DeepPot::validate_fparam_aparam<float>(
     const std::vector<float>& fparam,
     const std::vector<float>& aparam) const;
 
-template <typename VALUETYPE>
-void DeepPot::compute(ENERGYTYPE& dener,
+// ENERGYVTYPE: std::vector<ENERGYTYPE> or ENERGYTYPE
+
+template <typename VALUETYPE, typename ENERGYVTYPE>
+void DeepPot::compute(ENERGYVTYPE& dener,
                       std::vector<VALUETYPE>& dforce_,
                       std::vector<VALUETYPE>& dvirial,
                       const std::vector<VALUETYPE>& dcoord_,
@@ -406,7 +574,8 @@ void DeepPot::compute(ENERGYTYPE& dener,
                       const std::vector<VALUETYPE>& dbox,
                       const std::vector<VALUETYPE>& fparam,
                       const std::vector<VALUETYPE>& aparam) {
-  int nall = dcoord_.size() / 3;
+  int nall = datype_.size();
+  int nframes = dcoord_.size() / nall / 3;
   int nloc = nall;
   atommap = deepmd::AtomMap(datype_.begin(), datype_.begin() + nloc);
   assert(nloc == atommap.get_type().size());
@@ -419,36 +588,60 @@ void DeepPot::compute(ENERGYTYPE& dener,
         session_input_tensors<double>(input_tensors, dcoord_, ntypes, datype_,
                                       dbox, cell_size, fparam, aparam, atommap);
     assert(ret == nloc);
-    run_model<double>(dener, dforce_, dvirial, session, input_tensors, atommap);
+    run_model<double>(dener, dforce_, dvirial, session, input_tensors, atommap,
+                      nframes);
   } else {
     int ret =
         session_input_tensors<float>(input_tensors, dcoord_, ntypes, datype_,
                                      dbox, cell_size, fparam, aparam, atommap);
     assert(ret == nloc);
-    run_model<float>(dener, dforce_, dvirial, session, input_tensors, atommap);
+    run_model<float>(dener, dforce_, dvirial, session, input_tensors, atommap,
+                     nframes);
   }
 }
 
-template void DeepPot::compute<double>(ENERGYTYPE& dener,
-                                       std::vector<double>& dforce_,
-                                       std::vector<double>& dvirial,
-                                       const std::vector<double>& dcoord_,
-                                       const std::vector<int>& datype_,
-                                       const std::vector<double>& dbox,
-                                       const std::vector<double>& fparam,
-                                       const std::vector<double>& aparam);
+template void DeepPot::compute<double, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam);
 
-template void DeepPot::compute<float>(ENERGYTYPE& dener,
-                                      std::vector<float>& dforce_,
-                                      std::vector<float>& dvirial,
-                                      const std::vector<float>& dcoord_,
-                                      const std::vector<int>& datype_,
-                                      const std::vector<float>& dbox,
-                                      const std::vector<float>& fparam,
-                                      const std::vector<float>& aparam);
+template void DeepPot::compute<float, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam);
 
-template <typename VALUETYPE>
-void DeepPot::compute(ENERGYTYPE& dener,
+template void DeepPot::compute<double, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam);
+
+template void DeepPot::compute<float, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam);
+
+template <typename VALUETYPE, typename ENERGYVTYPE>
+void DeepPot::compute(ENERGYVTYPE& dener,
                       std::vector<VALUETYPE>& dforce_,
                       std::vector<VALUETYPE>& dvirial,
                       const std::vector<VALUETYPE>& dcoord_,
@@ -459,21 +652,23 @@ void DeepPot::compute(ENERGYTYPE& dener,
                       const int& ago,
                       const std::vector<VALUETYPE>& fparam,
                       const std::vector<VALUETYPE>& aparam_) {
+  int nall = datype_.size();
+  int nframes = dcoord_.size() / nall / 3;
   std::vector<VALUETYPE> dcoord, dforce, aparam;
   std::vector<int> datype, fwd_map, bkw_map;
   int nghost_real;
   select_real_atoms(fwd_map, bkw_map, nghost_real, dcoord_, datype_, nghost,
                     ntypes);
   // resize to nall_real
-  dcoord.resize(bkw_map.size() * 3);
+  dcoord.resize(nframes * bkw_map.size() * 3);
   datype.resize(bkw_map.size());
   // fwd map
-  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3);
-  select_map<int>(datype, datype_, fwd_map, 1);
+  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3, nframes, nall);
+  select_map<int>(datype, datype_, fwd_map, 1, nframes, nall);
   // aparam
   if (daparam > 0) {
-    aparam.resize(bkw_map.size() - nghost_real);
-    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam);
+    aparam.resize(nframes * (bkw_map.size() - nghost_real));
+    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam, nframes, nall);
   }
   // internal nlist
   if (ago == 0) {
@@ -483,36 +678,64 @@ void DeepPot::compute(ENERGYTYPE& dener,
   compute_inner(dener, dforce, dvirial, dcoord, datype, dbox, nghost_real, ago,
                 fparam, aparam);
   // bkw map
-  dforce_.resize(fwd_map.size() * 3);
-  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3);
+  dforce_.resize(nframes * fwd_map.size() * 3);
+  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3, nframes, nall);
 }
 
-template void DeepPot::compute<double>(ENERGYTYPE& dener,
-                                       std::vector<double>& dforce_,
-                                       std::vector<double>& dvirial,
-                                       const std::vector<double>& dcoord_,
-                                       const std::vector<int>& datype_,
-                                       const std::vector<double>& dbox,
-                                       const int nghost,
-                                       const InputNlist& lmp_list,
-                                       const int& ago,
-                                       const std::vector<double>& fparam,
-                                       const std::vector<double>& aparam_);
+template void DeepPot::compute<double, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam_);
 
-template void DeepPot::compute<float>(ENERGYTYPE& dener,
-                                      std::vector<float>& dforce_,
-                                      std::vector<float>& dvirial,
-                                      const std::vector<float>& dcoord_,
-                                      const std::vector<int>& datype_,
-                                      const std::vector<float>& dbox,
-                                      const int nghost,
-                                      const InputNlist& lmp_list,
-                                      const int& ago,
-                                      const std::vector<float>& fparam,
-                                      const std::vector<float>& aparam_);
+template void DeepPot::compute<float, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam_);
 
-template <typename VALUETYPE>
-void DeepPot::compute_inner(ENERGYTYPE& dener,
+template void DeepPot::compute<double, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam_);
+
+template void DeepPot::compute<float, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam_);
+
+template <typename VALUETYPE, typename ENERGYVTYPE>
+void DeepPot::compute_inner(ENERGYVTYPE& dener,
                             std::vector<VALUETYPE>& dforce_,
                             std::vector<VALUETYPE>& dvirial,
                             const std::vector<VALUETYPE>& dcoord_,
@@ -522,7 +745,8 @@ void DeepPot::compute_inner(ENERGYTYPE& dener,
                             const int& ago,
                             const std::vector<VALUETYPE>& fparam,
                             const std::vector<VALUETYPE>& aparam) {
-  int nall = dcoord_.size() / 3;
+  int nall = datype_.size();
+  int nframes = dcoord_.size() / nall / 3;
   int nloc = nall - nghost;
 
   validate_fparam_aparam(nloc, fparam, aparam);
@@ -541,30 +765,67 @@ void DeepPot::compute_inner(ENERGYTYPE& dener,
                                             aparam, atommap, nghost, ago);
     assert(nloc == ret);
     run_model<double>(dener, dforce_, dvirial, session, input_tensors, atommap,
-                      nghost);
+                      nframes, nghost);
   } else {
     int ret = session_input_tensors<float>(input_tensors, dcoord_, ntypes,
                                            datype_, dbox, nlist, fparam, aparam,
                                            atommap, nghost, ago);
     assert(nloc == ret);
     run_model<float>(dener, dforce_, dvirial, session, input_tensors, atommap,
-                     nghost);
+                     nframes, nghost);
   }
 }
 
-template void DeepPot::compute_inner<double>(ENERGYTYPE& dener,
-                                             std::vector<double>& dforce_,
-                                             std::vector<double>& dvirial,
-                                             const std::vector<double>& dcoord_,
-                                             const std::vector<int>& datype_,
-                                             const std::vector<double>& dbox,
-                                             const int nghost,
-                                             const int& ago,
-                                             const std::vector<double>& fparam,
-                                             const std::vector<double>& aparam);
+template void DeepPot::compute_inner<double, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const int nghost,
+    const int& ago,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam);
 
-template <typename VALUETYPE>
-void DeepPot::compute(ENERGYTYPE& dener,
+template void DeepPot::compute_inner<float, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const int nghost,
+    const int& ago,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam);
+
+template void DeepPot::compute_inner<double, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const int nghost,
+    const int& ago,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam);
+
+template void DeepPot::compute_inner<float, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const int nghost,
+    const int& ago,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam);
+
+template <typename VALUETYPE, typename ENERGYVTYPE>
+void DeepPot::compute(ENERGYVTYPE& dener,
                       std::vector<VALUETYPE>& dforce_,
                       std::vector<VALUETYPE>& dvirial,
                       std::vector<VALUETYPE>& datom_energy_,
@@ -574,6 +835,7 @@ void DeepPot::compute(ENERGYTYPE& dener,
                       const std::vector<VALUETYPE>& dbox,
                       const std::vector<VALUETYPE>& fparam,
                       const std::vector<VALUETYPE>& aparam) {
+  int nframes = dcoord_.size() / 3 / datype_.size();
   atommap = deepmd::AtomMap(datype_.begin(), datype_.end());
   validate_fparam_aparam(atommap.get_type().size(), fparam, aparam);
 
@@ -584,40 +846,66 @@ void DeepPot::compute(ENERGYTYPE& dener,
         session_input_tensors<double>(input_tensors, dcoord_, ntypes, datype_,
                                       dbox, cell_size, fparam, aparam, atommap);
     run_model<double>(dener, dforce_, dvirial, datom_energy_, datom_virial_,
-                      session, input_tensors, atommap);
+                      session, input_tensors, atommap, nframes);
   } else {
     int nloc =
         session_input_tensors<float>(input_tensors, dcoord_, ntypes, datype_,
                                      dbox, cell_size, fparam, aparam, atommap);
     run_model<float>(dener, dforce_, dvirial, datom_energy_, datom_virial_,
-                     session, input_tensors, atommap);
+                     session, input_tensors, atommap, nframes);
   }
 }
 
-template void DeepPot::compute<double>(ENERGYTYPE& dener,
-                                       std::vector<double>& dforce_,
-                                       std::vector<double>& dvirial,
-                                       std::vector<double>& datom_energy_,
-                                       std::vector<double>& datom_virial_,
-                                       const std::vector<double>& dcoord_,
-                                       const std::vector<int>& datype_,
-                                       const std::vector<double>& dbox,
-                                       const std::vector<double>& fparam,
-                                       const std::vector<double>& aparam);
+template void DeepPot::compute<double, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    std::vector<double>& datom_energy_,
+    std::vector<double>& datom_virial_,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam);
 
-template void DeepPot::compute<float>(ENERGYTYPE& dener,
-                                      std::vector<float>& dforce_,
-                                      std::vector<float>& dvirial,
-                                      std::vector<float>& datom_energy_,
-                                      std::vector<float>& datom_virial_,
-                                      const std::vector<float>& dcoord_,
-                                      const std::vector<int>& datype_,
-                                      const std::vector<float>& dbox,
-                                      const std::vector<float>& fparam,
-                                      const std::vector<float>& aparam);
+template void DeepPot::compute<float, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    std::vector<float>& datom_energy_,
+    std::vector<float>& datom_virial_,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam);
 
-template <typename VALUETYPE>
-void DeepPot::compute(ENERGYTYPE& dener,
+template void DeepPot::compute<double, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    std::vector<double>& datom_energy_,
+    std::vector<double>& datom_virial_,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam);
+
+template void DeepPot::compute<float, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    std::vector<float>& datom_energy_,
+    std::vector<float>& datom_virial_,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam);
+
+template <typename VALUETYPE, typename ENERGYVTYPE>
+void DeepPot::compute(ENERGYVTYPE& dener,
                       std::vector<VALUETYPE>& dforce_,
                       std::vector<VALUETYPE>& dvirial,
                       std::vector<VALUETYPE>& datom_energy_,
@@ -630,7 +918,8 @@ void DeepPot::compute(ENERGYTYPE& dener,
                       const int& ago,
                       const std::vector<VALUETYPE>& fparam,
                       const std::vector<VALUETYPE>& aparam_) {
-  int nall = dcoord_.size() / 3;
+  int nall = datype_.size();
+  int nframes = dcoord_.size() / 3 / nall;
   int nloc = nall - nghost;
   validate_fparam_aparam(nloc, fparam, aparam_);
   std::vector<std::pair<std::string, Tensor>> input_tensors;
@@ -643,15 +932,15 @@ void DeepPot::compute(ENERGYTYPE& dener,
   // resize to nall_real
   int nall_real = bkw_map.size();
   int nloc_real = nall_real - nghost_real;
-  dcoord.resize(nall_real * 3);
+  dcoord.resize(nframes * nall_real * 3);
   datype.resize(nall_real);
   // fwd map
-  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3);
-  select_map<int>(datype, datype_, fwd_map, 1);
+  select_map<VALUETYPE>(dcoord, dcoord_, fwd_map, 3, nframes, nall);
+  select_map<int>(datype, datype_, fwd_map, 1, nframes, nall);
   // aparam
   if (daparam > 0) {
-    aparam.resize(nloc_real);
-    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam);
+    aparam.resize(nframes * nloc_real);
+    select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam, nframes, nall);
   }
   if (ago == 0) {
     atommap = deepmd::AtomMap(datype.begin(), datype.begin() + nloc_real);
@@ -669,52 +958,84 @@ void DeepPot::compute(ENERGYTYPE& dener,
                                             atommap, nghost_real, ago);
     assert(nloc_real == ret);
     run_model<double>(dener, dforce, dvirial, datom_energy, datom_virial,
-                      session, input_tensors, atommap, nghost_real);
+                      session, input_tensors, atommap, nframes, nghost_real);
   } else {
     int ret = session_input_tensors<float>(input_tensors, dcoord, ntypes,
                                            datype, dbox, nlist, fparam, aparam,
                                            atommap, nghost_real, ago);
     assert(nloc_real == ret);
     run_model<float>(dener, dforce, dvirial, datom_energy, datom_virial,
-                     session, input_tensors, atommap, nghost_real);
+                     session, input_tensors, atommap, nframes, nghost_real);
   }
 
   // bkw map
-  dforce_.resize(fwd_map.size() * 3);
-  datom_energy_.resize(fwd_map.size());
-  datom_virial_.resize(fwd_map.size() * 9);
-  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3);
-  select_map<VALUETYPE>(datom_energy_, datom_energy, bkw_map, 1);
-  select_map<VALUETYPE>(datom_virial_, datom_virial, bkw_map, 9);
+  dforce_.resize(nframes * fwd_map.size() * 3);
+  datom_energy_.resize(nframes * fwd_map.size());
+  datom_virial_.resize(nframes * fwd_map.size() * 9);
+  select_map<VALUETYPE>(dforce_, dforce, bkw_map, 3, nframes, nall);
+  select_map<VALUETYPE>(datom_energy_, datom_energy, bkw_map, 1, nframes, nall);
+  select_map<VALUETYPE>(datom_virial_, datom_virial, bkw_map, 9, nframes, nall);
 }
 
-template void DeepPot::compute<double>(ENERGYTYPE& dener,
-                                       std::vector<double>& dforce_,
-                                       std::vector<double>& dvirial,
-                                       std::vector<double>& datom_energy_,
-                                       std::vector<double>& datom_virial_,
-                                       const std::vector<double>& dcoord_,
-                                       const std::vector<int>& datype_,
-                                       const std::vector<double>& dbox,
-                                       const int nghost,
-                                       const InputNlist& lmp_list,
-                                       const int& ago,
-                                       const std::vector<double>& fparam,
-                                       const std::vector<double>& aparam_);
+template void DeepPot::compute<double, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    std::vector<double>& datom_energy_,
+    std::vector<double>& datom_virial_,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam_);
 
-template void DeepPot::compute<float>(ENERGYTYPE& dener,
-                                      std::vector<float>& dforce_,
-                                      std::vector<float>& dvirial,
-                                      std::vector<float>& datom_energy_,
-                                      std::vector<float>& datom_virial_,
-                                      const std::vector<float>& dcoord_,
-                                      const std::vector<int>& datype_,
-                                      const std::vector<float>& dbox,
-                                      const int nghost,
-                                      const InputNlist& lmp_list,
-                                      const int& ago,
-                                      const std::vector<float>& fparam,
-                                      const std::vector<float>& aparam_);
+template void DeepPot::compute<float, ENERGYTYPE>(
+    ENERGYTYPE& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    std::vector<float>& datom_energy_,
+    std::vector<float>& datom_virial_,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam_);
+
+template void DeepPot::compute<double, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<double>& dforce_,
+    std::vector<double>& dvirial,
+    std::vector<double>& datom_energy_,
+    std::vector<double>& datom_virial_,
+    const std::vector<double>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<double>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<double>& fparam,
+    const std::vector<double>& aparam_);
+
+template void DeepPot::compute<float, std::vector<ENERGYTYPE>>(
+    std::vector<ENERGYTYPE>& dener,
+    std::vector<float>& dforce_,
+    std::vector<float>& dvirial,
+    std::vector<float>& datom_energy_,
+    std::vector<float>& datom_virial_,
+    const std::vector<float>& dcoord_,
+    const std::vector<int>& datype_,
+    const std::vector<float>& dbox,
+    const int nghost,
+    const InputNlist& lmp_list,
+    const int& ago,
+    const std::vector<float>& fparam,
+    const std::vector<float>& aparam_);
 
 void DeepPot::get_type_map(std::string& type_map) {
   type_map = get_scalar<STRINGTYPE>("model_attr/tmap");
@@ -977,10 +1298,10 @@ void DeepPotModelDevi::compute(std::vector<ENERGYTYPE>& all_energy,
   for (unsigned ii = 0; ii < numb_models; ++ii) {
     if (dtype == tensorflow::DT_DOUBLE) {
       run_model<double>(all_energy[ii], all_force[ii], all_virial[ii],
-                        sessions[ii], input_tensors, atommap, nghost);
+                        sessions[ii], input_tensors, atommap, 1, nghost);
     } else {
       run_model<float>(all_energy[ii], all_force[ii], all_virial[ii],
-                       sessions[ii], input_tensors, atommap, nghost);
+                       sessions[ii], input_tensors, atommap, 1, nghost);
     }
   }
 }
@@ -1062,11 +1383,11 @@ void DeepPotModelDevi::compute(
     if (dtype == tensorflow::DT_DOUBLE) {
       run_model<double>(all_energy[ii], all_force[ii], all_virial[ii],
                         all_atom_energy[ii], all_atom_virial[ii], sessions[ii],
-                        input_tensors, atommap, nghost);
+                        input_tensors, atommap, 1, nghost);
     } else {
       run_model<float>(all_energy[ii], all_force[ii], all_virial[ii],
                        all_atom_energy[ii], all_atom_virial[ii], sessions[ii],
-                       input_tensors, atommap, nghost);
+                       input_tensors, atommap, 1, nghost);
     }
   }
 }

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -301,12 +301,11 @@ int deepmd::session_input_tensors(
     const std::vector<VALUETYPE>& aparam_,
     const deepmd::AtomMap& atommap,
     const std::string scope) {
-  bool b_pbc = (dbox.size() == 9);
-
   int nframes = dcoord_.size() / 3 / datype_.size();
   int nall = datype_.size();
   int nloc = nall;
   assert(nall * 3 * nframes == dcoord_.size());
+  bool b_pbc = (dbox.size() == nframes * 9);
 
   std::vector<int> datype = atommap.get_type();
   std::vector<int> type_count(ntypes, 0);

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -609,7 +609,8 @@ void deepmd::select_map(std::vector<VT>& out,
                         const std::vector<int>& idx_map,
                         const int& stride,
                         const int& nframes,
-                        const int& nall) {
+                        const int& nall1,
+                        const int& nall2) {
   for (int kk = 0; kk < nframes; ++kk) {
 #ifdef DEBUG
     assert(in.size() / stride * stride == in.size()),
@@ -623,8 +624,8 @@ void deepmd::select_map(std::vector<VT>& out,
       if (idx_map[ii] >= 0) {
         int to_ii = idx_map[ii];
         for (int dd = 0; dd < stride; ++dd) {
-          out[kk * nall * stride + to_ii * stride + dd] =
-              in[kk * nall * stride + ii * stride + dd];
+          out[kk * nall1 * stride + to_ii * stride + dd] =
+              in[kk * nall2 * stride + ii * stride + dd];
         }
       }
     }
@@ -637,14 +638,15 @@ void deepmd::select_map(typename std::vector<VT>::iterator out,
                         const std::vector<int>& idx_map,
                         const int& stride,
                         const int& nframes,
-                        const int& nall) {
+                        const int& nall1,
+                        const int& nall2) {
   for (int kk = 0; kk < nframes; ++kk) {
     for (int ii = 0; ii < idx_map.size(); ++ii) {
       if (idx_map[ii] >= 0) {
         int to_ii = idx_map[ii];
         for (int dd = 0; dd < stride; ++dd) {
-          *(out + kk * nall * stride + to_ii * stride + dd) =
-              *(in + kk * nall * stride + ii * stride + dd);
+          *(out + kk * nall1 * stride + to_ii * stride + dd) =
+              *(in + kk * nall2 * stride + ii * stride + dd);
         }
       }
     }
@@ -704,7 +706,8 @@ template void deepmd::select_map<int>(std::vector<int>& out,
                                       const std::vector<int>& idx_map,
                                       const int& stride,
                                       const int& nframes,
-                                      const int& nall);
+                                      const int& nall1,
+                                      const int& nall2);
 
 template void deepmd::select_map<int>(
     typename std::vector<int>::iterator out,
@@ -712,7 +715,8 @@ template void deepmd::select_map<int>(
     const std::vector<int>& idx_map,
     const int& stride,
     const int& nframes,
-    const int& nall);
+    const int& nall1,
+    const int& nall2);
 
 template void deepmd::select_map_inv<int>(std::vector<int>& out,
                                           const std::vector<int>& in,
@@ -739,7 +743,8 @@ template void deepmd::select_map<float>(std::vector<float>& out,
                                         const std::vector<int>& idx_map,
                                         const int& stride,
                                         const int& nframes,
-                                        const int& nall);
+                                        const int& nall1,
+                                        const int& nall2);
 
 template void deepmd::select_map<float>(
     typename std::vector<float>::iterator out,
@@ -747,7 +752,8 @@ template void deepmd::select_map<float>(
     const std::vector<int>& idx_map,
     const int& stride,
     const int& nframes,
-    const int& nall);
+    const int& nall1,
+    const int& nall2);
 
 template void deepmd::select_map_inv<float>(std::vector<float>& out,
                                             const std::vector<float>& in,
@@ -774,7 +780,8 @@ template void deepmd::select_map<double>(std::vector<double>& out,
                                          const std::vector<int>& idx_map,
                                          const int& stride,
                                          const int& nframes,
-                                         const int& nall);
+                                         const int& nall1,
+                                         const int& nall2);
 
 template void deepmd::select_map<double>(
     typename std::vector<double>::iterator out,
@@ -782,7 +789,8 @@ template void deepmd::select_map<double>(
     const std::vector<int>& idx_map,
     const int& stride,
     const int& nframes,
-    const int& nall);
+    const int& nall1,
+    const int& nall2);
 
 template void deepmd::select_map_inv<double>(std::vector<double>& out,
                                              const std::vector<double>& in,
@@ -810,7 +818,8 @@ template void deepmd::select_map<deepmd::STRINGTYPE>(
     const std::vector<int>& idx_map,
     const int& stride,
     const int& nframes,
-    const int& nall);
+    const int& nall1,
+    const int& nall2);
 
 template void deepmd::select_map<deepmd::STRINGTYPE>(
     typename std::vector<deepmd::STRINGTYPE>::iterator out,
@@ -818,7 +827,8 @@ template void deepmd::select_map<deepmd::STRINGTYPE>(
     const std::vector<int>& idx_map,
     const int& stride,
     const int& nframes,
-    const int& nall);
+    const int& nall1,
+    const int& nall2);
 
 template void deepmd::select_map_inv<deepmd::STRINGTYPE>(
     std::vector<deepmd::STRINGTYPE>& out,

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -433,12 +433,11 @@ int deepmd::session_input_tensors(
     const int nghost,
     const int ago,
     const std::string scope) {
-  assert(dbox.size() == 9);
-
   int nframes = dcoord_.size() / 3 / datype_.size();
   int nall = datype_.size();
   int nloc = nall - nghost;
   assert(nall * 3 * nframes == dcoord_.size());
+  assert(dbox.size() == nframes * 9);
 
   std::vector<int> datype = atommap.get_type();
   std::vector<int> type_count(ntypes, 0);

--- a/source/api_cc/tests/test_deeppot_a_nframes.cc
+++ b/source/api_cc/tests/test_deeppot_a_nframes.cc
@@ -230,12 +230,13 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist) {
   deepmd::DeepPot& dp = this->dp;
   float rc = dp.cutoff();
   std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
   int nloc = coord_first.size() / 3;
   std::vector<VALUETYPE> coord_cpy;
   std::vector<int> atype_cpy, mapping;
   std::vector<std::vector<int> > nlist_data;
   _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
-                          coord_first, atype, box, rc);
+                          coord_first, atype, box_first, rc);
   int nall = coord_cpy.size() / 3;
   std::vector<int> ilist(nloc), numneigh(nloc);
   std::vector<int*> firstneigh(nloc);
@@ -306,12 +307,13 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_atomic) {
   deepmd::DeepPot& dp = this->dp;
   float rc = dp.cutoff();
   std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
   int nloc = coord_first.size() / 3;
   std::vector<VALUETYPE> coord_cpy;
   std::vector<int> atype_cpy, mapping;
   std::vector<std::vector<int> > nlist_data;
   _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
-                          coord_first, atype, box, rc);
+                          coord_first, atype, box_first, rc);
   int nall = coord_cpy.size() / 3;
   std::vector<int> ilist(nloc), numneigh(nloc);
   std::vector<int*> firstneigh(nloc);
@@ -404,12 +406,13 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_2rc) {
   deepmd::DeepPot& dp = this->dp;
   float rc = dp.cutoff();
   std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
   int nloc = coord_first.size() / 3;
   std::vector<VALUETYPE> coord_cpy;
   std::vector<int> atype_cpy, mapping;
   std::vector<std::vector<int> > nlist_data;
   _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
-                          coord_first, atype, box, rc * 2);
+                          coord_first, atype, box_first, rc * 2);
   int nall = coord_cpy.size() / 3;
   std::vector<int> ilist(nloc), numneigh(nloc);
   std::vector<int*> firstneigh(nloc);
@@ -480,6 +483,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel) {
   deepmd::DeepPot& dp = this->dp;
   float rc = dp.cutoff();
   std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
 
   // add vir atoms
   int nvir = 2;
@@ -501,7 +505,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel) {
   std::vector<int> atype_cpy, mapping;
   std::vector<std::vector<int> > nlist_data;
   _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
-                          coord_first, atype, box, rc);
+                          coord_first, atype, box_first, rc);
   int nall = coord_cpy.size() / 3;
   std::vector<int> ilist(nloc), numneigh(nloc);
   std::vector<int*> firstneigh(nloc);
@@ -553,6 +557,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel_atomic) {
   deepmd::DeepPot& dp = this->dp;
   float rc = dp.cutoff();
   std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
 
   // add vir atoms
   int nvir = 2;
@@ -574,7 +579,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel_atomic) {
   std::vector<int> atype_cpy, mapping;
   std::vector<std::vector<int> > nlist_data;
   _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
-                          coord_first, atype, box, rc);
+                          coord_first, atype, box_first, rc);
   int nall = coord_cpy.size() / 3;
   std::vector<int> ilist(nloc), numneigh(nloc);
   std::vector<int*> firstneigh(nloc);

--- a/source/api_cc/tests/test_deeppot_a_nframes.cc
+++ b/source/api_cc/tests/test_deeppot_a_nframes.cc
@@ -494,7 +494,10 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel) {
   atype.insert(atype.begin(), atype_vir.begin(), atype_vir.end());
   natoms += nvir;
   std::vector<VALUETYPE> expected_f_vir(nvir * 3, 0.0);
+  // two frames
   expected_f.insert(expected_f.begin(), expected_f_vir.begin(),
+                    expected_f_vir.end());
+  expected_f.insert(expected_f.begin() + natoms * 3, expected_f_vir.begin(),
                     expected_f_vir.end());
   std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
   std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
@@ -568,7 +571,10 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel_atomic) {
   atype.insert(atype.begin(), atype_vir.begin(), atype_vir.end());
   natoms += nvir;
   std::vector<VALUETYPE> expected_f_vir(nvir * 3, 0.0);
+  // two frames
   expected_f.insert(expected_f.begin(), expected_f_vir.begin(),
+                    expected_f_vir.end());
+  expected_f.insert(expected_f.begin() + natoms * 3, expected_f_vir.begin(),
                     expected_f_vir.end());
   std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
   std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);

--- a/source/api_cc/tests/test_deeppot_a_nframes.cc
+++ b/source/api_cc/tests/test_deeppot_a_nframes.cc
@@ -1,0 +1,768 @@
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <vector>
+
+#include "DeepPot.h"
+#include "neighbor_list.h"
+#include "test_utils.h"
+
+template <class VALUETYPE>
+class TestInferDeepPotANFrames : public ::testing::Test {
+ protected:
+  std::vector<VALUETYPE> coord = {
+      12.83, 2.56, 2.18, 12.09, 2.87, 2.74, 00.25, 3.32, 1.68,
+      3.36,  3.00, 1.81, 3.51,  2.51, 2.60, 4.27,  3.22, 1.56,
+      12.83, 2.56, 2.18, 12.09, 2.87, 2.74, 00.25, 3.32, 1.68,
+      3.36,  3.00, 1.81, 3.51,  2.51, 2.60, 4.27,  3.22, 1.56};
+  std::vector<int> atype = {0, 1, 1, 0, 1, 1};
+  std::vector<VALUETYPE> box = {13., 0., 0., 0., 13., 0., 0., 0., 13.,
+                                13., 0., 0., 0., 13., 0., 0., 0., 13.};
+  std::vector<VALUETYPE> expected_e = {
+      -9.275780747115504710e+01, -1.863501786584258468e+02,
+      -1.863392472863538103e+02, -9.279281325486221021e+01,
+      -1.863671545232153903e+02, -1.863619822847602165e+02,
+      -9.275780747115504710e+01, -1.863501786584258468e+02,
+      -1.863392472863538103e+02, -9.279281325486221021e+01,
+      -1.863671545232153903e+02, -1.863619822847602165e+02};
+  std::vector<VALUETYPE> expected_f = {
+      -3.034045420701179663e-01, 8.405844663871177014e-01,
+      7.696947487118485642e-02,  7.662001266663505117e-01,
+      -1.880601391333554251e-01, -6.183333871091722944e-01,
+      -5.036172391059643427e-01, -6.529525836149027151e-01,
+      5.432962643022043459e-01,  6.382357912332115024e-01,
+      -1.748518296794561167e-01, 3.457363524891907125e-01,
+      1.286482986991941552e-03,  3.757251165286925043e-01,
+      -5.972588700887541124e-01, -5.987006197104716154e-01,
+      -2.004450304880958100e-01, 2.495901655353461868e-01,
+      -3.034045420701179663e-01, 8.405844663871177014e-01,
+      7.696947487118485642e-02,  7.662001266663505117e-01,
+      -1.880601391333554251e-01, -6.183333871091722944e-01,
+      -5.036172391059643427e-01, -6.529525836149027151e-01,
+      5.432962643022043459e-01,  6.382357912332115024e-01,
+      -1.748518296794561167e-01, 3.457363524891907125e-01,
+      1.286482986991941552e-03,  3.757251165286925043e-01,
+      -5.972588700887541124e-01, -5.987006197104716154e-01,
+      -2.004450304880958100e-01, 2.495901655353461868e-01};
+  std::vector<VALUETYPE> expected_v = {
+      -2.912234126853306959e-01, -3.800610846612756388e-02,
+      2.776624987489437202e-01,  -5.053761003913598976e-02,
+      -3.152373041953385746e-01, 1.060894290092162379e-01,
+      2.826389131596073745e-01,  1.039129970665329250e-01,
+      -2.584378792325942586e-01, -3.121722367954994914e-01,
+      8.483275876786681990e-02,  2.524662342344257682e-01,
+      4.142176771106586414e-02,  -3.820285230785245428e-02,
+      -2.727311173065460545e-02, 2.668859789777112135e-01,
+      -6.448243569420382404e-02, -2.121731470426218846e-01,
+      -8.624335220278558922e-02, -1.809695356746038597e-01,
+      1.529875294531883312e-01,  -1.283658185172031341e-01,
+      -1.992682279795223999e-01, 1.409924999632362341e-01,
+      1.398322735274434292e-01,  1.804318474574856390e-01,
+      -1.470309318999652726e-01, -2.593983661598450730e-01,
+      -4.236536279233147489e-02, 3.386387920184946720e-02,
+      -4.174017537818433543e-02, -1.003500282164128260e-01,
+      1.525690815194478966e-01,  3.398976109910181037e-02,
+      1.522253908435125536e-01,  -2.349125581341701963e-01,
+      9.515545977581392825e-04,  -1.643218849228543846e-02,
+      1.993234765412972564e-02,  6.027265332209678569e-04,
+      -9.563256398907417355e-02, 1.510815124001868293e-01,
+      -7.738094816888557714e-03, 1.502832772532304295e-01,
+      -2.380965783745832010e-01, -2.309456719810296654e-01,
+      -6.666961081213038098e-02, 7.955566551234216632e-02,
+      -8.099093777937517447e-02, -3.386641099800401927e-02,
+      4.447884755740908608e-02,  1.008593228579038742e-01,
+      4.556718179228393811e-02,  -6.078081273849572641e-02,
+      -2.912234126853306959e-01, -3.800610846612756388e-02,
+      2.776624987489437202e-01,  -5.053761003913598976e-02,
+      -3.152373041953385746e-01, 1.060894290092162379e-01,
+      2.826389131596073745e-01,  1.039129970665329250e-01,
+      -2.584378792325942586e-01, -3.121722367954994914e-01,
+      8.483275876786681990e-02,  2.524662342344257682e-01,
+      4.142176771106586414e-02,  -3.820285230785245428e-02,
+      -2.727311173065460545e-02, 2.668859789777112135e-01,
+      -6.448243569420382404e-02, -2.121731470426218846e-01,
+      -8.624335220278558922e-02, -1.809695356746038597e-01,
+      1.529875294531883312e-01,  -1.283658185172031341e-01,
+      -1.992682279795223999e-01, 1.409924999632362341e-01,
+      1.398322735274434292e-01,  1.804318474574856390e-01,
+      -1.470309318999652726e-01, -2.593983661598450730e-01,
+      -4.236536279233147489e-02, 3.386387920184946720e-02,
+      -4.174017537818433543e-02, -1.003500282164128260e-01,
+      1.525690815194478966e-01,  3.398976109910181037e-02,
+      1.522253908435125536e-01,  -2.349125581341701963e-01,
+      9.515545977581392825e-04,  -1.643218849228543846e-02,
+      1.993234765412972564e-02,  6.027265332209678569e-04,
+      -9.563256398907417355e-02, 1.510815124001868293e-01,
+      -7.738094816888557714e-03, 1.502832772532304295e-01,
+      -2.380965783745832010e-01, -2.309456719810296654e-01,
+      -6.666961081213038098e-02, 7.955566551234216632e-02,
+      -8.099093777937517447e-02, -3.386641099800401927e-02,
+      4.447884755740908608e-02,  1.008593228579038742e-01,
+      4.556718179228393811e-02,  -6.078081273849572641e-02};
+  int natoms;
+  int nframes = 2;
+  std::vector<double> expected_tot_e;
+  std::vector<VALUETYPE> expected_tot_v;
+
+  deepmd::DeepPot dp;
+
+  void SetUp() override {
+    std::string file_name = "../../tests/infer/deeppot.pbtxt";
+    deepmd::convert_pbtxt_to_pb("../../tests/infer/deeppot.pbtxt",
+                                "deeppot.pb");
+
+    dp.init("deeppot.pb");
+
+    natoms = expected_e.size() / nframes;
+    EXPECT_EQ(nframes * natoms * 3, expected_f.size());
+    EXPECT_EQ(nframes * natoms * 9, expected_v.size());
+    expected_tot_e.resize(nframes);
+    expected_tot_v.resize(nframes * 9);
+    std::fill(expected_tot_e.begin(), expected_tot_e.end(), 0.);
+    std::fill(expected_tot_v.begin(), expected_tot_v.end(), 0.);
+    for (int kk = 0; kk < nframes; ++kk) {
+      for (int ii = 0; ii < natoms; ++ii) {
+        expected_tot_e[kk] += expected_e[kk * natoms + ii];
+      }
+      for (int ii = 0; ii < natoms; ++ii) {
+        for (int dd = 0; dd < 9; ++dd) {
+          expected_tot_v[kk * 9 + dd] +=
+              expected_v[kk * natoms * 9 + ii * 9 + dd];
+        }
+      }
+    }
+  };
+
+  void TearDown() override { remove("deeppot.pb"); };
+};
+
+TYPED_TEST_SUITE(TestInferDeepPotANFrames, ValueTypes);
+
+TYPED_TEST(TestInferDeepPotANFrames, cpu_build_nlist) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force, virial;
+  dp.compute(ener, force, virial, coord, atype, box);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
+TYPED_TEST(TestInferDeepPotANFrames, cpu_build_nlist_atomic) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force, virial, atom_ener, atom_vir;
+  dp.compute(ener, force, virial, atom_ener, atom_vir, coord, atype, box);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+  EXPECT_EQ(atom_ener.size(), nframes * natoms);
+  EXPECT_EQ(atom_vir.size(), nframes * natoms * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms; ++ii) {
+    EXPECT_LT(fabs(atom_ener[ii] - expected_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 9; ++ii) {
+    EXPECT_LT(fabs(atom_vir[ii] - expected_v[ii]), EPSILON);
+  }
+}
+
+TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  int nloc = coord_first.size() / 3;
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;
+  std::vector<std::vector<int> > nlist_data;
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+                          coord_first, atype, box, rc);
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_data);
+  std::vector<VALUETYPE> coord_cpy2(nframes * nall * 3);
+  for (int ii = 0; ii < nframes; ++ii) {
+    for (int jj = 0; jj < nall * 3; ++jj) {
+      coord_cpy2[ii * nall * 3 + jj] = coord_cpy[jj];
+    }
+  }
+
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force_, virial;
+  dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
+             inlist, 0);
+  std::vector<VALUETYPE> force;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+
+  std::fill(ener.begin(), ener.end(), 0.0);
+  std::fill(force_.begin(), force_.end(), 0.0);
+  std::fill(virial.begin(), virial.end(), 0.0);
+  dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
+             inlist, 1);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
+TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_atomic) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  int nloc = coord_first.size() / 3;
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;
+  std::vector<std::vector<int> > nlist_data;
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+                          coord_first, atype, box, rc);
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_data);
+
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force_, atom_ener_, atom_vir_, virial;
+  std::vector<VALUETYPE> force, atom_ener, atom_vir;
+  dp.compute(ener, force_, virial, atom_ener_, atom_vir_, coord_cpy, atype_cpy,
+             box, nall - nloc, inlist, 0);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(atom_ener, atom_ener_, mapping, nloc, nall, 1);
+  _fold_back<VALUETYPE>(atom_vir, atom_vir_, mapping, nloc, nall, 9);
+
+  EXPECT_EQ(ener.size(), 1);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+  EXPECT_EQ(atom_ener.size(), nframes * natoms);
+  EXPECT_EQ(atom_vir.size(), nframes * natoms * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms; ++ii) {
+    EXPECT_LT(fabs(atom_ener[ii] - expected_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 9; ++ii) {
+    EXPECT_LT(fabs(atom_vir[ii] - expected_v[ii]), EPSILON);
+  }
+
+  std::fill(ener.begin(), ener.end(), 0.0);
+  std::fill(force_.begin(), force_.end(), 0.0);
+  std::fill(virial.begin(), virial.end(), 0.0);
+  std::fill(atom_ener_.begin(), atom_ener_.end(), 0.0);
+  std::fill(atom_vir_.begin(), atom_vir_.end(), 0.0);
+  dp.compute(ener, force_, virial, atom_ener_, atom_vir_, coord_cpy, atype_cpy,
+             box, nall - nloc, inlist, 1);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(atom_ener, atom_ener_, mapping, nloc, nall, 1);
+  _fold_back<VALUETYPE>(atom_vir, atom_vir_, mapping, nloc, nall, 9);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+  EXPECT_EQ(atom_ener.size(), nframes * natoms);
+  EXPECT_EQ(atom_vir.size(), nframes * natoms * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms; ++ii) {
+    EXPECT_LT(fabs(atom_ener[ii] - expected_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 9; ++ii) {
+    EXPECT_LT(fabs(atom_vir[ii] - expected_v[ii]), EPSILON);
+  }
+}
+
+TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_2rc) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  int nloc = coord_first.size() / 3;
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;
+  std::vector<std::vector<int> > nlist_data;
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+                          coord_first, atype, box, rc * 2);
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_data);
+  std::vector<VALUETYPE> coord_cpy2(nframes * nall * 3);
+  for (int ii = 0; ii < nframes; ++ii) {
+    for (int jj = 0; jj < nall * 3; ++jj) {
+      coord_cpy2[ii * nall * 3 + jj] = coord_cpy[jj];
+    }
+  }
+
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force_(nall * 3, 0.0), virial(nframes * 9, 0.0);
+  dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
+             inlist, 0);
+  std::vector<VALUETYPE> force;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+
+  std::fill(ener.begin(), ener.end(), 0.0);
+  std::fill(force_.begin(), force_.end(), 0.0);
+  std::fill(virial.begin(), virial.end(), 0.0);
+  dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
+             inlist, 1);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
+TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+
+  // add vir atoms
+  int nvir = 2;
+  std::vector<VALUETYPE> coord_vir(nvir * 3);
+  std::vector<int> atype_vir(nvir, 2);
+  for (int ii = 0; ii < nvir; ++ii) {
+    coord_vir[ii] = coord[ii];
+  }
+  coord.insert(coord.begin(), coord_vir.begin(), coord_vir.end());
+  atype.insert(atype.begin(), atype_vir.begin(), atype_vir.end());
+  natoms += nvir;
+  std::vector<VALUETYPE> expected_f_vir(nvir * 3, 0.0);
+  expected_f.insert(expected_f.begin(), expected_f_vir.begin(),
+                    expected_f_vir.end());
+
+  // build nlist
+  int nloc = coord_first.size() / 3;
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;
+  std::vector<std::vector<int> > nlist_data;
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+                          coord_first, atype, box, rc);
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_data);
+  std::vector<VALUETYPE> coord_cpy2(nframes * nall * 3);
+  for (int ii = 0; ii < nframes; ++ii) {
+    for (int jj = 0; jj < nall * 3; ++jj) {
+      coord_cpy2[ii * nall * 3 + jj] = coord_cpy[jj];
+    }
+  }
+
+  // dp compute
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force_(nall * 3, 0.0), virial(nframes * 9, 0.0);
+  dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
+             inlist, 0);
+  // fold back
+  std::vector<VALUETYPE> force;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
+TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel_atomic) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+
+  // add vir atoms
+  int nvir = 2;
+  std::vector<VALUETYPE> coord_vir(nvir * 3);
+  std::vector<int> atype_vir(nvir, 2);
+  for (int ii = 0; ii < nvir; ++ii) {
+    coord_vir[ii] = coord[ii];
+  }
+  coord.insert(coord.begin(), coord_vir.begin(), coord_vir.end());
+  atype.insert(atype.begin(), atype_vir.begin(), atype_vir.end());
+  natoms += nvir;
+  std::vector<VALUETYPE> expected_f_vir(nvir * 3, 0.0);
+  expected_f.insert(expected_f.begin(), expected_f_vir.begin(),
+                    expected_f_vir.end());
+
+  // build nlist
+  int nloc = coord_first.size() / 3;
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;
+  std::vector<std::vector<int> > nlist_data;
+  _build_nlist<VALUETYPE>(nlist_data, coord_cpy, atype_cpy, mapping,
+                          coord_first, atype, box, rc);
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_data);
+  std::vector<VALUETYPE> coord_cpy2(nframes * nall * 3);
+  for (int ii = 0; ii < nframes; ++ii) {
+    for (int jj = 0; jj < nall * 3; ++jj) {
+      coord_cpy2[ii * nall * 3 + jj] = coord_cpy[jj];
+    }
+  }
+
+  // dp compute
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force_(nall * 3, 0.0), virial(nframes * 9, 0.0),
+      atomic_energy, atomic_virial;
+  dp.compute(ener, force_, virial, atomic_energy, atomic_virial, coord_cpy2,
+             atype_cpy, box, nall - nloc, inlist, 0);
+  // fold back
+  std::vector<VALUETYPE> force;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
+template <class VALUETYPE>
+class TestInferDeepPotANFramesNoPbc : public ::testing::Test {
+ protected:
+  std::vector<VALUETYPE> coord = {
+      12.83, 2.56, 2.18, 12.09, 2.87, 2.74, 00.25, 3.32, 1.68,
+      3.36,  3.00, 1.81, 3.51,  2.51, 2.60, 4.27,  3.22, 1.56,
+      12.83, 2.56, 2.18, 12.09, 2.87, 2.74, 00.25, 3.32, 1.68,
+      3.36,  3.00, 1.81, 3.51,  2.51, 2.60, 4.27,  3.22, 1.56};
+  std::vector<int> atype = {0, 1, 1, 0, 1, 1};
+  std::vector<VALUETYPE> box = {};
+  std::vector<VALUETYPE> expected_e = {
+      -9.255934839310273787e+01, -1.863253376736990106e+02,
+      -1.857237299341402945e+02, -9.279308539717486326e+01,
+      -1.863708105823244239e+02, -1.863635196514972563e+02,
+      -9.255934839310273787e+01, -1.863253376736990106e+02,
+      -1.857237299341402945e+02, -9.279308539717486326e+01,
+      -1.863708105823244239e+02, -1.863635196514972563e+02};
+  std::vector<VALUETYPE> expected_f = {
+      -2.161037360255332107e+00, 9.052994347015581589e-01,
+      1.635379623977007979e+00,  2.161037360255332107e+00,
+      -9.052994347015581589e-01, -1.635379623977007979e+00,
+      -1.167128117249453811e-02, 1.371975700096064992e-03,
+      -1.575265180249604477e-03, 6.226508593971802341e-01,
+      -1.816734122009256991e-01, 3.561766019664774907e-01,
+      -1.406075393906316626e-02, 3.789140061530929526e-01,
+      -6.018777878642909140e-01, -5.969188242856223736e-01,
+      -1.986125696522633155e-01, 2.472764510780630642e-01,
+      -2.161037360255332107e+00, 9.052994347015581589e-01,
+      1.635379623977007979e+00,  2.161037360255332107e+00,
+      -9.052994347015581589e-01, -1.635379623977007979e+00,
+      -1.167128117249453811e-02, 1.371975700096064992e-03,
+      -1.575265180249604477e-03, 6.226508593971802341e-01,
+      -1.816734122009256991e-01, 3.561766019664774907e-01,
+      -1.406075393906316626e-02, 3.789140061530929526e-01,
+      -6.018777878642909140e-01, -5.969188242856223736e-01,
+      -1.986125696522633155e-01, 2.472764510780630642e-01};
+  std::vector<VALUETYPE> expected_v = {
+      -7.042445481792056761e-01, 2.950213647777754078e-01,
+      5.329418202437231633e-01,  2.950213647777752968e-01,
+      -1.235900311906896754e-01, -2.232594111831812944e-01,
+      5.329418202437232743e-01,  -2.232594111831813499e-01,
+      -4.033073234276823849e-01, -8.949230984097404917e-01,
+      3.749002169013777030e-01,  6.772391014992630298e-01,
+      3.749002169013777586e-01,  -1.570527935667933583e-01,
+      -2.837082722496912512e-01, 6.772391014992631408e-01,
+      -2.837082722496912512e-01, -5.125052659994422388e-01,
+      4.858210330291591605e-02,  -6.902596153269104431e-03,
+      6.682612642430500391e-03,  -5.612247004554610057e-03,
+      9.767795567660207592e-04,  -9.773758942738038254e-04,
+      5.638322117219018645e-03,  -9.483806049779926932e-04,
+      8.493873281881353637e-04,  -2.941738570564985666e-01,
+      -4.482529909499673171e-02, 4.091569840186781021e-02,
+      -4.509020615859140463e-02, -1.013919988807244071e-01,
+      1.551440772665269030e-01,  4.181857726606644232e-02,
+      1.547200233064863484e-01,  -2.398213304685777592e-01,
+      -3.218625798524068354e-02, -1.012438450438508421e-02,
+      1.271639330380921855e-02,  3.072814938490859779e-03,
+      -9.556241797915024372e-02, 1.512251983492413077e-01,
+      -8.277872384009607454e-03, 1.505412040827929787e-01,
+      -2.386150620881526407e-01, -2.312295470054945568e-01,
+      -6.631490213524345034e-02, 7.932427266386249398e-02,
+      -8.053754366323923053e-02, -3.294595881137418747e-02,
+      4.342495071150231922e-02,  1.004599500126941436e-01,
+      4.450400364869536163e-02,  -5.951077548033092968e-02,
+      -7.042445481792056761e-01, 2.950213647777754078e-01,
+      5.329418202437231633e-01,  2.950213647777752968e-01,
+      -1.235900311906896754e-01, -2.232594111831812944e-01,
+      5.329418202437232743e-01,  -2.232594111831813499e-01,
+      -4.033073234276823849e-01, -8.949230984097404917e-01,
+      3.749002169013777030e-01,  6.772391014992630298e-01,
+      3.749002169013777586e-01,  -1.570527935667933583e-01,
+      -2.837082722496912512e-01, 6.772391014992631408e-01,
+      -2.837082722496912512e-01, -5.125052659994422388e-01,
+      4.858210330291591605e-02,  -6.902596153269104431e-03,
+      6.682612642430500391e-03,  -5.612247004554610057e-03,
+      9.767795567660207592e-04,  -9.773758942738038254e-04,
+      5.638322117219018645e-03,  -9.483806049779926932e-04,
+      8.493873281881353637e-04,  -2.941738570564985666e-01,
+      -4.482529909499673171e-02, 4.091569840186781021e-02,
+      -4.509020615859140463e-02, -1.013919988807244071e-01,
+      1.551440772665269030e-01,  4.181857726606644232e-02,
+      1.547200233064863484e-01,  -2.398213304685777592e-01,
+      -3.218625798524068354e-02, -1.012438450438508421e-02,
+      1.271639330380921855e-02,  3.072814938490859779e-03,
+      -9.556241797915024372e-02, 1.512251983492413077e-01,
+      -8.277872384009607454e-03, 1.505412040827929787e-01,
+      -2.386150620881526407e-01, -2.312295470054945568e-01,
+      -6.631490213524345034e-02, 7.932427266386249398e-02,
+      -8.053754366323923053e-02, -3.294595881137418747e-02,
+      4.342495071150231922e-02,  1.004599500126941436e-01,
+      4.450400364869536163e-02,  -5.951077548033092968e-02};
+  int natoms;
+  int nframes = 2;
+  std::vector<double> expected_tot_e;
+  std::vector<VALUETYPE> expected_tot_v;
+
+  deepmd::DeepPot dp;
+
+  void SetUp() override {
+    std::string file_name = "../../tests/infer/deeppot.pbtxt";
+    deepmd::convert_pbtxt_to_pb(file_name, "deeppot.pb");
+
+    dp.init("deeppot.pb");
+
+    natoms = expected_e.size() / nframes;
+    EXPECT_EQ(nframes * natoms * 3, expected_f.size());
+    EXPECT_EQ(nframes * natoms * 9, expected_v.size());
+    expected_tot_e.resize(nframes);
+    expected_tot_v.resize(nframes * 9);
+    std::fill(expected_tot_e.begin(), expected_tot_e.end(), 0.);
+    std::fill(expected_tot_v.begin(), expected_tot_v.end(), 0.);
+    for (int kk = 0; kk < nframes; ++kk) {
+      for (int ii = 0; ii < natoms; ++ii) {
+        expected_tot_e[kk] += expected_e[kk * natoms + ii];
+      }
+      for (int ii = 0; ii < natoms; ++ii) {
+        for (int dd = 0; dd < 9; ++dd) {
+          expected_tot_v[kk * 9 + dd] +=
+              expected_v[kk * natoms * 9 + ii * 9 + dd];
+        }
+      }
+    }
+  };
+
+  void TearDown() override { remove("deeppot.pb"); };
+};
+
+TYPED_TEST_SUITE(TestInferDeepPotANFramesNoPbc, ValueTypes);
+
+TYPED_TEST(TestInferDeepPotANFramesNoPbc, cpu_build_nlist) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_e = this->expected_e;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  std::vector<VALUETYPE>& expected_v = this->expected_v;
+  int& natoms = this->natoms;
+  int& nframes = this->nframes;
+  std::vector<double>& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  std::vector<double> ener;
+  std::vector<VALUETYPE> force, virial;
+  dp.compute(ener, force, virial, coord, atype, box);
+
+  EXPECT_EQ(ener.size(), nframes);
+  EXPECT_EQ(force.size(), nframes * natoms * 3);
+  EXPECT_EQ(virial.size(), nframes * 9);
+
+  for (int ii = 0; ii < nframes; ++ii) {
+    EXPECT_LT(fabs(ener[ii] - expected_tot_e[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < nframes * 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}

--- a/source/api_cc/tests/test_deeppot_a_nframes.cc
+++ b/source/api_cc/tests/test_deeppot_a_nframes.cc
@@ -482,8 +482,6 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel) {
   std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
   deepmd::DeepPot& dp = this->dp;
   float rc = dp.cutoff();
-  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
-  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
 
   // add vir atoms
   int nvir = 2;
@@ -498,6 +496,8 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel) {
   std::vector<VALUETYPE> expected_f_vir(nvir * 3, 0.0);
   expected_f.insert(expected_f.begin(), expected_f_vir.begin(),
                     expected_f_vir.end());
+  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
 
   // build nlist
   int nloc = coord_first.size() / 3;
@@ -556,8 +556,6 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel_atomic) {
   std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
   deepmd::DeepPot& dp = this->dp;
   float rc = dp.cutoff();
-  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
-  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
 
   // add vir atoms
   int nvir = 2;
@@ -572,6 +570,8 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel_atomic) {
   std::vector<VALUETYPE> expected_f_vir(nvir * 3, 0.0);
   expected_f.insert(expected_f.begin(), expected_f_vir.begin(),
                     expected_f_vir.end());
+  std::vector<VALUETYPE> coord_first(coord.begin(), coord.begin() + 3 * natoms);
+  std::vector<VALUETYPE> box_first(box.begin(), box.begin() + 9);
 
   // build nlist
   int nloc = coord_first.size() / 3;

--- a/source/api_cc/tests/test_deeppot_a_nframes.cc
+++ b/source/api_cc/tests/test_deeppot_a_nframes.cc
@@ -253,7 +253,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist) {
   dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
              inlist, 0);
   std::vector<VALUETYPE> force;
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
 
   EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);
@@ -274,7 +274,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist) {
   std::fill(virial.begin(), virial.end(), 0.0);
   dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
              inlist, 1);
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
 
   EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);
@@ -317,17 +317,23 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_atomic) {
   std::vector<int*> firstneigh(nloc);
   deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
   convert_nlist(inlist, nlist_data);
+  std::vector<VALUETYPE> coord_cpy2(nframes * nall * 3);
+  for (int ii = 0; ii < nframes; ++ii) {
+    for (int jj = 0; jj < nall * 3; ++jj) {
+      coord_cpy2[ii * nall * 3 + jj] = coord_cpy[jj];
+    }
+  }
 
   std::vector<double> ener;
   std::vector<VALUETYPE> force_, atom_ener_, atom_vir_, virial;
   std::vector<VALUETYPE> force, atom_ener, atom_vir;
-  dp.compute(ener, force_, virial, atom_ener_, atom_vir_, coord_cpy, atype_cpy,
+  dp.compute(ener, force_, virial, atom_ener_, atom_vir_, coord_cpy2, atype_cpy,
              box, nall - nloc, inlist, 0);
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
-  _fold_back<VALUETYPE>(atom_ener, atom_ener_, mapping, nloc, nall, 1);
-  _fold_back<VALUETYPE>(atom_vir, atom_vir_, mapping, nloc, nall, 9);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
+  _fold_back<VALUETYPE>(atom_ener, atom_ener_, mapping, nloc, nall, 1, nframes);
+  _fold_back<VALUETYPE>(atom_vir, atom_vir_, mapping, nloc, nall, 9, nframes);
 
-  EXPECT_EQ(ener.size(), 1);
+  EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);
   EXPECT_EQ(virial.size(), nframes * 9);
   EXPECT_EQ(atom_ener.size(), nframes * natoms);
@@ -354,11 +360,11 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_atomic) {
   std::fill(virial.begin(), virial.end(), 0.0);
   std::fill(atom_ener_.begin(), atom_ener_.end(), 0.0);
   std::fill(atom_vir_.begin(), atom_vir_.end(), 0.0);
-  dp.compute(ener, force_, virial, atom_ener_, atom_vir_, coord_cpy, atype_cpy,
+  dp.compute(ener, force_, virial, atom_ener_, atom_vir_, coord_cpy2, atype_cpy,
              box, nall - nloc, inlist, 1);
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
-  _fold_back<VALUETYPE>(atom_ener, atom_ener_, mapping, nloc, nall, 1);
-  _fold_back<VALUETYPE>(atom_vir, atom_vir_, mapping, nloc, nall, 9);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
+  _fold_back<VALUETYPE>(atom_ener, atom_ener_, mapping, nloc, nall, 1, nframes);
+  _fold_back<VALUETYPE>(atom_vir, atom_vir_, mapping, nloc, nall, 9, nframes);
 
   EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);
@@ -421,7 +427,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_2rc) {
   dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
              inlist, 0);
   std::vector<VALUETYPE> force;
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
 
   EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);
@@ -442,7 +448,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_2rc) {
   std::fill(virial.begin(), virial.end(), 0.0);
   dp.compute(ener, force_, virial, coord_cpy2, atype_cpy, box, nall - nloc,
              inlist, 1);
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
 
   EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);
@@ -515,7 +521,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel) {
              inlist, 0);
   // fold back
   std::vector<VALUETYPE> force;
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
 
   EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);
@@ -589,7 +595,7 @@ TYPED_TEST(TestInferDeepPotANFrames, cpu_lmp_nlist_type_sel_atomic) {
              atype_cpy, box, nall - nloc, inlist, 0);
   // fold back
   std::vector<VALUETYPE> force;
-  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3, nframes);
 
   EXPECT_EQ(ener.size(), nframes);
   EXPECT_EQ(force.size(), nframes * natoms * 3);

--- a/source/api_cc/tests/test_utils.h
+++ b/source/api_cc/tests/test_utils.h
@@ -19,16 +19,18 @@ inline void _fold_back(typename std::vector<VALUETYPE>::iterator out,
                        const int ndim,
                        const int nframes = 1) {
   // out.resize(nloc*ndim);
-  std::copy(in, in + nloc * ndim, out);
-  for (int kk = 0; kk < nframes; ++kk)
+  for (int kk = 0; kk < nframes; ++kk) {
+    std::copy(in + kk * nall * ndim, in + kk * nall * ndim + nloc * ndim,
+              out + kk * nloc * ndim);
     for (int ii = nloc; ii < nall; ++ii) {
       int in_idx = ii;
       int out_idx = mapping[in_idx];
       for (int dd = 0; dd < ndim; ++dd) {
-        *(out + kk * nall * ndim + out_idx * ndim + dd) +=
+        *(out + kk * nloc * ndim + out_idx * ndim + dd) +=
             *(in + kk * nall * ndim + in_idx * ndim + dd);
       }
     }
+  }
 }
 
 template <typename VALUETYPE>

--- a/source/api_cc/tests/test_utils.h
+++ b/source/api_cc/tests/test_utils.h
@@ -16,16 +16,19 @@ inline void _fold_back(typename std::vector<VALUETYPE>::iterator out,
                        const std::vector<int> &mapping,
                        const int nloc,
                        const int nall,
-                       const int ndim) {
+                       const int ndim,
+                       const int nframes = 1) {
   // out.resize(nloc*ndim);
   std::copy(in, in + nloc * ndim, out);
-  for (int ii = nloc; ii < nall; ++ii) {
-    int in_idx = ii;
-    int out_idx = mapping[in_idx];
-    for (int dd = 0; dd < ndim; ++dd) {
-      *(out + out_idx * ndim + dd) += *(in + in_idx * ndim + dd);
+  for (int kk = 0; kk < nframes; ++kk)
+    for (int ii = nloc; ii < nall; ++ii) {
+      int in_idx = ii;
+      int out_idx = mapping[in_idx];
+      for (int dd = 0; dd < ndim; ++dd) {
+        *(out + kk * nall * ndim + out_idx * ndim + dd) +=
+            *(in + kk * nall * ndim + in_idx * ndim + dd);
+      }
     }
-  }
 }
 
 template <typename VALUETYPE>
@@ -34,9 +37,11 @@ inline void _fold_back(std::vector<VALUETYPE> &out,
                        const std::vector<int> &mapping,
                        const int nloc,
                        const int nall,
-                       const int ndim) {
-  out.resize(nloc * ndim);
-  _fold_back<VALUETYPE>(out.begin(), in.begin(), mapping, nloc, nall, ndim);
+                       const int ndim,
+                       const int nframes = 1) {
+  out.resize(nframes * nloc * ndim);
+  _fold_back<VALUETYPE>(out.begin(), in.begin(), mapping, nloc, nall, ndim,
+                        nframes);
 }
 
 template <typename VALUETYPE>


### PR DESCRIPTION
Fix #2234.

When evaluating multiple frames, `ener` should be `std::vector<double>` instead of `double`. We assume `atype` is the same for all frames (follow the current docs).