### PR TITLE
download cub using CMake FetchContent

### DIFF
--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -21,8 +21,6 @@ jobs:
           dp_variant: clang
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: true
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -56,7 +56,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
           # https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
       - uses: docker/setup-qemu-action@v3
@@ -77,8 +76,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: actions/setup-python@v4
         name: Install Python
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "source/lib/src/gpu/cub"]
-	path = source/lib/src/gpu/cub
-	url = https://github.com/NVIDIA/cub.git

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -5,9 +5,8 @@ Please follow our [GitHub](https://github.com/deepmodeling/deepmd-kit) webpage t
 Or get the DeePMD-kit source code by `git clone`
 ```bash
 cd /some/workspace
-git clone --recursive https://github.com/deepmodeling/deepmd-kit.git deepmd-kit
+git clone https://github.com/deepmodeling/deepmd-kit.git deepmd-kit
 ```
-The `--recursive` option clones all [submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) needed by DeePMD-kit.
 
 For convenience, you may want to record the location of the source to a variable, saying `deepmd_source_dir` by
 ```bash

--- a/source/lib/src/gpu/CMakeLists.txt
+++ b/source/lib/src/gpu/CMakeLists.txt
@@ -26,7 +26,17 @@ if(USE_CUDA_TOOLKIT)
   # cub has been included in CUDA Toolkit 11, we do not need to include it any
   # more see https://github.com/NVIDIA/cub
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_LESS "11")
-    include_directories(cub)
+    include(FetchContent)
+    FetchContent_Declare(
+      cub_download
+      GIT_REPOSITORY https://github.com/NVIDIA/cub
+      GIT_TAG b229817e3963fc942c7cc2c61715a6b2b2c49bed)
+    FetchContent_GetProperties(cub_download)
+    if(NOT cub_download_POPULATED)
+      FetchContent_Populate(cub_download)
+      set(CUB_SOURCE_ROOT ${cub_download_SOURCE_DIR})
+    endif()
+    include_directories(${CUB_SOURCE_ROOT})
   endif()
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_LESS "9")
     message(FATAL_ERROR "CUDA version must be >= 9.0")


### PR DESCRIPTION
Many people suggest not using `git submodule`. CMake FetchContent might be a better option (which we have used for googletest and lammps).

(only take effect for CUDA 10; CUDA 11 contains cub)