### PR TITLE
fix se_atten variable names when suffix is given

### DIFF
--- a/deepmd/descriptor/se_atten.py
+++ b/deepmd/descriptor/se_atten.py
@@ -649,7 +649,7 @@ class DescrptSeAtten(DescrptSeA):
             type_i,
             natoms,
             name="filter_type_all" + suffix,
-            suffix=suffix
+            suffix=suffix,
             reuse=reuse,
             trainable=trainable,
             activation_fn=self.filter_activation_fn,

--- a/deepmd/descriptor/se_atten.py
+++ b/deepmd/descriptor/se_atten.py
@@ -649,6 +649,7 @@ class DescrptSeAtten(DescrptSeA):
             type_i,
             natoms,
             name="filter_type_all" + suffix,
+            suffix=suffix
             reuse=reuse,
             trainable=trainable,
             activation_fn=self.filter_activation_fn,
@@ -1015,7 +1016,7 @@ class DescrptSeAtten(DescrptSeA):
                         self.filter_precision,
                         activation_fn=activation_fn,
                         resnet_dt=self.filter_resnet_dt,
-                        name_suffix=suffix,
+                        name_suffix="",
                         stddev=stddev,
                         bavg=bavg,
                         seed=self.seed,
@@ -1040,7 +1041,7 @@ class DescrptSeAtten(DescrptSeA):
                             self.filter_precision,
                             activation_fn=activation_fn,
                             resnet_dt=self.filter_resnet_dt,
-                            name_suffix=suffix,
+                            name_suffix="",
                             stddev=stddev,
                             bavg=bavg,
                             seed=self.seed,
@@ -1089,7 +1090,7 @@ class DescrptSeAtten(DescrptSeA):
                             two_side_type_embedding,
                             [-1, two_side_type_embedding.shape[-1]],
                         )
-                        two_side_type_embedding_suffix = suffix + "_two_side_ebd"
+                        two_side_type_embedding_suffix = "_two_side_ebd"
                         embedding_of_two_side_type_embedding = embedding_net(
                             two_side_type_embedding,
                             self.filter_neuron,

--- a/deepmd/descriptor/se_atten.py
+++ b/deepmd/descriptor/se_atten.py
@@ -649,7 +649,6 @@ class DescrptSeAtten(DescrptSeA):
             type_i,
             natoms,
             name="filter_type_all" + suffix,
-            suffix=suffix,
             reuse=reuse,
             trainable=trainable,
             activation_fn=self.filter_activation_fn,


### PR DESCRIPTION
It seems that #1891 wrongly added a suffix to the variable names to make them like `filter_type_all_suffix/matrix_1_suffix`. However, it is expected to be `filter_type_all_suffix/matrix_1`, consistent in other descriptors and the following method.

https://github.com/deepmodeling/deepmd-kit/blob/5308c66d4f3069047af4a8aa07ece1df4b9628bc/deepmd/utils/graph.py#L166-L171