### PR TITLE
Update raw_to_set.sh

### DIFF
--- a/data/raw/raw_to_set.sh
+++ b/data/raw/raw_to_set.sh
@@ -41,69 +41,69 @@ for ii in $(seq 0 $nset_1); do
 	test -f atomic_polarizability.raw$pi && mv atomic_polarizability.raw$pi set.$pi/atomic_polarizability.raw
 
 	cd set.$pi
-	python -c 'import numpy as np; data = np.loadtxt("box.raw"   , ndmin = 2); data = data.astype (np.float32); np.save ("box",    data)'
-	python -c 'import numpy as np; data = np.loadtxt("coord.raw" , ndmin = 2); data = data.astype (np.float32); np.save ("coord",  data)'
+	python -c 'import numpy as np; data = np.loadtxt("box.raw"   , ndmin = 2); data = data.astype (np.float64); np.save ("box",    data)'
+	python -c 'import numpy as np; data = np.loadtxt("coord.raw" , ndmin = 2); data = data.astype (np.float64); np.save ("coord",  data)'
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("energy.raw"):
    data = np.loadtxt("energy.raw");
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("energy", data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("force.raw" ):
    data = np.loadtxt("force.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("force",  data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("virial.raw"):
    data = np.loadtxt("virial.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("virial", data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("atom_ener.raw"):
    data = np.loadtxt("atom_ener.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("atom_ener", data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("fparam.raw"):
    data = np.loadtxt("fparam.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("fparam", data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("dipole.raw"):
    data = np.loadtxt("dipole.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("dipole", data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("polarizability.raw"):
    data = np.loadtxt("polarizability.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("polarizability", data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("atomic_dipole.raw"):
    data = np.loadtxt("atomic_dipole.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("atomic_dipole", data)
 '
 	python -c \
 		'import numpy as np; import os.path;
 if os.path.isfile("atomic_polarizability.raw"):
    data = np.loadtxt("atomic_polarizability.raw", ndmin = 2);
-   data = data.astype (np.float32);
+   data = data.astype (np.float64);
    np.save ("atomic_polarizability", data)
 '
 	rm *.raw


### PR DESCRIPTION
changing the default data format from 'float32' into 'float64' when save .npy files.  
Float32 maybe not long enough in treating total energies from lammps output, where systems usually have many atoms that consums much significiant figures before the decimal point.
The residual errors may confuse developers when doing consistence-check for new features.
Cases would be worse when the absolute energy of one atom is very large. 

Practical illed senario was provided by @iProzd from the trial application by @Manyi-Yang.  The total potenal energy of 66 atom system:
```
>>> a=np.loadtxt("energy.raw",dtype="float32")
>>> a
array([-59455.145, -59455.4  , -59455.508, -59455.566,-59455.605,
       -59455.64 , -59455.67 , -59455.69 , -59455.703, -59455.71 ,
       -59455.727, -59455.73 , -59455.73 ], dtype=float32)
>>> a=np.loadtxt("energy.raw",dtype="float64")
>>> a
array([-59455.14628376, -59455.40031997, -59455.50957327,-59455.56612404,-59455.60684196, 
       -59455.64125964, -59455.67112131, -59455.6900273 , -59455.70292029, -59455.71278897, 
       -59455.72540161, -59455.73137573,-59455.73137573])
```
and the accompanying dp test error (reproducing the lammps inferrence by dp.evaluate) improves from ~2e-5 eV/atom to ~5e-13 eV/atom