### PR TITLE
`tf.accumulate_n` -> `tf.add_n`

### DIFF
--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -1054,8 +1054,8 @@ class DescrptSeA(DescrptSe):
                         # add zero is meaningless; skip
                         rets.append(ret)
                     start_index += self.sel_a[type_i]
-                # faster to use accumulate_n than multiple add
-                xyz_scatter_1 = tf.accumulate_n(rets)
+                # faster to use add_n than multiple add
+                xyz_scatter_1 = tf.add_n(rets)
             else:
                 xyz_scatter_1 = self._filter_lower(
                     type_i,


### PR DESCRIPTION
`tf.accumulate_n` has been deprecated, and from the source code, I see that `tf.accumulate_n` is just a wrapper of `tf.add_n` since TF 2.1 (https://github.com/tensorflow/tensorflow/commit/292d3094313136b77bb5f444561bc3ffc529b246).

See:
https://www.tensorflow.org/api_docs/python/tf/math/accumulate_n
https://www.tensorflow.org/api_docs/python/tf/math/add_n