### PR TITLE
support combining frozen models into a pairwise DPRc model

### DIFF
--- a/deepmd/model/pairwise_dprc.py
+++ b/deepmd/model/pairwise_dprc.py
@@ -183,6 +183,14 @@ class PairwiseDPRc(Model):
 
         mesh_mixed_type = make_default_mesh(False, True)
 
+        # allow loading a frozen QM model that has only QM types
+        # Note: here we don't map the type between models, so
+        #       the type of the frozen model must be the same as
+        #       the first Ntypes of the current model
+        if self.get_ntypes() > self.qm_model.get_ntypes():
+            natoms_qm = tf.slice(natoms_qm, [0], [self.qm_model.get_ntypes() + 2])
+        assert self.get_ntypes() == self.qmmm_model.get_ntypes()
+
         qm_dict = self.qm_model.build(
             coord_qm,
             atype_qm,
@@ -297,7 +305,7 @@ class PairwiseDPRc(Model):
         return max(self.qm_model.get_rcut(), self.qmmm_model.get_rcut())
 
     def get_ntypes(self) -> int:
-        return self.qmmm_model.get_ntypes()
+        return self.ntypes
 
     def data_stat(self, data):
         self.qm_model.data_stat(data)

--- a/deepmd/model/pairwise_dprc.py
+++ b/deepmd/model/pairwise_dprc.py
@@ -32,10 +32,6 @@ from deepmd.utils.type_embed import (
     TypeEmbedNet,
 )
 
-from .ener import (
-    EnerModel,
-)
-
 
 class PairwiseDPRc(Model):
     """Pairwise Deep Potential - Range Correction."""
@@ -87,19 +83,19 @@ class PairwiseDPRc(Model):
                 padding=True,
             )
 
-        self.qm_model = EnerModel(
+        self.qm_model = Model(
             **qm_model,
             type_map=type_map,
             type_embedding=self.typeebd,
             compress=compress,
         )
-        self.qmmm_model = EnerModel(
+        self.qmmm_model = Model(
             **qmmm_model,
             type_map=type_map,
             type_embedding=self.typeebd,
             compress=compress,
         )
-        add_data_requirement("aparam", 1, atomic=True, must=True, high_prec=False)
+        add_data_requirement("aparam", 1, atomic=True, must=False, high_prec=False)
         self.ntypes = len(type_map)
         self.rcut = max(self.qm_model.get_rcut(), self.qmmm_model.get_rcut())
 
@@ -301,7 +297,7 @@ class PairwiseDPRc(Model):
         return max(self.qm_model.get_rcut(), self.qmmm_model.get_rcut())
 
     def get_ntypes(self) -> int:
-        return self.qm_model.get_ntypes()
+        return self.qmmm_model.get_ntypes()
 
     def data_stat(self, data):
         self.qm_model.data_stat(data)

--- a/deepmd/model/pairwise_dprc.py
+++ b/deepmd/model/pairwise_dprc.py
@@ -95,7 +95,7 @@ class PairwiseDPRc(Model):
             type_embedding=self.typeebd,
             compress=compress,
         )
-        add_data_requirement("aparam", 1, atomic=True, must=False, high_prec=False)
+        add_data_requirement("aparam", 1, atomic=True, must=True, high_prec=False)
         self.ntypes = len(type_map)
         self.rcut = max(self.qm_model.get_rcut(), self.qmmm_model.get_rcut())
 


### PR DESCRIPTION
The "frozen" model has been previously supported in #2781, so this PR allows it to be used in the pairwise DPRc model.
Allow QM model type maps to be just the first $N$ type maps of the whole models, as the QM model doesn't need MM types.

One can load two separated models into one model or load the existing QM model and train the rest of the model.