### PR TITLE
test lmp for linux wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,10 @@ write_to = "deepmd/_version.py"
 [tool.cibuildwheel]
 test-command = [
     "dp -h",
+    "dp_ipi",
+    "pytest {project}/source/tests/test_lammps.py"
 ]
-test-extras = ["cpu"]
+test-extras = ["cpu", "test", "lmp", "ipi"]
 build = ["cp310-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
 # TODO: bump to "latest" tag when CUDA supports GCC 12
@@ -63,12 +65,6 @@ manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64:2022-11-19-1b19e8
 environment = { PIP_PREFER_BINARY="1", DP_LAMMPS_VERSION="stable_23Jun2022_update4", DP_ENABLE_IPI="1" }
 before-all = ["brew install mpich"]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"
-test-extras = ["cpu", "test", "lmp", "ipi"]
-test-command = [
-    "dp -h",
-    "dp_ipi",
-    "pytest {project}/source/tests/test_lammps.py"
-]
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so --exclude _pywrap_tensorflow_internal.so --exclude libtensorflow_cc.so.2 -w {dest_dir} {wheel}"
@@ -81,7 +77,10 @@ before-all = [
 
 [tool.cibuildwheel.windows]
 environment = { PIP_PREFER_BINARY="1" }
-
+test-extras = ["cpu"]
+test-command = [
+    "dp -h",
+]
 
 # selectively turn of lintner warnings, always include reasoning why any warning should
 # be silenced


### PR DESCRIPTION
Before, it linked with libpython, so it wasn't tested. But now it doesn't link with libpython any more.