### PR TITLE
lmp: throw error for traditional installation if dependent packages are not installed

### DIFF
--- a/source/lmp/Install.sh
+++ b/source/lmp/Install.sh
@@ -30,15 +30,15 @@ action() {
 	fi
 }
 
-if (test $1 = 1) then
-  if (test ! -e ../pppm.cpp) then
-    echo "Must install KSPACE package with USER-DEEPMD package"
-    exit 1
-  fi
-  if (test ! -e ../fix_ttm.cpp) then
-    echo "Must install EXTRA-FIX package with USER-DEEPMD package"
-    exit 1
-  fi
+if (test $1 = 1); then
+	if (test ! -e ../pppm.cpp); then
+		echo "Must install KSPACE package with USER-DEEPMD package"
+		exit 1
+	fi
+	if (test ! -e ../fix_ttm.cpp); then
+		echo "Must install EXTRA-FIX package with USER-DEEPMD package"
+		exit 1
+	fi
 fi
 
 # all package files with no dependencies

--- a/source/lmp/Install.sh
+++ b/source/lmp/Install.sh
@@ -30,6 +30,17 @@ action() {
 	fi
 }
 
+if (test $1 = 1) then
+  if (test ! -e ../pppm.cpp) then
+    echo "Must install KSPACE package with USER-DEEPMD package"
+    exit 1
+  fi
+  if (test ! -e ../fix_ttm.cpp) then
+    echo "Must install EXTRA-FIX package with USER-DEEPMD package"
+    exit 1
+  fi
+fi
+
 # all package files with no dependencies
 
 for file in *.cpp *.h; do


### PR DESCRIPTION
See https://github.com/search?q=repo%3Alammps%2Flammps+%22Must+install%22&type=code. Just use the same logic as LAMMPS.