### PR TITLE
symlink `model.ckpt.*` to relative paths

### DIFF
--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -811,7 +811,7 @@ class DPTrainer:
         try:
             ckpt_prefix = self.saver.save(
                 self.sess,
-                self.save_ckpt,
+                os.path.join(os.getcwd(), self.save_ckpt),
                 global_step=cur_batch,
             )
         except google.protobuf.message.DecodeError as e:

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -811,7 +811,7 @@ class DPTrainer:
         try:
             ckpt_prefix = self.saver.save(
                 self.sess,
-                os.path.join(os.getcwd(), self.save_ckpt),
+                self.save_ckpt,
                 global_step=cur_batch,
             )
         except google.protobuf.message.DecodeError as e:

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -832,7 +832,7 @@ class DPTrainer:
                 pass
             if platform.system() != "Windows":
                 # by default one does not have access to create symlink on Windows
-                os.symlink(ori_ff, new_ff)
+                os.symlink(os.path.relpath(ori_ff, os.path.dirname(new_ff)), new_ff)
             else:
                 shutil.copyfile(ori_ff, new_ff)
         log.info("saved checkpoint %s" % self.save_ckpt)


### PR DESCRIPTION
Before, `model.ckpt.*` is symilnks to an abosulote path. If users wants to move the whole directory, the relative path will be more user-friendly.