### PR TITLE
fix compile gromacs with precompiled C library

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -271,6 +271,7 @@ if(DEEPMD_C_ROOT)
                IMPORTED_LOCATION "${deepmd_c}"
                INTERFACE_INCLUDE_DIRECTORIES "${DEEPMD_INCLUDE_C_DIR}/deepmd")
   # use variable for TF path to set deepmd_c path
+  set(TENSORFLOW_ROOT "${DEEPMD_C_ROOT}")
   set(TensorFlow_LIBRARY_PATH "${DEEPMD_C_ROOT}/lib")
   set(TENSORFLOW_INCLUDE_DIRS "${DEEPMD_C_ROOT}/include")
   set(TORCH_LIBRARIES "${DEEPMD_C_ROOT}/lib/libtorch.so")


### PR DESCRIPTION
Fix #3214.

In the gmx patch file, `${TENSORFLOW_ROOT}` is used other than `${TensorFlow_LIBRARY_PATH}$` or `${TENSORFLOW_INCLUDE_DIRS}`, so the fastest workaround is to set `${TENSORFLOW_ROOT}`.

https://github.com/deepmodeling/deepmd-kit/blob/eb9b2efedf4efc946894800a0d7abf5056f4bb7a/source/gmx/patches/2020.2/CMakeLists.txt.patch.in#L14-L18