### PR TITLE
bump python to 3.12 in the test environment

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -18,7 +18,7 @@ jobs:
           - python: 3.8
             tf:
             torch:
-          - python: "3.11"
+          - python: "3.12"
             tf:
             torch:
 

--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
 import site
-import sys
 from functools import (
     lru_cache,
 )
@@ -138,13 +137,10 @@ def get_tf_requirement(tf_version: str = "") -> dict:
     if not (tf_version == "" or tf_version in SpecifierSet(">=2.12", prereleases=True)):
         extra_requires.append("protobuf<3.20")
     # keras 3 is not compatible with tf.compat.v1
-    if (
-        tf_version == ""
-        or tf_version in SpecifierSet(">=2.16.0rc0", prereleases=True)
+    if tf_version == "" or tf_version in SpecifierSet(">=2.16.0rc0", prereleases=True):
+        extra_requires.append("tf-keras; python_version>='3.9'")
         # only TF>=2.16 is compatible with Python 3.12
-        or sys.version_info >= (3, 12)
-    ):
-        extra_requires.append("tf-keras>=2.16.0rc0")
+        extra_requires.append("tf-keras>=2.16.0rc0; python_version>='3.12'")
     if tf_version == "" or tf_version in SpecifierSet(">=1.15", prereleases=True):
         extra_select["mpi"] = [
             "horovod",

--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
 import site
+import sys
 from functools import (
     lru_cache,
 )
@@ -136,6 +137,14 @@ def get_tf_requirement(tf_version: str = "") -> dict:
     extra_select = {}
     if not (tf_version == "" or tf_version in SpecifierSet(">=2.12", prereleases=True)):
         extra_requires.append("protobuf<3.20")
+    # keras 3 is not compatible with tf.compat.v1
+    if (
+        tf_version == ""
+        or tf_version in SpecifierSet(">=2.16", prereleases=True)
+        # only TF>=2.16 is compatible with Python 3.12
+        or sys.version_info >= (3, 12)
+    ):
+        extra_requires.append("tf-keras")
     if tf_version == "" or tf_version in SpecifierSet(">=1.15", prereleases=True):
         extra_select["mpi"] = [
             "horovod",

--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -137,7 +137,7 @@ def get_tf_requirement(tf_version: str = "") -> dict:
     if not (tf_version == "" or tf_version in SpecifierSet(">=2.12", prereleases=True)):
         extra_requires.append("protobuf<3.20")
     # keras 3 is not compatible with tf.compat.v1
-    if tf_version == "" or tf_version in SpecifierSet(">=2.16.0rc0", prereleases=True):
+    if tf_version == "" or tf_version in SpecifierSet(">=2.15.0rc0", prereleases=True):
         extra_requires.append("tf-keras; python_version>='3.9'")
         # only TF>=2.16 is compatible with Python 3.12
         extra_requires.append("tf-keras>=2.16.0rc0; python_version>='3.12'")

--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -140,11 +140,11 @@ def get_tf_requirement(tf_version: str = "") -> dict:
     # keras 3 is not compatible with tf.compat.v1
     if (
         tf_version == ""
-        or tf_version in SpecifierSet(">=2.16", prereleases=True)
+        or tf_version in SpecifierSet(">=2.16.0rc0", prereleases=True)
         # only TF>=2.16 is compatible with Python 3.12
         or sys.version_info >= (3, 12)
     ):
-        extra_requires.append("tf-keras")
+        extra_requires.append("tf-keras>=2.16.0rc0")
     if tf_version == "" or tf_version in SpecifierSet(">=1.15", prereleases=True):
         extra_select["mpi"] = [
             "horovod",

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -990,6 +990,7 @@ class DescrptSeAtten(DescrptSeA):
                 input_xyz = tf.keras.layers.LayerNormalization(
                     beta_initializer=tf.constant_initializer(self.beta[i]),
                     gamma_initializer=tf.constant_initializer(self.gamma[i]),
+                    dtype=self.filter_precision,
                 )(input_xyz)
                 # input_xyz = self._feedforward(input_xyz, outputs_size[-1], self.att_n)
         return input_xyz

--- a/deepmd/tf/env.py
+++ b/deepmd/tf/env.py
@@ -75,7 +75,9 @@ if platform.system() == "Linux":
     dlopen_library("nvidia.cusparse.lib", "libcusparse.so*")
     dlopen_library("nvidia.cudnn.lib", "libcudnn.so*")
 
-
+# keras 3 is incompatible with tf.compat.v1
+# https://keras.io/getting_started/#tensorflow--keras-2-backwards-compatibility
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
 # import tensorflow v1 compatability
 try:
     import tensorflow.compat.v1 as tf


### PR DESCRIPTION
Fix a bug caused by the breaking change in Keras 3 (shipped by TF 2.16).