### PR TITLE
print model deviation of total energy per atom in `dp model_devi`

### DIFF
--- a/deepmd/infer/model_devi.py
+++ b/deepmd/infer/model_devi.py
@@ -181,15 +181,16 @@ def calc_model_devi(
     energies = []
     forces = []
     virials = []
+    natom = atype.shape[-1]
     for dp in models:
         ret = dp.eval(
             coord,
             box,
             atype,
         )
-        energies.append(ret[0] / len(atype))
+        energies.append(ret[0] / natom)
         forces.append(ret[1])
-        virials.append(ret[2] / len(atype))
+        virials.append(ret[2] / natom)
 
     energies = np.array(energies)
     forces = np.array(forces)

--- a/source/tests/test_model_devi.py
+++ b/source/tests/test_model_devi.py
@@ -50,6 +50,7 @@ class TestMakeModelDevi(unittest.TestCase):
                 5.095047e-01,
                 4.584241e-01,
                 4.819783e-01,
+                1.594131e-02,
             ]
         )
 
@@ -64,8 +65,8 @@ class TestMakeModelDevi(unittest.TestCase):
         )
         self.assertAlmostEqual(model_devi[0][0], 0)
         self.assertAlmostEqual(model_devi[1][0], self.freq)
-        np.testing.assert_almost_equal(model_devi[0][1:7], self.expect[1:7], 6)
-        np.testing.assert_almost_equal(model_devi[0][1:7], model_devi[1][1:7], 6)
+        np.testing.assert_almost_equal(model_devi[0][1:8], self.expect[1:8], 6)
+        np.testing.assert_almost_equal(model_devi[0][1:8], model_devi[1][1:8], 6)
         self.assertTrue(os.path.isfile(self.output))
 
     def tearDown(self):


### PR DESCRIPTION
Here total energy per atom ($E/N$) is used instead of atomic energy $E_i$, as the decomposition of energy is arbitrary and not unique.