### PR TITLE
fix DP_ENABLE_TENSORFLOW support

### DIFF
--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -47,6 +47,8 @@ def find_tensorflow() -> Tuple[Optional[str], List[str]]:
     list of str
         TensorFlow requirement if not found. Empty if found.
     """
+    if os.environ.get("DP_ENABLE_TENSORFLOW", "1") == "0":
+        return None, []
     requires = []
 
     tf_spec = None


### PR DESCRIPTION
Avoid installing tensorflow as build requires when `DP_ENABLE_TENSORFLOW` is `0`.