### PR TITLE
modify deepmd/utils/convertpy to solve error "model_version not unique" when convert from TF1.x to TF2.x

### DIFF
--- a/deepmd/utils/convert.py
+++ b/deepmd/utils/convert.py
@@ -187,7 +187,9 @@ def convert_20_to_21(input_model: str, output_model: str):
     print("the converted output model (2.1 support) is saved in %s" % output_model)
 
 
-def convert_pb_to_pbtxt(pbfile: str, pbtxtfile: str, incompat_from_v1_to_v2: bool=False):
+def convert_pb_to_pbtxt(
+    pbfile: str, pbtxtfile: str, incompat_from_v1_to_v2: bool = False
+):
     """Convert DP graph to graph text.
 
     Parameters
@@ -196,11 +198,11 @@ def convert_pb_to_pbtxt(pbfile: str, pbtxtfile: str, incompat_from_v1_to_v2: boo
         filename of the input graph
     pbtxtfile : str
         filename of the output graph text
-    incompat_from_v1_to_v2: bool
+    incompat_from_v1_to_v2 : bool
         model_attr/model_version of TF incompatible when convert from TF1.x to TF2.x
     """
     if incompat_from_v1_to_v2:
-        with tf.compat.v1.gfile.GFile(pbfile, 'rb') as f:
+        with tf.compat.v1.gfile.GFile(pbfile, "rb") as f:
             graph_def = tf.compat.v1.GraphDef()
             graph_def.ParseFromString(f.read())
             tf.import_graph_def(graph_def, name="")


### PR DESCRIPTION
## Problem
When I convert a model from DP1.2 to DP2.0, and compress the converted model, the following error is raised
```
tensorflow.python.framework.errors_impl.InvalidArgumentError: Node 'model_attr/model_version' is not unique
```
When I convert a compressed model from DP1.2 to DP2.0, and run MD with the converted model, the following error is raised
```
INVALID_ARGUMENT: Node 'model_attr/model_version' is not unique
ERROR: DeePMD-kit Error: TensorFlow Error: INVALID_ARGUMENT: Node 'model_attr/model_version' is not unique (../pair_deepmd.cpp:852)
```
## Related issue from tensorflow repo
A related issue was raised here: https://github.com/tensorflow/tensorflow/issues/53866
## Solution
**A solution was proposed by new bing, when I asked:**
*Is there a way to run frozen model of TF 1.x in TF 2.x environment?*

**The reply from new bing was:**
*[Yes, it is possible to run a frozen model of TensorFlow 1.x in a TensorFlow 2.x environment](https://stackoverflow.com/questions/66525883/unable-to-load-the-frozen-model-pb-in-graphdef-in-tensorflow-version-2-x)[1](https://stackoverflow.com/questions/66525883/unable-to-load-the-frozen-model-pb-in-graphdef-in-tensorflow-version-2-x). [You can use the tf.compat.v1 module to load the frozen graph and then use it with TensorFlow 2.x](https://stackoverflow.com/questions/66525883/unable-to-load-the-frozen-model-pb-in-graphdef-in-tensorflow-version-2-x)[1](https://stackoverflow.com/questions/66525883/unable-to-load-the-frozen-model-pb-in-graphdef-in-tensorflow-version-2-x).*

*Here’s an example of how you can load a frozen graph in TensorFlow 2.x using tf.compat.v1:*
```
import tensorflow as tf

with tf.compat.v1.gfile.GFile('path/to/frozen_graph.pb', 'rb') as f:
    graph_def = tf.compat.v1.GraphDef()
    graph_def.ParseFromString(f.read())

with tf.Graph().as_default() as graph:
    tf.import_graph_def(graph_def, name='')

# Use the graph with TensorFlow 2.x
```
So I modified `deepmd/utils/convert.py` and the problem was solved.