### PR TITLE
breaking: change the default value of `rcond` from `1e-3` to `None`

### DIFF
--- a/deepmd/fit/dos.py
+++ b/deepmd/fit/dos.py
@@ -97,7 +97,7 @@ class DOSFitting(Fitting):
         numb_fparam: int = 0,
         numb_aparam: int = 0,
         numb_dos: int = 300,
-        rcond: float = 1e-3,
+        rcond: Optional[float] = None,
         trainable: List[bool] = None,
         seed: int = None,
         activation_function: str = "tanh",

--- a/deepmd/fit/ener.py
+++ b/deepmd/fit/ener.py
@@ -135,7 +135,7 @@ class EnerFitting(Fitting):
         resnet_dt: bool = True,
         numb_fparam: int = 0,
         numb_aparam: int = 0,
-        rcond: float = 1e-3,
+        rcond: Optional[float] = None,
         tot_ener_zero: bool = False,
         trainable: Optional[List[bool]] = None,
         seed: Optional[int] = None,

--- a/deepmd/fit/polar.py
+++ b/deepmd/fit/polar.py
@@ -216,7 +216,7 @@ class PolarFittingSeA(Fitting):
             matrix, bias = np.concatenate(sys_matrix, axis=0), np.concatenate(
                 polar_bias, axis=0
             )
-            atom_polar, _, _, _ = np.linalg.lstsq(matrix, bias, rcond=1e-3)
+            atom_polar, _, _, _ = np.linalg.lstsq(matrix, bias, rcond=None)
             for itype in range(len(self.sel_type)):
                 self.constant_matrix[self.sel_type[itype]] = np.mean(
                     np.diagonal(atom_polar[itype].reshape((3, 3)))

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -526,7 +526,9 @@ def fitting_ener():
         Argument(
             "trainable", [list, bool], optional=True, default=True, doc=doc_trainable
         ),
-        Argument("rcond", [float, type(None)], optional=True, default=None, doc=doc_rcond),
+        Argument(
+            "rcond", [float, type(None)], optional=True, default=None, doc=doc_rcond
+        ),
         Argument("seed", [int, None], optional=True, doc=doc_seed),
         Argument("atom_ener", list, optional=True, default=[], doc=doc_atom_ener),
         Argument("layer_name", list, optional=True, doc=doc_layer_name),
@@ -574,7 +576,9 @@ def fitting_dos():
         Argument(
             "trainable", [list, bool], optional=True, default=True, doc=doc_trainable
         ),
-        Argument("rcond", [float, type(None)], optional=True, default=None, doc=doc_rcond),
+        Argument(
+            "rcond", [float, type(None)], optional=True, default=None, doc=doc_rcond
+        ),
         Argument("seed", [int, None], optional=True, doc=doc_seed),
         Argument("numb_dos", int, optional=True, default=300, doc=doc_numb_dos),
     ]

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -487,7 +487,7 @@ def fitting_ener():
     doc_trainable = "Whether the parameters in the fitting net are trainable. This option can be\n\n\
 - bool: True if all parameters of the fitting net are trainable, False otherwise.\n\n\
 - list of bool: Specifies if each layer is trainable. Since the fitting net is composed by hidden layers followed by a output layer, the length of tihs list should be equal to len(`neuron`)+1."
-    doc_rcond = "The condition number used to determine the inital energy shift for each type of atoms."
+    doc_rcond = "The condition number used to determine the inital energy shift for each type of atoms. See `rcond` in :py:meth:`numpy.linalg.lstsq` for more details."
     doc_seed = "Random seed for parameter initialization of the fitting net"
     doc_atom_ener = "Specify the atomic energy in vacuum for each type"
     doc_layer_name = (
@@ -526,7 +526,7 @@ def fitting_ener():
         Argument(
             "trainable", [list, bool], optional=True, default=True, doc=doc_trainable
         ),
-        Argument("rcond", float, optional=True, default=1e-3, doc=doc_rcond),
+        Argument("rcond", [float, type(None)], optional=True, default=None, doc=doc_rcond),
         Argument("seed", [int, None], optional=True, doc=doc_seed),
         Argument("atom_ener", list, optional=True, default=[], doc=doc_atom_ener),
         Argument("layer_name", list, optional=True, doc=doc_layer_name),

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -550,7 +550,7 @@ def fitting_dos():
     doc_trainable = "Whether the parameters in the fitting net are trainable. This option can be\n\n\
 - bool: True if all parameters of the fitting net are trainable, False otherwise.\n\n\
 - list of bool: Specifies if each layer is trainable. Since the fitting net is composed by hidden layers followed by a output layer, the length of tihs list should be equal to len(`neuron`)+1."
-    doc_rcond = "The condition number used to determine the inital energy shift for each type of atoms."
+    doc_rcond = "The condition number used to determine the inital energy shift for each type of atoms. See `rcond` in :py:meth:`numpy.linalg.lstsq` for more details."
     doc_seed = "Random seed for parameter initialization of the fitting net"
     doc_numb_dos = (
         "The number of gridpoints on which the DOS is evaluated (NEDOS in VASP)"
@@ -574,7 +574,7 @@ def fitting_dos():
         Argument(
             "trainable", [list, bool], optional=True, default=True, doc=doc_trainable
         ),
-        Argument("rcond", float, optional=True, default=1e-3, doc=doc_rcond),
+        Argument("rcond", [float, type(None)], optional=True, default=None, doc=doc_rcond),
         Argument("seed", [int, None], optional=True, doc=doc_seed),
         Argument("numb_dos", int, optional=True, default=300, doc=doc_numb_dos),
     ]

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -236,7 +236,7 @@ class DeepmdDataSystem:
             for ii in range(self.nsystems)
         ]
 
-    def compute_energy_shift(self, rcond=1e-3, key="energy"):
+    def compute_energy_shift(self, rcond=None, key="energy"):
         sys_ener = []
         for ss in self.data_systems:
             sys_ener.append(ss.avg(key))

--- a/deepmd/utils/multi_init.py
+++ b/deepmd/utils/multi_init.py
@@ -169,7 +169,5 @@ def _change_sub_config(jdata: Dict[str, Any], src_jdata: Dict[str, Any], sub_key
     # keep some params that are irrelevant to model structures (need to discuss) TODO
     if "trainable" in cur_para.keys():
         target_para["trainable"] = cur_para["trainable"]
-    log.info(
-        f"Change the '{sub_key}' from {str(cur_para)} to {str(target_para)}."
-    )
+    log.info(f"Change the '{sub_key}' from {str(cur_para)} to {str(target_para)}.")
     jdata[sub_key] = target_para

--- a/source/tests/common.py
+++ b/source/tests/common.py
@@ -964,7 +964,7 @@ class DataSystem:
         sys_tynatom = np.reshape(sys_tynatom, [self.nsystems, -1])
         sys_tynatom = sys_tynatom[:, 2:]
         energy_shift, resd, rank, s_value = np.linalg.lstsq(
-            sys_tynatom, sys_ener, rcond=1e-3
+            sys_tynatom, sys_ener, rcond=None
         )
         return energy_shift
 


### PR DESCRIPTION
This is a breaking change. `rcond=1e-3` is found inaccurate. Using NumPy's default value is more accurate and not too slow.