### PR TITLE
bump scikit-build-core to 0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     # dynamic metadata API is still unstable
     # TODO: unpin the upper bound when it is stable
-    "scikit-build-core>=0.5,<0.6",
+    "scikit-build-core>=0.5,<0.7,!=0.6.0",
     "packaging",
 ]
 build-backend = "backend.dp_backend"


### PR DESCRIPTION
Bump scikit-build-core from `>=0.5,<0.6` to `>=0.5,<0.7,!=0.6.0`. (by default it will install 0.6.1)