### PR TITLE
pt: improve nlist performance

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -950,7 +950,7 @@ class Trainer:
                     batch_data = next(iter(self.validation_data[task_key]))
 
         for key in batch_data.keys():
-            if key == "sid" or key == "fid":
+            if key == "sid" or key == "fid" or key == "box":
                 continue
             elif not isinstance(batch_data[key], list):
                 if batch_data[key] is not None:

--- a/deepmd/pt/utils/nlist.py
+++ b/deepmd/pt/utils/nlist.py
@@ -307,18 +307,14 @@ def extend_coord_with_ghosts(
         nbuff = torch.ceil(rcut / to_face).to(torch.long)
         # 3
         nbuff = torch.max(nbuff, dim=0, keepdim=False).values
-        xi = torch.arange(-nbuff[0], nbuff[0] + 1, 1, device=device)
-        yi = torch.arange(-nbuff[1], nbuff[1] + 1, 1, device=device)
-        zi = torch.arange(-nbuff[2], nbuff[2] + 1, 1, device=device)
-        xyz = xi.view(-1, 1, 1, 1) * torch.tensor(
-            [1, 0, 0], dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=device
-        )
-        xyz = xyz + yi.view(1, -1, 1, 1) * torch.tensor(
-            [0, 1, 0], dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=device
-        )
-        xyz = xyz + zi.view(1, 1, -1, 1) * torch.tensor(
-            [0, 0, 1], dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=device
-        )
+        nbuff_cpu = nbuff.cpu()
+        xi = torch.arange(-nbuff_cpu[0], nbuff_cpu[0] + 1, 1, device=device)
+        yi = torch.arange(-nbuff_cpu[1], nbuff_cpu[1] + 1, 1, device=device)
+        zi = torch.arange(-nbuff_cpu[2], nbuff_cpu[2] + 1, 1, device=device)
+        eye_3 = torch.eye(3, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=device)
+        xyz = xi.view(-1, 1, 1, 1) * eye_3[0]
+        xyz = xyz + yi.view(1, -1, 1, 1) * eye_3[1]
+        xyz = xyz + zi.view(1, 1, -1, 1) * eye_3[2]
         xyz = xyz.view(-1, 3)
         # ns x 3
         shift_idx = xyz[torch.argsort(torch.norm(xyz, dim=1))]

--- a/deepmd/pt/utils/nlist.py
+++ b/deepmd/pt/utils/nlist.py
@@ -314,14 +314,15 @@ def extend_coord_with_ghosts(
         # 3
         nbuff = torch.max(nbuff, dim=0, keepdim=False).values
         nbuff_cpu = nbuff.cpu()
-        xi = torch.arange(-nbuff_cpu[0], nbuff_cpu[0] + 1, 1, device=device)
-        yi = torch.arange(-nbuff_cpu[1], nbuff_cpu[1] + 1, 1, device=device)
-        zi = torch.arange(-nbuff_cpu[2], nbuff_cpu[2] + 1, 1, device=device)
-        eye_3 = torch.eye(3, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=device)
+        xi = torch.arange(-nbuff_cpu[0], nbuff_cpu[0] + 1, 1, device="cpu")
+        yi = torch.arange(-nbuff_cpu[1], nbuff_cpu[1] + 1, 1, device="cpu")
+        zi = torch.arange(-nbuff_cpu[2], nbuff_cpu[2] + 1, 1, device="cpu")
+        eye_3 = torch.eye(3, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device="cpu")
         xyz = xi.view(-1, 1, 1, 1) * eye_3[0]
         xyz = xyz + yi.view(1, -1, 1, 1) * eye_3[1]
         xyz = xyz + zi.view(1, 1, -1, 1) * eye_3[2]
         xyz = xyz.view(-1, 3)
+        xyz = xyz.to(device=device, non_blocking=True)
         # ns x 3
         shift_idx = xyz[torch.argsort(torch.norm(xyz, dim=1))]
         ns, _ = shift_idx.shape

--- a/deepmd/pt/utils/region.py
+++ b/deepmd/pt/utils/region.py
@@ -21,7 +21,7 @@ def phys2inter(
         the internal coordinates
 
     """
-    rec_cell = torch.linalg.inv(cell)
+    rec_cell, _ = torch.linalg.inv_ex(cell)
     return torch.matmul(coord, rec_cell)
 
 


### PR DESCRIPTION
1. use inv_ex instead of inv. `inv_ex` does not check errors. We can assume the input is correct.
2. pass CPU box for `torch.arange`;
3. avoid torch.tensor.