### PR TITLE
fix source distribution version in build-wheel.yml

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -76,6 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         name: Install Python
         with:


### PR DESCRIPTION
#2324 sets `fetch-depth: 0` for wheels but not source distribution so that the wheel versions are correct, but the source distribution version is wrong.

![image](https://github.com/deepmodeling/deepmd-kit/assets/9496702/cdac903e-37d4-4ca8-8470-f243a13532f5)
