### PR TITLE
ci: reduce ASLR entropy

### DIFF
--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -31,6 +31,10 @@ jobs:
       run: |
          wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.1.2%2Bcpu.zip -O libtorch.zip
          unzip libtorch.zip
+    # https://github.com/actions/runner-images/issues/9491
+    - name: Fix kernel mmap rnd bits
+      run: sudo sysctl vm.mmap_rnd_bits=28
+      if: ${{ matrix.check_memleak }}
     - run: |
          export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/libtorch
          source/install/test_cc_local.sh


### PR DESCRIPTION
This week, a random segfault occurred in GHA when using `-fsanitize=leak`. It seems related to https://github.com/actions/runner-images/issues/9491. Workaround: https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917
See also: https://stackoverflow.com/questions/77894856/possible-bug-in-gcc-sanitizers