### PR TITLE
fix macOS library suffix for TF 2.12

### DIFF
--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -89,8 +89,14 @@ if(BUILD_CPP_IF AND NOT USE_TF_PYTHON_LIBS)
     set(TensorFlow_FIND_COMPONENTS tensorflow_cc tensorflow_framework)
   endif()
   # the lib
-  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.1)
-  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.2)
+  if(WIN32)
+    # pass
+  elseif(APPLE)
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .2.dylib)
+  else()
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.1)
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.2)
+  endif()
   set(TensorFlow_LIBRARY_PATH "")
   foreach(module ${TensorFlow_FIND_COMPONENTS})
     find_library(

--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -130,6 +130,8 @@ endif()
 # the lib
 if(WIN32)
   list(APPEND TensorFlow_search_PATHS ${TENSORFLOW_ROOT}/python)
+elseif(APPLE)
+  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .2.dylib)
 else()
   list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.1)
   list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.2)


### PR DESCRIPTION
In TF 2.12, `.dylib` files was removed from macOS wheels with only `.2.dylib` left.