### PR TITLE
`source` a relative path

### DIFF
--- a/source/lmp/Install.sh
+++ b/source/lmp/Install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source env.sh
+source ./env.sh
 
 # Install/unInstall package files in LAMMPS
 # mode = 0/1/2 for uninstall/install/update


### PR DESCRIPTION
Fix #2409.
By default, `source` searches the file from `PATH` (see the help from `source --help`). This might conflict with other packages. To prevent this behavior, one has to source the relative path instead.