### PR TITLE
cmake: skip executing python when cross compiling

### DIFF
--- a/source/cmake/Findtensorflow.cmake
+++ b/source/cmake/Findtensorflow.cmake
@@ -41,6 +41,7 @@ endif()
 
 if(BUILD_CPP_IF
    AND USE_TF_PYTHON_LIBS
+   AND NOT CMAKE_CROSSCOMPILING
    AND NOT SKBUILD
    AND NOT INSTALL_TENSORFLOW)
   # Here we try to install libtensorflow_cc.so as well as


### PR DESCRIPTION
When cross compiling, TensorFlow cannot be imported. TENSORFLOW_ROOT needs to be given manually.

This commit has been patched in https://github.com/conda-forge/deepmd-kit-feedstock/pull/57