### PR TITLE
fix: model check assumes __call__ as the forward method

### DIFF
--- a/deepmd_utils/model_format/__init__.py
+++ b/deepmd_utils/model_format/__init__.py
@@ -2,6 +2,7 @@
 from .common import (
     DEFAULT_PRECISION,
     PRECISION_DICT,
+    NativeOP,
 )
 from .env_mat import (
     EnvMat,
@@ -34,6 +35,7 @@ __all__ = [
     "NativeLayer",
     "NativeNet",
     "NetworkCollection",
+    "NativeOP",
     "load_dp_model",
     "save_dp_model",
     "traverse_model_dict",

--- a/deepmd_utils/model_format/common.py
+++ b/deepmd_utils/model_format/common.py
@@ -22,3 +22,7 @@ class NativeOP(ABC):
     def call(self, *args, **kwargs):
         """Forward pass in NumPy implementation."""
         raise NotImplementedError
+
+    def __call__(self, *args, **kwargs):
+        """Forward pass in NumPy implementation."""
+        return self.call(*args, **kwargs)

--- a/deepmd_utils/model_format/output_def.py
+++ b/deepmd_utils/model_format/output_def.py
@@ -27,7 +27,7 @@ def model_check_output(cls):
 
     Two methods are assumed to be provided by the Model:
     1. Model.output_def that gives the output definition.
-    2. Model.forward that defines the forward path of the model.
+    2. Model.__call__ that defines the forward path of the model.
 
     """
 
@@ -40,12 +40,12 @@ def model_check_output(cls):
             super().__init__(*args, **kwargs)
             self.md = cls.output_def(self)
 
-        def forward(
+        def __call__(
             self,
             *args,
             **kwargs,
         ):
-            ret = cls.forward(self, *args, **kwargs)
+            ret = cls.__call__(self, *args, **kwargs)
             for kk in self.md.keys_outp():
                 dd = self.md[kk]
                 check_var(ret[kk], dd)
@@ -66,7 +66,7 @@ def fitting_check_output(cls):
 
     Two methods are assumed to be provided by the Fitting:
     1. Fitting.output_def that gives the output definition.
-    2. Fitting.forward defines the forward path of the fitting.
+    2. Fitting.__call__ defines the forward path of the fitting.
 
     """
 
@@ -79,12 +79,12 @@ def fitting_check_output(cls):
             super().__init__(*args, **kwargs)
             self.md = cls.output_def(self)
 
-        def forward(
+        def __call__(
             self,
             *args,
             **kwargs,
         ):
-            ret = cls.forward(self, *args, **kwargs)
+            ret = cls.__call__(self, *args, **kwargs)
             for kk in self.md.keys():
                 dd = self.md[kk]
                 check_var(ret[kk], dd)


### PR DESCRIPTION
- add `__call__` method for `NativeOP`. 
- adapt UTs accordingly.