### PR TITLE
remove warnings of batch size for mixed systems training

### DIFF
--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -194,7 +194,7 @@ class DeepmdDataSystem:
         # check batch and test size
         for ii in range(self.nsystems):
             chk_ret = self.data_systems[ii].check_batch_size(self.batch_size[ii])
-            if chk_ret is not None and not is_auto_bs:
+            if chk_ret is not None and not is_auto_bs and not self.mixed_systems:
                 warnings.warn(
                     "system %s required batch size is larger than the size of the dataset %s (%d > %d)"
                     % (
@@ -205,7 +205,7 @@ class DeepmdDataSystem:
                     )
                 )
             chk_ret = self.data_systems[ii].check_test_size(self.test_size[ii])
-            if chk_ret is not None and not is_auto_bs:
+            if chk_ret is not None and not is_auto_bs and not self.mixed_systems:
                 warnings.warn(
                     "system %s required test size is larger than the size of the dataset %s (%d > %d)"
                     % (self.system_dirs[ii], chk_ret[0], self.test_size[ii], chk_ret[1])


### PR DESCRIPTION
Here for mixed systems, the system batch size is just a placeholder.