### PR TITLE
Fix possible memory leak in constructors

### DIFF
--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -25,7 +25,6 @@ jobs:
         TF_INTER_OP_PARALLELISM_THREADS: 1
         LMP_CXX11_ABI_0: 1
         CMAKE_GENERATOR: Ninja
-        CXXFLAGS: "-fsanitize=leak"
     # test lammps
     # ASE issue: https://gitlab.com/ase/ase/-/merge_requests/2843
     # TODO: remove ase version when ase has new release

--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -25,6 +25,7 @@ jobs:
         TF_INTER_OP_PARALLELISM_THREADS: 1
         LMP_CXX11_ABI_0: 1
         CMAKE_GENERATOR: Ninja
+        CXXFLAGS: "-fsanitize=leak"
     # test lammps
     # ASE issue: https://gitlab.com/ase/ase/-/merge_requests/2843
     # TODO: remove ase version when ase has new release

--- a/source/api_cc/src/DataModifier.cc
+++ b/source/api_cc/src/DataModifier.cc
@@ -12,8 +12,8 @@ DipoleChargeModifier::DipoleChargeModifier(const std::string& model,
                                            const std::string& name_scope_)
     : inited(false), name_scope(name_scope_), graph_def(new GraphDef()) {
   try {
-  init(model, gpu_rank, name_scope_);
-    } catch (...) {
+    init(model, gpu_rank, name_scope_);
+  } catch (...) {
     // Clean up and rethrow, as the destructor will not be called
     delete graph_def;
     throw;

--- a/source/api_cc/src/DataModifier.cc
+++ b/source/api_cc/src/DataModifier.cc
@@ -11,7 +11,13 @@ DipoleChargeModifier::DipoleChargeModifier(const std::string& model,
                                            const int& gpu_rank,
                                            const std::string& name_scope_)
     : inited(false), name_scope(name_scope_), graph_def(new GraphDef()) {
+  try {
   init(model, gpu_rank, name_scope_);
+    } catch (...) {
+    // Clean up and rethrow, as the destructor will not be called
+    delete graph_def;
+    throw;
+  }
 }
 
 DipoleChargeModifier::~DipoleChargeModifier() { delete graph_def; };

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -1242,7 +1242,15 @@ DeepPotModelDevi::DeepPotModelDevi(
     const int& gpu_rank,
     const std::vector<std::string>& file_contents)
     : inited(false), init_nbor(false), numb_models(0) {
-  init(models, gpu_rank, file_contents);
+  try {
+    init(models, gpu_rank, file_contents);
+      } catch (...) {
+    // Clean up and rethrow, as the destructor will not be called
+    for (unsigned ii = 0; ii < numb_models; ++ii) {
+      delete graph_defs[ii];
+    }
+    throw;
+  }
 }
 
 DeepPotModelDevi::~DeepPotModelDevi() {

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -404,7 +404,13 @@ DeepPot::DeepPot(const std::string& model,
                  const int& gpu_rank,
                  const std::string& file_content)
     : inited(false), init_nbor(false), graph_def(new GraphDef()) {
-  init(model, gpu_rank, file_content);
+  try {
+      init(model, gpu_rank, file_content);
+  } catch (...) {
+    // Clean up and rethrow, as the destructor will not be called
+    delete graph_def;
+    throw;
+  }
 }
 
 DeepPot::~DeepPot() { delete graph_def; }

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -405,7 +405,7 @@ DeepPot::DeepPot(const std::string& model,
                  const std::string& file_content)
     : inited(false), init_nbor(false), graph_def(new GraphDef()) {
   try {
-      init(model, gpu_rank, file_content);
+    init(model, gpu_rank, file_content);
   } catch (...) {
     // Clean up and rethrow, as the destructor will not be called
     delete graph_def;
@@ -1244,7 +1244,7 @@ DeepPotModelDevi::DeepPotModelDevi(
     : inited(false), init_nbor(false), numb_models(0) {
   try {
     init(models, gpu_rank, file_contents);
-      } catch (...) {
+  } catch (...) {
     // Clean up and rethrow, as the destructor will not be called
     for (unsigned ii = 0; ii < numb_models; ++ii) {
       delete graph_defs[ii];

--- a/source/api_cc/src/DeepTensor.cc
+++ b/source/api_cc/src/DeepTensor.cc
@@ -10,7 +10,13 @@ DeepTensor::DeepTensor(const std::string &model,
                        const int &gpu_rank,
                        const std::string &name_scope_)
     : inited(false), name_scope(name_scope_), graph_def(new GraphDef()) {
-  init(model, gpu_rank, name_scope_);
+  try {
+    init(model, gpu_rank, name_scope_);
+  } catch (...) {
+    // Clean up and rethrow, as the destructor will not be called
+    delete graph_def;
+    throw;
+  }
 }
 
 DeepTensor::~DeepTensor() { delete graph_def; }

--- a/source/api_cc/tests/test_deepmd_exception.cc
+++ b/source/api_cc/tests/test_deepmd_exception.cc
@@ -28,7 +28,7 @@ TEST(TestDeepmdException, deepmdexception_nofile_deeppot) {
 }
 
 TEST(TestDeepmdException, deepmdexception_nofile_deeppotmodeldevi) {
-  ASSERT_THROW(deepmd::DeepPotModelDevi(std::vector<std::string>("_no_such_file.pb", "_no_such_file.pb")), deepmd::deepmd_exception);
+  ASSERT_THROW(deepmd::DeepPotModelDevi({"_no_such_file.pb", "_no_such_file.pb"}), deepmd::deepmd_exception);
 }
 
 TEST(TestDeepmdException, deepmdexception_nofile_deeptensor) {

--- a/source/api_cc/tests/test_deepmd_exception.cc
+++ b/source/api_cc/tests/test_deepmd_exception.cc
@@ -28,7 +28,7 @@ TEST(TestDeepmdException, deepmdexception_nofile_deeppot) {
 }
 
 TEST(TestDeepmdException, deepmdexception_nofile_deeppotmodeldevi) {
-  ASSERT_THROW(deepmd::DeepPotModelDevi(std::vector<std::string>("_no_such_file.pb", "_no_such_file.pb"), deepmd::deepmd_exception);
+  ASSERT_THROW(deepmd::DeepPotModelDevi(std::vector<std::string>("_no_such_file.pb", "_no_such_file.pb")), deepmd::deepmd_exception);
 }
 
 TEST(TestDeepmdException, deepmdexception_nofile_deeptensor) {

--- a/source/api_cc/tests/test_deepmd_exception.cc
+++ b/source/api_cc/tests/test_deepmd_exception.cc
@@ -11,6 +11,8 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepTensor.h"
+#include "DataModifier.h"
 #include "errors.h"
 TEST(TestDeepmdException, deepmdexception) {
   std::string expected_error_message = "DeePMD-kit Error: unittest";
@@ -21,6 +23,18 @@ TEST(TestDeepmdException, deepmdexception) {
   }
 }
 
-TEST(TestDeepmdException, deepmdexception_nofile) {
+TEST(TestDeepmdException, deepmdexception_nofile_deeppot) {
   ASSERT_THROW(deepmd::DeepPot("_no_such_file.pb"), deepmd::deepmd_exception);
+}
+
+TEST(TestDeepmdException, deepmdexception_nofile_deeppotmodeldevi) {
+  ASSERT_THROW(deepmd::DeepPotModelDevi(std::vector<std::string>("_no_such_file.pb", "_no_such_file.pb"), deepmd::deepmd_exception);
+}
+
+TEST(TestDeepmdException, deepmdexception_nofile_deeptensor) {
+  ASSERT_THROW(deepmd::DeepTensor("_no_such_file.pb"), deepmd::deepmd_exception);
+}
+
+TEST(TestDeepmdException, deepmdexception_nofile_dipolechargemodifier) {
+  ASSERT_THROW(deepmd::DipoleChargeModifier("_no_such_file.pb"), deepmd::deepmd_exception);
 }

--- a/source/api_cc/tests/test_deepmd_exception.cc
+++ b/source/api_cc/tests/test_deepmd_exception.cc
@@ -10,9 +10,9 @@
 #include <string>
 #include <vector>
 
+#include "DataModifier.h"
 #include "DeepPot.h"
 #include "DeepTensor.h"
-#include "DataModifier.h"
 #include "errors.h"
 TEST(TestDeepmdException, deepmdexception) {
   std::string expected_error_message = "DeePMD-kit Error: unittest";
@@ -28,13 +28,17 @@ TEST(TestDeepmdException, deepmdexception_nofile_deeppot) {
 }
 
 TEST(TestDeepmdException, deepmdexception_nofile_deeppotmodeldevi) {
-  ASSERT_THROW(deepmd::DeepPotModelDevi({"_no_such_file.pb", "_no_such_file.pb"}), deepmd::deepmd_exception);
+  ASSERT_THROW(
+      deepmd::DeepPotModelDevi({"_no_such_file.pb", "_no_such_file.pb"}),
+      deepmd::deepmd_exception);
 }
 
 TEST(TestDeepmdException, deepmdexception_nofile_deeptensor) {
-  ASSERT_THROW(deepmd::DeepTensor("_no_such_file.pb"), deepmd::deepmd_exception);
+  ASSERT_THROW(deepmd::DeepTensor("_no_such_file.pb"),
+               deepmd::deepmd_exception);
 }
 
 TEST(TestDeepmdException, deepmdexception_nofile_dipolechargemodifier) {
-  ASSERT_THROW(deepmd::DipoleChargeModifier("_no_such_file.pb"), deepmd::deepmd_exception);
+  ASSERT_THROW(deepmd::DipoleChargeModifier("_no_such_file.pb"),
+               deepmd::deepmd_exception);
 }


### PR DESCRIPTION
When a constructor throws an exception, it will not call the destructor as the constructor is not finished. The memory leak happens here and is detected by LeakSanitizer (thanks, @Cloudac7, for reminding me to use it). We must catch the exception, delete the memory, and re-throw the exception.