### PR TITLE
use parse_version from packaging.version instead of pkg_resources

### DIFF
--- a/source/tests/test_pairwise_dprc.py
+++ b/source/tests/test_pairwise_dprc.py
@@ -9,9 +9,7 @@ from common import (
     run_dp,
     tests_path,
 )
-from pkg_resources import (
-    parse_version,
-)
+from packaging.version import parse as parse_version
 
 from deepmd import (
     DeepPotential,


### PR DESCRIPTION
it seems pkg_resources is deprecated