### PR TITLE
fix github actions for release

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - "gh-readonly-queue/**"
+    tags:
+      - "v*"
   pull_request:
   merge_group:
 

--- a/.github/workflows/package_c.yml
+++ b/.github/workflows/package_c.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - "gh-readonly-queue/**"
+    tags:
+      - "v*"
   pull_request:
   merge_group:
 concurrency:


### PR DESCRIPTION
It looks when setting `branches-ignore`, the push on tags will not trigger the GitHub Actions. Setting `tags` is necessary. (So I have to manually upload the package again...)