### PR TITLE
fix np.loadtxt DeprecationWarning

### DIFF
--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -580,7 +580,7 @@ class DeepmdData:
             return np.float32(0.0), data
 
     def _load_type(self, sys_path: DPPath):
-        atom_type = (sys_path / "type.raw").load_txt(dtype=np.int32, ndmin=1)
+        atom_type = (sys_path / "type.raw").load_txt(ndmin=1).astype(np.int32)
         return atom_type
 
     def _load_type_mix(self, set_name: DPPath):


### PR DESCRIPTION
```
DeprecationWarning: loadtxt(): Parsing an integer via a float is deprecated.  To avoid this warning, you can:
    * make sure the original data is stored as integers.
    * use the `converters=` keyword argument.  If you only use
      NumPy 1.23 or later, `converters=float` will normally work.
    * Use `np.loadtxt(...).astype(np.int64)` parsing the file as
      floating point and then convert it.  (On all NumPy versions.)
  (Deprecated NumPy 1.23)
  return np.loadtxt(str(self.path), **kwargs)
```