### PR TITLE
[Paddle Backend][Fix] Fix wrong custom operator installation filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ``` sh
 cd ./source/lib/paddle_src
-python setup_ins.py install
+python custom_op_install.py install
 ```
 
 安装完毕之后建议运行如下命令测试一下 python 端自定义算子在 CPU、GPU 上的正确性：

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -7,7 +7,6 @@ from typing import (
 import numpy as np
 
 from deepmd.common import (
-    cast_precision,
     get_activation_func,
     get_precision,
 )
@@ -973,7 +972,9 @@ class DescrptSeA(paddle.nn.Layer):
                 transpose_x=True,
             )
 
-    @cast_precision
+    # FIXME: @cast_precision should be annotated when convert to static model
+    # will restore it when it fixed.
+    # @cast_precision
     def _filter(
         self,
         inputs: paddle.Tensor,

--- a/deepmd/descriptor/se_a.py
+++ b/deepmd/descriptor/se_a.py
@@ -1026,8 +1026,12 @@ class DescrptSeA(paddle.nn.Layer):
         outputs_size = [1, *self.filter_neuron]
         outputs_size_2 = self.n_axis_neuron  # 16
         all_excluded = all(
-            (type_input, type_i) in self.exclude_types  #  set()
-            for type_i in range(self.ntypes)
+            # FIXME: the bracket '[]' is needed when convert to static model, will be
+            # removed when fixed.
+            [  # noqa
+                (type_input, type_i) in self.exclude_types  #  set() noqa
+                for type_i in range(self.ntypes)
+            ]
         )
         if all_excluded:
             # all types are excluded so result and qmat should be zeros

--- a/deepmd/entrypoints/gui.py
+++ b/deepmd/entrypoints/gui.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""DP-GUI entrypoint."""
+
+
+def start_dpgui(*, port: int, bind_all: bool, **kwargs):
+    """Host DP-GUI server.
+
+    Parameters
+    ----------
+    port : int
+        The port to serve DP-GUI on.
+    bind_all : bool
+        Serve on all public interfaces. This will expose your DP-GUI instance
+        to the network on both IPv4 and IPv6 (where available).
+    **kwargs
+        additional arguments
+
+    Raises
+    ------
+    ModuleNotFoundError
+        The dpgui package is not installed
+    """
+    try:
+        from dpgui import (
+            start_dpgui,
+        )
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "To use DP-GUI, please install the dpgui package:\npip install dpgui"
+        ) from e
+    start_dpgui(port=port, bind_all=bind_all)

--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -1,6 +1,5 @@
 """Module that sets tensorflow working environment and exports inportant constants."""
 
-import ctypes
 import logging
 import os
 import platform
@@ -46,11 +45,11 @@ def dlopen_library(module: str, filename: str):
         m = import_module(module)
     except ModuleNotFoundError:
         pass
-    else:
-        libs = sorted(Path(m.__file__).parent.glob(filename))
-        # hope that there is only one version installed...
-        if len(libs):
-            ctypes.CDLL(str(libs[0].absolute()))
+    # else:
+    #     libs = sorted(Path(m.__file__).parent.glob(filename))
+    #     # hope that there is only one version installed...
+    #     if len(libs):
+    #         ctypes.CDLL(str(libs[0].absolute()))
 
 
 # dlopen pip cuda library before tensorflow


### PR DESCRIPTION
1. Fix wrong custom operator installation filename
2. Fix missing file `deepmd/entrypoints/gui.py`
3. Annotated `@cast_precision` and keep brackets `[]` util problems fixed @SigureMo

@njzjz Besides, can you please help to rename `paddle` branch to `paddle_1` or other backup name, and then change `paddle2` to `paddle` branch? Because user may get confused aboout the difference between `paddle2 and `paddle`. Thanks a lot.

