### PR TITLE
docs: configuring automatically generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  exclude:
+    authors:
+      - app/pre-commit-ci
+      - app/dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - "breaking change"
+    - title: New Features
+      labels:
+        - "new feature"
+    - title: Enhancement
+      labels:
+        - enhancement
+    - title: Documentation
+      labels:
+        - Docs
+      exclude:
+        labels:
+          - build
+          - bug
+    - title: Build and release
+      labels:
+        - build
+    - title: Bug fixings
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,7 +15,10 @@ changelog:
         - enhancement
     - title: Documentation
       labels:
+        # automatically added
         - Docs
+        # for docs outside the doc directory
+        - "other docs"
       exclude:
         labels:
           - build


### PR DESCRIPTION
See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes.

We shall add proper labels when submitting and merging PRs, so release notes can be more automatic.