### PR TITLE
lmp: `fix_dplr` use the same `type_map` from `pair_deepmd`

### DIFF
--- a/doc/model/dplr.md
+++ b/doc/model/dplr.md
@@ -171,8 +171,8 @@ fix_modify	0 virial yes
 ```
 
 The fix command `dplr` calculates the position of WCs by the DW model and back-propagates the long-range interaction on virtual atoms to real toms.
-At this time, the training parameter {ref}`type_map <model/type_map>` will be mapped to LAMMPS atom types.
-
+The atom names specified in [pair_style `deepmd`](../third-party/lammps-command.md#pair_style-deepmd) will be used to determine elements.
+If it is not set, the training parameter {ref}`type_map <model/type_map>` will be mapped to LAMMPS atom types.
 
 To use a time-dependent electric field, LAMMPS's `variable` feature can be utilized:
 ```lammps

--- a/source/api_c/include/c_api.h
+++ b/source/api_c/include/c_api.h
@@ -1034,6 +1034,13 @@ int* DP_DeepTensorGetSelTypes(DP_DeepTensor* dt);
 int DP_DeepTensorGetNumbSelTypes(DP_DeepTensor* dt);
 
 /**
+ * @brief Get the type map of a Deep Tensor.
+ * @param[in] dt The Deep Tensor to use.
+ * @return The type map of the Deep Tensor.
+ */
+const char* DP_DeepTensorGetTypeMap(DP_DeepTensor* dt);
+
+/**
  * @brief Check if there is any exceptions throw.
  *
  * @param dt The Deep Tensor to use.

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -1842,7 +1842,7 @@ class DeepTensor {
    * @param[out] type_map The type map of this model.
    **/
   void get_type_map(std::string &type_map) {
-    const char *type_map_c = DP_DeepTensorGetTypeMap(dp);
+    const char *type_map_c = DP_DeepTensorGetTypeMap(dt);
     type_map.assign(type_map_c);
     delete[] type_map_c;
   };

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -1837,6 +1837,15 @@ class DeepTensor {
   void print_summary(const std::string &pre) const {
     DP_PrintSummary(pre.c_str());
   }
+  /**
+   * @brief Get the type map (element name of the atom types) of this model.
+   * @param[out] type_map The type map of this model.
+   **/
+  void get_type_map(std::string &type_map) {
+    const char *type_map_c = DP_DeepTensorGetTypeMap(dp);
+    type_map.assign(type_map_c);
+    delete[] type_map_c;
+  };
 
  private:
   DP_DeepTensor *dt;

--- a/source/api_c/src/c_api.cc
+++ b/source/api_c/src/c_api.cc
@@ -1267,6 +1267,12 @@ int DP_DeepTensorGetNumbSelTypes(DP_DeepTensor* dt) {
   return dt->dt.sel_types().size();
 }
 
+const char* DP_DeepTensorGetTypeMap(DP_DeepTensor* dt) {
+  std::string type_map;
+  dt->dt.get_type_map(type_map);
+  return string_to_char(type_map);
+}
+
 const char* DP_DeepTensorCheckOK(DP_DeepTensor* dt) {
   return string_to_char(dt->exception);
 }

--- a/source/api_cc/include/DeepTensor.h
+++ b/source/api_cc/include/DeepTensor.h
@@ -39,7 +39,6 @@ class DeepTensor {
    **/
   void print_summary(const std::string& pre) const;
 
- public:
   /**
    * @brief Evaluate the value by using this model.
    * @param[out] value The value to evalute, usually would be the atomic tensor.
@@ -198,6 +197,11 @@ class DeepTensor {
     assert(inited);
     return sel_type;
   };
+  /**
+   * @brief Get the type map (element name of the atom types) of this model.
+   * @param[out] type_map The type map of this model.
+   **/
+  void get_type_map(std::string& type_map);
 
  private:
   tensorflow::Session* session;

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -793,6 +793,6 @@ template void DeepTensor::compute_inner<float>(
     const int nghost,
     const InputNlist &nlist_);
 
-void DeepTensor::get_type_map(std::string& type_map) {
+void DeepTensor::get_type_map(std::string &type_map) {
   type_map = get_scalar<STRINGTYPE>("model_attr/tmap");
 }

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -792,3 +792,7 @@ template void DeepTensor::compute_inner<float>(
     const std::vector<float> &dbox,
     const int nghost,
     const InputNlist &nlist_);
+
+void DeepTensor::get_type_map(std::string& type_map) {
+  type_map = get_scalar<STRINGTYPE>("model_attr/tmap");
+}

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -190,13 +190,12 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
         error->all(FLERR, "pair_coeff: element " + type_name +
                           " not found in the DPLR model");
       }
-      iarg += 1;
     }
     int numb_types = type_idx_map.size();
     if (numb_types < n) {
       type_idx_map.resize(n);
       for (int ii = numb_types; ii < n; ++ii) {
-        type_idx_map[ii] = -1;
+        type_idx_map[ii] = ii;
       }
     }
   }

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -156,22 +156,21 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
 
   int n = atom->ntypes;
   std::vector<std::string> type_names = pair_deepmd->type_names;
-  if (type_names.size() == 0){
+  std::vector<std::string> type_map;
+  std::string type_map_str;
+  dpt.get_type_map(type_map_str);
+  // convert the string to a vector of strings
+  std::istringstream iss(type_map_str);
+  std::string type_name;
+  while (iss >> type_name) {
+    type_map.push_back(type_name);
+  }
+  if (type_names.size() == 0 || type_map.size() == 0){
     type_idx_map.resize(n);
     for (int ii = 0; ii < n; ++ii) {
       type_idx_map[ii] = ii;
     }
   } else {
-    std::vector<std::string> type_map;
-    std::string type_map_str;
-    deep_pot.get_type_map(type_map_str);
-    // convert the string to a vector of strings
-    std::istringstream iss(type_map_str);
-    std::string type_name;
-    while (iss >> type_name) {
-      type_map.push_back(type_name);
-    }
-
     type_idx_map.clear();
     for (std::string type_name: type_names) {
       bool found_element = false;
@@ -192,7 +191,7 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
       }
       iarg += 1;
     }
-    numb_types = type_idx_map.size();
+    int numb_types = type_idx_map.size();
     if (numb_types < n) {
       type_idx_map.resize(n);
       for (int ii = numb_types; ii < n; ++ii) {

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -191,7 +191,8 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
   for (int ii = 0; ii < map_vec.size() / 2; ++ii) {
     type_asso[type_idx_map[map_vec[ii * 2 + 0]]] =
         type_idx_map[map_vec[ii * 2 + 1]];
-    bk_type_asso[type_idx_mapmap_vec[ii * 2 + 1]]] = type_idx_map[map_vec[ii * 2 + 0]];
+    bk_type_asso[type_idx_map[map_vec[ii * 2 + 1]]] =
+        type_idx_map[map_vec[ii * 2 + 0]];
   }
 
   sel_type = dpt.sel_types();

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -330,7 +330,7 @@ void FixDPLR::get_valid_pairs(vector<pair<int, int> > &pairs) {
   // get type
   int *type = atom->type;
   for (int ii = 0; ii < nall; ++ii) {
-    dtype[ii] = type[ii] - 1;
+    dtype[ii] = type_idx_map[type[ii] - 1];
   }
 
   int **bondlist = neighbor->bondlist;
@@ -440,7 +440,7 @@ void FixDPLR::pre_force(int vflag) {
   vector<FLOAT_PREC> dcoord(nall * 3, 0.);
   // get type
   for (int ii = 0; ii < nall; ++ii) {
-    dtype[ii] = type[ii] - 1;
+    dtype[ii] = type_idx_map[type[ii] - 1];
   }
   // get box
   dbox[0] = domain->h[0];  // xx
@@ -564,7 +564,7 @@ void FixDPLR::post_force(int vflag) {
   {
     int *type = atom->type;
     for (int ii = 0; ii < nall; ++ii) {
-      dtype[ii] = type[ii] - 1;
+      dtype[ii] = type_idx_map[type[ii] - 1];
     }
     dbox[0] = domain->h[0];  // xx
     dbox[4] = domain->h[1];  // yy

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <sstream>
 
 #include "atom.h"
 #include "comm.h"

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -72,8 +72,7 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
   bond_type.clear();
   while (iarg < narg) {
     if (!is_key(arg[iarg])) {
-      error->all(FLERR,
-                 "Illegal fix command\nwrong number of parameters\n");
+      error->all(FLERR, "Illegal fix command\nwrong number of parameters\n");
     }
     if (string(arg[iarg]) == string("model")) {
       if (iarg + 1 > narg) {
@@ -129,10 +128,6 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
   }
   assert(map_vec.size() % 2 == 0),
       "number of ints provided by type_associate should be even";
-  for (int ii = 0; ii < map_vec.size() / 2; ++ii) {
-    type_asso[map_vec[ii * 2 + 0]] = map_vec[ii * 2 + 1];
-    bk_type_asso[map_vec[ii * 2 + 1]] = map_vec[ii * 2 + 0];
-  }
 
   // dpt.init(model);
   // dtm.init("frozen_model.pb");
@@ -141,13 +136,6 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
     dtm.init(model, 0, "dipole_charge");
   } catch (deepmd_compat::deepmd_exception &e) {
     error->one(FLERR, e.what());
-  }
-
-  sel_type = dpt.sel_types();
-  sort(sel_type.begin(), sel_type.end());
-  dpl_type.clear();
-  for (int ii = 0; ii < sel_type.size(); ++ii) {
-    dpl_type.push_back(type_asso[sel_type[ii]]);
   }
 
   pair_deepmd = (PairDeepMD *)force->pair_match("deepmd", 1);
@@ -166,14 +154,14 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
   while (iss >> type_name) {
     type_map.push_back(type_name);
   }
-  if (type_names.size() == 0 || type_map.size() == 0){
+  if (type_names.size() == 0 || type_map.size() == 0) {
     type_idx_map.resize(n);
     for (int ii = 0; ii < n; ++ii) {
       type_idx_map[ii] = ii;
     }
   } else {
     type_idx_map.clear();
-    for (std::string type_name: type_names) {
+    for (std::string type_name : type_names) {
       bool found_element = false;
       for (int ii = 0; ii < type_map.size(); ++ii) {
         if (type_map[ii] == type_name) {
@@ -188,7 +176,7 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
       }
       if (!found_element) {
         error->all(FLERR, "pair_coeff: element " + type_name +
-                          " not found in the DPLR model");
+                              " not found in the DPLR model");
       }
     }
     int numb_types = type_idx_map.size();
@@ -198,6 +186,19 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
         type_idx_map[ii] = ii;
       }
     }
+  }
+
+  for (int ii = 0; ii < map_vec.size() / 2; ++ii) {
+    type_asso[type_idx_map[map_vec[ii * 2 + 0]]] =
+        type_idx_map[map_vec[ii * 2 + 1]];
+    bk_type_asso[type_idx_mapmap_vec[ii * 2 + 1]]] = type_idx_map[map_vec[ii * 2 + 0]];
+  }
+
+  sel_type = dpt.sel_types();
+  sort(sel_type.begin(), sel_type.end());
+  dpl_type.clear();
+  for (int ii = 0; ii < sel_type.size(); ++ii) {
+    dpl_type.push_back(type_asso[sel_type[ii]]);
   }
 
   // set comm size needed by this fix

--- a/source/lmp/fix_dplr.h
+++ b/source/lmp/fix_dplr.h
@@ -78,6 +78,7 @@ class FixDPLR : public Fix {
   double qe2f;
   void update_efield_variables();
   enum { NONE, CONSTANT, EQUAL };
+  std::vector<int> type_idx_map;
 };
 }  // namespace LAMMPS_NS
 

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1143,6 +1143,7 @@ void PairDeepMD::coeff(int narg, char **arg) {
     }
 
     type_idx_map.clear();
+    type_names.clear();
     while (iarg < narg) {
       std::string type_name = arg[iarg];
       type_names.push_back(type_name);

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1145,7 +1145,7 @@ void PairDeepMD::coeff(int narg, char **arg) {
     type_idx_map.clear();
     while (iarg < narg) {
       std::string type_name = arg[iarg];
-      type_names.push(type_name);
+      type_names.push_back(type_name);
       bool found_element = false;
       for (int ii = 0; ii < type_map.size(); ++ii) {
         if (type_map[ii] == type_name) {

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1145,6 +1145,7 @@ void PairDeepMD::coeff(int narg, char **arg) {
     type_idx_map.clear();
     while (iarg < narg) {
       std::string type_name = arg[iarg];
+      type_names.push(type_name);
       bool found_element = false;
       for (int ii = 0; ii < type_map.size(); ++ii) {
         if (type_map[ii] == type_name) {

--- a/source/lmp/pair_deepmd.h
+++ b/source/lmp/pair_deepmd.h
@@ -75,6 +75,7 @@ class PairDeepMD : public Pair {
   std::string get_file_content(const std::string &model);
   std::vector<std::string> get_file_content(
       const std::vector<std::string> &models);
+  std::vector<std::string> type_names;
 
  protected:
   virtual void allocate();

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -277,7 +277,7 @@ def setup_module():
     write_lmp_data_full(
         box, coord, mol_list, type_OH, charge, data_file, bond_list, mass_list
     )
-    write_lmp_data(box, coord, mol_list, type_HO, charge, data_type_map_file, bond_list, mass_list)
+    write_lmp_data_full(box, coord, mol_list, type_HO, charge, data_type_map_file, bond_list, mass_list)
 
 
 def teardown_module():

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -286,13 +286,13 @@ def teardown_module():
     os.remove(data_file)
 
 
-def _lammps(data_file) -> PyLammps:
+def _lammps(data_file, exclude_type="1 3") -> PyLammps:
     lammps = PyLammps()
     lammps.units("metal")
     lammps.boundary("p p p")
     lammps.atom_style("full")
     lammps.neighbor("0.2 bin")
-    lammps.neigh_modify("every 1 delay 0 check no exclude type 1 3")
+    lammps.neigh_modify("every 1 delay 0 check no exclude type " + exclude_type)
     lammps.read_data(data_file.resolve())
     lammps.timestep(0.0005)
     lammps.fix("1 all nve")
@@ -308,7 +308,7 @@ def lammps():
 
 @pytest.fixture
 def lammps_type_map():
-    lmp = _lammps(data_file=data_type_map_file)
+    lmp = _lammps(data_file=data_type_map_file, exclude_type="2 3")
     yield lmp
     lmp.close()
 

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -477,7 +477,7 @@ def test_pair_deepmd_lr_type_map(lammps):
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.kspace_style("pppm/dplr 1e-5")
     lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1")
+    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 2")
     lammps.fix_modify("0 virial yes")
     lammps.run(0)
     for ii in range(8):

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -469,7 +469,8 @@ def test_min_dplr(lammps):
             expected_f_min_step1[lammps.atoms[ii].id - 1]
         )
 
-def test_pair_deepmd_lr_type_map(lammps):
+def test_pair_deepmd_lr_type_map(lammps_type_map):
+    lammps = lammps_type_map
     lammps.pair_style(f"deepmd {pb_file.resolve()}")
     lammps.pair_coeff("* * H O")
     lammps.bond_style("zero")

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -470,27 +470,26 @@ def test_min_dplr(lammps):
         )
 
 def test_pair_deepmd_lr_type_map(lammps_type_map):
-    lammps = lammps_type_map
-    lammps.pair_style(f"deepmd {pb_file.resolve()}")
-    lammps.pair_coeff("* * H O")
-    lammps.bond_style("zero")
-    lammps.bond_coeff("*")
-    lammps.special_bonds("lj/coul 1 1 1 angle no")
-    lammps.kspace_style("pppm/dplr 1e-5")
-    lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 2")
-    lammps.fix_modify("0 virial yes")
-    lammps.run(0)
+    lammps_type_map.pair_style(f"deepmd {pb_file.resolve()}")
+    lammps_type_map.pair_coeff("* * H O")
+    lammps_type_map.bond_style("zero")
+    lammps_type_map.bond_coeff("*")
+    lammps_type_map.special_bonds("lj/coul 1 1 1 angle no")
+    lammps_type_map.kspace_style("pppm/dplr 1e-5")
+    lammps_type_map.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
+    lammps_type_map.fix(f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 2")
+    lammps_type_map.fix_modify("0 virial yes")
+    lammps_type_map.run(0)
     for ii in range(8):
-        if lammps.atoms[ii].id > 6:
-            assert lammps.atoms[ii].position == pytest.approx(
-                expected_WC[lammps.atoms[ii].id - 7]
+        if lammps_type_map.atoms[ii].id > 6:
+            assert lammps_type_map.atoms[ii].position == pytest.approx(
+                expected_WC[lammps_type_map.atoms[ii].id - 7]
             )
-    assert lammps.eval("elong") == pytest.approx(expected_e_kspace)
-    assert lammps.eval("pe") == pytest.approx(expected_e_lr)
+    assert lammps_type_map.eval("elong") == pytest.approx(expected_e_kspace)
+    assert lammps_type_map.eval("pe") == pytest.approx(expected_e_lr)
     for ii in range(8):
-        if lammps.atoms[ii].id <= 6:
-            assert lammps.atoms[ii].force == pytest.approx(
-                expected_f_lr[lammps.atoms[ii].id - 1]
+        if lammps_type_map.atoms[ii].id <= 6:
+            assert lammps_type_map.atoms[ii].force == pytest.approx(
+                expected_f_lr[lammps_type_map.atoms[ii].id - 1]
             )
-    lammps.run(1)
+    lammps_type_map.run(1)

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -20,6 +20,7 @@ pb_file = Path(__file__).parent / "lrmodel.pb"
 dipole_pbtxt_file = Path(__file__).parent / "lrdipole.pbtxt"
 dipole_pb_file = Path(__file__).parent / "lrdipole.pb"
 data_file = Path(__file__).parent / "data.lmp"
+data_type_map_file = Path(__file__).parent / "data_type_map.lmp"
 
 # this is as the same as python and c++ tests, test_deeppot_a.py
 expected_e_sr = -40.56538550
@@ -252,6 +253,7 @@ coord = np.array(
 )
 mol_list = np.array([1, 2, 1, 1, 2, 2, 1, 2])
 type_OH = np.array([1, 1, 2, 2, 2, 2, 3, 3])
+type_HO = np.array([2, 2, 1, 1, 1, 1, 3, 3])
 charge = np.array([6, 6, 1, 1, 1, 1, -8, -8])
 bond_list = (((1, 7), (2, 8)),)
 mass_list = np.array([15.99940, 1.00794, 15.99940])
@@ -275,6 +277,7 @@ def setup_module():
     write_lmp_data_full(
         box, coord, mol_list, type_OH, charge, data_file, bond_list, mass_list
     )
+    write_lmp_data(box, coord, mol_list, type_HO, charge, data_type_map_file, bond_list, mass_list)
 
 
 def teardown_module():
@@ -300,6 +303,11 @@ def lammps():
     yield lmp
     lmp.close()
 
+@pytest.fixture
+def lammps_type_map():
+    lmp = _lammps(data_file=data_type_map_file)
+    yield lmp
+    lmp.close()
 
 def test_pair_deepmd_sr(lammps):
     lammps.pair_style(f"deepmd {pb_file.resolve()}")
@@ -460,3 +468,28 @@ def test_min_dplr(lammps):
         assert lammps.atoms[ii].force == pytest.approx(
             expected_f_min_step1[lammps.atoms[ii].id - 1]
         )
+
+def test_pair_deepmd_lr_type_map(lammps):
+    lammps.pair_style(f"deepmd {pb_file.resolve()}")
+    lammps.pair_coeff("* * H O")
+    lammps.bond_style("zero")
+    lammps.bond_coeff("*")
+    lammps.special_bonds("lj/coul 1 1 1 angle no")
+    lammps.kspace_style("pppm/dplr 1e-5")
+    lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
+    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1")
+    lammps.fix_modify("0 virial yes")
+    lammps.run(0)
+    for ii in range(8):
+        if lammps.atoms[ii].id > 6:
+            assert lammps.atoms[ii].position == pytest.approx(
+                expected_WC[lammps.atoms[ii].id - 7]
+            )
+    assert lammps.eval("elong") == pytest.approx(expected_e_kspace)
+    assert lammps.eval("pe") == pytest.approx(expected_e_lr)
+    for ii in range(8):
+        if lammps.atoms[ii].id <= 6:
+            assert lammps.atoms[ii].force == pytest.approx(
+                expected_f_lr[lammps.atoms[ii].id - 1]
+            )
+    lammps.run(1)

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -277,7 +277,9 @@ def setup_module():
     write_lmp_data_full(
         box, coord, mol_list, type_OH, charge, data_file, bond_list, mass_list
     )
-    write_lmp_data_full(box, coord, mol_list, type_HO, charge, data_type_map_file, bond_list, mass_list)
+    write_lmp_data_full(
+        box, coord, mol_list, type_HO, charge, data_type_map_file, bond_list, mass_list
+    )
 
 
 def teardown_module():
@@ -303,11 +305,13 @@ def lammps():
     yield lmp
     lmp.close()
 
+
 @pytest.fixture
 def lammps_type_map():
     lmp = _lammps(data_file=data_type_map_file)
     yield lmp
     lmp.close()
+
 
 def test_pair_deepmd_sr(lammps):
     lammps.pair_style(f"deepmd {pb_file.resolve()}")
@@ -469,6 +473,7 @@ def test_min_dplr(lammps):
             expected_f_min_step1[lammps.atoms[ii].id - 1]
         )
 
+
 def test_pair_deepmd_lr_type_map(lammps_type_map):
     lammps_type_map.pair_style(f"deepmd {pb_file.resolve()}")
     lammps_type_map.pair_coeff("* * H O")
@@ -476,8 +481,12 @@ def test_pair_deepmd_lr_type_map(lammps_type_map):
     lammps_type_map.bond_coeff("*")
     lammps_type_map.special_bonds("lj/coul 1 1 1 angle no")
     lammps_type_map.kspace_style("pppm/dplr 1e-5")
-    lammps_type_map.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps_type_map.fix(f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 2")
+    lammps_type_map.kspace_modify(
+        f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}"
+    )
+    lammps_type_map.fix(
+        f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 1"
+    )
     lammps_type_map.fix_modify("0 virial yes")
     lammps_type_map.run(0)
     for ii in range(8):


### PR DESCRIPTION
When `pair_coeff` has set LAMMPS `type_map` (e.g. `pair_coeff * * O H`), `fix_dplr` uses the same LAMMPS `type_map` (i.e. `O H` in this case) to map from LAMMPS types to the DP model types, considering LAMMPS types should always be the same among different commands.