### PR TITLE
move `OutOfMemoryError` from `deepmd` to `deepmd_utils`

### DIFF
--- a/deepmd/utils/errors.py
+++ b/deepmd/utils/errors.py
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd_utils.utils.errors import (
+    OutOfMemoryError,
+)
+
+
 class GraphTooLargeError(Exception):
     """The graph is too large, exceeding protobuf's hard limit of 2GB."""
 
@@ -7,5 +12,8 @@ class GraphWithoutTensorError(Exception):
     pass
 
 
-class OutOfMemoryError(Exception):
-    """This error is caused by out-of-memory (OOM)."""
+__all__ = [
+    "OutOfMemoryError",
+    "GraphTooLargeError",
+    "GraphWithoutTensorError",
+]

--- a/deepmd_utils/utils/batch_size.py
+++ b/deepmd_utils/utils/batch_size.py
@@ -12,7 +12,7 @@ from typing import (
 
 import numpy as np
 
-from deepmd.utils.errors import (
+from deepmd_utils.utils.errors import (
     OutOfMemoryError,
 )
 

--- a/deepmd_utils/utils/errors.py
+++ b/deepmd_utils/utils/errors.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+class OutOfMemoryError(Exception):
+    """This error is caused by out-of-memory (OOM)."""


### PR DESCRIPTION
To prevent circular import