### PR TITLE
fix memory leaking in test_env_mat_a_mix.cc

### DIFF
--- a/source/lib/tests/test_env_mat_a_mix.cc
+++ b/source/lib/tests/test_env_mat_a_mix.cc
@@ -721,7 +721,7 @@ TEST_F(TestEnvMatAMix, prod_gpu_cuda) {
       EXPECT_EQ(nmask[ii * nnei + jj], expected_nmask[ii * nnei + jj]);
     }
   }
-  free(nmask);
+  delete[] nmask;
 }
 
 TEST_F(TestEnvMatAMix, prod_gpu_cuda_equal_cpu) {
@@ -939,7 +939,7 @@ TEST_F(TestEnvMatAMix, prod_gpu_rocm) {
       EXPECT_EQ(nmask[ii * nnei + jj], expected_nmask[ii * nnei + jj]);
     }
   }
-  free(nmask);
+  delete[] nmask;
 }
 
 TEST_F(TestEnvMatAMix, prod_gpu_rocm_equal_cpu) {

--- a/source/lib/tests/test_env_mat_a_mix.cc
+++ b/source/lib/tests/test_env_mat_a_mix.cc
@@ -553,7 +553,7 @@ TEST_F(TestEnvMatAMix, prod_cpu) {
       EXPECT_EQ(nmask[ii * nnei + jj], expected_nmask[ii * nnei + jj]);
     }
   }
-  del[] nmask;
+  delete[] nmask;
 }
 
 TEST_F(TestEnvMatAMix, prod_cpu_equal_cpu) {

--- a/source/lib/tests/test_env_mat_a_mix.cc
+++ b/source/lib/tests/test_env_mat_a_mix.cc
@@ -553,7 +553,7 @@ TEST_F(TestEnvMatAMix, prod_cpu) {
       EXPECT_EQ(nmask[ii * nnei + jj], expected_nmask[ii * nnei + jj]);
     }
   }
-  free(nmask);
+  del[] nmask;
 }
 
 TEST_F(TestEnvMatAMix, prod_cpu_equal_cpu) {


### PR DESCRIPTION
`new[]` should be used with `delete[]`.