### PR TITLE
add sub fields of hybrid descriptor

### DIFF
--- a/deepmd/entrypoints/main.py
+++ b/deepmd/entrypoints/main.py
@@ -414,7 +414,11 @@ def main_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parsers_doc.add_argument(
-        "--out-type", default="rst", type=str, help="The output type"
+        "--out-type",
+        default="rst",
+        choices=["rst", "json"],
+        type=str,
+        help="The output type",
     )
 
     # * make model deviation ***********************************************************

--- a/source/tests/test_examples.py
+++ b/source/tests/test_examples.py
@@ -22,6 +22,7 @@ input_files = (
     p_examples / "water" / "se_e2_a_tebd" / "input.json",
     p_examples / "water" / "se_e2_a_mixed_prec" / "input.json",
     p_examples / "water" / "se_atten" / "input.json",
+    p_examples / "water" / "hybrid" / "input.json",
     p_examples / "water" / "dplr" / "train" / "dw.json",
     p_examples / "water" / "dplr" / "train" / "ener.json",
     p_examples / "nopbc" / "train" / "input.json",


### PR DESCRIPTION
Migrate sub arguments of hybrid descriptor from a seperated normalize method to the main argument. (by using `repeat=True, fold_subdoc=True`)

Miror changes:
1. add tests for hybrid example;
2. merge gen_args;
3. add choice for `dp doc-train-input --out-type`