### PR TITLE
docs: document horovod on Conda-Forge

### DIFF
--- a/doc/install/easy-install.md
+++ b/doc/install/easy-install.md
@@ -58,7 +58,7 @@ conda activate deepmd
 DeePMD-kit is also available on the [conda-forge](https://conda-forge.org/) channel:
 
 ```bash
-conda create -n deepmd deepmd-kit lammps -c conda-forge
+conda create -n deepmd deepmd-kit lammps horovod -c conda-forge
 ```
 
 The supported platform includes Linux x86-64, macOS x86-64, and macOS arm64.


### PR DESCRIPTION
Recently I contributed Horovod to conda-forge at https://github.com/conda-forge/staged-recipes/pull/24472. I have tested it with DeePMD-kit. Now the Conda-forge channel has all the features in our deepmodeling channel and even more available platforms.

I wonder if we should recommend Conda-forge in favor of our DeepModeling channel and use it for the offline installer. In 2019, Conda-forge lacked support for TensorFlow, so we hosted and built our own channel against the Anaconda channel. But now Conda-forge has become a mature channel and has better support for TensorFlow than the Anaconda channel.