### PR TITLE
`tf.test.TestCase.test_session` -> `tf.test.TestCase.cached_session`

### DIFF
--- a/source/tests/test_activation_fn_gelu.py
+++ b/source/tests/test_activation_fn_gelu.py
@@ -17,7 +17,7 @@ from deepmd.utils.network import (
 class TestGelu(tf.test.TestCase):
     def setUp(self):
         self.places = 6
-        self.sess = self.test_session().__enter__()
+        self.sess = self.cached_session().__enter__()
         self.inputs = tf.reshape(
             tf.constant([0.0, 1.0, 2.0, 3.0], dtype=tf.float64), [-1, 1]
         )

--- a/source/tests/test_data_large_batch.py
+++ b/source/tests/test_data_large_batch.py
@@ -180,7 +180,7 @@ class TestDataLargeBatch(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         # print(sess.run(model.type_embedding))
@@ -376,7 +376,7 @@ class TestDataLargeBatch(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         # print(sess.run(model.type_embedding))
@@ -572,7 +572,7 @@ class TestDataLargeBatch(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         # print(sess.run(model.type_embedding))

--- a/source/tests/test_data_modifier.py
+++ b/source/tests/test_data_modifier.py
@@ -80,7 +80,7 @@ class TestDataModifier(tf.test.TestCase):
         model.build(data)
 
         # freeze the graph
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             init_op = tf.global_variables_initializer()
             sess.run(init_op)
             graph = tf.get_default_graph()

--- a/source/tests/test_data_modifier_shuffle.py
+++ b/source/tests/test_data_modifier_shuffle.py
@@ -81,7 +81,7 @@ class TestDataModifier(tf.test.TestCase):
         model.build(data)
 
         # freeze the graph
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             init_op = tf.global_variables_initializer()
             sess.run(init_op)
             graph = tf.get_default_graph()

--- a/source/tests/test_descrpt_hybrid.py
+++ b/source/tests/test_descrpt_hybrid.py
@@ -115,7 +115,7 @@ class TestHybrid(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [model_dout] = sess.run([dout], feed_dict=feed_dict_test)
 

--- a/source/tests/test_descrpt_nonsmth.py
+++ b/source/tests/test_descrpt_nonsmth.py
@@ -160,7 +160,7 @@ class TestNonSmooth(Inter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        Inter.setUp(self, data, sess=self.test_session().__enter__())
+        Inter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, suffix="_se")
@@ -180,8 +180,8 @@ class TestLFPbc(tf.test.TestCase):
         data = Data()
         inter0 = Inter()
         inter1 = Inter()
-        inter0.setUp(data, pbc=True, sess=self.test_session().__enter__())
-        inter1.setUp(data, pbc=False, sess=self.test_session().__enter__())
+        inter0.setUp(data, pbc=True, sess=self.cached_session().__enter__())
+        inter1.setUp(data, pbc=False, sess=self.cached_session().__enter__())
         inter0.net_w_i = np.copy(np.ones(inter0.ndescrpt))
         inter1.net_w_i = np.copy(np.ones(inter1.ndescrpt))
 
@@ -233,8 +233,8 @@ class TestLFPbc(tf.test.TestCase):
         data1 = Data(box_scale=2)
         inter0 = Inter()
         inter1 = Inter()
-        inter0.setUp(data0, pbc=True, sess=self.test_session().__enter__())
-        inter1.setUp(data1, pbc=False, sess=self.test_session().__enter__())
+        inter0.setUp(data0, pbc=True, sess=self.cached_session().__enter__())
+        inter1.setUp(data1, pbc=False, sess=self.cached_session().__enter__())
         inter0.net_w_i = np.copy(np.ones(inter0.ndescrpt))
         inter1.net_w_i = np.copy(np.ones(inter1.ndescrpt))
 

--- a/source/tests/test_descrpt_se_a_mask.py
+++ b/source/tests/test_descrpt_se_a_mask.py
@@ -277,7 +277,7 @@ class TestModel(tf.test.TestCase):
             t_aparam: test_data["aparam"][:numb_test, :],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [op_dout] = sess.run([dout], feed_dict=feed_dict_test)
         op_dout = op_dout.reshape([-1])

--- a/source/tests/test_descrpt_se_a_type.py
+++ b/source/tests/test_descrpt_se_a_type.py
@@ -120,7 +120,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [model_dout] = sess.run([dout], feed_dict=feed_dict_test)
         model_dout = model_dout.reshape([-1])
@@ -284,7 +284,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [model_dout] = sess.run([dout], feed_dict=feed_dict_test)
         model_dout = model_dout.reshape([-1])

--- a/source/tests/test_descrpt_se_atten.py
+++ b/source/tests/test_descrpt_se_atten.py
@@ -141,7 +141,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [model_dout] = sess.run([dout], feed_dict=feed_dict_test)
         model_dout = model_dout.reshape([-1])
@@ -318,7 +318,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [model_dout] = sess.run([dout], feed_dict=feed_dict_test)
         model_dout = model_dout.reshape([-1])
@@ -488,7 +488,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [model_dout] = sess.run([dout], feed_dict=feed_dict_test)
         model_dout = model_dout.reshape([-1])
@@ -666,7 +666,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [model_dout] = sess.run([dout], feed_dict=feed_dict_test)
         model_dout = model_dout.reshape([-1])

--- a/source/tests/test_descrpt_se_r.py
+++ b/source/tests/test_descrpt_se_r.py
@@ -135,7 +135,7 @@ class TestSmooth(Inter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        Inter.setUp(self, data, sess=self.test_session().__enter__())
+        Inter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, suffix="_se_r")
@@ -155,8 +155,8 @@ class TestSeRPbc(tf.test.TestCase):
         data = Data()
         inter0 = Inter()
         inter1 = Inter()
-        inter0.setUp(data, pbc=True, sess=self.test_session().__enter__())
-        inter1.setUp(data, pbc=False, sess=self.test_session().__enter__())
+        inter0.setUp(data, pbc=True, sess=self.cached_session().__enter__())
+        inter1.setUp(data, pbc=False, sess=self.cached_session().__enter__())
         inter0.net_w_i = np.copy(np.ones(inter0.ndescrpt))
         inter1.net_w_i = np.copy(np.ones(inter1.ndescrpt))
 
@@ -208,8 +208,8 @@ class TestSeRPbc(tf.test.TestCase):
         data1 = Data(box_scale=2)
         inter0 = Inter()
         inter1 = Inter()
-        inter0.setUp(data0, pbc=True, sess=self.test_session().__enter__())
-        inter1.setUp(data1, pbc=False, sess=self.test_session().__enter__())
+        inter0.setUp(data0, pbc=True, sess=self.cached_session().__enter__())
+        inter1.setUp(data1, pbc=False, sess=self.cached_session().__enter__())
         inter0.net_w_i = np.copy(np.ones(inter0.ndescrpt))
         inter1.net_w_i = np.copy(np.ones(inter1.ndescrpt))
 

--- a/source/tests/test_descrpt_sea_ef.py
+++ b/source/tests/test_descrpt_sea_ef.py
@@ -154,7 +154,7 @@ class TestSmooth(Inter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        Inter.setUp(self, data, sess=self.test_session().__enter__())
+        Inter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, suffix="_sea_ef")

--- a/source/tests/test_descrpt_sea_ef_para.py
+++ b/source/tests/test_descrpt_sea_ef_para.py
@@ -154,7 +154,7 @@ class TestSmooth(Inter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        Inter.setUp(self, data, sess=self.test_session().__enter__())
+        Inter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, suffix="_sea_ef_para")

--- a/source/tests/test_descrpt_sea_ef_rot.py
+++ b/source/tests/test_descrpt_sea_ef_rot.py
@@ -17,7 +17,7 @@ from deepmd.env import (
 
 class TestEfRot(tf.test.TestCase):
     def setUp(self):
-        self.sess = self.test_session().__enter__()
+        self.sess = self.cached_session().__enter__()
         self.natoms = [5, 5, 2, 3]
         self.ntypes = 2
         self.sel_a = [12, 24]

--- a/source/tests/test_descrpt_sea_ef_vert.py
+++ b/source/tests/test_descrpt_sea_ef_vert.py
@@ -154,7 +154,7 @@ class TestSmooth(Inter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        Inter.setUp(self, data, sess=self.test_session().__enter__())
+        Inter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, suffix="_sea_ef_vert")

--- a/source/tests/test_descrpt_smooth.py
+++ b/source/tests/test_descrpt_smooth.py
@@ -153,7 +153,7 @@ class TestSmooth(Inter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        Inter.setUp(self, data, sess=self.test_session().__enter__())
+        Inter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, suffix="_smth")
@@ -173,8 +173,8 @@ class TestSeAPbc(tf.test.TestCase):
         data = Data()
         inter0 = Inter()
         inter1 = Inter()
-        inter0.setUp(data, pbc=True, sess=self.test_session().__enter__())
-        inter1.setUp(data, pbc=False, sess=self.test_session().__enter__())
+        inter0.setUp(data, pbc=True, sess=self.cached_session().__enter__())
+        inter1.setUp(data, pbc=False, sess=self.cached_session().__enter__())
         inter0.net_w_i = np.copy(np.ones(inter0.ndescrpt))
         inter1.net_w_i = np.copy(np.ones(inter1.ndescrpt))
 
@@ -226,8 +226,8 @@ class TestSeAPbc(tf.test.TestCase):
         data1 = Data(box_scale=2)
         inter0 = Inter()
         inter1 = Inter()
-        inter0.setUp(data0, pbc=True, sess=self.test_session().__enter__())
-        inter1.setUp(data1, pbc=False, sess=self.test_session().__enter__())
+        inter0.setUp(data0, pbc=True, sess=self.cached_session().__enter__())
+        inter1.setUp(data1, pbc=False, sess=self.cached_session().__enter__())
         inter0.net_w_i = np.copy(np.ones(inter0.ndescrpt))
         inter1.net_w_i = np.copy(np.ones(inter1.ndescrpt))
 

--- a/source/tests/test_dipole_se_a.py
+++ b/source/tests/test_dipole_se_a.py
@@ -111,7 +111,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [p, gp] = sess.run([dipole, gdipole], feed_dict=feed_dict_test)
 

--- a/source/tests/test_dipole_se_a_tebd.py
+++ b/source/tests/test_dipole_se_a_tebd.py
@@ -129,7 +129,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [p, gp] = sess.run([dipole, gdipole], feed_dict=feed_dict_test)
 

--- a/source/tests/test_embedding_net.py
+++ b/source/tests/test_embedding_net.py
@@ -13,7 +13,7 @@ from deepmd.utils.network import (
 
 class Inter(tf.test.TestCase):
     def setUp(self):
-        self.sess = self.test_session().__enter__()
+        self.sess = self.cached_session().__enter__()
         self.inputs = tf.constant([0.0, 1.0, 2.0], dtype=tf.float64)
         self.ndata = 3
         self.inputs = tf.reshape(self.inputs, [-1, 1])

--- a/source/tests/test_ewald.py
+++ b/source/tests/test_ewald.py
@@ -64,7 +64,7 @@ class TestEwaldRecp(tf.test.TestCase):
     def test_py_interface(self):
         hh = 1e-4
         places = 4
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         t_energy, t_force, t_virial = op_module.ewald_recp(
             self.coord,
             self.charge,
@@ -91,7 +91,7 @@ class TestEwaldRecp(tf.test.TestCase):
     def test_force(self):
         hh = 1e-4
         places = 6
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         t_energy, t_force, t_virial = op_module.ewald_recp(
             self.coord,
             self.charge,
@@ -144,7 +144,7 @@ class TestEwaldRecp(tf.test.TestCase):
     def test_virial(self):
         hh = 1e-4
         places = 6
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         t_energy, t_force, t_virial = op_module.ewald_recp(
             self.coord,
             self.charge,

--- a/source/tests/test_fitting_dos.py
+++ b/source/tests/test_fitting_dos.py
@@ -180,7 +180,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [pred_atom_dos] = sess.run([atom_dos], feed_dict=feed_dict_test)
 

--- a/source/tests/test_fitting_ener_type.py
+++ b/source/tests/test_fitting_ener_type.py
@@ -188,7 +188,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [pred_atom_ener] = sess.run([atom_ener], feed_dict=feed_dict_test)
 

--- a/source/tests/test_layer_name.py
+++ b/source/tests/test_layer_name.py
@@ -137,7 +137,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             sess.run(tf.global_variables_initializer())
             [e1, f1, v1, e2, f2, v2] = sess.run(
                 [e_energy1, e_force1, e_virial1, e_energy2, e_force2, e_virial2],

--- a/source/tests/test_linear_model.py
+++ b/source/tests/test_linear_model.py
@@ -94,7 +94,7 @@ class TestLinearModel(tf.test.TestCase):
             t_mesh: test_data["default_mesh"],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         e = np.reshape(e, [1, -1])

--- a/source/tests/test_model_dos.py
+++ b/source/tests/test_model_dos.py
@@ -116,7 +116,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [pred_dos, pred_atom_dos] = sess.run([dos, atom_dos], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_loc_frame.py
+++ b/source/tests/test_model_loc_frame.py
@@ -114,7 +114,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_multi.py
+++ b/source/tests/test_model_multi.py
@@ -141,7 +141,7 @@ class TestModel(tf.test.TestCase):
             t_mesh: test_data["default_mesh"],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
 
         # test water energy
         sess.run(tf.global_variables_initializer())

--- a/source/tests/test_model_se_a.py
+++ b/source/tests/test_model_se_a.py
@@ -123,7 +123,7 @@ class TestModel(tf.test.TestCase):
             t_mesh: test_data["default_mesh"],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         self.assertAlmostEqual(e[0], set_atom_ener[0], places=10)
@@ -212,7 +212,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 
@@ -347,7 +347,7 @@ class TestModel(tf.test.TestCase):
             t_mesh: test_data["default_mesh"],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         self.assertAlmostEqual(e[0], set_atom_ener[0], places=10)

--- a/source/tests/test_model_se_a_aparam.py
+++ b/source/tests/test_model_se_a_aparam.py
@@ -115,7 +115,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_se_a_ebd.py
+++ b/source/tests/test_model_se_a_ebd.py
@@ -115,7 +115,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_se_a_fparam.py
+++ b/source/tests/test_model_se_a_fparam.py
@@ -116,7 +116,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_se_a_srtab.py
+++ b/source/tests/test_model_se_a_srtab.py
@@ -140,7 +140,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_se_a_type.py
+++ b/source/tests/test_model_se_a_type.py
@@ -121,7 +121,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         # print(sess.run(model.type_embedding))

--- a/source/tests/test_model_se_atten.py
+++ b/source/tests/test_model_se_atten.py
@@ -132,7 +132,7 @@ class TestModel(tf.test.TestCase):
             t_mesh: test_data["default_mesh"],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         # print(sess.run(model.type_embedding))
@@ -258,7 +258,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             sess.run(tf.global_variables_initializer())
             [des] = sess.run([dout], feed_dict=feed_dict_test1)
 
@@ -357,7 +357,7 @@ class TestModel(tf.test.TestCase):
             t_mesh: test_data["default_mesh"],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         # print(sess.run(model.type_embedding))
@@ -485,7 +485,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             sess.run(tf.global_variables_initializer())
             [des] = sess.run([dout], feed_dict=feed_dict_test1)
 
@@ -587,7 +587,7 @@ class TestModel(tf.test.TestCase):
             t_mesh: test_data["default_mesh"],
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
         # print(sess.run(model.type_embedding))
@@ -719,7 +719,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             sess.run(tf.global_variables_initializer())
             [des] = sess.run([dout], feed_dict=feed_dict_test1)
 

--- a/source/tests/test_model_se_r.py
+++ b/source/tests/test_model_se_r.py
@@ -111,7 +111,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_se_t.py
+++ b/source/tests/test_model_se_t.py
@@ -109,7 +109,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_model_spin.py
+++ b/source/tests/test_model_spin.py
@@ -122,7 +122,7 @@ class TestModelSpin(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [out_ener, out_force, out_virial] = sess.run(
             [energy, force, virial], feed_dict=feed_dict_test

--- a/source/tests/test_nvnmd_entrypoints.py
+++ b/source/tests/test_nvnmd_entrypoints.py
@@ -454,7 +454,7 @@ class TestNvnmdEntrypointsV0(tf.test.TestCase):
             dic_ph["default_mesh"]: mesh_dat,
         }
         #
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         # get tensordic
         keys = "o_descriptor,o_rmat,o_energy".split(",")
@@ -762,7 +762,7 @@ class TestNvnmdEntrypointsV1(tf.test.TestCase):
             dic_ph["default_mesh"]: mesh_dat,
         }
         #
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         # get tensordic
         keys = "o_descriptor,o_rmat,o_energy".split(",")
@@ -818,7 +818,7 @@ class TestNvnmdEntrypointsV1(tf.test.TestCase):
         ref_dout = 60.73941362
         np.testing.assert_almost_equal(pred, ref_dout, 8)
         # test freeze
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         weight_file1 = str(tests_path / "nvnmd" / "ref" / "weight_v1_cnn.npy")
         weight_file2 = str(tests_path / "nvnmd" / "out" / "weight_v1_qnn.npy")
         save_weight(sess, weight_file2)

--- a/source/tests/test_nvnmd_op.py
+++ b/source/tests/test_nvnmd_op.py
@@ -17,7 +17,7 @@ class TestOpAddFltNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -110,7 +110,7 @@ class TestOpCopyFltNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -140,7 +140,7 @@ class TestOpDotmulFltNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -166,7 +166,7 @@ class TestOpFltNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -192,7 +192,7 @@ class TestOpMatmulFitnetNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -238,7 +238,7 @@ class TestOpMatmulFltNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -284,7 +284,7 @@ class TestOpMatmulFlt2fixNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -330,7 +330,7 @@ class TestOpMulFltNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -376,7 +376,7 @@ class TestOpQuantizeNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph
@@ -402,7 +402,7 @@ class TestOpTanh4FltNvnmd(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
 
     def test_op(self):
         # graph

--- a/source/tests/test_pairwise_dprc.py
+++ b/source/tests/test_pairwise_dprc.py
@@ -349,7 +349,7 @@ class TestPairwiseModel(tf.test.TestCase):
             t_aparam: np.reshape(np.tile(test_data["aparam"], 5), [-1]),
             is_training: False,
         }
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [e, f, v] = sess.run([energy, force, virial], feed_dict=feed_dict_test)
 

--- a/source/tests/test_polar_se_a.py
+++ b/source/tests/test_polar_se_a.py
@@ -110,7 +110,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [p, gp] = sess.run([polar, gpolar], feed_dict=feed_dict_test)
 

--- a/source/tests/test_polar_se_a_tebd.py
+++ b/source/tests/test_polar_se_a_tebd.py
@@ -128,7 +128,7 @@ class TestModel(tf.test.TestCase):
             is_training: False,
         }
 
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         [p, gp] = sess.run([polar, gpolar], feed_dict=feed_dict_test)
 

--- a/source/tests/test_prod_env_mat.py
+++ b/source/tests/test_prod_env_mat.py
@@ -11,7 +11,7 @@ from deepmd.env import (
 
 class TestProdEnvMat(tf.test.TestCase):
     def setUp(self):
-        self.sess = self.test_session().__enter__()
+        self.sess = self.cached_session().__enter__()
         self.nframes = 2
         self.dcoord = [
             12.83,

--- a/source/tests/test_prod_force.py
+++ b/source/tests/test_prod_force.py
@@ -18,7 +18,7 @@ class TestProdForce(tf.test.TestCase):
             config.graph_options.rewrite_options.custom_optimizers.add().name = (
                 "dpparallel"
             )
-        self.sess = self.test_session(config=config).__enter__()
+        self.sess = self.cached_session(config=config).__enter__()
         self.nframes = 2
         self.dcoord = [
             12.83,

--- a/source/tests/test_prod_force_grad.py
+++ b/source/tests/test_prod_force_grad.py
@@ -10,7 +10,7 @@ from deepmd.env import (
 
 class TestProdForceGrad(tf.test.TestCase):
     def setUp(self):
-        self.sess = self.test_session().__enter__()
+        self.sess = self.cached_session().__enter__()
         self.nframes = 2
         self.dcoord = [
             12.83,

--- a/source/tests/test_prod_virial.py
+++ b/source/tests/test_prod_virial.py
@@ -10,7 +10,7 @@ from deepmd.env import (
 
 class TestProdVirial(tf.test.TestCase):
     def setUp(self):
-        self.sess = self.test_session().__enter__()
+        self.sess = self.cached_session().__enter__()
         self.nframes = 2
         self.dcoord = [
             12.83,

--- a/source/tests/test_prod_virial_grad.py
+++ b/source/tests/test_prod_virial_grad.py
@@ -10,7 +10,7 @@ from deepmd.env import (
 
 class TestProdVirialGrad(tf.test.TestCase):
     def setUp(self):
-        self.sess = self.test_session().__enter__()
+        self.sess = self.cached_session().__enter__()
         self.nframes = 2
         self.dcoord = [
             12.83,

--- a/source/tests/test_tab_nonsmth.py
+++ b/source/tests/test_tab_nonsmth.py
@@ -178,7 +178,7 @@ class TestTabNonSmooth(IntplInter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        IntplInter.setUp(self, data, sess=self.test_session().__enter__())
+        IntplInter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, places=5, suffix="_tab")

--- a/source/tests/test_tab_smooth.py
+++ b/source/tests/test_tab_smooth.py
@@ -175,7 +175,7 @@ class TestTabSmooth(IntplInter, tf.test.TestCase):
     def setUp(self):
         self.places = 5
         data = Data()
-        IntplInter.setUp(self, data, sess=self.test_session().__enter__())
+        IntplInter.setUp(self, data, sess=self.cached_session().__enter__())
 
     def test_force(self):
         force_test(self, self, places=5, suffix="_tab_smth")

--- a/source/tests/test_type_embed.py
+++ b/source/tests/test_type_embed.py
@@ -23,14 +23,14 @@ class TestTypeEbd(tf.test.TestCase):
         )
         expected_out = [[1, 2, 3], [1, 2, 3], [1, 2, 3], [7, 7, 7], [7, 7, 7]]
         atom_embed = embed_atom_type(ntypes, natoms, type_embedding)
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         atom_embed = sess.run(atom_embed)
         np.testing.assert_almost_equal(atom_embed, expected_out, 10)
 
     def test_type_embed_net(self):
         ten = TypeEmbedNet([2, 4, 8], seed=1, uniform_seed=True)
         type_embedding = ten.build(2)
-        sess = self.test_session().__enter__()
+        sess = self.cached_session().__enter__()
         sess.run(tf.global_variables_initializer())
         type_embedding = sess.run(type_embedding)
 

--- a/source/tests/test_type_one_side.py
+++ b/source/tests/test_type_one_side.py
@@ -125,7 +125,7 @@ class TestModel(tf.test.TestCase):
         feed_dict_test2[t_type] = np.reshape(new_type2[:numb_test, :], [-1])
         feed_dict_test2[t_natoms] = new_natoms2
 
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             sess.run(tf.global_variables_initializer())
             [model_dout1] = sess.run([dout], feed_dict=feed_dict_test1)
             [model_dout2] = sess.run([dout], feed_dict=feed_dict_test2)
@@ -231,7 +231,7 @@ class TestModel(tf.test.TestCase):
         feed_dict_test2[t_type] = np.reshape(new_type2[:numb_test, :], [-1])
         feed_dict_test2[t_natoms] = new_natoms2
 
-        with self.test_session() as sess:
+        with self.cached_session() as sess:
             sess.run(tf.global_variables_initializer())
             [model_dout1] = sess.run([dout], feed_dict=feed_dict_test1)
             [model_dout2] = sess.run([dout], feed_dict=feed_dict_test2)


### PR DESCRIPTION
`tf.test.TestCase.test_session` is deprecated in TF 1.11. We used it when we still tested TF 1.8, and now it is ok to replace it.