### PR TITLE
Cleanup with flake8 E and F rule sets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,13 @@ repos:
     rev: 5.12.0
     hooks:
     - id: isort
-    files: \.py$
+      files: \.py$
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.243
+    hooks:
+    - id: ruff
+      args: ["--fix"]
 # numpydoc
 -   repo: https://github.com/Carreau/velin
     rev: 0.0.12

--- a/deepmd/entrypoints/compress.py
+++ b/deepmd/entrypoints/compress.py
@@ -99,7 +99,7 @@ def compress(
         )
         jdata = json.loads(t_jdata)
     except GraphWithoutTensorError as e:
-        if training_script == None:
+        if training_script is None:
             raise RuntimeError(
                 "The input frozen model: %s has no training script or min_nbor_dist information, "
                 "which is not supported by the model compression interface. "
@@ -193,6 +193,5 @@ def _check_compress_type(graph: tf.Graph):
 
     if t_model_type == "compressed_model":
         raise RuntimeError(
-            "The input frozen model %s has already been compressed! Please do not compress the model repeatedly. "
-            % model_file
+            "The input frozen model has already been compressed! Please do not compress the model repeatedly. "
         )

--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -539,7 +539,7 @@ def test_polar(
     if not atomic:
         log.info(f"Polarizability  RMSE/sqrtN : {rmse_fs:e}")
         log.info(f"Polarizability  RMSE/N     : {rmse_fa:e}")
-    log.info(f"The unit of error is the same as the unit of provided label.")
+    log.info("The unit of error is the same as the unit of provided label.")
 
     if detail_file is not None:
         detail_path = Path(detail_file)
@@ -629,7 +629,7 @@ def test_dipole(
     if not atomic:
         log.info(f"Dipole  RMSE/sqrtN : {rmse_fs:e}")
         log.info(f"Dipole  RMSE/N     : {rmse_fa:e}")
-    log.info(f"The unit of error is the same as the unit of provided label.")
+    log.info("The unit of error is the same as the unit of provided label.")
 
     if detail_file is not None:
         detail_path = Path(detail_file)

--- a/deepmd/entrypoints/transfer.py
+++ b/deepmd/entrypoints/transfer.py
@@ -150,7 +150,7 @@ def transform_graph(raw_graph: tf.Graph, old_graph: tf.Graph) -> tf.Graph:
                     cp_attr.from_array(tensor, tf.float16, [1])
 
             elif old_graph_dtype[1] == "float16":
-                tensor = convertMatrix(np.array(old_node.half_val), tensor_shape)
+                tensor = convert_matrix(np.array(old_node.half_val), tensor_shape)
                 cp_attr.from_array(tensor, raw_graph_dtype)
 
         elif raw_graph_dtype == np.float64 or raw_graph_dtype == np.float32:
@@ -167,12 +167,12 @@ def transform_graph(raw_graph: tf.Graph, old_graph: tf.Graph) -> tf.Graph:
 
             elif old_graph_dtype == np.float16:
                 if (len(tensor_shape) != 1) or (tensor_shape[0] != 1):
-                    tensor = convertMatrix(
+                    tensor = convert_matrix(
                         np.array(old_node.half_val), tensor_shape
                     ).astype(raw_graph_dtype)
                     cp_attr.from_str(tensor)
                 else:
-                    tensor = convertMatrix(
+                    tensor = convert_matrix(
                         np.array(old_node.half_val), tensor_shape
                     ).astype(raw_graph_dtype)
                     cp_attr.from_array(tensor, raw_graph_dtype)

--- a/deepmd/fit/polar.py
+++ b/deepmd/fit/polar.py
@@ -147,7 +147,7 @@ class PolarFittingSeA(Fitting):
         protection
             Divided-by-zero protection
         """
-        if not ("polarizability" in all_stat.keys()):
+        if "polarizability" not in all_stat.keys():
             self.avgeig = np.zeros([9])
             warnings.warn(
                 "no polarizability data, cannot do data stat. use zeros as guess"

--- a/deepmd/infer/deep_pot.py
+++ b/deepmd/infer/deep_pot.py
@@ -124,7 +124,7 @@ class DeepPot(DeepEval):
             self._get_tensor("t_efield:0", "t_efield")
             self.has_efield = True
         else:
-            log.debug(f"Could not get tensor 't_efield:0'")
+            log.debug("Could not get tensor 't_efield:0'")
             self.t_efield = None
             self.has_efield = False
 
@@ -132,7 +132,7 @@ class DeepPot(DeepEval):
             self.tensors.update({"t_fparam": "t_fparam:0"})
             self.has_fparam = True
         else:
-            log.debug(f"Could not get tensor 't_fparam:0'")
+            log.debug("Could not get tensor 't_fparam:0'")
             self.t_fparam = None
             self.has_fparam = False
 
@@ -140,7 +140,7 @@ class DeepPot(DeepEval):
             self.tensors.update({"t_aparam": "t_aparam:0"})
             self.has_aparam = True
         else:
-            log.debug(f"Could not get tensor 't_aparam:0'")
+            log.debug("Could not get tensor 't_aparam:0'")
             self.t_aparam = None
             self.has_aparam = False
 

--- a/deepmd/infer/deep_tensor.py
+++ b/deepmd/infer/deep_tensor.py
@@ -306,7 +306,7 @@ class DeepTensor(DeepEval):
             The atomic virial. Only returned when atomic == True
             shape: [nframes x nout x natoms x 9]
         """
-        assert self._support_gfv, f"do not support eval_full with old tensor model"
+        assert self._support_gfv, "do not support eval_full with old tensor model"
 
         # standarize the shape of inputs
         if mixed_type:

--- a/deepmd/nvnmd/entrypoints/mapt.py
+++ b/deepmd/nvnmd/entrypoints/mapt.py
@@ -503,7 +503,7 @@ class MapTable:
         log.info(f"the range of s is [{smin}, {smax}]")
         # check
         if (smax - smin) > 16.0:
-            log.warning(f"the range of s is over the limit (smax - smin) > 16.0")
+            log.warning("the range of s is over the limit (smax - smin) > 16.0")
         prec = N / N2
         smin_ = np.floor(smin * prec - 1) / prec
         #

--- a/deepmd/nvnmd/utils/config.py
+++ b/deepmd/nvnmd/utils/config.py
@@ -230,9 +230,9 @@ class NvnmdConfig:
         # check
         log.info(f"the range of s is [{smin}, {smax}]")
         if smax - smin > 16.0:
-            log.warning(f"the range of s is over the limit (smax - smin) > 16.0")
+            log.warning("the range of s is over the limit (smax - smin) > 16.0")
             log.warning(
-                f"Please reset the rcut_smth as a bigger value to fix this warning"
+                "Please reset the rcut_smth as a bigger value to fix this warning"
             )
 
     def get_dscp_jdata(self):

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -22,9 +22,6 @@ from deepmd.common import (
     get_precision,
     j_must_have,
 )
-from deepmd.descriptor import (
-    Descriptor,
-)
 from deepmd.descriptor.descriptor import (
     Descriptor,
 )

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -306,7 +306,7 @@ def descrpt_se_r_args():
 
 @descrpt_args_plugin.register("hybrid")
 def descrpt_hybrid_args():
-    doc_list = f"A list of descriptor definitions"
+    doc_list = "A list of descriptor definitions"
 
     return [Argument("list", list, optional=False, doc=doc_list)]
 
@@ -382,7 +382,7 @@ def descrpt_variant_type_args(exclude_hybrid: bool = False) -> Variant:
     link_se_a_tpe = make_link("se_a_tpe", "model/descriptor[se_a_tpe]")
     link_hybrid = make_link("hybrid", "model/descriptor[hybrid]")
     link_se_atten = make_link("se_atten", "model/descriptor[se_atten]")
-    doc_descrpt_type = f"The type of the descritpor. See explanation below. \n\n\
+    doc_descrpt_type = "The type of the descritpor. See explanation below. \n\n\
 - `loc_frame`: Defines a local frame at each atom, and the compute the descriptor as local coordinates under this frame.\n\n\
 - `se_e2_a`: Used by the smooth edition of Deep Potential. The full relative coordinates are used to construct the descriptor.\n\n\
 - `se_e2_r`: Used by the smooth edition of Deep Potential. Only the distance between atoms is used to construct the descriptor.\n\n\
@@ -558,7 +558,7 @@ def modifier_dipole_charge():
     doc_model_name = "The name of the frozen dipole model file."
     doc_model_charge_map = f"The charge of the WFCC. The list length should be the same as the {make_link('sel_type', 'model/fitting_net[dipole]/sel_type')}. "
     doc_sys_charge_map = f"The charge of real atoms. The list length should be the same as the {make_link('type_map', 'model/type_map')}"
-    doc_ewald_h = f"The grid spacing of the FFT grid. Unit is A"
+    doc_ewald_h = "The grid spacing of the FFT grid. Unit is A"
     doc_ewald_beta = f"The splitting parameter of Ewald sum. Unit is A^{-1}"
 
     return [
@@ -585,12 +585,10 @@ def modifier_variant_type_args():
 
 #  --- model compression configurations: --- #
 def model_compression():
-    doc_model_file = (
-        f"The input model file, which will be compressed by the DeePMD-kit."
-    )
-    doc_table_config = f"The arguments of model compression, including extrapolate(scale of model extrapolation), stride(uniform stride of tabulation's first and second table), and frequency(frequency of tabulation overflow check)."
+    doc_model_file = "The input model file, which will be compressed by the DeePMD-kit."
+    doc_table_config = "The arguments of model compression, including extrapolate(scale of model extrapolation), stride(uniform stride of tabulation's first and second table), and frequency(frequency of tabulation overflow check)."
     doc_min_nbor_dist = (
-        f"The nearest distance between neighbor atoms saved in the frozen model."
+        "The nearest distance between neighbor atoms saved in the frozen model."
     )
 
     return [

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -197,7 +197,7 @@ class DeepmdData:
         """
         assert key_in in self.data_dict, "cannot find input key"
         assert self.data_dict[key_in]["atomic"], "reduced property should be atomic"
-        assert not (key_out in self.data_dict), "output key should not have been added"
+        assert key_out not in self.data_dict, "output key should not have been added"
         assert (
             self.data_dict[key_in]["repeat"] == 1
         ), "reduced proerties should not have been repeated"
@@ -462,7 +462,7 @@ class DeepmdData:
                 type(data[kk]) == np.ndarray
                 and len(data[kk].shape) == 2
                 and data[kk].shape[0] == nframes
-                and not ("find_" in kk)
+                and "find_" not in kk
             ):
                 ret[kk] = data[kk][idx]
             else:

--- a/deepmd/utils/graph.py
+++ b/deepmd/utils/graph.py
@@ -145,7 +145,7 @@ def get_pattern_nodes_from_graph_def(graph_def: tf.GraphDef, pattern: str) -> Di
     nodes = {}
     pattern = re.compile(pattern)
     for node in graph_def.node:
-        if re.fullmatch(pattern, node.name) != None:
+        if re.fullmatch(pattern, node.name) is not None:
             nodes[node.name] = node.attr["value"].tensor
     return nodes
 

--- a/deepmd/utils/network.py
+++ b/deepmd/utils/network.py
@@ -72,7 +72,7 @@ def one_layer(
             b = tf.cast(b, get_precision(mixed_prec["compute_prec"]))
 
         hidden = tf.nn.bias_add(tf.matmul(inputs, w), b)
-        if activation_fn != None and use_timestep:
+        if activation_fn is not None and use_timestep:
             idt_initializer = tf.random_normal_initializer(
                 stddev=0.001,
                 mean=0.1,
@@ -86,7 +86,7 @@ def one_layer(
                 "idt", [outputs_size], precision, idt_initializer, trainable=trainable
             )
             variable_summaries(idt, "idt")
-        if activation_fn != None:
+        if activation_fn is not None:
             if useBN:
                 None
                 # hidden_bn = self._batch_norm(hidden, name=name+'_normalization', reuse=reuse)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,7 @@ from deepmd.utils.argcheck import (
 )
 
 sys.path.append(os.path.dirname(__file__))
-import sphinx_contrib_exhale_multiproject as _
+import sphinx_contrib_exhale_multiproject
 
 
 def mkindex(dirname):

--- a/doc/sphinx_contrib_exhale_multiproject.py
+++ b/doc/sphinx_contrib_exhale_multiproject.py
@@ -118,7 +118,7 @@ def exhale_environment_ready(app):
         # Generate the full API!
         try:
             exhale.deploy.explode()
-        except:
+        except Exception:
             exhale.utils.fancyError(
                 "Exhale: could not generate reStructuredText documents :/"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,5 +109,8 @@ ignore = "D413, D416, D203, D107, D213"
 profile = "black"
 force_grid_wrap = 1
 
+[tool.ruff]
+ignore = ["E501"]
+
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,4 +110,4 @@ profile = "black"
 force_grid_wrap = 1
 
 [tool.ruff]
-ignore = ["E501", "F401", "F841"]
+ignore = ["E501", "F401", "F841", "E741"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,4 +113,4 @@ force_grid_wrap = 1
 ignore = ["E501"]
 
 [tool.ruff.per-file-ignores]
-"__init__.py" = ["E401"]
+"__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,4 @@ profile = "black"
 force_grid_wrap = 1
 
 [tool.ruff]
-ignore = ["E501"]
-
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]
+ignore = ["E501", "F401", "F841"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,4 +110,4 @@ profile = "black"
 force_grid_wrap = 1
 
 [tool.ruff]
-ignore = ["E501", "F401", "F841", "E741"]
+ignore = ["E501", "F401", "F841", "E741", "E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,6 @@ ignore = "D413, D416, D203, D107, D213"
 [tool.isort]
 profile = "black"
 force_grid_wrap = 1
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E401"]

--- a/source/tests/common.py
+++ b/source/tests/common.py
@@ -3,7 +3,6 @@ import glob
 import os
 import pathlib
 import shutil
-import sys
 
 import dpdata
 import numpy as np

--- a/source/tests/test_data_large_batch.py
+++ b/source/tests/test_data_large_batch.py
@@ -9,12 +9,10 @@ from common import (
     Data,
     gen_data,
     j_loader,
-    tf,
 )
 from packaging.version import parse as parse_version
 
 from deepmd.common import (
-    data_requirement,
     j_must_have,
 )
 from deepmd.descriptor import (

--- a/source/tests/test_deepmd_data_sys.py
+++ b/source/tests/test_deepmd_data_sys.py
@@ -326,7 +326,7 @@ class TestDataSystem(unittest.TestCase):
             / float(self.nframes[2] * (self.nset - 1) + shift),
         )
 
-    def test_prob_sys_size_1(self):
+    def test_prob_sys_size_2(self):
         batch_size = 1
         test_size = 1
         ds = DeepmdDataSystem(self.sys_name, batch_size, test_size, 2.0)

--- a/source/tests/test_descrpt_se_atten.py
+++ b/source/tests/test_descrpt_se_atten.py
@@ -10,7 +10,6 @@ from common import (
     DataSystem,
     gen_data,
     j_loader,
-    tf,
 )
 from packaging.version import parse as parse_version
 

--- a/source/tests/test_embedding_net.py
+++ b/source/tests/test_embedding_net.py
@@ -103,7 +103,7 @@ class Inter(tf.test.TestCase):
         ]
         np.testing.assert_almost_equal(refout, myout, self.places)
 
-    def test_enlarger_net_2(self):
+    def test_enlarger_net_3(self):
         network_size = [2, 4]
         out = embedding_net(
             self.inputs,

--- a/source/tests/test_model_se_a.py
+++ b/source/tests/test_model_se_a.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import unittest
 
 import dpdata

--- a/source/tests/test_model_se_atten.py
+++ b/source/tests/test_model_se_atten.py
@@ -10,7 +10,6 @@ from common import (
     DataSystem,
     gen_data,
     j_loader,
-    tf,
 )
 from packaging.version import parse as parse_version
 

--- a/source/tests/test_nvnmd_op.py
+++ b/source/tests/test_nvnmd_op.py
@@ -460,7 +460,7 @@ class TestOpMatmulFltNvnmd(tf.test.TestCase):
         tf.reset_default_graph()
 
 
-class TestOpMatmulFltNvnmd(tf.test.TestCase):
+class TestOpMatmulFltNvnmd2(tf.test.TestCase):
     def setUp(self):
         config = tf.ConfigProto()
         if int(os.environ.get("DP_AUTO_PARALLELIZATION", 0)):


### PR DESCRIPTION
Generally, with my configuration, it will automatically fix the following:
- `== None` -> `is None`
- unnecessary f-string
- `not xx in yy` -> `xx not in yy`

It will check but does not automatically fix the following:
- F821: undefined name (critical)
- F811: Redefinition of unused variable (maybe critical or typo)
- F722: bare except (critical)

I have ignored these rules: E501 (line too long), F401 (unused imports), F841 (unused variable), E741 (one-char variable), E402 (import should be the top)