### PR TITLE
remove unnecessary files from pypi source distribution 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+# all "tests" file/directory under "source" directory
+exclude source tests
+prune doc
+prune examples
+prune data
+prune .github

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
-# all "tests" file/directory under "source" directory
-exclude source tests
+prune source/tests
+prune source/api_c/tests
+prune source/api_cc/tests
+prune source/lib/tests
+prune source/lmp/tests
 prune doc
 prune examples
 prune data


### PR DESCRIPTION
Our PyPi source distribution package is over 30MB which is too large! See https://pypi.org/project/deepmd-kit/2.2.2/#files
By default, when using `setuptools-scm`, all files will be added to the package. This PR excludes directories that are not used for building and installing, including:

- source/tests
- source/api_c/tests
- source/api_cc/tests
- source/lib/tests
- source/lmp/tests
- doc
- examples
- data
- .github

After removing these files from the source distribution, the package is only 708 KB.