### PR TITLE
format ipynb files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ profile = "black"
 force_grid_wrap = 1
 
 [tool.ruff]
-target-version = "py37"
+include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 select = [
     "E", # errors
     "F", # pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ profile = "black"
 force_grid_wrap = 1
 
 [tool.ruff]
-include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
+include = ["**/*.py", "**/pyproject.toml", "**/*.ipynb"]
 select = [
     "E", # errors
     "F", # pyflakes


### PR DESCRIPTION
Format ipynb files, supported in [ruff 0.0.276](https://github.com/astral-sh/ruff/releases/tag/v0.0.276).
Remove target-version, which is not required since [ruff v0.0.255](https://github.com/astral-sh/ruff/releases/tag/v0.0.255).