### PR TITLE
support mixed systems training

### DIFF
--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -972,7 +972,8 @@ def training_data_args():  # ! added by Ziyao: new specification style for data 
 - list: the length of which is the same as the {link_sys}. The batch size of each system is given by the elements of the list.\n\n\
 - int: all {link_sys} use the same batch size.\n\n\
 - string "auto": automatically determines the batch size so that the batch_size times the number of atoms in the system is no less than 32.\n\n\
-- string "auto:N": automatically determines the batch size so that the batch_size times the number of atoms in the system is no less than N.'
+- string "auto:N": automatically determines the batch size so that the batch_size times the number of atoms in the system is no less than N.\n\n\
+- string "mixed:N": the batch data will be sampled from all systems and merged into a mixed system with the batch size N. Only support the se_atten descriptor.'
     doc_auto_prob_style = 'Determine the probability of systems automatically. The method is assigned by this key and can be\n\n\
 - "prob_uniform"  : the probability all the systems are equal, namely 1.0/self.get_nsystems()\n\n\
 - "prob_sys_size" : the probability of a system is proportional to the number of batches in the system\n\n\

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -393,9 +393,9 @@ class DeepmdDataSystem:
         if not hasattr(self, "default_mesh"):
             self._make_default_mesh()
         if not self.mixed_systems:
-            self.get_batch_standard(sys_idx)
+            b_data = self.get_batch_standard(sys_idx)
         else:
-            self.get_batch_mixed()
+            b_data = self.get_batch_mixed()
         return b_data
 
     def get_batch_standard(self, sys_idx: Optional[int] = None) -> dict:

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -417,9 +417,7 @@ class DeepmdDataSystem:
             self.pick_idx = sys_idx
         else:
             # prob = self._get_sys_probs(sys_probs, auto_prob_style)
-            self.pick_idx = dp_random.choice(
-                np.arange(self.nsystems), p=self.sys_probs
-            )
+            self.pick_idx = dp_random.choice(np.arange(self.nsystems), p=self.sys_probs)
         b_data = self.data_systems[self.pick_idx].get_batch(
             self.batch_size[self.pick_idx]
         )
@@ -439,9 +437,7 @@ class DeepmdDataSystem:
         batch_size = self.batch_size[0]
         batch_data = []
         for _ in range(batch_size):
-            self.pick_idx = dp_random.choice(
-                np.arange(self.nsystems), p=self.sys_probs
-            )
+            self.pick_idx = dp_random.choice(np.arange(self.nsystems), p=self.sys_probs)
             bb_data = self.data_systems[self.pick_idx].get_batch(1)
             bb_data["natoms_vec"] = self.natoms_vec[self.pick_idx]
             bb_data["default_mesh"] = self.default_mesh[self.pick_idx]

--- a/examples/nopbc/mixed/input.json
+++ b/examples/nopbc/mixed/input.json
@@ -1,0 +1,71 @@
+{
+  "_comment": " model parameters",
+  "model": {
+    "type_map": [
+      "C",
+      "H",
+      "O"
+    ],
+    "descriptor": {
+      "type": "se_atten",
+      "sel": 120,
+      "rcut_smth": 1.00,
+      "rcut": 6.00,
+      "neuron": [
+        25,
+        50,
+        100
+      ],
+      "resnet_dt": false,
+      "axis_neuron": 12,
+      "seed": 1,
+      "_comment": " that's all"
+    },
+    "fitting_net": {
+      "neuron": [
+        240,
+        240,
+        240
+      ],
+      "resnet_dt": true,
+      "seed": 1,
+      "_comment": " that's all"
+    },
+    "_comment": " that's all"
+  },
+
+  "learning_rate": {
+    "type": "exp",
+    "decay_steps": 4000,
+    "start_lr": 0.001,
+    "stop_lr": 3.51e-8,
+    "_comment": "that's all"
+  },
+
+  "loss": {
+    "type": "ener",
+    "start_pref_e": 0.02,
+    "limit_pref_e": 1,
+    "start_pref_f": 1000,
+    "limit_pref_f": 1,
+    "start_pref_v": 0,
+    "limit_pref_v": 0,
+    "_comment": " that's all"
+  },
+
+  "training": {
+    "training_data": {
+      "systems": "../data/",
+      "batch_size": "mixed:4",
+      "_comment": "that's all"
+    },
+    "numb_steps": 4000000,
+    "seed": 10,
+    "disp_file": "lcurve.out",
+    "disp_freq": 100,
+    "save_freq": 1000,
+    "_comment": "that's all"
+  },
+
+  "_comment": "that's all"
+}


### PR DESCRIPTION
With the new option, a batch of data could come from all systems with different numbers of atoms and is generated and padded into a mixed system on the fly.

This PR is independent of #2366, which provides a manual way to use mixed systems. In theory #2366 should have better performance and this PR is more convenient.