### PR TITLE
fix: invalid read and write when natom grows

### DIFF
--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -1280,7 +1280,7 @@ void deepmd::print_summary(const std::string& pre) {
   std::cout << pre << "source branch:       " + global_git_branch << "\n";
   std::cout << pre << "source commit:      " + global_git_hash << "\n";
   std::cout << pre << "source commit at:   " + global_git_date << "\n";
-  std::cout << pre << "surpport model ver.:" + global_model_version << "\n";
+  std::cout << pre << "supported model ver.:" + global_model_version << "\n";
 #if defined(GOOGLE_CUDA)
   std::cout << pre << "build variant:      cuda"
             << "\n";

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -1277,10 +1277,10 @@ void deepmd::print_summary(const std::string& pre) {
   deepmd::get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
   std::cout << pre << "installed to:       " + global_install_prefix << "\n";
   std::cout << pre << "source:             " + global_git_summ << "\n";
-  std::cout << pre << "source branch:       " + global_git_branch << "\n";
+  std::cout << pre << "source branch:      " + global_git_branch << "\n";
   std::cout << pre << "source commit:      " + global_git_hash << "\n";
   std::cout << pre << "source commit at:   " + global_git_date << "\n";
-  std::cout << pre << "supported model ver.:" + global_model_version << "\n";
+  std::cout << pre << "support model ver.: " + global_model_version << "\n";
 #if defined(GOOGLE_CUDA)
   std::cout << pre << "build variant:      cuda"
             << "\n";

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -783,6 +783,17 @@ void PairDeepMD::compute(int eflag, int vflag) {
           // Gather std_f and tags
           tagint *tag = atom->tag;
           int nprocs = comm->nprocs;
+          int newntotal = atom->natoms;
+          if (newntotal > sizeof(stdfsend)) {
+            memory->destroy(stdfsend);
+            memory->destroy(stdfrecv);
+            memory->destroy(tagsend);
+            memory->destroy(tagrecv);
+            memory->create(stdfsend, newntotal, "deepmd:stdfsendall");
+            memory->create(stdfrecv, newntotal, "deepmd:stdfrecvall");
+            memory->create(tagsend, newntotal, "deepmd:tagsendall");
+            memory->create(tagrecv, newntotal, "deepmd:tagrecvall");
+          }
           for (int ii = 0; ii < nlocal; ii++) {
             tagsend[ii] = tag[ii];
             stdfsend[ii] = std_f[ii];

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -721,13 +721,11 @@ void PairDeepMD::compute(int eflag, int vflag) {
         }
         double min = numeric_limits<double>::max(), max = 0, avg = 0;
         ana_st(max, min, avg, std_f, nlocal);
-        int all_nlocal = atom->natoms;
-        MPI_Reduce(&nlocal, &all_nlocal, 1, MPI_INT, MPI_SUM, 0, world);
         double all_f_min = 0, all_f_max = 0, all_f_avg = 0;
         MPI_Reduce(&min, &all_f_min, 1, MPI_DOUBLE, MPI_MIN, 0, world);
         MPI_Reduce(&max, &all_f_max, 1, MPI_DOUBLE, MPI_MAX, 0, world);
         MPI_Reduce(&avg, &all_f_avg, 1, MPI_DOUBLE, MPI_SUM, 0, world);
-        all_f_avg /= double(all_nlocal);
+        all_f_avg /= double(atom->natoms);
         // std v
         std::vector<double> send_v(9 * numb_models);
         std::vector<double> recv_v(9 * numb_models);
@@ -780,13 +778,13 @@ void PairDeepMD::compute(int eflag, int vflag) {
              << " " << setw(18) << all_f_avg;
         }
         if (out_each == 1) {
-          vector<double> std_f_all(all_nlocal);
+          vector<double> std_f_all(atom->natoms);
           // Gather std_f and tags
           tagint *tag = atom->tag;
           int nprocs = comm->nprocs;
           // Grow arrays if necessary
-          if (all_nlocal > stdf_comm_buff_size) {
-            stdf_comm_buff_size = all_nlocal;
+          if (atom->natoms > stdf_comm_buff_size) {
+            stdf_comm_buff_size = atom->natoms;
             memory->destroy(stdfsend);
             memory->destroy(stdfrecv);
             memory->destroy(tagsend);
@@ -810,11 +808,11 @@ void PairDeepMD::compute(int eflag, int vflag) {
           MPI_Gatherv(stdfsend, nlocal, MPI_DOUBLE, stdfrecv, counts,
                       displacements, MPI_DOUBLE, 0, world);
           if (rank == 0) {
-            for (int dd = 0; dd < all_nlocal; ++dd) {
+            for (int dd = 0; dd < atom->natoms; ++dd) {
               std_f_all[tagrecv[dd] - 1] =
                   stdfrecv[dd] * scale[1][1] * force_unit_cvt_factor;
             }
-            for (int dd = 0; dd < all_nlocal; ++dd) {
+            for (int dd = 0; dd < atom->natoms; ++dd) {
               fp << " " << setw(18) << std_f_all[dd];
             }
           }

--- a/source/lmp/pair_deepmd.cpp
+++ b/source/lmp/pair_deepmd.cpp
@@ -785,16 +785,16 @@ void PairDeepMD::compute(int eflag, int vflag) {
           tagint *tag = atom->tag;
           int nprocs = comm->nprocs;
           // Grow arrays if necessary
-          if (nlocal > max_nlocal) {
-            max_nlocal = nlocal;
+          if (all_nlocal > max_nlocal) {
+            max_nlocal = all_nlocal;
             memory->destroy(stdfsend);
             memory->destroy(stdfrecv);
             memory->destroy(tagsend);
             memory->destroy(tagrecv);
-            memory->create(stdfsend, nlocal, "deepmd:stdfsendall");
-            memory->create(stdfrecv, nlocal, "deepmd:stdfrecvall");
-            memory->create(tagsend, nlocal, "deepmd:tagsendall");
-            memory->create(tagrecv, nlocal, "deepmd:tagrecvall");
+            memory->create(stdfsend, all_nlocal, "deepmd:stdfsendall");
+            memory->create(stdfrecv, all_nlocal, "deepmd:stdfrecvall");
+            memory->create(tagsend, all_nlocal, "deepmd:tagsendall");
+            memory->create(tagrecv, all_nlocal, "deepmd:tagrecvall");
           }
           for (int ii = 0; ii < nlocal; ii++) {
             tagsend[ii] = tag[ii];

--- a/source/lmp/pair_deepmd.h
+++ b/source/lmp/pair_deepmd.h
@@ -95,6 +95,7 @@ class PairDeepMD : public Pair {
   std::string out_file;
   int dim_fparam;
   int dim_aparam;
+  int max_nlocal;
   int out_each;
   int out_rel;
   int out_rel_v;

--- a/source/lmp/pair_deepmd.h
+++ b/source/lmp/pair_deepmd.h
@@ -95,10 +95,10 @@ class PairDeepMD : public Pair {
   std::string out_file;
   int dim_fparam;
   int dim_aparam;
-  int max_nlocal;
   int out_each;
   int out_rel;
   int out_rel_v;
+  int stdf_comm_buff_size;
   bool single_model;
   bool multi_models_mod_devi;
   bool multi_models_no_mod_devi;


### PR DESCRIPTION
This PR fixes #3015, which reported an invalid memory read and write when running `fix deposition` in Lammps to add atoms into the system. The issue could not be reproduced when `atomic` was removed from the `pair_style deepmd` line.

As suggested by @njzjz , the possible cause of the bug was the allocation of `stdfsend`, `stdfrecv`, etc., which only happened when `out_each == 1`, set by `atomic` in the `pair_style deepmd` command. Moreover, their size was only determined in the initialization step, based on the initial `natoms`. The valgrind log also supported this hypothesis, as it showed `MPI_Gather` and `MPI_Gatherv` errors in the traceback.

Therefore, we decided to destroy and recreate the memory when `atom->natoms` became larger than `stdfsend`. This should prevent the invalid memory access and resolve the issue.