### PR TITLE
fix missing version file with setuptools-scm v8

### DIFF
--- a/deepmd/__init__.py
+++ b/deepmd/__init__.py
@@ -32,7 +32,7 @@ from .infer.data_modifier import (
 set_mkl()
 
 try:
-    from ._version import version as __version__
+    from deepmd_cli._version import version as __version__
 except ImportError:
     from .__about__ import (
         __version__,

--- a/deepmd_cli/main.py
+++ b/deepmd_cli/main.py
@@ -1,31 +1,16 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import argparse
-import importlib.util
 import logging
-import os
-import sys
 import textwrap
 from typing import (
     List,
     Optional,
 )
 
-
-def load_child_module(name):
-    """Load a child module without loading its parent module."""
-    names = name.split(".")
-    parent_spec = importlib.util.find_spec(names[0])
-    paths = os.path.join(*names[1:]) + ".py"
-    spec = importlib.util.spec_from_file_location(
-        name, os.path.join(parent_spec.submodule_search_locations[0], paths)
-    )
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-__version__ = load_child_module("deepmd._version").__version__
+try:
+    from deepmd_cli._version import version as __version__
+except ImportError:
+    __version__ = "unknown"
 
 
 def get_ll(log_level: str) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,12 @@ documentation = "https://docs.deepmodeling.com/projects/deepmd"
 repository = "https://github.com/deepmodeling/deepmd-kit"
 
 [tool.setuptools_scm]
-write_to = "deepmd/_version.py"
+
+[[tool.scikit-build.generate]]
+path = "deepmd/_version.py"
+template = '''
+version = "${version}"
+'''
 
 [tool.scikit-build]
 experimental = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,6 @@ repository = "https://github.com/deepmodeling/deepmd-kit"
 
 [tool.setuptools_scm]
 
-[[tool.scikit-build.generate]]
-path = "deepmd/_version.py"
-template = '''
-version = "${version}"
-'''
-
 [tool.scikit-build]
 experimental = true
 minimum-version = "0.5"
@@ -101,6 +95,12 @@ provider-path = "backend"
 [tool.scikit-build.metadata.scripts]
 provider = "backend.dynamic_metadata"
 provider-path = "backend"
+
+[[tool.scikit-build.generate]]
+path = "deepmd_cli/_version/__init__.py"
+template = '''
+version = "${version}"
+'''
 
 [tool.cibuildwheel]
 test-command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ provider = "backend.dynamic_metadata"
 provider-path = "backend"
 
 [[tool.scikit-build.generate]]
-path = "deepmd_cli/_version/__init__.py"
+path = "deepmd_cli/_version.py"
 template = '''
 version = "${version}"
 '''


### PR DESCRIPTION
See https://github.com/scikit-build/scikit-build-core/issues/507.

Now it's written to `{site_packages}/deepmd_cli/_version/__init__.py`. The previous implementation is too complex.