### PR TITLE
lmp: add unit_style requirement for compute deeptensor/atom

### DIFF
--- a/source/lmp/compute_deeptensor_atom.cpp
+++ b/source/lmp/compute_deeptensor_atom.cpp
@@ -26,10 +26,12 @@ using namespace LAMMPS_NS;
 
 ComputeDeeptensorAtom::ComputeDeeptensorAtom(LAMMPS *lmp, int narg, char **arg)
     : Compute(lmp, narg, arg), dp(lmp), tensor(nullptr) {
-  if (!(strcmp(update->unit_style, "metal") == 0 || strcmp(update->unit_style, "real") == 0)) {
-    error->all(FLERR,
-               "Compute deeptensor/atom requires metal or real unit; please set it by "
-               "\"units metal\" or \"units real\"");
+  if (!(strcmp(update->unit_style, "metal") == 0 ||
+        strcmp(update->unit_style, "real") == 0)) {
+    error->all(
+        FLERR,
+        "Compute deeptensor/atom requires metal or real unit; please set it by "
+        "\"units metal\" or \"units real\"");
   }
 
   if (narg < 4) {

--- a/source/lmp/compute_deeptensor_atom.cpp
+++ b/source/lmp/compute_deeptensor_atom.cpp
@@ -26,6 +26,12 @@ using namespace LAMMPS_NS;
 
 ComputeDeeptensorAtom::ComputeDeeptensorAtom(LAMMPS *lmp, int narg, char **arg)
     : Compute(lmp, narg, arg), dp(lmp), tensor(nullptr) {
+  if (!(strcmp(update->unit_style, "metal") == 0 || strcmp(update->unit_style, "real") == 0)) {
+    error->all(FLERR,
+               "Compute deeptensor/atom requires metal or real unit; please set it by "
+               "\"units metal\" or \"units real\"");
+  }
+
   if (narg < 4) {
     error->all(FLERR, "Illegal compute deeptensor/atom command");
   }


### PR DESCRIPTION
The input of the model should be Angstron so that the unit style can only be metal or real.