### PR TITLE
support mapping to ghost type

### DIFF
--- a/doc/third-party/lammps-command.md
+++ b/doc/third-party/lammps-command.md
@@ -85,6 +85,7 @@ If the keyword `ttm` is set, electronic temperatures from [fix ttm command](http
 
 Only a single `pair_coeff` command is used with the deepmd style which specifies atom names. These are mapped to LAMMPS atom types (integers from 1 to Ntypes) by specifying Ntypes additional arguments after `* *` in the `pair_coeff` command.
 If atom names are not set in the `pair_coeff` command, the training parameter {ref}`type_map <model/type_map>` will be used by default.
+If a mapping value is specified as `NULL`, the mapping is not performed. This can be used when a deepmd potential is used as part of the hybrid pair style. The `NULL` values are placeholders for atom types that will be used with other potentials.
 If the training parameter {ref}`type_map <model/type_map>` is not set, atom names in the `pair_coeff` command cannot be set. In this case, atom type indexes in [`type.raw`](../data/system.md) (integers from 0 to Ntypes-1) will map to LAMMPS atom types.
 
 Spin is specified by keywords `virtual_len` and `spin_norm`. If the keyword `virtual_len` is set, the distance between virtual atom and its corresponding real atom for each type of magnetic atoms will be fed to the model as the spin parameters. If the keyword `spin_norm` is set, the magnitude of the magnetic moment for each type of magnetic atoms will be fed to the model as the spin parameters.

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1146,13 +1146,19 @@ void PairDeepMD::coeff(int narg, char **arg) {
     while (iarg < narg) {
       std::string type_name = arg[iarg];
       bool found_element = false;
-      for (int ii = 0; ii < type_map.size(); ++ii) {
-        if (type_map[ii] == type_name) {
-          type_idx_map.push_back(ii);
-          found_element = true;
-          break;
+      if ("-" == type_name) {
+        type_index_map.push_back(type_map.size());  // ghost type
+        found_element = true;
+      } else {
+        for (int ii = 0; ii < type_map.size(); ++ii) {
+          if (type_map[ii] == type_name) {
+            type_idx_map.push_back(ii);
+            found_element = true;
+            break;
+          }
         }
       }
+
       if (!found_element) {
         error->all(FLERR, "pair_coeff: element " + type_name +
                               " not found in the model");

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1146,19 +1146,17 @@ void PairDeepMD::coeff(int narg, char **arg) {
     while (iarg < narg) {
       std::string type_name = arg[iarg];
       bool found_element = false;
-      if ("-" == type_name) {
-        type_index_map.push_back(type_map.size());  // ghost type
-        found_element = true;
-      } else {
-        for (int ii = 0; ii < type_map.size(); ++ii) {
-          if (type_map[ii] == type_name) {
-            type_idx_map.push_back(ii);
-            found_element = true;
-            break;
-          }
+      for (int ii = 0; ii < type_map.size(); ++ii) {
+        if (type_map[ii] == type_name) {
+          type_idx_map.push_back(ii);
+          found_element = true;
+          break;
         }
       }
-
+      if (!found_element && "NULL" == type_name) {
+        type_idx_map.push_back(type_map.size());  // ghost type
+        found_element = true;
+      }
       if (!found_element) {
         error->all(FLERR, "pair_coeff: element " + type_name +
                               " not found in the model");


### PR DESCRIPTION
Currently  `pair_coeff` support customizing mapping rule by the following way
```
pair_coeff * * H O H
```
But there are cases that need to mapping specific atom type to ghost type, or type that doesn't existed in deepmd. 

This PR addresses the issue by treating `NULL` as ghost type, so that users can specify atoms type to be ghost type by the following way
```
pair coeff * * H O NULL
```
