### PR TITLE
improve configurations of Python lint tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     -   id: check-symlinks
     -   id: check-toml
 # Python
--   repo: https://github.com/psf/black
+-   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.9.1
     hooks:
     -   id: black-jupyter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,6 @@ repos:
     -   id: check-symlinks
     -   id: check-toml
 # Python
--   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
-    hooks:
-    -   id: black-jupyter
 -   repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:
@@ -37,6 +33,10 @@ repos:
     hooks:
     - id: ruff
       args: ["--fix"]
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
+    hooks:
+    -   id: black-jupyter
 # numpydoc
 -   repo: https://github.com/Carreau/velin
     rev: 0.0.12

--- a/data/raw/shuffle_raw.py
+++ b/data/raw/shuffle_raw.py
@@ -69,7 +69,8 @@ def _main():
     tmp = np.reshape(tmp, [nframe, -1])
     nframe = tmp.shape[0]
     idx = np.arange(nframe)
-    np.random.shuffle(idx)
+    rng = np.random.default_rng()
+    rng.shuffle(idx)
 
     for ii in raws:
         data = np.loadtxt(inpath + "/" + ii)

--- a/deepmd/calculator.py
+++ b/deepmd/calculator.py
@@ -75,7 +75,7 @@ class DP(Calculator):
         self,
         model: Union[str, "Path"],
         label: str = "DP",
-        type_dict: Dict[str, int] = None,
+        type_dict: Optional[Dict[str, int]] = None,
         **kwargs,
     ) -> None:
         Calculator.__init__(self, label=label, **kwargs)

--- a/deepmd/calculator.py
+++ b/deepmd/calculator.py
@@ -6,6 +6,7 @@ from pathlib import (
 )
 from typing import (
     TYPE_CHECKING,
+    ClassVar,
     Dict,
     List,
     Optional,
@@ -69,7 +70,13 @@ class DP(Calculator):
     """
 
     name = "DP"
-    implemented_properties = ["energy", "free_energy", "forces", "virial", "stress"]
+    implemented_properties: ClassVar[List[str]] = [
+        "energy",
+        "free_energy",
+        "forces",
+        "virial",
+        "stress",
+    ]
 
     def __init__(
         self,

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -890,7 +890,7 @@ class DescrptSeA(DescrptSe):
         suffix="",
     ):
         """Input env matrix, returns R.G."""
-        outputs_size = [1] + self.filter_neuron
+        outputs_size = [1, *self.filter_neuron]
         # cut-out inputs
         # with natom x (nei_type_i x 4)
         inputs_i = tf.slice(inputs, [0, start_index * 4], [-1, incrs_index * 4])
@@ -1006,7 +1006,7 @@ class DescrptSeA(DescrptSe):
         nframes = tf.shape(tf.reshape(inputs, [-1, natoms[0], self.ndescrpt]))[0]
         # natom x (nei x 4)
         shape = inputs.get_shape().as_list()
-        outputs_size = [1] + self.filter_neuron
+        outputs_size = [1, *self.filter_neuron]
         outputs_size_2 = self.n_axis_neuron
         all_excluded = all(
             (type_input, type_i) in self.exclude_types for type_i in range(self.ntypes)

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -144,7 +144,7 @@ class DescrptSeA(DescrptSe):
     .. [1] Linfeng Zhang, Jiequn Han, Han Wang, Wissam A. Saidi, Roberto Car, and E. Weinan. 2018.
        End-to-end symmetry preserving inter-atomic potential energy model for finite and extended
        systems. In Proceedings of the 32nd International Conference on Neural Information Processing
-       Systems (NIPS'18). Curran Associates Inc., Red Hook, NY, USA, 4441–4451.
+       Systems (NIPS'18). Curran Associates Inc., Red Hook, NY, USA, 4441-4451.
     """
 
     def __init__(

--- a/deepmd/descriptor/se_a_ebd.py
+++ b/deepmd/descriptor/se_a_ebd.py
@@ -230,7 +230,7 @@ class DescrptSeAEbd(DescrptSeA):
         # natom x (nei x 4)
         inputs = tf.reshape(inputs, [-1, self.ndescrpt])
         shape = inputs.get_shape().as_list()
-        outputs_size = [1] + filter_neuron
+        outputs_size = [1, *filter_neuron]
         with tf.variable_scope(name, reuse=reuse):
             xyz_scatter_total = []
             # with natom x (nei x 4)

--- a/deepmd/descriptor/se_a_mask.py
+++ b/deepmd/descriptor/se_a_mask.py
@@ -112,7 +112,7 @@ class DescrptSeAMask(DescrptSeA):
     .. [1] Linfeng Zhang, Jiequn Han, Han Wang, Wissam A. Saidi, Roberto Car, and E. Weinan. 2018.
        End-to-end symmetry preserving inter-atomic potential energy model for finite and extended
        systems. In Proceedings of the 32nd International Conference on Neural Information Processing
-       Systems (NIPS'18). Curran Associates Inc., Red Hook, NY, USA, 4441–4451.
+       Systems (NIPS'18). Curran Associates Inc., Red Hook, NY, USA, 4441-4451.
     """
 
     def __init__(

--- a/deepmd/descriptor/se_atten.py
+++ b/deepmd/descriptor/se_atten.py
@@ -1057,7 +1057,7 @@ class DescrptSeAtten(DescrptSeA):
         reuse=None,
     ):
         """Input env matrix, returns R.G."""
-        outputs_size = [1] + self.filter_neuron
+        outputs_size = [1, *self.filter_neuron]
         # cut-out inputs
         # with natom x (nei_type_i x 4)
         inputs_i = tf.slice(inputs, [0, start_index * 4], [-1, incrs_index * 4])
@@ -1260,7 +1260,7 @@ class DescrptSeAtten(DescrptSeA):
         nframes = tf.shape(tf.reshape(inputs, [-1, natoms[0], self.ndescrpt]))[0]
         # natom x (nei x 4)
         shape = inputs.get_shape().as_list()
-        outputs_size = [1] + self.filter_neuron
+        outputs_size = [1, *self.filter_neuron]
         outputs_size_2 = self.n_axis_neuron
 
         start_index = 0

--- a/deepmd/descriptor/se_r.py
+++ b/deepmd/descriptor/se_r.py
@@ -638,7 +638,7 @@ class DescrptSeR(DescrptSe):
         trainable=True,
     ):
         # natom x nei
-        outputs_size = [1] + self.filter_neuron
+        outputs_size = [1, *self.filter_neuron]
         with tf.variable_scope(name, reuse=reuse):
             start_index = 0
             xyz_scatter_total = []

--- a/deepmd/descriptor/se_t.py
+++ b/deepmd/descriptor/se_t.py
@@ -633,7 +633,7 @@ class DescrptSeT(DescrptSe):
     ):
         # natom x (nei x 4)
         shape = inputs.get_shape().as_list()
-        outputs_size = [1] + self.filter_neuron
+        outputs_size = [1, *self.filter_neuron]
         with tf.variable_scope(name, reuse=reuse):
             start_index_i = 0
             result = None

--- a/deepmd/entrypoints/ipi.py
+++ b/deepmd/entrypoints/ipi.py
@@ -24,7 +24,7 @@ def _program(name: str, args: List[str]):
     args : list of str
         list of arguments
     """
-    return subprocess.call([os.path.join(ROOT_DIR, name)] + args, close_fds=False)
+    return subprocess.call([os.path.join(ROOT_DIR, name), *args], close_fds=False)
 
 
 def dp_ipi():

--- a/deepmd/fit/dos.py
+++ b/deepmd/fit/dos.py
@@ -98,8 +98,8 @@ class DOSFitting(Fitting):
         numb_aparam: int = 0,
         numb_dos: int = 300,
         rcond: Optional[float] = None,
-        trainable: List[bool] = None,
-        seed: int = None,
+        trainable: Optional[List[bool]] = None,
+        seed: Optional[int] = None,
         activation_function: str = "tanh",
         precision: str = "default",
         uniform_seed: bool = False,
@@ -380,8 +380,8 @@ class DOSFitting(Fitting):
         self,
         inputs: tf.Tensor,
         natoms: tf.Tensor,
-        input_dict: dict = None,
-        reuse: bool = None,
+        input_dict: Optional[dict] = None,
+        reuse: Optional[bool] = None,
         suffix: str = "",
     ) -> tf.Tensor:
         """Build the computational graph for fitting net.

--- a/deepmd/infer/deep_tensor.py
+++ b/deepmd/infer/deep_tensor.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 from typing import (
     TYPE_CHECKING,
+    ClassVar,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -39,7 +41,7 @@ class DeepTensor(DeepEval):
         The input map for tf.import_graph_def. Only work with default tf graph
     """
 
-    tensors = {
+    tensors: ClassVar[Dict[str, str]] = {
         # descriptor attrs
         "t_ntypes": "descrpt_attr/ntypes:0",
         "t_rcut": "descrpt_attr/rcut:0",

--- a/deepmd/loss/ener.py
+++ b/deepmd/loss/ener.py
@@ -388,9 +388,9 @@ class EnerSpinLoss(Loss):
         limit_pref_ae: float = 0.0,
         start_pref_pf: float = 0.0,
         limit_pref_pf: float = 0.0,
-        relative_f: float = None,
+        relative_f: Optional[float] = None,
         enable_atom_ener_coeff: bool = False,
-        use_spin: list = None,
+        use_spin: Optional[list] = None,
     ) -> None:
         self.starter_learning_rate = starter_learning_rate
         self.start_pref_e = start_pref_e

--- a/deepmd/model/model_stat.py
+++ b/deepmd/model/model_stat.py
@@ -58,7 +58,7 @@ def make_stat_input(data, nbatches, merge_sys=True):
 
 
 def merge_sys_stat(all_stat):
-    first_key = list(all_stat.keys())[0]
+    first_key = next(iter(all_stat.keys()))
     nsys = len(all_stat[first_key])
     ret = defaultdict(list)
     for ii in range(nsys):

--- a/deepmd/nvnmd/entrypoints/wrap.py
+++ b/deepmd/nvnmd/entrypoints/wrap.py
@@ -145,7 +145,7 @@ class Wrap:
         nvnmd_cfg.save(nvnmd_cfg.config_file)
         head = self.wrap_head(nhs, nws)
         # output model
-        hs = [] + head
+        hs = [*head]
         for d in datas:
             hs.extend(d)
 

--- a/deepmd/train/run_options.py
+++ b/deepmd/train/run_options.py
@@ -45,7 +45,7 @@ log = logging.getLogger(__name__)
 
 
 # http://patorjk.com/software/taag. Font:Big"
-WELCOME = (  # noqa
+WELCOME = (
     r" _____               _____   __  __  _____           _     _  _   ",
     r"|  __ \             |  __ \ |  \/  ||  __ \         | |   (_)| |  ",
     r"| |  | |  ___   ___ | |__) || \  / || |  | | ______ | | __ _ | |_ ",
@@ -71,7 +71,7 @@ BUILD = (
     f"build float prec:     {global_float_prec}",
     f"build variant:        {GLOBAL_CONFIG['dp_variant']}",
     f"build with tf inc:    {GLOBAL_CONFIG['tf_include_dir']}",
-    f"build with tf lib:    {GLOBAL_CONFIG['tf_libs'].replace(';', _sep)}",  # noqa
+    f"build with tf lib:    {GLOBAL_CONFIG['tf_libs'].replace(';', _sep)}",
 )
 
 

--- a/deepmd/train/trainer.py
+++ b/deepmd/train/trainer.py
@@ -250,7 +250,7 @@ class DPTrainer:
             if not self.multi_task_mode:
                 single_data = data
             else:
-                single_data = data[list(data.keys())[0]]
+                single_data = data[next(iter(data.keys()))]
             if self.ntypes < single_data.get_ntypes():
                 raise ValueError(
                     "The number of types of the training data is %d, but that of the "
@@ -373,7 +373,7 @@ class DPTrainer:
             if not self.multi_task_mode:
                 self._get_place_horders(data.get_data_dict())
             else:
-                self._get_place_horders(data[list(data.keys())[0]].get_data_dict())
+                self._get_place_horders(data[next(iter(data.keys()))].get_data_dict())
 
         self.place_holders["type"] = tf.placeholder(tf.int32, [None], name="t_type")
         self.place_holders["natoms_vec"] = tf.placeholder(
@@ -467,7 +467,7 @@ class DPTrainer:
                 var_list=trainable_variables,
                 name="train_step",
             )
-            train_ops = [apply_op] + self._extra_train_ops
+            train_ops = [apply_op, *self._extra_train_ops]
             self.train_op = tf.group(*train_ops)
         else:
             self.train_op = {}
@@ -479,7 +479,7 @@ class DPTrainer:
                     var_list=trainable_variables,
                     name=f"train_step_{fitting_key}",
                 )
-                train_ops = [apply_op] + self._extra_train_ops
+                train_ops = [apply_op, *self._extra_train_ops]
                 self.train_op[fitting_key] = tf.group(*train_ops)
         log.info("built training")
 

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -263,7 +263,8 @@ def descrpt_se_a_tpe_args():
     doc_type_nlayer = "number of hidden layers of type embedding net"
     doc_numb_aparam = "dimension of atomic parameter. if set to a value > 0, the atomic parameters are embedded."
 
-    return descrpt_se_a_args() + [
+    return [
+        *descrpt_se_a_args(),
         Argument("type_nchanl", int, optional=True, default=4, doc=doc_type_nchanl),
         Argument("type_nlayer", int, optional=True, default=2, doc=doc_type_nlayer),
         Argument("numb_aparam", int, optional=True, default=0, doc=doc_numb_aparam),
@@ -397,7 +398,8 @@ def descrpt_se_atten_args():
     doc_smooth_type_embdding = "When using stripped type embedding, whether to dot smooth factor on the network output of type embedding to keep the network smooth, instead of setting `set_davg_zero` to be True."
     doc_set_davg_zero = "Set the normalization average to zero. This option should be set when `se_atten` descriptor or `atom_ener` in the energy fitting is used"
 
-    return descrpt_se_atten_common_args() + [
+    return [
+        *descrpt_se_atten_common_args(),
         Argument(
             "stripped_type_embedding",
             bool,
@@ -422,7 +424,8 @@ def descrpt_se_atten_args():
 def descrpt_se_atten_v2_args():
     doc_set_davg_zero = "Set the normalization average to zero. This option should be set when `se_atten` descriptor or `atom_ener` in the energy fitting is used"
 
-    return descrpt_se_atten_common_args() + [
+    return [
+        *descrpt_se_atten_common_args(),
         Argument(
             "set_davg_zero", bool, optional=True, default=False, doc=doc_set_davg_zero
         ),

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -177,7 +177,7 @@ def descrpt_se_a_args():
     doc_axis_neuron = "Size of the submatrix of G (embedding matrix)."
     doc_activation_function = f'The activation function in the embedding net. Supported activation functions are {list_to_doc(ACTIVATION_FN_DICT.keys())} Note that "gelu" denotes the custom operator version, and "gelu_tf" denotes the TF standard version. If you set "None" or "none" here, no activation function will be used.'
     doc_resnet_dt = 'Whether to use a "Timestep" in the skip connection'
-    doc_type_one_side = r"If true, the embedding network parameters vary by types of neighbor atoms only, so there will be $N_\text{types}$ sets of embedding network parameters. Otherwise, the embedding network parameters vary by types of centric atoms and types of neighbor atoms, so there will be $N_\text{types}^2$ sets of embedding network parameters."
+    doc_type_one_side = r"If true, the embedding network parameters vary by types of neighbor atoms only, so there will be $N_\text{types}$ sets of embedding network parameters. Otherwise, the embedding network parameters vary by types of centric atoms and types of neighbor atoms, so there will be $N_\text{types}^2$ sets of embedding network parameters."
     doc_precision = f"The precision of the embedding net parameters, supported options are {list_to_doc(PRECISION_DICT.keys())} Default follows the interface precision."
     doc_trainable = "If the parameters in the embedding net is trainable"
     doc_seed = "Random seed for parameter initialization"
@@ -281,7 +281,7 @@ def descrpt_se_r_args():
     doc_neuron = "Number of neurons in each hidden layers of the embedding net. When two layers are of the same size or one layer is twice as large as the previous layer, a skip connection is built."
     doc_activation_function = f'The activation function in the embedding net. Supported activation functions are {list_to_doc(ACTIVATION_FN_DICT.keys())} Note that "gelu" denotes the custom operator version, and "gelu_tf" denotes the TF standard version. If you set "None" or "none" here, no activation function will be used.'
     doc_resnet_dt = 'Whether to use a "Timestep" in the skip connection'
-    doc_type_one_side = r"If true, the embedding network parameters vary by types of neighbor atoms only, so there will be $N_\text{types}$ sets of embedding network parameters. Otherwise, the embedding network parameters vary by types of centric atoms and types of neighbor atoms, so there will be $N_\text{types}^2$ sets of embedding network parameters."
+    doc_type_one_side = r"If true, the embedding network parameters vary by types of neighbor atoms only, so there will be $N_\text{types}$ sets of embedding network parameters. Otherwise, the embedding network parameters vary by types of centric atoms and types of neighbor atoms, so there will be $N_\text{types}^2$ sets of embedding network parameters."
     doc_precision = f"The precision of the embedding net parameters, supported options are {list_to_doc(PRECISION_DICT.keys())} Default follows the interface precision."
     doc_trainable = "If the parameters in the embedding net are trainable"
     doc_seed = "Random seed for parameter initialization"
@@ -345,7 +345,7 @@ def descrpt_se_atten_common_args():
     doc_axis_neuron = "Size of the submatrix of G (embedding matrix)."
     doc_activation_function = f'The activation function in the embedding net. Supported activation functions are {list_to_doc(ACTIVATION_FN_DICT.keys())} Note that "gelu" denotes the custom operator version, and "gelu_tf" denotes the TF standard version. If you set "None" or "none" here, no activation function will be used.'
     doc_resnet_dt = 'Whether to use a "Timestep" in the skip connection'
-    doc_type_one_side = r"If true, the embedding network parameters vary by types of neighbor atoms only, so there will be $N_\text{types}$ sets of embedding network parameters. Otherwise, the embedding network parameters vary by types of centric atoms and types of neighbor atoms, so there will be $N_\text{types}^2$ sets of embedding network parameters."
+    doc_type_one_side = r"If true, the embedding network parameters vary by types of neighbor atoms only, so there will be $N_\text{types}$ sets of embedding network parameters. Otherwise, the embedding network parameters vary by types of centric atoms and types of neighbor atoms, so there will be $N_\text{types}^2$ sets of embedding network parameters."
     doc_precision = f"The precision of the embedding net parameters, supported options are {list_to_doc(PRECISION_DICT.keys())} Default follows the interface precision."
     doc_trainable = "If the parameters in the embedding net is trainable"
     doc_seed = "Random seed for parameter initialization"

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -618,9 +618,7 @@ class DeepmdDataSystem:
                 min_len = min([len(ii), len(ret)])
                 for idx in range(min_len):
                     if ii[idx] != ret[idx]:
-                        raise RuntimeError(
-                            f"inconsistent type map: {str(ret)} {str(ii)}"
-                        )
+                        raise RuntimeError(f"inconsistent type map: {ret!s} {ii!s}")
                 if len(ii) > len(ret):
                     ret = ii
         return ret

--- a/deepmd/utils/finetune.py
+++ b/deepmd/utils/finetune.py
@@ -56,7 +56,7 @@ def replace_model_params_with_pretrained_model(
         if i not in pretrained_type_map:
             out_line_type.append(i)
     assert not out_line_type, (
-        f"{str(out_line_type)} type(s) not contained in the pretrained model! "
+        f"{out_line_type!s} type(s) not contained in the pretrained model! "
         "Please choose another suitable one."
     )
     if cur_type_map != pretrained_type_map:
@@ -103,9 +103,7 @@ def replace_model_params_with_pretrained_model(
             # keep some params that are irrelevant to model structures (need to discuss) TODO
             if "trainable" in cur_para.keys():
                 target_para["trainable"] = cur_para["trainable"]
-            log.info(
-                f"Change the '{config_key}' from {str(cur_para)} to {str(target_para)}."
-            )
+            log.info(f"Change the '{config_key}' from {cur_para!s} to {target_para!s}.")
             jdata["model"][config_key] = target_para
 
     return jdata, cur_type_map

--- a/deepmd/utils/multi_init.py
+++ b/deepmd/utils/multi_init.py
@@ -54,7 +54,7 @@ def replace_model_params_with_frz_multi_model(
         if i not in pretrained_type_map:
             out_line_type.append(i)
     assert not out_line_type, (
-        f"{str(out_line_type)} type(s) not contained in the pretrained model! "
+        f"{out_line_type!s} type(s) not contained in the pretrained model! "
         "Please choose another suitable one."
     )
     if cur_type_map != pretrained_type_map:
@@ -169,5 +169,5 @@ def _change_sub_config(jdata: Dict[str, Any], src_jdata: Dict[str, Any], sub_key
     # keep some params that are irrelevant to model structures (need to discuss) TODO
     if "trainable" in cur_para.keys():
         target_para["trainable"] = cur_para["trainable"]
-    log.info(f"Change the '{sub_key}' from {str(cur_para)} to {str(target_para)}.")
+    log.info(f"Change the '{sub_key}' from {cur_para!s} to {target_para!s}.")
     jdata[sub_key] = target_para

--- a/deepmd/utils/network.py
+++ b/deepmd/utils/network.py
@@ -187,7 +187,7 @@ def embedding_net(
        International Publishing, 2016.
     """
     input_shape = xx.get_shape().as_list()
-    outputs_size = [input_shape[1]] + network_size
+    outputs_size = [input_shape[1], *network_size]
 
     for ii in range(1, len(outputs_size)):
         w_initializer = tf.random_normal_initializer(

--- a/deepmd/utils/network.py
+++ b/deepmd/utils/network.py
@@ -183,7 +183,7 @@ def embedding_net(
     References
     ----------
     .. [1] Kaiming  He,  Xiangyu  Zhang,  Shaoqing  Ren,  and  Jian  Sun. Identitymappings
-       in deep residual networks. InComputer Vision – ECCV 2016,pages 630–645. Springer
+       in deep residual networks. InComputer Vision - ECCV 2016,pages 630-645. Springer
        International Publishing, 2016.
     """
     input_shape = xx.get_shape().as_list()

--- a/deepmd/utils/path.py
+++ b/deepmd/utils/path.py
@@ -114,7 +114,7 @@ class DPPath(ABC):
         """Represent string."""
 
     def __repr__(self) -> str:
-        return f"{type(self)} ({str(self)})"
+        return f"{type(self)} ({self!s})"
 
     def __eq__(self, other) -> bool:
         return str(self) == str(other)

--- a/deepmd/utils/spin.py
+++ b/deepmd/utils/spin.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 from typing import (
     List,
+    Optional,
 )
 
 from deepmd.env import (
@@ -24,9 +25,9 @@ class Spin:
 
     def __init__(
         self,
-        use_spin: List[bool] = None,
-        spin_norm: List[float] = None,
-        virtual_len: List[float] = None,
+        use_spin: Optional[List[bool]] = None,
+        spin_norm: Optional[List[float]] = None,
+        virtual_len: Optional[List[float]] = None,
     ) -> None:
         """Constructor."""
         self.use_spin = use_spin

--- a/deepmd_cli/main.py
+++ b/deepmd_cli/main.py
@@ -312,7 +312,7 @@ def main_parser() -> argparse.ArgumentParser:
     # The table is composed of fifth-order polynomial coefficients and is assembled
     # from two sub-tables. The first table takes the step(parameter) as it's uniform
     # step, while the second table takes 10 * step as it\s uniform step
-    #  The range of the first table is automatically detected by deepmd-kit, while the
+    #  The range of the first table is automatically detected by deepmd-kit, while the
     # second table ranges from the first table's upper boundary(upper) to the
     # extrapolate(parameter) * upper.
     parser_compress = subparsers.add_parser(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,24 +166,20 @@ profile = "black"
 force_grid_wrap = 1
 
 [tool.ruff]
-target-version = "py37"
 select = [
     "E", # errors
     "F", # pyflakes
     "D", # pydocstyle
     "UP", # pyupgrade
     "C4", # flake8-comprehensions
+    "RUF", # ruff
+    "NPY", # numpy
 ]
 ignore = [
     "E501", # line too long
     "F841", # local variable is assigned to but never used
     "E741", # ambiguous variable name
     "E402", # module level import not at top of file
-    "D413", # missing blank line after last section
-    "D416", # section name should end with a colon
-    "D203", # 1 blank line required before class docstring
-    "D107", # missing docstring in __init__
-    "D213", # multi-line docstring summary should start at the second line
     "D100", # TODO: missing docstring in public module
     "D101", # TODO: missing docstring in public class
     "D102", # TODO: missing docstring in public method
@@ -195,3 +191,6 @@ ignore = [
     "D404", # TODO: first word of the docstring should not be This
 ]
 ignore-init-module-imports = true
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/source/install/build_tf.py
+++ b/source/install/build_tf.py
@@ -151,7 +151,7 @@ class OnlineResource:
             if not self.exists:
                 raise RuntimeError(
                     f"Download {self.filename} from {self.url} failed! "
-                    f"You can manually download it to {str(self.path)} and "
+                    f"You can manually download it to {self.path!s} and "
                     "retry the script."
                 )
         self.post_process()

--- a/source/tests/common.py
+++ b/source/tests/common.py
@@ -919,9 +919,7 @@ class DataSystem:
                 min_len = min([len(ii), len(ret)])
                 for idx in range(min_len):
                     if ii[idx] != ret[idx]:
-                        raise RuntimeError(
-                            f"inconsistent type map: {str(ret)} {str(ii)}"
-                        )
+                        raise RuntimeError(f"inconsistent type map: {ret!s} {ii!s}")
                 if len(ii) > len(ret):
                     ret = ii
         return ret

--- a/source/tests/test_argument_parser.py
+++ b/source/tests/test_argument_parser.py
@@ -184,7 +184,7 @@ class TestParserOutput(unittest.TestCase):
                     )
 
         # test default values
-        cmd_args = [command] + required
+        cmd_args = [command, *required]
         buffer = StringIO()
         try:
             with redirect_stderr(buffer):

--- a/source/tests/test_descrpt_sea_ef_rot.py
+++ b/source/tests/test_descrpt_sea_ef_rot.py
@@ -108,7 +108,7 @@ class TestEfRot(tf.test.TestCase):
         one_type = []
         for ii in range(2, 2 + self.ntypes):
             one_type = one_type + [ii - 2 for jj in range(self.natoms[ii])]
-        np.random.shuffle(one_type)
+        np.random.shuffle(one_type)  # noqa: NPY002
         one_type = np.array(one_type, dtype=int).reshape([1, -1])
         dtype = np.tile(one_type, [nframes, 1])
         defield = np.random.random(dcoord.shape)
@@ -162,7 +162,7 @@ class TestEfRot(tf.test.TestCase):
         )
         self.sess.run(tf.global_variables_initializer())
 
-        np.random.seed(0)
+        np.random.seed(0)  # noqa: NPY002
         # make test data
         nframes = 2
         dcoord, dbox, dtype, defield = self.make_test_data(nframes)
@@ -308,7 +308,7 @@ class TestEfRot(tf.test.TestCase):
         )
         self.sess.run(tf.global_variables_initializer())
 
-        np.random.seed(0)
+        np.random.seed(0)  # noqa: NPY002
         # make test data
         nframes = 2
         dcoord, dbox, dtype, defield = self.make_test_data(nframes)
@@ -423,7 +423,7 @@ class TestEfRot(tf.test.TestCase):
         )
         self.sess.run(tf.global_variables_initializer())
 
-        np.random.seed(0)
+        np.random.seed(0)  # noqa: NPY002
         # make test data
         nframes = 2
         dcoord, dbox, dtype, defield = self.make_test_data(nframes)

--- a/source/tests/test_fitting_stat.py
+++ b/source/tests/test_fitting_stat.py
@@ -28,12 +28,12 @@ def _make_fake_data(sys_natoms, sys_nframes, avgs, stds):
         tmp_data_a = []
         for jj in range(ndof):
             tmp_data_f.append(
-                np.random.normal(
+                np.random.normal(  # noqa: NPY002
                     loc=avgs[jj], scale=stds[jj], size=(sys_nframes[ii], 1)
                 )
             )
             tmp_data_a.append(
-                np.random.normal(
+                np.random.normal(  # noqa: NPY002
                     loc=avgs[jj], scale=stds[jj], size=(sys_nframes[ii], sys_natoms[ii])
                 )
             )


### PR DESCRIPTION
1. use `black-pre-commit-mirror` instead of `black` which is faster;
2. first ruff and then black;
3. remove `tool.ruff.target-version` which can be detected automatically;
4. add `RUF` and `NPY` rules to `tool.ruff.select`;
5. set `tool.ruff.pydocstyle.convention` to `numpy`, which can automatically add several rules to `ignore`.