### PR TITLE
add more abstractmethods to universal `DeepPot`

### DIFF
--- a/deepmd_utils/infer/deep_pot.py
+++ b/deepmd_utils/infer/deep_pot.py
@@ -130,5 +130,13 @@ class DeepPot(ABC):
     def get_type_map(self) -> List[str]:
         """Get the type map (element name of the atom types) of this model."""
 
+    @abstractmethod
+    def get_dim_fparam(self) -> int:
+        """Get the number (dimension) of frame parameters of this DP."""
+
+    @abstractmethod
+    def get_dim_aparam(self) -> int:
+        """Get the number (dimension) of atomic parameters of this DP."""
+
 
 __all__ = ["DeepPot"]

--- a/deepmd_utils/infer/deep_pot.py
+++ b/deepmd_utils/infer/deep_pot.py
@@ -122,5 +122,13 @@ class DeepPot(ABC):
         # dpdata
         # ase
 
+    @abstractmethod
+    def get_ntypes(self) -> int:
+        """Get the number of atom types of this model."""
+
+    @abstractmethod
+    def get_type_map(self) -> List[str]:
+        """Get the type map (element name of the atom types) of this model."""
+
 
 __all__ = ["DeepPot"]


### PR DESCRIPTION
They are used by the downstream APIs, so must be implemented.