### PR TITLE
keep the file permission when `make lammps`

### DIFF
--- a/source/cmake/cmake_lammps.cmake.in
+++ b/source/cmake/cmake_lammps.cmake.in
@@ -5,6 +5,7 @@ string(REGEX REPLACE "\n" "" files "${files}")
 foreach (cur_file ${files})
   file (
     INSTALL DESTINATION "${LMP_INSTALL_PREFIX}"
+    USE_SOURCE_PERMISSIONS
     TYPE FILE
     FILES "${cur_file}"
     )


### PR DESCRIPTION
It looks that by default, CMake will remove the execute permission.