### PR TITLE
cc: fix returning type of sel_types

### DIFF
--- a/source/api_cc/include/DataModifier.h
+++ b/source/api_cc/include/DataModifier.h
@@ -84,7 +84,7 @@ class DipoleChargeModifierBase {
    * @brief Get the list of sel types.
    * @return The list of sel types.
    */
-  virtual std::vector<int> sel_types() const = 0;
+  virtual std::vector<int>& sel_types() const = 0;
 };
 
 /**
@@ -161,7 +161,7 @@ class DipoleChargeModifier {
    * @brief Get the list of sel types.
    * @return The list of sel types.
    */
-  std::vector<int> sel_types() const;
+  std::vector<int>& sel_types() const;
 
  private:
   bool inited;

--- a/source/api_cc/include/DataModifier.h
+++ b/source/api_cc/include/DataModifier.h
@@ -84,7 +84,7 @@ class DipoleChargeModifierBase {
    * @brief Get the list of sel types.
    * @return The list of sel types.
    */
-  virtual std::vector<int>& sel_types() const = 0;
+  virtual const std::vector<int>& sel_types() const = 0;
 };
 
 /**
@@ -161,7 +161,7 @@ class DipoleChargeModifier {
    * @brief Get the list of sel types.
    * @return The list of sel types.
    */
-  std::vector<int>& sel_types() const;
+  const std::vector<int>& sel_types() const;
 
  private:
   bool inited;

--- a/source/api_cc/include/DataModifierTF.h
+++ b/source/api_cc/include/DataModifierTF.h
@@ -84,7 +84,7 @@ class DipoleChargeModifierTF : public DipoleChargeModifierBase {
    * @brief Get the list of sel types.
    * @return The list of sel types.
    */
-  std::vector<int> sel_types() const {
+  std::vector<int>& sel_types() const {
     assert(inited);
     return sel_type;
   };

--- a/source/api_cc/include/DataModifierTF.h
+++ b/source/api_cc/include/DataModifierTF.h
@@ -84,7 +84,7 @@ class DipoleChargeModifierTF : public DipoleChargeModifierBase {
    * @brief Get the list of sel types.
    * @return The list of sel types.
    */
-  std::vector<int>& sel_types() const {
+  const std::vector<int>& sel_types() const {
     assert(inited);
     return sel_type;
   };

--- a/source/api_cc/src/DataModifier.cc
+++ b/source/api_cc/src/DataModifier.cc
@@ -92,6 +92,6 @@ double DipoleChargeModifier::cutoff() const { return dcm->cutoff(); }
 
 int DipoleChargeModifier::numb_types() const { return dcm->numb_types(); }
 
-std::vector<int>& DipoleChargeModifier::sel_types() const {
+const std::vector<int>& DipoleChargeModifier::sel_types() const {
   return dcm->sel_types();
 }

--- a/source/api_cc/src/DataModifier.cc
+++ b/source/api_cc/src/DataModifier.cc
@@ -92,6 +92,6 @@ double DipoleChargeModifier::cutoff() const { return dcm->cutoff(); }
 
 int DipoleChargeModifier::numb_types() const { return dcm->numb_types(); }
 
-std::vector<int> DipoleChargeModifier::sel_types() const {
+std::vector<int>& DipoleChargeModifier::sel_types() const {
   return dcm->sel_types();
 }


### PR DESCRIPTION
Fix the following compiler warning:
```
/home/runner/work/deepmd-kit/deepmd-kit/source/api_c/src/c_api.cc:1336:17: warning: returning address of local temporary object [-Wreturn-stack-address]
  return (int*)&(dcm->dcm.sel_types())[0];
                ^~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
by returning the reference of `sel_type`.

`DataChargeModifier.sel_types` is not used anywhere, even in the test, so we don't have a chance to determine if there is a possible segfault, and this warning has no actual impact.

It seems `DeepTensor` has returned a reference since the beginning (https://github.com/deepmodeling/deepmd-kit/pull/137). (perhaps because `DeepTensor.sel_types` is used) `DeepTensor` and `DataChargeModifier` have different returned types.