### PR TITLE
lmp: let fparam_do_compute not execute by default

### DIFF
--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -382,6 +382,7 @@ PairDeepMD::PairDeepMD(LAMMPS *lmp)
   eps_v = 0.;
   scale = NULL;
   do_ttm = false;
+  do_compute = false;
   single_model = false;
   multi_models_mod_devi = false;
   multi_models_no_mod_devi = false;


### PR DESCRIPTION
One should set the variable do_compute in pair_deepmd.cpp false by default, so that fparam can be used correctly. The current version will trigger the error https://github.com/deepmodeling/deepmd-kit/blob/7da9aaf075e8dea1eca9a08f99f3917235b55e3b/source/lmp/pair_deepmd.cpp#L1044-L1046 unexpectedly.