### PR TITLE
Fix incompatibility after fixing the incontinuity of se_atten

### DIFF
--- a/deepmd/descriptor/se_atten.py
+++ b/deepmd/descriptor/se_atten.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import (
     List,
     Optional,
@@ -5,7 +6,6 @@ from typing import (
 )
 
 import numpy as np
-import warnings
 from packaging.version import (
     Version,
 )
@@ -112,8 +112,10 @@ class DescrptSeAtten(DescrptSeA):
         multi_task: bool = False,
     ) -> None:
         if not set_davg_zero:
-            warnings.warn("Set 'set_davg_zero' False in descriptor 'se_atten' "
-                          "may cause unexpected incontinuity during model inference!")
+            warnings.warn(
+                "Set 'set_davg_zero' False in descriptor 'se_atten' "
+                "may cause unexpected incontinuity during model inference!"
+            )
         DescrptSeA.__init__(
             self,
             rcut,

--- a/deepmd/descriptor/se_atten.py
+++ b/deepmd/descriptor/se_atten.py
@@ -5,6 +5,7 @@ from typing import (
 )
 
 import numpy as np
+import warnings
 from packaging.version import (
     Version,
 )
@@ -67,6 +68,8 @@ class DescrptSeAtten(DescrptSeA):
     exclude_types : List[List[int]]
             The excluded pairs of types which have no interaction with each other.
             For example, `[[0, 1]]` means no interaction between type 0 and type 1.
+    set_davg_zero
+            Set the shift of embedding net input to zero.
     activation_function
             The activation function in the embedding net. Supported options are |ACTIVATION_FN|
     precision
@@ -97,6 +100,7 @@ class DescrptSeAtten(DescrptSeA):
         trainable: bool = True,
         seed: Optional[int] = None,
         type_one_side: bool = True,
+        set_davg_zero: bool = True,
         exclude_types: List[List[int]] = [],
         activation_function: str = "tanh",
         precision: str = "default",
@@ -107,6 +111,9 @@ class DescrptSeAtten(DescrptSeA):
         attn_mask: bool = False,
         multi_task: bool = False,
     ) -> None:
+        if not set_davg_zero:
+            warnings.warn("Set 'set_davg_zero' False in descriptor 'se_atten' "
+                          "may cause unexpected incontinuity during model inference!")
         DescrptSeA.__init__(
             self,
             rcut,
@@ -119,7 +126,7 @@ class DescrptSeAtten(DescrptSeA):
             seed=seed,
             type_one_side=type_one_side,
             exclude_types=exclude_types,
-            set_davg_zero=True,
+            set_davg_zero=set_davg_zero,
             activation_function=activation_function,
             precision=precision,
             uniform_seed=uniform_seed,

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -325,6 +325,7 @@ def descrpt_se_atten_args():
     doc_precision = f"The precision of the embedding net parameters, supported options are {list_to_doc(PRECISION_DICT.keys())} Default follows the interface precision."
     doc_trainable = "If the parameters in the embedding net is trainable"
     doc_seed = "Random seed for parameter initialization"
+    doc_set_davg_zero = "Set the normalization average to zero. This option should be set when `se_atten` descriptor or `atom_ener` in the energy fitting is used"
     doc_exclude_types = "The excluded pairs of types which have no interaction with each other. For example, `[[0, 1]]` means no interaction between type 0 and type 1."
     doc_attn = "The length of hidden vectors in attention layers"
     doc_attn_layer = "The number of attention layers"
@@ -360,6 +361,9 @@ def descrpt_se_atten_args():
         Argument("seed", [int, None], optional=True, doc=doc_seed),
         Argument(
             "exclude_types", list, optional=True, default=[], doc=doc_exclude_types
+        ),
+        Argument(
+            "set_davg_zero", bool, optional=True, default=True, doc=doc_set_davg_zero
         ),
         Argument("attn", int, optional=True, default=128, doc=doc_attn),
         Argument("attn_layer", int, optional=True, default=2, doc=doc_attn_layer),


### PR DESCRIPTION
Add `set_davg_zero` para in `se_atten` with default value True. This will fix incompatibility after fixing the incontinuity of se_atten. #2393 #2394 