### PR TITLE
fix the missing modifier issue of dp compress

### DIFF
--- a/deepmd/entrypoints/train.py
+++ b/deepmd/entrypoints/train.py
@@ -260,6 +260,9 @@ def _do_work(jdata: Dict[str, Any], run_opt: RunOptions, is_compress: bool = Fal
                         valid_data[data_systems].print_summary(
                             f"validation in {data_systems}"
                         )
+    else:
+        if modifier is not None:
+            modifier.build_fv_graph()
 
     # get training info
     stop_batch = j_must_have(jdata["training"], "numb_steps")


### PR DESCRIPTION
The current model compression feature will miss data modifier if it is used to compress a dplr model. This PR builds the modifier in the compressing process if there is a modifier in the uncompressed model.