### PR TITLE
`ndarray.tostring` -> `ndarray.tobytes`

### DIFF
--- a/deepmd/entrypoints/transfer.py
+++ b/deepmd/entrypoints/transfer.py
@@ -196,7 +196,7 @@ class CopyNodeAttr:
         )
 
     def from_str(self, tensor: np.ndarray):
-        self.node.attr["value"].tensor.tensor_content = tensor.tostring()
+        self.node.attr["value"].tensor.tensor_content = tensor.tobytes()
 
 
 def load_tensor(node: tf.Tensor, dtype_old: type, dtype_new: type) -> np.ndarray:


### PR DESCRIPTION
`tostring` has been deprecated. See https://numpy.org/devdocs/reference/generated/numpy.ndarray.tostring.html