### PR TITLE
improve messages for model compatability

### DIFF
--- a/deepmd/infer/deep_eval.py
+++ b/deepmd/infer/deep_eval.py
@@ -63,6 +63,7 @@ class DeepEval:
             raise RuntimeError(
                 f"model in graph (version {self.model_version}) is incompatible"
                 f"with the model (version {MODEL_VERSION}) supported by the current code."
+                "See https://deepmd.rtfd.io/compatability/ for details."
             )
 
         # set default to False, as subclasses may not support

--- a/doc/troubleshooting/model-compatability.md
+++ b/doc/troubleshooting/model-compatability.md
@@ -6,11 +6,11 @@ DeePMD-kit guarantees that the codes with the same major and minor revisions are
 
 One can execute `dp convert-from` to convert an old model to a new one.
 
-| Model version | v0.12 | v1.0 | v1.1 | v1.2 | v1.3 | v2.0 | v2.1 |
-|:-:|:-----------:|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
-| Compatibility  | 😊 | 😊 | 😊 | 😊 | 😊 | 😄 | 😄 |
+| Model version | v0.12 | v1.0 | v1.1 | v1.2 | v1.3 | v2.0 | v2.1 | v2.2 |
+|:-:|:-----------:|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
+| Compatibility  | 😊 | 😊 | 😊 | 😊 | 😊 | 😄 | 😄 | 😄 |
 
 **Legend**:
 - 😄: The model is compatible with the DeePMD-kit package.
-- 😊: The model is incompatible with the DeePMD-kit package, but one can execute `dp convert-from` to convert an old model to v2.1.
+- 😊: The model is incompatible with the DeePMD-kit package, but one can execute `dp convert-from` to convert an old model to v2.2.
 - 😢: The model is incompatible with the DeePMD-kit package, and there is no way to convert models.

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -443,6 +443,18 @@ void DeepPot::init(const std::string& model,
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   check_status(NewSession(options, &session));
   check_status(session->Create(*graph_def));
+  try {
+    model_version = get_scalar<STRINGTYPE>("model_attr/model_version");
+  } catch (deepmd::tf_exception& e) {
+    // no model version defined in old models
+    model_version = "0.0";
+  }
+  if (!model_compatable(model_version)) {
+    throw deepmd::deepmd_exception("incompatable model: version " +
+                                   model_version + " in graph, but version " +
+                                   global_model_version + " supported "
+                                   "See https://deepmd.rtfd.io/compatability/ for details.");
+  }
   dtype = session_get_dtype(session, "descrpt_attr/rcut");
   if (dtype == tensorflow::DT_DOUBLE) {
     rcut = get_scalar<double>("descrpt_attr/rcut");
@@ -461,17 +473,6 @@ void DeepPot::init(const std::string& model,
   if (dfparam < 0) dfparam = 0;
   if (daparam < 0) daparam = 0;
   model_type = get_scalar<STRINGTYPE>("model_attr/model_type");
-  try {
-    model_version = get_scalar<STRINGTYPE>("model_attr/model_version");
-  } catch (deepmd::tf_exception& e) {
-    // no model version defined in old models
-    model_version = "0.0";
-  }
-  if (!model_compatable(model_version)) {
-    throw deepmd::deepmd_exception("incompatable model: version " +
-                                   model_version + " in graph, but version " +
-                                   global_model_version + " supported ");
-  }
   inited = true;
 
   init_nbor = false;
@@ -1264,6 +1265,18 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
     check_status(NewSession(options, &(sessions[ii])));
     check_status(sessions[ii]->Create(*graph_defs[ii]));
   }
+  try {
+    model_version = get_scalar<STRINGTYPE>("model_attr/model_version");
+  } catch (deepmd::tf_exception& e) {
+    // no model version defined in old models
+    model_version = "0.0";
+  }
+  if (!model_compatable(model_version)) {
+    throw deepmd::deepmd_exception("incompatable model: version " +
+                                   model_version + " in graph, but version " +
+                                   global_model_version + " supported. "
+                                   "See https://deepmd.rtfd.io/compatability/ for details.");
+  }
   dtype = session_get_dtype(sessions[0], "descrpt_attr/rcut");
   if (dtype == tensorflow::DT_DOUBLE) {
     rcut = get_scalar<double>("descrpt_attr/rcut");
@@ -1282,12 +1295,6 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
   if (dfparam < 0) dfparam = 0;
   if (daparam < 0) daparam = 0;
   model_type = get_scalar<STRINGTYPE>("model_attr/model_type");
-  model_version = get_scalar<STRINGTYPE>("model_attr/model_version");
-  if (!model_compatable(model_version)) {
-    throw deepmd::deepmd_exception("incompatable model: version " +
-                                   model_version + " in graph, but version " +
-                                   global_model_version + " supported ");
-  }
   // rcut = get_rcut();
   // cell_size = rcut;
   // ntypes = get_ntypes();

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -450,10 +450,11 @@ void DeepPot::init(const std::string& model,
     model_version = "0.0";
   }
   if (!model_compatable(model_version)) {
-    throw deepmd::deepmd_exception("incompatable model: version " +
-                                   model_version + " in graph, but version " +
-                                   global_model_version + " supported "
-                                   "See https://deepmd.rtfd.io/compatability/ for details.");
+    throw deepmd::deepmd_exception(
+        "incompatable model: version " + model_version +
+        " in graph, but version " + global_model_version +
+        " supported "
+        "See https://deepmd.rtfd.io/compatability/ for details.");
   }
   dtype = session_get_dtype(session, "descrpt_attr/rcut");
   if (dtype == tensorflow::DT_DOUBLE) {
@@ -1272,10 +1273,11 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
     model_version = "0.0";
   }
   if (!model_compatable(model_version)) {
-    throw deepmd::deepmd_exception("incompatable model: version " +
-                                   model_version + " in graph, but version " +
-                                   global_model_version + " supported. "
-                                   "See https://deepmd.rtfd.io/compatability/ for details.");
+    throw deepmd::deepmd_exception(
+        "incompatable model: version " + model_version +
+        " in graph, but version " + global_model_version +
+        " supported. "
+        "See https://deepmd.rtfd.io/compatability/ for details.");
   }
   dtype = session_get_dtype(sessions[0], "descrpt_attr/rcut");
   if (dtype == tensorflow::DT_DOUBLE) {

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -34,15 +34,16 @@ void DeepTensor::init(const std::string &model,
   deepmd::check_status(session->Create(*graph_def));
   try {
     model_version = get_scalar<STRINGTYPE>("model_attr/model_version");
-  } catch (deepmd::tf_exception& e) {
+  } catch (deepmd::tf_exception &e) {
     // no model version defined in old models
     model_version = "0.0";
   }
   if (!model_compatable(model_version)) {
-    throw deepmd::deepmd_exception("incompatable model: version " +
-                                   model_version + " in graph, but version " +
-                                   global_model_version + " supported "
-                                   "See https://deepmd.rtfd.io/compatability/ for details.");
+    throw deepmd::deepmd_exception(
+        "incompatable model: version " + model_version +
+        " in graph, but version " + global_model_version +
+        " supported "
+        "See https://deepmd.rtfd.io/compatability/ for details.");
   }
   dtype = session_get_dtype(session, "descrpt_attr/rcut");
   if (dtype == tensorflow::DT_DOUBLE) {


### PR DESCRIPTION
1. add the documentation link to the error message;
2. check compatability before fetching rcut, so there will be a clear message for #2293.