### PR TITLE
Use `module.__path__[0]` instead of `module.__file__`

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -48,7 +48,7 @@ def dlopen_library(module: str, filename: str):
     except ModuleNotFoundError:
         pass
     else:
-        libs = sorted(Path(m.__file__).parent.glob(filename))
+        libs = sorted(Path(m.__path__[0]).glob(filename))
         # hope that there is only one version installed...
         if len(libs):
             ctypes.CDLL(str(libs[0].absolute()))


### PR DESCRIPTION
Fix #2751.

If `__init__.py` does not exist, `module.__file__` is `None` (it is expected to give the path to `__init__.py`). In this case, `module.__path__[0]` will give the directory path.
