### PR TITLE
print system prob using scientific natation

### DIFF
--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -560,11 +560,11 @@ class DeepmdDataSystem:
         log.info("found %d system(s):" % self.nsystems)
         log.info(
             ("%s  " % self._format_name_length("system", sys_width))
-            + ("%6s  %6s  %6s  %5s  %3s" % ("natoms", "bch_sz", "n_bch", "prob", "pbc"))
+            + ("%6s  %6s  %6s  %9s  %3s" % ("natoms", "bch_sz", "n_bch", "prob", "pbc"))
         )
         for ii in range(self.nsystems):
             log.info(
-                "%s  %6d  %6d  %6d  %5.3f  %3s"
+                "%s  %6d  %6d  %6d  %.3e  %3s"
                 % (
                     self._format_name_length(self.system_dirs[ii], sys_width),
                     self.natoms[ii],

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -564,7 +564,7 @@ class DeepmdDataSystem:
         )
         for ii in range(self.nsystems):
             log.info(
-                "%s  %6d  %6d  %6d  %.3e  %3s"
+                "%s  %6d  %6d  %6d  %9.3e  %3s"
                 % (
                     self._format_name_length(self.system_dirs[ii], sys_width),
                     self.natoms[ii],


### PR DESCRIPTION
When the probability of a system is smaller than 1e-3, it is shown as `0.000`, which is useless. This commit changes it to the scientific notation, displaying it like `1.547e-06`.