### PR TITLE
fix py lmp plugin path for editable installation

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -89,6 +89,7 @@ __all__ = [
     "global_cvt_2_tf_float",
     "global_cvt_2_ener_float",
     "MODEL_VERSION",
+    "SHARED_LIB_DIR",
     "SHARED_LIB_MODULE",
     "default_tf_session_config",
     "reset_default_tf_session_config",

--- a/deepmd/lmp.py
+++ b/deepmd/lmp.py
@@ -18,6 +18,7 @@ from packaging.version import (
 )
 
 from deepmd.env import (
+    SHARED_LIB_DIR,
     TF_VERSION,
     tf,
 )
@@ -74,7 +75,7 @@ else:
     raise RuntimeError("Unsupported platform")
 
 tf_dir = tf.sysconfig.get_lib()
-op_dir = str((Path(__file__).parent / "lib").absolute())
+op_dir = str(SHARED_LIB_DIR)
 
 
 cuda_library_paths = []


### PR DESCRIPTION
When using `pip install -e`, the library and the source code are not in the same directory, so `__file__` should not be used.