### PR TITLE
respect user defined CUDAARCHS

### DIFF
--- a/source/lib/src/gpu/CMakeLists.txt
+++ b/source/lib/src/gpu/CMakeLists.txt
@@ -5,7 +5,9 @@ if(USE_CUDA_TOOLKIT)
   project(deepmd_op_cuda)
   set(GPU_LIB_NAME deepmd_op_cuda)
 
-  set(CMAKE_CUDA_ARCHITECTURES all)
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES all)
+  endif()
   enable_language(CUDA)
   set(CMAKE_CUDA_STANDARD 11)
   add_compile_definitions(


### PR DESCRIPTION
Although we set it to `all` by default, one may manually set it via [CMAKE_CUDA_ARCHITECTURES](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html)  or [CUDAARCHS](https://cmake.org/cmake/help/latest/envvar/CUDAARCHS.html#envvar:CUDAARCHS).