### PR TITLE
allow loading either nsel or natoms atomic tensor data

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -78,6 +78,7 @@ def add_data_requirement(
     repeat: int = 1,
     default: float = 0.0,
     dtype: Optional[np.dtype] = None,
+    output_natoms_for_type_sel: bool = False,
 ):
     """Specify data requirements for training.
 
@@ -103,6 +104,8 @@ def add_data_requirement(
         default value of data
     dtype : np.dtype, optional
         the dtype of data, overwrites `high_prec` if provided
+    output_natoms_for_type_sel : bool, optional
+        if True and type_sel is True, the atomic dimension will be natoms instead of nsel
     """
     data_requirement[key] = {
         "ndof": ndof,
@@ -113,6 +116,7 @@ def add_data_requirement(
         "repeat": repeat,
         "default": default,
         "dtype": dtype,
+        "output_natoms_for_type_sel": output_natoms_for_type_sel,
     }
 
 

--- a/deepmd/pt/utils/dataset.py
+++ b/deepmd/pt/utils/dataset.py
@@ -61,4 +61,5 @@ class DeepmdDataSetForLoader(Dataset):
                 repeat=data_item["repeat"],
                 default=data_item["default"],
                 dtype=data_item["dtype"],
+                output_natoms_for_type_sel=data_item["output_natoms_for_type_sel"],
             )

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -741,6 +741,8 @@ class DataRequirementItem:
         default value of data
     dtype : np.dtype, optional
         the dtype of data, overwrites `high_prec` if provided
+    output_natoms_for_type_sel : bool, optional
+        if True and type_sel is True, the atomic dimension will be natoms instead of nsel
     """
 
     def __init__(
@@ -754,6 +756,7 @@ class DataRequirementItem:
         repeat: int = 1,
         default: float = 0.0,
         dtype: Optional[np.dtype] = None,
+        output_natoms_for_type_sel: bool = False,
     ) -> None:
         self.key = key
         self.ndof = ndof
@@ -764,6 +767,7 @@ class DataRequirementItem:
         self.repeat = repeat
         self.default = default
         self.dtype = dtype
+        self.output_natoms_for_type_sel = output_natoms_for_type_sel
         self.dict = self.to_dict()
 
     def to_dict(self) -> dict:
@@ -777,6 +781,7 @@ class DataRequirementItem:
             "repeat": self.repeat,
             "default": self.default,
             "dtype": self.dtype,
+            "output_natoms_for_type_sel": self.output_natoms_for_type_sel,
         }
 
     def __getitem__(self, key: str):

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -293,6 +293,7 @@ class DeepmdDataSystem:
                 type_sel=adict[kk]["type_sel"],
                 repeat=adict[kk]["repeat"],
                 default=adict[kk]["default"],
+                output_natoms_for_type_sel=adict[kk]["output_natoms_for_type_sel"],
             )
 
     def add(
@@ -305,6 +306,7 @@ class DeepmdDataSystem:
         type_sel: Optional[List[int]] = None,
         repeat: int = 1,
         default: float = 0.0,
+        output_natoms_for_type_sel: bool = False,
     ):
         """Add a data item that to be loaded.
 
@@ -329,6 +331,8 @@ class DeepmdDataSystem:
             The data will be repeated `repeat` times.
         default, default=0.
             Default value of data
+        output_natoms_for_type_sel : bool
+            If True and type_sel is True, the atomic dimension will be natoms instead of nsel
         """
         for ii in self.data_systems:
             ii.add(

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -344,6 +344,7 @@ class DeepmdDataSystem:
                 repeat=repeat,
                 type_sel=type_sel,
                 default=default,
+                output_natoms_for_type_sel=output_natoms_for_type_sel,
             )
 
     def reduce(self, key_out, key_in):

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -293,7 +293,10 @@ class DeepmdDataSystem:
                 type_sel=adict[kk]["type_sel"],
                 repeat=adict[kk]["repeat"],
                 default=adict[kk]["default"],
-                output_natoms_for_type_sel=adict[kk]["output_natoms_for_type_sel"],
+                dtype=adict[kk].get("dtype"),
+                output_natoms_for_type_sel=adict[kk].get(
+                    "output_natoms_for_type_sel", False
+                ),
             )
 
     def add(
@@ -306,6 +309,7 @@ class DeepmdDataSystem:
         type_sel: Optional[List[int]] = None,
         repeat: int = 1,
         default: float = 0.0,
+        dtype: Optional[np.dtype] = None,
         output_natoms_for_type_sel: bool = False,
     ):
         """Add a data item that to be loaded.
@@ -331,6 +335,8 @@ class DeepmdDataSystem:
             The data will be repeated `repeat` times.
         default, default=0.
             Default value of data
+        dtype
+            The dtype of data, overwrites `high_prec` if provided
         output_natoms_for_type_sel : bool
             If True and type_sel is True, the atomic dimension will be natoms instead of nsel
         """
@@ -344,6 +350,7 @@ class DeepmdDataSystem:
                 repeat=repeat,
                 type_sel=type_sel,
                 default=default,
+                dtype=dtype,
                 output_natoms_for_type_sel=output_natoms_for_type_sel,
             )
 

--- a/source/tests/tf/test_data_requirement.py
+++ b/source/tests/tf/test_data_requirement.py
@@ -16,3 +16,4 @@ class TestDataRequirement(unittest.TestCase):
         self.assertEqual(data_requirement["test"]["high_prec"], False)
         self.assertEqual(data_requirement["test"]["repeat"], 1)
         self.assertEqual(data_requirement["test"]["default"], 0.0)
+        self.assertEqual(data_requirement["test"]["output_natoms_for_type_sel"], False)


### PR DESCRIPTION
A new parameter, `output_natoms_for_type_sel`, is added for the data requirement. (default=false)
If sel_types is given, output_natoms_for_type_sel is true, and the data dimension is nsel, it will be converted to natoms.
If sel_types is given, output_natoms_for_type_sel is false, and the data dimension is natoms, it will be converted to nsel.
In other situations, it keeps the original shape.
The user can give data in either nsel or natoms, if `sel_types` and `output_natoms_for_type_sel` are set.