### PR TITLE
cc: refactor DeepPotModelDevi, making it framework-independent

### DIFF
--- a/source/api_cc/include/DeepPot.h
+++ b/source/api_cc/include/DeepPot.h
@@ -595,34 +595,7 @@ class DeepPotModelDevi {
 
  private:
   unsigned numb_models;
-  std::vector<tensorflow::Session*> sessions;
-  int num_intra_nthreads, num_inter_nthreads;
-  std::vector<tensorflow::GraphDef*> graph_defs;
+  std::vector<deepmd::DeepPot> dps;
   bool inited;
-  template <class VT>
-  VT get_scalar(const std::string name) const;
-  // VALUETYPE get_rcut () const;
-  // int get_ntypes () const;
-  double rcut;
-  double cell_size;
-  int dtype;
-  std::string model_type;
-  std::string model_version;
-  int ntypes;
-  int ntypes_spin;
-  int dfparam;
-  int daparam;
-  bool aparam_nall;
-  template <typename VALUETYPE>
-  void validate_fparam_aparam(const int& nloc,
-                              const std::vector<VALUETYPE>& fparam,
-                              const std::vector<VALUETYPE>& aparam) const;
-
-  // copy neighbor list info from host
-  bool init_nbor;
-  std::vector<std::vector<int> > sec;
-  deepmd::AtomMap atommap;
-  NeighborListData nlist_data;
-  InputNlist nlist;
 };
 }  // namespace deepmd

--- a/source/api_cc/include/DeepPot.h
+++ b/source/api_cc/include/DeepPot.h
@@ -480,7 +480,7 @@ class DeepPotModelDevi {
    **/
   double cutoff() const {
     assert(inited);
-    return rcut;
+    return dps[0].cutoff();
   };
   /**
    * @brief Get the number of types.
@@ -488,7 +488,7 @@ class DeepPotModelDevi {
    **/
   int numb_types() const {
     assert(inited);
-    return ntypes;
+    return dps[0].numb_types();
   };
   /**
    * @brief Get the number of types with spin.
@@ -496,7 +496,7 @@ class DeepPotModelDevi {
    **/
   int numb_types_spin() const {
     assert(inited);
-    return ntypes_spin;
+    return dps[0].numb_types_spin();
   };
   /**
    * @brief Get the dimension of the frame parameter.
@@ -504,7 +504,7 @@ class DeepPotModelDevi {
    **/
   int dim_fparam() const {
     assert(inited);
-    return dfparam;
+    return dps[0].dim_fparam();
   };
   /**
    * @brief Get the dimension of the atomic parameter.
@@ -512,7 +512,7 @@ class DeepPotModelDevi {
    **/
   int dim_aparam() const {
     assert(inited);
-    return daparam;
+    return dps[0].dim_aparam();
   };
   /**
    * @brief Compute the average energy.
@@ -590,7 +590,7 @@ class DeepPotModelDevi {
    **/
   bool is_aparam_nall() const {
     assert(inited);
-    return aparam_nall;
+    return dps[0].is_aparam_nall();
   };
 
  private:

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -1261,8 +1261,8 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
   }
   dps.resize(numb_models);
   for (unsigned int ii = 0; ii < numb_models; ++ii) {
-    dps[ii] = DeepPot(models[ii], gpu_rank,
-                      file_contents.size() > ii ? file_contents[ii] : "");
+    dps[ii].init(models[ii], gpu_rank,
+                 file_contents.size() > ii ? file_contents[ii] : "");
   }
   inited = true;
 }

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -1260,6 +1260,9 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
     throw deepmd::deepmd_exception("no model is specified");
   }
   dps.resize(numb_models);
+  if (file_contents.size() != numb_models) {
+    file_contents.resize(numb_models);
+  }
   for (unsigned int ii = 0; ii < numb_models; ++ii) {
     dps[ii] = DeepPot(models[ii], gpu_rank, file_contents[ii]);
   }

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -1234,14 +1234,13 @@ void DeepPot::get_type_map(std::string& type_map) {
   type_map = get_scalar<STRINGTYPE>("model_attr/tmap");
 }
 
-DeepPotModelDevi::DeepPotModelDevi()
-    : inited(false), init_nbor(false), numb_models(0) {}
+DeepPotModelDevi::DeepPotModelDevi() : inited(false), numb_models(0) {}
 
 DeepPotModelDevi::DeepPotModelDevi(
     const std::vector<std::string>& models,
     const int& gpu_rank,
     const std::vector<std::string>& file_contents)
-    : inited(false), init_nbor(false), numb_models(0) {
+    : inited(false), numb_models(0) {
   init(models, gpu_rank, file_contents);
 }
 

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -1260,11 +1260,9 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
     throw deepmd::deepmd_exception("no model is specified");
   }
   dps.resize(numb_models);
-  if (file_contents.size() != numb_models) {
-    file_contents.resize(numb_models);
-  }
   for (unsigned int ii = 0; ii < numb_models; ++ii) {
-    dps[ii] = DeepPot(models[ii], gpu_rank, file_contents[ii]);
+    dps[ii] = DeepPot(models[ii], gpu_rank,
+                      file_contents.size() > ii ? file_contents[ii] : "");
   }
   inited = true;
 }

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -1242,22 +1242,10 @@ DeepPotModelDevi::DeepPotModelDevi(
     const int& gpu_rank,
     const std::vector<std::string>& file_contents)
     : inited(false), init_nbor(false), numb_models(0) {
-  try {
-    init(models, gpu_rank, file_contents);
-  } catch (...) {
-    // Clean up and rethrow, as the destructor will not be called
-    for (unsigned ii = 0; ii < numb_models; ++ii) {
-      delete graph_defs[ii];
-    }
-    throw;
-  }
+  init(models, gpu_rank, file_contents);
 }
 
-DeepPotModelDevi::~DeepPotModelDevi() {
-  for (unsigned ii = 0; ii < numb_models; ++ii) {
-    delete graph_defs[ii];
-  }
-}
+DeepPotModelDevi::~DeepPotModelDevi() {}
 
 void DeepPotModelDevi::init(const std::vector<std::string>& models,
                             const int& gpu_rank,
@@ -1269,6 +1257,9 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
     return;
   }
   numb_models = models.size();
+  if (numb_models == 0) {
+    throw deepmd::deepmd_exception("no model is specified");
+  }
   for (unsigned int ii = 0; ii < numb_models; ++ii) {
     dps[ii] = DeepPot(models[ii], gpu_rank, file_contents[ii]);
   }

--- a/source/api_cc/src/DeepPot.cc
+++ b/source/api_cc/src/DeepPot.cc
@@ -1259,6 +1259,7 @@ void DeepPotModelDevi::init(const std::vector<std::string>& models,
   if (numb_models == 0) {
     throw deepmd::deepmd_exception("no model is specified");
   }
+  dps.resize(numb_models);
   for (unsigned int ii = 0; ii < numb_models; ++ii) {
     dps[ii] = DeepPot(models[ii], gpu_rank, file_contents[ii]);
   }


### PR DESCRIPTION
Refactor `DeepPotModelDevi` as a step of #3122. Now, it is just a wrapper of multiple `DeepPot` classes. Models can have different behaviors inside different `DeepPot`.

One may argue that the new class needs to prepare the input multiple times. However, it's not expensive only to copy the memory. Also, during the simulations, usually we run it every 100 steps.
