### PR TITLE
pt: Fix compilation with libtorch

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -155,7 +155,7 @@ endif()
 if(ENABLE_PYTORCH AND NOT DEEPMD_C_ROOT)
   find_package(Torch REQUIRED)
   string(REGEX MATCH "_GLIBCXX_USE_CXX11_ABI=([0-9]+)" CXXABI_PT_MATCH
-               ${TORCH_CXX_FLAGS})
+               "${TORCH_CXX_FLAGS}")
   if(CXXABI_PT_MATCH)
     message(STATUS "PyTorch CXX11 ABI: ${CMAKE_MATCH_1}")
     if(DEFINED OP_CXX_ABI)

--- a/source/api_cc/CMakeLists.txt
+++ b/source/api_cc/CMakeLists.txt
@@ -33,8 +33,10 @@ if(Protobuf_LIBRARY)
 endif()
 
 set_target_properties(
-  ${libname} PROPERTIES INSTALL_RPATH "$ORIGIN;${TensorFlow_LIBRARY_PATH}"
-                        BUILD_RPATH "$ORIGIN/../op")
+  ${libname}
+  PROPERTIES INSTALL_RPATH "$ORIGIN;${TensorFlow_LIBRARY_PATH}"
+             INSTALL_RPATH_USE_LINK_PATH TRUE
+             BUILD_RPATH "$ORIGIN/../op")
 target_compile_definitions(${libname} PRIVATE TF_PRIVATE)
 if(CMAKE_TESTING_ENABLED)
   target_link_libraries(${libname} PRIVATE coverage_config)


### PR DESCRIPTION
Backported from https://github.com/conda-forge/deepmd-kit-feedstock/pull/71.
1. The rpath of libdeepmd_cc should contain the libtorch directory if it differs from the path of libdeepmd_cc. Setting `INSTALL_RPATH_USE_LINK_PATH` to `true` resolves the problem.
2. `${TORCH_CXX_FLAGS}` is empty in macOS, so the variable with quotes, i.e. `"${TORCH_CXX_FLAGS}"`, should be used.