### PR TITLE
clean old handlers before adding new one

### DIFF
--- a/deepmd/loggers/loggers.py
+++ b/deepmd/loggers/loggers.py
@@ -229,6 +229,8 @@ def set_log_handles(
 
     ch.setLevel(level)
     ch.addFilter(_AppFilter())
+    # clean old handlers before adding new one
+    root_log.handlers.clear()
     root_log.addHandler(ch)
 
     # * add file handler ***************************************************************


### PR DESCRIPTION
It's not a problem for production, but during tests there might be multiple handlers added.