### PR TITLE
breaking: dp test all data

### DIFF
--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -71,7 +71,7 @@ def test(
     set_prefix : str
         string prefix of set
     numb_test : int
-        munber of tests to do
+        munber of tests to do. 0 means all data.
     rand_seed : Optional[int]
         seed for random generator
     shuffle_test : bool
@@ -88,6 +88,9 @@ def test(
     RuntimeError
         if no valid system was found
     """
+    if numb_test == 0:
+        # only float has inf, but should work for min
+        numb_test = float("inf")
     if datafile is not None:
         datalist = open(datafile)
         all_sys = datalist.read().splitlines()

--- a/deepmd_cli/main.py
+++ b/deepmd_cli/main.py
@@ -276,7 +276,7 @@ def main_parser() -> argparse.ArgumentParser:
     parser_tst.add_argument(
         "-n",
         "--numb-test",
-        default=100,
+        default=0,
         type=int,
         help="The number of data for test. 0 means all data.",
     )

--- a/deepmd_cli/main.py
+++ b/deepmd_cli/main.py
@@ -274,7 +274,11 @@ def main_parser() -> argparse.ArgumentParser:
         "-S", "--set-prefix", default="set", type=str, help="The set prefix"
     )
     parser_tst.add_argument(
-        "-n", "--numb-test", default=100, type=int, help="The number of data for test"
+        "-n",
+        "--numb-test",
+        default=100,
+        type=int,
+        help="The number of data for test. 0 means all data.",
     )
     parser_tst.add_argument(
         "-r", "--rand-seed", type=int, default=None, help="The random seed"


### PR DESCRIPTION
Previously, we need to set `numb_test` to a quite large number to test all data. In this PR, passing 0 will lead to infinity.

Breaking change: the default value of `numb_test` is set to 0.