### PR TITLE
lmp: add the header for atomic model deviation

### DIFF
--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1039,7 +1039,12 @@ void PairDeepMD::settings(int narg, char **arg) {
         fp << "#" << setw(12 - 1) << "step" << setw(18 + 1) << "max_devi_v"
            << setw(18 + 1) << "min_devi_v" << setw(18 + 1) << "avg_devi_v"
            << setw(18 + 1) << "max_devi_f" << setw(18 + 1) << "min_devi_f"
-           << setw(18 + 1) << "avg_devi_f" << endl;
+           << setw(18 + 1) << "avg_devi_f";
+        if (out_each) {
+            // at this time, we don't know how many atoms
+            fp << setw(18 + 1) << "atm_devi_f(N)";
+        }
+        fp << endl;
       } else {
         fp.open(out_file, std::ofstream::out | std::ofstream::app);
         fp << scientific;

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -1041,8 +1041,8 @@ void PairDeepMD::settings(int narg, char **arg) {
            << setw(18 + 1) << "max_devi_f" << setw(18 + 1) << "min_devi_f"
            << setw(18 + 1) << "avg_devi_f";
         if (out_each) {
-            // at this time, we don't know how many atoms
-            fp << setw(18 + 1) << "atm_devi_f(N)";
+          // at this time, we don't know how many atoms
+          fp << setw(18 + 1) << "atm_devi_f(N)";
         }
         fp << endl;
       } else {


### PR DESCRIPTION
Previously, the header line does not have columns for atomic model deviation.