### PR TITLE
fix deepmd-kit-cu11 again

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -84,7 +84,7 @@ jobs:
         if: matrix.dp_pkg_name == 'deepmd-kit-cu11'
       - run: |
           python -m pip install setuptools_scm
-          python -c "from setuptools_scm import get_version;print('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DEEPMD-KIT-CU11='+get_version())" >> $GITHUB_ENV
+          python -c "from setuptools_scm import get_version;print('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_deepmd-kit-cu11='+get_version())" >> $GITHUB_ENV
           rm -rf .git
         if: matrix.dp_pkg_name == 'deepmd-kit-cu11'
       - name: Build wheels

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -85,6 +85,7 @@ jobs:
       - run: |
           python -m pip install setuptools_scm
           python -c "from setuptools_scm import get_version;print('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DEEPMD-KIT-CU11='+get_version())" >> $GITHUB_ENV
+          rm -rf .git
         if: matrix.dp_pkg_name == 'deepmd-kit-cu11'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -84,7 +84,7 @@ jobs:
         if: matrix.dp_pkg_name == 'deepmd-kit-cu11'
       - run: |
           python -m pip install setuptools_scm
-          python -c "from setuptools_scm import get_version;print('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_deepmd-kit-cu11='+get_version())" >> $GITHUB_ENV
+          python -c "from setuptools_scm import get_version;print('SETUPTOOLS_SCM_PRETEND_VERSION='+get_version())" >> $GITHUB_ENV
           rm -rf .git
         if: matrix.dp_pkg_name == 'deepmd-kit-cu11'
       - name: Build wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ environment-pass = [
     "DP_VARIANT",
     "CUDA_VERSION",
     "DP_PKG_NAME",
-    "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DEEPMD-KIT-CU11",
+    "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_deepmd-kit-cu11",
 ]
 environment = { PIP_PREFER_BINARY="1", DP_LAMMPS_VERSION="stable_2Aug2023_update3", DP_ENABLE_IPI="1", MPI_HOME="/usr/lib64/mpich", PATH="/usr/lib64/mpich/bin:$PATH" }
 before-all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ environment-pass = [
     "DP_VARIANT",
     "CUDA_VERSION",
     "DP_PKG_NAME",
-    "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_deepmd-kit-cu11",
+    "SETUPTOOLS_SCM_PRETEND_VERSION",
 ]
 environment = { PIP_PREFER_BINARY="1", DP_LAMMPS_VERSION="stable_2Aug2023_update3", DP_ENABLE_IPI="1", MPI_HOME="/usr/lib64/mpich", PATH="/usr/lib64/mpich/bin:$PATH" }
 before-all = [


### PR DESCRIPTION
Fix #3168.

#3172 didn't fix #3168. The environmental variable `SETUPTOOLS_SCM_PRETEND_VERSION` works. I don't know what's wrong with the previous one.
In this PR, I deleted the `.git` directory for `deepmd-kit-cu11`, which will throw an error if it doesn't work.