### PR TITLE
speed up GitHub Actions

### DIFF
--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -54,7 +54,7 @@ jobs:
       env:
         DP_VARIANT: ${{ matrix.dp_variant }}
         DOWNLOAD_TENSORFLOW: "FALSE"
-        CMAKE_GENERATOR: ninja
+        CMAKE_GENERATOR: Ninja
       if: matrix.variant != 'clang'
     - run: source/install/build_cc.sh
       env:
@@ -62,7 +62,7 @@ jobs:
         DOWNLOAD_TENSORFLOW: "FALSE"
         CC: clang
         CXX: clang++
-        CMAKE_GENERATOR: ninja
+        CMAKE_GENERATOR: Ninja
       if: matrix.variant == 'clang'
     - name: Test files exist
       run: |

--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+    - uses: lukka/get-cmake@latest
     - run: python -m pip install tensorflow
     - run: sudo apt-get update && sudo apt-get install -y nvidia-cuda-toolkit
       if: matrix.variant == 'cuda'
@@ -49,6 +50,7 @@ jobs:
       env:
         DP_VARIANT: ${{ matrix.dp_variant }}
         DOWNLOAD_TENSORFLOW: "FALSE"
+        CMAKE_GENERATOR: ninja
       if: matrix.variant != 'clang'
     - run: source/install/build_cc.sh
       env:
@@ -56,6 +58,7 @@ jobs:
         DOWNLOAD_TENSORFLOW: "FALSE"
         CC: clang
         CXX: clang++
+        CMAKE_GENERATOR: ninja
       if: matrix.variant == 'clang'
     - name: Test files exist
       run: |

--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+        cache: 'pip'
     - run: python -m pip install tensorflow
     - run: sudo apt-get update && sudo apt-get install -y nvidia-cuda-toolkit
       if: matrix.variant == 'cuda'
@@ -33,7 +34,7 @@ jobs:
          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb \
          && sudo dpkg -i cuda-keyring_1.0-1_all.deb \
          && sudo apt-get update \
-         && sudo apt-get -y install cuda-12-0
+         && sudo apt-get -y install cuda-cudart-dev-12-0 cuda-nvcc-12-0
       if: matrix.variant == 'cuda120'
       env:
         DEBIAN_FRONTEND: noninteractive
@@ -44,8 +45,6 @@ jobs:
          && sudo apt-get update \
          && sudo apt-get install -y rocm-dev hipcub-dev
       if: matrix.variant == 'rocm'
-    - run: sudo apt-get update && sudo apt-get install -y clang
-      if: matrix.variant == 'clang'
     - run: source/install/build_cc.sh
       env:
         DP_VARIANT: ${{ matrix.dp_variant }}

--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -29,7 +29,11 @@ jobs:
         cache: 'pip'
     - uses: lukka/get-cmake@latest
     - run: python -m pip install tensorflow
-    - run: sudo apt-get update && sudo apt-get install -y nvidia-cuda-toolkit
+    - run: |
+         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb \
+         && sudo dpkg -i cuda-keyring_1.0-1_all.deb \
+         && sudo apt-get update \
+         && sudo apt-get -y install cuda-cudart-dev-11-8 cuda-nvcc-11-8
       if: matrix.variant == 'cuda'
     - run: |
          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb \

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -67,6 +67,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.11'
+          cache: 'pip'
       - run: python -m pip install build
       - name: Build sdist
         run: python -m build --sdist

--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -16,6 +16,7 @@ jobs:
       uses: mpi4py/setup-mpi@v1
       with:
         mpi: mpich
+    - uses: lukka/get-cmake@latest
     - run: python -m pip install tensorflow
     - run: source/install/test_cc_local.sh
       env:
@@ -23,6 +24,7 @@ jobs:
         TF_INTRA_OP_PARALLELISM_THREADS: 1
         TF_INTER_OP_PARALLELISM_THREADS: 1
         LMP_CXX11_ABI_0: 1
+        CMAKE_GENERATOR: ninja
     # test lammps
     # ASE issue: https://gitlab.com/ase/ase/-/merge_requests/2843
     # TODO: remove ase version when ase has new release

--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -24,7 +24,7 @@ jobs:
         TF_INTRA_OP_PARALLELISM_THREADS: 1
         TF_INTER_OP_PARALLELISM_THREADS: 1
         LMP_CXX11_ABI_0: 1
-        CMAKE_GENERATOR: ninja
+        CMAKE_GENERATOR: Ninja
     # test lammps
     # ASE issue: https://gitlab.com/ase/ase/-/merge_requests/2843
     # TODO: remove ase version when ase has new release

--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Setup MPI
       uses: mpi4py/setup-mpi@v1
       with:

--- a/source/install/build_cc.sh
+++ b/source/install/build_cc.sh
@@ -21,8 +21,8 @@ BUILD_TMP_DIR=${SCRIPT_PATH}/../build
 mkdir -p ${BUILD_TMP_DIR}
 cd ${BUILD_TMP_DIR}
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DUSE_TF_PYTHON_LIBS=TRUE ${CUDA_ARGS} -DLAMMPS_VERSION=stable_2Aug2023 ..
-make -j${NPROC}
-make install
+cmake --build . -j${NPROC}
+cmake --install .
 
 #------------------
 echo "Congratulations! DeePMD-kit has been installed at ${INSTALL_PREFIX}"

--- a/source/install/build_from_c.sh
+++ b/source/install/build_from_c.sh
@@ -14,9 +14,9 @@ BUILD_TMP_DIR=${SCRIPT_PATH}/../build
 mkdir -p ${BUILD_TMP_DIR}
 cd ${BUILD_TMP_DIR}
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DDEEPMD_C_ROOT=${DEEPMD_C_ROOT} -DLAMMPS_VERSION=stable_2Aug2023 ..
-make -j${NPROC}
-make install
-make lammps
+cmake --build . -j${NPROC}
+cmake --install .
+cmake --build . --target=lammps
 
 #------------------
 echo "Congratulations! DeePMD-kit has been installed at ${INSTALL_PREFIX}"

--- a/source/install/package_c.sh
+++ b/source/install/package_c.sh
@@ -20,8 +20,8 @@ cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
 	-DPACKAGE_C=TRUE \
 	-DUSE_TF_PYTHON_LIBS=TRUE \
 	..
-make -j${NPROC}
-make install
+cmake --build . -j${NPROC}
+cmake --install .
 
 #------------------
 

--- a/source/install/test_cc.sh
+++ b/source/install/test_cc.sh
@@ -12,8 +12,8 @@ BUILD_TMP_DIR=${SCRIPT_PATH}/../build_tests
 mkdir -p ${BUILD_TMP_DIR}
 cd ${BUILD_TMP_DIR}
 cmake -DINSTALL_TENSORFLOW=TRUE -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DTENSORFLOW_ROOT=${INSTALL_PREFIX} -DBUILD_TESTING:BOOL=TRUE -DLAMMPS_VERSION=stable_2Aug2023 ..
-make -j${NPROC}
-make install
+cmake --build . -j${NPROC}
+cmake --install .
 
 #------------------
 # go to a subdirectory...

--- a/source/install/test_cc_local.sh
+++ b/source/install/test_cc_local.sh
@@ -13,8 +13,8 @@ BUILD_TMP_DIR=${SCRIPT_PATH}/../build_tests
 mkdir -p ${BUILD_TMP_DIR}
 cd ${BUILD_TMP_DIR}
 cmake -DINSTALL_TENSORFLOW=FALSE -DUSE_TF_PYTHON_LIBS=TRUE -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DBUILD_TESTING:BOOL=TRUE -DLAMMPS_VERSION=stable_2Aug2023 ..
-make -j${NPROC}
-make install
+cmake --build . -j${NPROC}
+cmake --install .
 
 #------------------
 # go to a subdirectory...


### PR DESCRIPTION
This PR speeds up multiple GitHub Actions in the following way:

- only install `cuda-nvcc` and `cuda-cudart-dev` instead of the whole cudatoolkit
- skip installing clang as it's already shipped with the GitHub Action image
- enable cache for all `setup-python`
- use Ninja instead of Make as the CMake generator