### PR TITLE
Fix macro issue with multiple arguments

### DIFF
--- a/source/lmp/deepmd_version.h.in
+++ b/source/lmp/deepmd_version.h.in
@@ -5,7 +5,7 @@
 #define DEEPMD_ROOT @CMAKE_INSTALL_PREFIX@
 #define TensorFlow_INCLUDE_DIRS @TensorFlow_INCLUDE_DIRS@
 #define TensorFlow_LIBRARY @TensorFlow_LIBRARY@
-#define DPMD_CVT_STR(x) #x
+#define DPMD_CVT_STR(...) #__VA_ARGS__
 #define DPMD_CVT_ASSTR(X) DPMD_CVT_STR(X)
 #define STR_GIT_SUMM DPMD_CVT_ASSTR(GIT_SUMM)
 #define STR_GIT_HASH DPMD_CVT_ASSTR(GIT_HASH)


### PR DESCRIPTION
Modified the `DPMD_CVT_STR` macro to handle multiple arguments by using `__VA_ARGS__`. This resolves #2952, the error caused by commas in the branch name during compilation.

This commit (including the above message) is entirely generated by ChatGPT 3.5.