### PR TITLE
PT: keep the same checkpoint behavior as TF

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -275,7 +275,7 @@ def main_parser() -> argparse.ArgumentParser:
         "--checkpoint",
         type=str,
         default=".",
-        help="Path to checkpoint. TensorFlow backend: a folder; PyTorch backend: either a folder containing model.pt, or a pt file",
+        help="Path to checkpoint. TensorFlow backend: a folder; PyTorch backend: either a folder containing checkpoint, or a pt file",
     )
     parser_frz.add_argument(
         "-o",

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -308,9 +308,9 @@ def main(args: Optional[Union[List[str], argparse.Namespace]] = None):
         test(FLAGS)
     elif FLAGS.command == "freeze":
         if Path(FLAGS.checkpoint_folder).is_dir():
-            # TODO: automatically generate model.pt during training
-            # FLAGS.model = str(Path(FLAGS.checkpoint).joinpath("model.pt"))
-            raise NotImplementedError("Checkpoint should give a file")
+            checkpoint_path = Path(FLAGS.checkpoint_folder)
+            latest_ckpt_file = (checkpoint_path / "checkpoint").read_text()
+            FLAGS.model = str(checkpoint_path.joinpath(latest_ckpt_file))
         else:
             FLAGS.model = FLAGS.checkpoint_folder
         FLAGS.output = str(Path(FLAGS.output).with_suffix(".pth"))

--- a/source/tests/pt/water/se_atten.json
+++ b/source/tests/pt/water/se_atten.json
@@ -79,6 +79,7 @@
     "disp_file": "lcurve.out",
     "disp_freq": 100,
     "save_freq": 1000,
+    "save_ckpt": "model",
     "_comment": "that's all"
   }
 }


### PR DESCRIPTION
Set the default `save_ckpt` to `model.ckpt` as the prefix. When saving checkpoints, `model.ckpt-100.pt` will be saved, and `model.ckpt.pt` will be symlinked to `model.ckpt-100.pt`. A `checkpoint` file will be dedicated to record `model.ckpt-100.pt`.

This keeps the same behavior as the TF backend. One can do the below using the PT backend just like the TF backend:

```sh
dp --pt train input.json
# one can cancel the training before it finishes
dp --pt freeze
```
