### PR TITLE
pt: avoid D2H in se_e2_a

### DIFF
--- a/deepmd/pt/model/descriptor/se_a.py
+++ b/deepmd/pt/model/descriptor/se_a.py
@@ -342,9 +342,8 @@ class DescrptBlockSeA(DescriptorBlock):
         self.reinit_exclude(exclude_types)
 
         self.sel = sel
-        self.sec = torch.tensor(
-            np.append([0], np.cumsum(self.sel)), dtype=int, device=env.DEVICE
-        )
+        # should be on CPU to avoid D2H, as it is used as slice index
+        self.sec = [0, *np.cumsum(self.sel).tolist()]
         self.split_sel = self.sel
         self.nnei = sum(sel)
         self.ndescrpt = self.nnei * 4


### PR DESCRIPTION
sec is used as a slice index, so it should not stored on the GPU, otherwise, D2H will happen to create the tensor with the shape.

Before:
![image](https://github.com/deepmodeling/deepmd-kit/assets/9496702/f5a520d8-ed83-4520-aed0-d8fed547c293)

After:
![image](https://github.com/deepmodeling/deepmd-kit/assets/9496702/5548632b-3099-4fe2-ab53-5c570abd714a)
