### PR TITLE
docs: add links to documentation in LAMMPS input

### DIFF
--- a/examples/water/lmp/in.lammps
+++ b/examples/water/lmp/in.lammps
@@ -11,6 +11,7 @@ read_data	water.lmp
 mass 		1 16
 mass		2 2
 
+# See https://deepmd.rtfd.io/lammps/ for usage
 pair_style	deepmd frozen_model.pb
 pair_coeff  * *	O H
 

--- a/examples/water/lmp/in.lammps
+++ b/examples/water/lmp/in.lammps
@@ -13,6 +13,7 @@ mass		2 2
 
 # See https://deepmd.rtfd.io/lammps/ for usage
 pair_style	deepmd frozen_model.pb
+# If atom names (O H in this example) are not set in the pair_coeff command, the type_map defined by the training parameter will be used by default.
 pair_coeff  * *	O H
 
 velocity        all create 330.0 23456789

--- a/examples/water/lmp/in.plugin.lammps
+++ b/examples/water/lmp/in.plugin.lammps
@@ -16,6 +16,7 @@ plugin load libdeepmd_lmp.so
 
 # See https://deepmd.rtfd.io/lammps/ for usage
 pair_style	deepmd frozen_model.pb
+# If atom names (O H in this example) are not set in the pair_coeff command, the type_map defined by the training parameter will be used by default.
 pair_coeff  * *	O H
 
 velocity        all create 330.0 23456789

--- a/examples/water/lmp/in.plugin.lammps
+++ b/examples/water/lmp/in.plugin.lammps
@@ -14,6 +14,7 @@ mass		2 2
 # load the deepmd plugin
 plugin load libdeepmd_lmp.so
 
+# See https://deepmd.rtfd.io/lammps/ for usage
 pair_style	deepmd frozen_model.pb
 pair_coeff  * *	O H
 


### PR DESCRIPTION
Closes #2425.

It takes work to explain everything in the comment. So, instead, I add a link to the documentation.