### PR TITLE
Fix LAMMPS plugin symlink path on macOS platform

### DIFF
--- a/source/lmp/plugin/CMakeLists.txt
+++ b/source/lmp/plugin/CMakeLists.txt
@@ -126,7 +126,7 @@ if(DEFINED LAMMPS_SOURCE_ROOT OR DEFINED LAMMPS_VERSION)
       install(
         CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
-		../${CMAKE_SHARED_LIBRARY_PREFIX}${libname}${CMAKE_SHARED_LIBRARY_SUFFIX} \
+		../${CMAKE_SHARED_MODULE_PREFIX}${libname}${CMAKE_SHARED_MODULE_SUFFIX} \
         ${CMAKE_INSTALL_PREFIX}/lib/${libname}/${PLUGINNAME}   \
         )")
     endif()


### PR DESCRIPTION
This pull request fixes the broken symlink for `dpplugin.so` on macOS. It should point to `libdeepmd_lmp.so` but point to `libdeepmd_lmp.dylib` instead.

### Details

The `libdeepmd_lmp` is a shared module.

https://github.com/deepmodeling/deepmd-kit/blob/b875ea8f6661b6e1567537ead7e2b4a8b14ea113/source/lmp/plugin/CMakeLists.txt#L72

The build target name on macOS is `libdeepmd_lmp.so`.

Because on macOS, the `CMAKE_SHARED_MODULE_SUFFIX` (`.so`) is different from `CMAKE_SHARED_LIBRARY_SUFFIX` (`.dynlib`). As a result, in previous versions, on macOS the symbolic link `dpplugin.so` was pointed to `libdeepmd_lmp.dylib`, which does not exist. One can check the conda-forge builds to confirm (e.g., [osx-arm64/deepmd-kit-2.2.9-cpu_py311hf5376d5_mpi_openmpi_0.conda](https://anaconda.org/conda-forge/deepmd-kit/2.2.9/download/osx-arm64/deepmd-kit-2.2.9-cpu_py311hf5376d5_mpi_openmpi_0.conda)).