### PR TITLE
add precision arguments explicitly to examples

### DIFF
--- a/examples/dos/train/input.json
+++ b/examples/dos/train/input.json
@@ -17,6 +17,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
+      "precision": "float32",
       "seed": 1
     },
     "fitting_net": {
@@ -29,6 +30,7 @@
       ],
       "resnet_dt": true,
       "numb_fparam": 0,
+      "precision": "float32",
       "seed": 1
     }
   },

--- a/examples/dos/train/input.json
+++ b/examples/dos/train/input.json
@@ -17,7 +17,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1
     },
     "fitting_net": {
@@ -30,7 +30,7 @@
       ],
       "resnet_dt": true,
       "numb_fparam": 0,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1
     }
   },

--- a/examples/fparam/train/input.json
+++ b/examples/fparam/train/input.json
@@ -16,6 +16,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
+      "precision": "float32",
       "seed": 1
     },
     "fitting_net": {
@@ -26,6 +27,7 @@
       ],
       "resnet_dt": true,
       "numb_fparam": 1,
+      "precision": "float32",
       "seed": 1
     }
   },

--- a/examples/fparam/train/input.json
+++ b/examples/fparam/train/input.json
@@ -16,7 +16,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1
     },
     "fitting_net": {
@@ -27,7 +27,7 @@
       ],
       "resnet_dt": true,
       "numb_fparam": 1,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1
     }
   },

--- a/examples/fparam/train/input_aparam.json
+++ b/examples/fparam/train/input_aparam.json
@@ -16,6 +16,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
+      "precision": "float32",
       "seed": 1
     },
     "fitting_net": {
@@ -26,6 +27,7 @@
       ],
       "resnet_dt": true,
       "numb_aparam": 1,
+      "precision": "float32",
       "seed": 1
     }
   },

--- a/examples/fparam/train/input_aparam.json
+++ b/examples/fparam/train/input_aparam.json
@@ -16,7 +16,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1
     },
     "fitting_net": {
@@ -27,7 +27,7 @@
       ],
       "resnet_dt": true,
       "numb_aparam": 1,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1
     }
   },

--- a/examples/nopbc/mixed/input.json
+++ b/examples/nopbc/mixed/input.json
@@ -18,7 +18,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 12,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -29,7 +29,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/nopbc/mixed/input.json
+++ b/examples/nopbc/mixed/input.json
@@ -18,6 +18,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 12,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -28,6 +29,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/spin/se_e2_a/input.json
+++ b/examples/spin/se_e2_a/input.json
@@ -20,7 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -31,7 +31,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/spin/se_e2_a/input.json
+++ b/examples/spin/se_e2_a/input.json
@@ -20,6 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -30,6 +31,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/dplr/train/dw.json
+++ b/examples/water/dplr/train/dw.json
@@ -20,7 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -35,7 +35,7 @@
         128
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/dplr/train/dw.json
+++ b/examples/water/dplr/train/dw.json
@@ -20,6 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -34,6 +35,7 @@
         128
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/dplr/train/ener.json
+++ b/examples/water/dplr/train/ener.json
@@ -20,6 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
+      "precision": "float32",
       "seed": 3458359619,
       "_comment": " that's all"
     },
@@ -30,6 +31,7 @@
         128
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 108835393,
       "_comment": " that's all"
     },

--- a/examples/water/dplr/train/ener.json
+++ b/examples/water/dplr/train/ener.json
@@ -20,7 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 8,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 3458359619,
       "_comment": " that's all"
     },
@@ -31,7 +31,7 @@
         128
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 108835393,
       "_comment": " that's all"
     },

--- a/examples/water/hybrid/input.json
+++ b/examples/water/hybrid/input.json
@@ -23,6 +23,7 @@
           ],
           "resnet_dt": false,
           "axis_neuron": 4,
+          "precision": "float32",
           "seed": 1,
           "_comment": " that's all"
         },
@@ -40,6 +41,7 @@
             20
           ],
           "resnet_dt": false,
+          "precision": "float32",
           "seed": 1,
           "_comment": " that's all"
         }

--- a/examples/water/hybrid/input.json
+++ b/examples/water/hybrid/input.json
@@ -23,7 +23,7 @@
           ],
           "resnet_dt": false,
           "axis_neuron": 4,
-          "precision": "float32",
+          "precision": "float64",
           "seed": 1,
           "_comment": " that's all"
         },
@@ -41,7 +41,7 @@
             20
           ],
           "resnet_dt": false,
-          "precision": "float32",
+          "precision": "float64",
           "seed": 1,
           "_comment": " that's all"
         }

--- a/examples/water/se_atten/input.json
+++ b/examples/water/se_atten/input.json
@@ -23,7 +23,7 @@
       "attn_layer": 2,
       "attn_dotr": true,
       "attn_mask": false,
-      "precision": "float32",
+      "precision": "float64",
       "_comment": " that's all"
     },
     "fitting_net": {
@@ -33,7 +33,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_atten/input.json
+++ b/examples/water/se_atten/input.json
@@ -23,6 +23,7 @@
       "attn_layer": 2,
       "attn_dotr": true,
       "attn_mask": false,
+      "precision": "float32",
       "_comment": " that's all"
     },
     "fitting_net": {
@@ -32,6 +33,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_atten_compressible/input.json
+++ b/examples/water/se_atten_compressible/input.json
@@ -23,6 +23,7 @@
       "attn_layer": 0,
       "attn_dotr": true,
       "attn_mask": false,
+      "precision": "float32",
       "_comment": " that's all"
     },
     "fitting_net": {
@@ -32,6 +33,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_atten_compressible/input.json
+++ b/examples/water/se_atten_compressible/input.json
@@ -23,7 +23,7 @@
       "attn_layer": 0,
       "attn_dotr": true,
       "attn_mask": false,
-      "precision": "float32",
+      "precision": "float64",
       "_comment": " that's all"
     },
     "fitting_net": {
@@ -33,7 +33,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_atten_dpa1_compat/input.json
+++ b/examples/water/se_atten_dpa1_compat/input.json
@@ -23,7 +23,7 @@
       "attn_layer": 2,
       "attn_dotr": true,
       "attn_mask": false,
-      "precision": "float32",
+      "precision": "float64",
       "_comment": " that's all"
     },
     "fitting_net": {
@@ -33,7 +33,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_atten_dpa1_compat/input.json
+++ b/examples/water/se_atten_dpa1_compat/input.json
@@ -23,6 +23,7 @@
       "attn_layer": 2,
       "attn_dotr": true,
       "attn_mask": false,
+      "precision": "float32",
       "_comment": " that's all"
     },
     "fitting_net": {
@@ -32,6 +33,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_e2_a/input.json
+++ b/examples/water/se_e2_a/input.json
@@ -20,7 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -31,7 +31,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_e2_a/input.json
+++ b/examples/water/se_e2_a/input.json
@@ -20,6 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -30,6 +31,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_e2_a_mixed_prec/input.json
+++ b/examples/water/se_e2_a_mixed_prec/input.json
@@ -75,7 +75,7 @@
     },
     "mixed_precision": {
       "compute_prec": "float16",
-      "output_prec": "float32"
+      "output_prec": "float64"
     },
     "numb_steps": 1000000,
     "seed": 10,

--- a/examples/water/se_e2_a_tebd/input.json
+++ b/examples/water/se_e2_a_tebd/input.json
@@ -12,6 +12,7 @@
         8
       ],
       "resnet_dt": false,
+      "precision": "float32",
       "seed": 1
     },
     "descriptor": {
@@ -30,6 +31,7 @@
       "resnet_dt": false,
       "axis_neuron": 16,
       "type_one_side": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -40,6 +42,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_e2_a_tebd/input.json
+++ b/examples/water/se_e2_a_tebd/input.json
@@ -12,7 +12,7 @@
         8
       ],
       "resnet_dt": false,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1
     },
     "descriptor": {
@@ -31,7 +31,7 @@
       "resnet_dt": false,
       "axis_neuron": 16,
       "type_one_side": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -42,7 +42,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_e2_r/input.json
+++ b/examples/water/se_e2_r/input.json
@@ -19,6 +19,7 @@
         20
       ],
       "resnet_dt": false,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -29,6 +30,7 @@
         120
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": "that's all"
     },

--- a/examples/water/se_e2_r/input.json
+++ b/examples/water/se_e2_r/input.json
@@ -19,7 +19,7 @@
         20
       ],
       "resnet_dt": false,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -30,7 +30,7 @@
         120
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": "that's all"
     },

--- a/examples/water/se_e3/input.json
+++ b/examples/water/se_e3/input.json
@@ -16,6 +16,7 @@
         8
       ],
       "resnet_dt": false,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -26,6 +27,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/se_e3/input.json
+++ b/examples/water/se_e3/input.json
@@ -16,7 +16,7 @@
         8
       ],
       "resnet_dt": false,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -27,7 +27,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/zbl/input.json
+++ b/examples/water/zbl/input.json
@@ -24,6 +24,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -34,6 +35,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/zbl/input.json
+++ b/examples/water/zbl/input.json
@@ -24,7 +24,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -35,7 +35,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water_multi_task/ener_dipole/input.json
+++ b/examples/water_multi_task/ener_dipole/input.json
@@ -20,7 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -36,7 +36,7 @@
           100
         ],
         "resnet_dt": true,
-        "precision": "float32",
+        "precision": "float64",
         "seed": 1,
         "_comment": " that's all"
       },
@@ -47,7 +47,7 @@
           240
         ],
         "resnet_dt": true,
-        "precision": "float32",
+        "precision": "float64",
         "seed": 1,
         "_comment": " that's all"
       }

--- a/examples/water_multi_task/ener_dipole/input.json
+++ b/examples/water_multi_task/ener_dipole/input.json
@@ -20,6 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -35,6 +36,7 @@
           100
         ],
         "resnet_dt": true,
+        "precision": "float32",
         "seed": 1,
         "_comment": " that's all"
       },
@@ -45,6 +47,7 @@
           240
         ],
         "resnet_dt": true,
+        "precision": "float32",
         "seed": 1,
         "_comment": " that's all"
       }

--- a/examples/water_tensor/dipole/dipole_input.json
+++ b/examples/water_tensor/dipole/dipole_input.json
@@ -20,6 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 6,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -34,6 +35,7 @@
         100
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water_tensor/dipole/dipole_input.json
+++ b/examples/water_tensor/dipole/dipole_input.json
@@ -20,7 +20,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 6,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -35,7 +35,7 @@
         100
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water_tensor/polar/polar_input.json
+++ b/examples/water_tensor/polar/polar_input.json
@@ -21,6 +21,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -36,6 +37,7 @@
         100
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water_tensor/polar/polar_input.json
+++ b/examples/water_tensor/polar/polar_input.json
@@ -21,7 +21,7 @@
       ],
       "resnet_dt": false,
       "axis_neuron": 16,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -37,7 +37,7 @@
         100
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/zinc_protein/zinc_se_a_mask.json
+++ b/examples/zinc_protein/zinc_se_a_mask.json
@@ -27,7 +27,7 @@
       ],
       "resnet_dt": true,
       "axis_neuron": 16,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -38,7 +38,7 @@
         240
       ],
       "resnet_dt": true,
-      "precision": "float32",
+      "precision": "float64",
       "seed": 1,
       "numb_aparam": 1,
       "use_aparam_as_mask": true,

--- a/examples/zinc_protein/zinc_se_a_mask.json
+++ b/examples/zinc_protein/zinc_se_a_mask.json
@@ -27,6 +27,7 @@
       ],
       "resnet_dt": true,
       "axis_neuron": 16,
+      "precision": "float32",
       "seed": 1,
       "_comment": " that's all"
     },
@@ -37,6 +38,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float32",
       "seed": 1,
       "numb_aparam": 1,
       "use_aparam_as_mask": true,


### PR DESCRIPTION
Set precision=float32 for NNs in examples, since we have found that float64 and float32 have the same accuracy in almost all the situation.