### PR TITLE
build macos-arm64 wheel on M1 runners

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -41,12 +41,12 @@ jobs:
             cuda_version: 11.8
             dp_pkg_name: deepmd-kit-cu11
           # macos-x86-64
-          - os: macos-latest
+          - os: macos-13
             python: 311
             platform_id: macosx_x86_64
             dp_variant: cpu
           # macos-arm64
-          - os: macos-latest
+          - os: macos-14
             python: 311
             platform_id: macosx_arm64
             dp_variant: cpu

--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -50,12 +50,6 @@ def find_tensorflow() -> Tuple[Optional[str], List[str]]:
     requires = []
 
     tf_spec = None
-    if os.environ.get("CIBUILDWHEEL", "0") == "1" and os.environ.get(
-        "CIBW_BUILD", ""
-    ).endswith("macosx_arm64"):
-        # cibuildwheel cross build
-        site_packages = Path(os.environ.get("RUNNER_TEMP")) / "tensorflow"
-        tf_spec = FileFinder(str(site_packages)).find_spec("tensorflow")
 
     if (tf_spec is None or not tf_spec) and os.environ.get(
         "TENSORFLOW_ROOT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,12 +143,10 @@ manylinux-aarch64-image = "manylinux_2_28"
 [tool.cibuildwheel.macos]
 environment = { PIP_PREFER_BINARY="1", DP_LAMMPS_VERSION="stable_2Aug2023_update2", DP_ENABLE_IPI="1" }
 before-all = [
+    # enable MPI for macos-arm64 in the next lammps release for compatibility
     """if [[ "$CIBW_BUILD" != *macosx_arm64* ]]; then brew install mpich; fi""",
 ]
-before-build = [
-    """if [[ "$CIBW_BUILD" == *macosx_arm64* ]]; then python -m pip install "tensorflow-macos>=2.13.0rc0" --platform macosx_12_0_arm64 --no-deps --target=$RUNNER_TEMP/tensorflow; fi""",
-]
-repair-wheel-command = """if [[ "$CIBW_BUILD" == *macosx_arm64* ]]; then rm -rf $RUNNER_TEMP/tensorflow; fi && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"""
+repair-wheel-command = """delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"""
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so --exclude _pywrap_tensorflow_internal.so --exclude libtensorflow_cc.so.2 -w {dest_dir} {wheel}"


### PR DESCRIPTION
Today [GitHub introduced the new M1 runners](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/), making it possible to build macos-arm64 wheels without cross-building.

Remove old hacked codes for cross-building.