### PR TITLE
fix restarting from the original model

### DIFF
--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -1188,12 +1188,7 @@ class DPTrainer(object):
         try:
             t_model_type = get_tensor_by_name_from_graph(graph, "model_type")
         except GraphWithoutTensorError as e:
-            # throw runtime error if the frozen_model has no model type information...
-            raise RuntimeError(
-                "The input frozen model: %s has no 'model_type' information, "
-                "which is not supported by the 'dp train init-frz-model' interface. "
-                % self.run_opt.init_frz_model
-            ) from e
+            t_model_type = "original_model"
         else:
             self.model_type = bytes.decode(t_model_type)
         if self.model_type == "compressed_model":

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -1188,7 +1188,7 @@ class DPTrainer(object):
         try:
             t_model_type = get_tensor_by_name_from_graph(graph, "model_type")
         except GraphWithoutTensorError as e:
-            t_model_type = "original_model"
+            self.model_type = "original_model"
         else:
             self.model_type = bytes.decode(t_model_type)
         if self.model_type == "compressed_model":


### PR DESCRIPTION
#2253 supports restarting from the compressed model but breaks the original model. This PR fixes the error by detecting the model type first.

```
FAILED_PRECONDITION: Attempting to use uninitialized value
```