### PR TITLE
move deepmd.entrypoints.{doc,gui} to deepmd_utils.entrypoints.{doc,gui}

### DIFF
--- a/deepmd/entrypoints/doc.py
+++ b/deepmd/entrypoints/doc.py
@@ -1,20 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-"""Module that prints train input arguments docstrings."""
-
-from deepmd.utils.argcheck import (
-    gen_doc,
-    gen_json,
+from deepmd_utils.entrypoints.doc import (
+    doc_train_input,
 )
 
 __all__ = ["doc_train_input"]
-
-
-def doc_train_input(*, out_type: str = "rst", **kwargs):
-    """Print out trining input arguments to console."""
-    if out_type == "rst":
-        doc_str = gen_doc(make_anchor=True)
-    elif out_type == "json":
-        doc_str = gen_json()
-    else:
-        raise RuntimeError("Unsupported out type %s" % out_type)
-    print(doc_str)

--- a/deepmd/entrypoints/gui.py
+++ b/deepmd/entrypoints/gui.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 from deepmd_utils.entrypoints.gui import (
-    start_gui,
+    start_dpgui,
 )
 
-__all__ = ["start_gui"]
+__all__ = ["start_dpgui"]

--- a/deepmd/entrypoints/gui.py
+++ b/deepmd/entrypoints/gui.py
@@ -1,31 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-"""DP-GUI entrypoint."""
+from deepmd_utils.entrypoints.gui import (
+    start_gui,
+)
 
-
-def start_dpgui(*, port: int, bind_all: bool, **kwargs):
-    """Host DP-GUI server.
-
-    Parameters
-    ----------
-    port : int
-        The port to serve DP-GUI on.
-    bind_all : bool
-        Serve on all public interfaces. This will expose your DP-GUI instance
-        to the network on both IPv4 and IPv6 (where available).
-    **kwargs
-        additional arguments
-
-    Raises
-    ------
-    ModuleNotFoundError
-        The dpgui package is not installed
-    """
-    try:
-        from dpgui import (
-            start_dpgui,
-        )
-    except ModuleNotFoundError as e:
-        raise ModuleNotFoundError(
-            "To use DP-GUI, please install the dpgui package:\npip install dpgui"
-        ) from e
-    start_dpgui(port=port, bind_all=bind_all)
+__all__ = ["start_gui"]

--- a/deepmd_utils/entrypoints/__init__.py
+++ b/deepmd_utils/entrypoints/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/deepmd_utils/entrypoints/doc.py
+++ b/deepmd_utils/entrypoints/doc.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Module that prints train input arguments docstrings."""
+
+from deepmd_utils.utils.argcheck import (
+    gen_doc,
+    gen_json,
+)
+
+__all__ = ["doc_train_input"]
+
+
+def doc_train_input(*, out_type: str = "rst", **kwargs):
+    """Print out trining input arguments to console."""
+    if out_type == "rst":
+        doc_str = gen_doc(make_anchor=True)
+    elif out_type == "json":
+        doc_str = gen_json()
+    else:
+        raise RuntimeError("Unsupported out type %s" % out_type)
+    print(doc_str)

--- a/deepmd_utils/entrypoints/gui.py
+++ b/deepmd_utils/entrypoints/gui.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""DP-GUI entrypoint."""
+
+
+def start_dpgui(*, port: int, bind_all: bool, **kwargs):
+    """Host DP-GUI server.
+
+    Parameters
+    ----------
+    port : int
+        The port to serve DP-GUI on.
+    bind_all : bool
+        Serve on all public interfaces. This will expose your DP-GUI instance
+        to the network on both IPv4 and IPv6 (where available).
+    **kwargs
+        additional arguments
+
+    Raises
+    ------
+    ModuleNotFoundError
+        The dpgui package is not installed
+    """
+    try:
+        from dpgui import (
+            start_dpgui,
+        )
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "To use DP-GUI, please install the dpgui package:\npip install dpgui"
+        ) from e
+    start_dpgui(port=port, bind_all=bind_all)


### PR DESCRIPTION
See #3118