### PR TITLE
add an URL to the warning of parallelism

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -263,7 +263,8 @@ def set_tf_default_nthreads():
             "To get the best performance, it is recommended to adjust "
             "the number of threads by setting the environment variables "
             "OMP_NUM_THREADS, TF_INTRA_OP_PARALLELISM_THREADS, and "
-            "TF_INTER_OP_PARALLELISM_THREADS."
+            "TF_INTER_OP_PARALLELISM_THREADS. See "
+            "https://deepmd.rtfd.io/parallelism/ for more information."
         )
     set_env_if_empty("TF_INTRA_OP_PARALLELISM_THREADS", "0", verbose=False)
     set_env_if_empty("TF_INTER_OP_PARALLELISM_THREADS", "0", verbose=False)

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -233,7 +233,9 @@ void deepmd::check_status(const tensorflow::Status& status) {
 void throw_env_not_set_warning(std::string env_name) {
   std::cerr << "DeePMD-kit WARNING: Environmental variable " << env_name
             << " is not set. "
-            << "Tune " << env_name << " for the best performance." << std::endl;
+            << "Tune " << env_name << " for the best performance. "
+            << "See https://deepmd.rtfd.io/parallelism/ for more information."
+            << std::endl;
 }
 
 void deepmd::get_env_nthreads(int& num_intra_nthreads,


### PR DESCRIPTION
The URL links to https://deepmd.rtfd.io/parallelism/.