### PR TITLE
add tox configutation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,31 @@ test-command = [
     "dp -h",
 ]
 
+# One can run `tox` or `tox -e gpu`
+# to run pytest in an insolated environment
+# Use with pipx:
+# $ pip install -U pipx
+# $ pipx tox
+[tool.tox]
+legacy_tox_ini = """
+    [tox]
+    min_version = 4.0
+
+    [testenv]
+    extras =
+        test
+        cpu
+    commands = pytest source/tests
+
+    [testenv:gpu]
+    extras =
+        test
+        gpu
+    commands = pytest source/tests
+    setenv =
+        DP_VARIANT = cuda
+"""
+
 # selectively turn of lintner warnings, always include reasoning why any warning should
 # be silenced
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ test-command = [
 ]
 
 # One can run `tox` or `tox -e gpu`
-# to run pytest in an insolated environment
+# to run pytest in an isolated environment
 # Use with pipx:
 # $ pip install -U pipx
 # $ pipx tox


### PR DESCRIPTION
Now, one can execute `tox` to test the Python package in an isolated environment. (The required packages can be automatically installed)