### PR TITLE
cmake: fix setting `CMAKE_HIP_FLAGS`

### DIFF
--- a/source/lib/src/gpu/CMakeLists.txt
+++ b/source/lib/src/gpu/CMakeLists.txt
@@ -73,7 +73,8 @@ elseif(USE_ROCM_TOOLKIT)
 
   message(STATUS "HIP major version is " ${hip_VERSION_MAJOR})
 
-  set(CMAKE_HIP_FLAGS "-fno-gpu-rdc ${CMAKE_HIP_FLAGS}") # --amdgpu-target=gfx906
+  set(CMAKE_HIP_FLAGS "-fno-gpu-rdc ${CMAKE_HIP_FLAGS}"
+  )# --amdgpu-target=gfx906
   if(hip_VERSION VERSION_LESS 3.5.1)
     set(CMAKE_HIP_FLAGS "-hc ${CMAKE_HIP_FLAGS}")
   endif()

--- a/source/lib/src/gpu/CMakeLists.txt
+++ b/source/lib/src/gpu/CMakeLists.txt
@@ -73,9 +73,9 @@ elseif(USE_ROCM_TOOLKIT)
 
   message(STATUS "HIP major version is " ${hip_VERSION_MAJOR})
 
-  set(CMAKE_HIP_FLAGS -fno-gpu-rdc ${CMAKE_HIP_FLAGS}) # --amdgpu-target=gfx906
+  set(CMAKE_HIP_FLAGS "-fno-gpu-rdc ${CMAKE_HIP_FLAGS}") # --amdgpu-target=gfx906
   if(hip_VERSION VERSION_LESS 3.5.1)
-    set(CMAKE_HIP_FLAGS -hc ${CMAKE_HIP_FLAGS})
+    set(CMAKE_HIP_FLAGS "-hc ${CMAKE_HIP_FLAGS}")
   endif()
 
   file(GLOB SOURCE_FILES "*.cu")


### PR DESCRIPTION
Fix https://github.com/deepmodeling/deepmd-kit/discussions/2523#discussioncomment-8176469.

[`CMAKE_<LANG>_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html#variable:CMAKE_%3CLANG%3E_FLAGS) is a string, so when using `set`, we should use quotes.