### PR TITLE
lmp: do not write model deviation if the same step written previously

### DIFF
--- a/source/lmp/pair_deepmd.h
+++ b/source/lmp/pair_deepmd.h
@@ -136,6 +136,7 @@ class PairDeepMD : public Pair {
   tagint *tagsend, *tagrecv;
   double *stdfsend, *stdfrecv;
   std::vector<int> type_idx_map;
+  int model_devi_last_dump;
 };
 
 }  // namespace LAMMPS_NS


### PR DESCRIPTION
Fix #1311.

#1311 was not clearly described. I checked the LAMMPS source code and think the following line is the closest to the description: https://github.com/lammps/lammps/blob/f0801338f325e185e49a9b5b081455c7964de9d9/src/output.cpp#L260
