### PR TITLE
ignore drdq when generalized force loss is not set

### DIFF
--- a/deepmd/loss/ener.py
+++ b/deepmd/loss/ener.py
@@ -121,13 +121,14 @@ class EnerStdLoss(Loss):
         )
         # drdq: the partial derivative of atomic coordinates w.r.t. generalized coordinates
         # TODO: could numb_generalized_coord decided from the training data?
-        add_data_requirement(
-            "drdq",
-            self.numb_generalized_coord * 3,
-            atomic=True,
-            must=False,
-            high_prec=False,
-        )
+        if self.has_gf > 0:
+            add_data_requirement(
+                "drdq",
+                self.numb_generalized_coord * 3,
+                atomic=True,
+                must=False,
+                high_prec=False,
+            )
         if self.enable_atom_ener_coeff:
             add_data_requirement(
                 "atom_ener_coeff",


### PR DESCRIPTION
This PR fixes an error for the example in the `examples` directory.