### PR TITLE
feat: Support bfloat16 and ensure valid precision and activation functions consistent everywhere

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -17,8 +17,10 @@ from typing import (
     Dict,
     List,
     Optional,
+    Set,
     TypeVar,
     Union,
+    get_args,
 )
 
 try:
@@ -45,23 +47,28 @@ __all__ = [
     "j_loader",
     "expand_sys_str",
     "get_np_precision",
+    "VALID_PRECISION",
+    "VALID_ACTIVATION",
 ]
 
+_PRECISION = Literal["default", "float16", "float32", "float64"]
+_ACTIVATION = Literal[
+    "relu",
+    "relu6",
+    "softplus",
+    "sigmoid",
+    "tanh",
+    "gelu",
+    "gelu_tf",
+    "none",
+    "linear",
+]
+# get_args is new in py38
+VALID_PRECISION: Set[_PRECISION] = set(get_args(_PRECISION))
+VALID_ACTIVATION: Set[_ACTIVATION] = set(get_args(_ACTIVATION))
 
 if TYPE_CHECKING:
     _DICT_VAL = TypeVar("_DICT_VAL")
-    _PRECISION = Literal["default", "float16", "float32", "float64"]
-    _ACTIVATION = Literal[
-        "relu",
-        "relu6",
-        "softplus",
-        "sigmoid",
-        "tanh",
-        "gelu",
-        "gelu_tf",
-        "none",
-        "linear",
-    ]
     __all__.extend(
         [
             "_DICT_VAL",

--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -24,7 +24,10 @@ PRECISION_DICT = {
     "int32": np.int32,
     "int64": np.int64,
     "default": GLOBAL_NP_FLOAT_PRECISION,
-    # NumPy doesn't have bfloat16 (and does't plan to add). Use float32 as a substitute.
+    # NumPy doesn't have bfloat16 (and does't plan to add)
+    # ml_dtypes is a solution, but it seems not supporting np.save/np.load
+    # hdf5 hasn't supported bfloat16 as well (see https://forum.hdfgroup.org/t/11975)
+    # Use float32 as a substitute.
     "bfloat16": np.float32,
 }
 assert VALID_PRECISION.issubset(PRECISION_DICT.keys())

--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -4,6 +4,7 @@ from abc import (
     abstractmethod,
 )
 
+import ml_dtypes
 import numpy as np
 
 from deepmd.common import (
@@ -27,8 +28,7 @@ PRECISION_DICT = {
     # NumPy doesn't have bfloat16 (and does't plan to add)
     # ml_dtypes is a solution, but it seems not supporting np.save/np.load
     # hdf5 hasn't supported bfloat16 as well (see https://forum.hdfgroup.org/t/11975)
-    # Use float32 as a substitute.
-    "bfloat16": np.float32,
+    "bfloat16": ml_dtypes.bfloat16,
 }
 assert VALID_PRECISION.issubset(PRECISION_DICT.keys())
 
@@ -38,6 +38,7 @@ RESERVED_PRECISON_DICT = {
     np.float64: "float64",
     np.int32: "int32",
     np.int64: "int64",
+    ml_dtypes.bfloat16: "bfloat16",
 }
 assert set(RESERVED_PRECISON_DICT.keys()) == set(PRECISION_DICT.values())
 DEFAULT_PRECISION = "float64"

--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -6,6 +6,9 @@ from abc import (
 
 import numpy as np
 
+from deepmd.common import (
+    VALID_PRECISION,
+)
 from deepmd.env import (
     GLOBAL_ENER_FLOAT_PRECISION,
     GLOBAL_NP_FLOAT_PRECISION,
@@ -21,7 +24,11 @@ PRECISION_DICT = {
     "int32": np.int32,
     "int64": np.int64,
     "default": GLOBAL_NP_FLOAT_PRECISION,
+    # NumPy doesn't have bfloat16 (and does't plan to add). Use float32 as a substitute.
+    "bfloat16": np.float32,
 }
+assert VALID_PRECISION.issubset(PRECISION_DICT.keys())
+
 RESERVED_PRECISON_DICT = {
     np.float16: "float16",
     np.float32: "float32",
@@ -29,6 +36,7 @@ RESERVED_PRECISON_DICT = {
     np.int32: "int32",
     np.int64: "int64",
 }
+assert set(RESERVED_PRECISON_DICT.keys()) == set(PRECISION_DICT.values())
 DEFAULT_PRECISION = "float64"
 
 

--- a/deepmd/pt/model/network/mlp.py
+++ b/deepmd/pt/model/network/mlp.py
@@ -30,6 +30,7 @@ from deepmd.pt.utils.env import (
 )
 from deepmd.pt.utils.utils import (
     ActivationFn,
+    to_numpy_array,
 )
 
 try:
@@ -151,9 +152,9 @@ class MLPLayer(nn.Module):
             precision=self.precision,
         )
         nl.w, nl.b, nl.idt = (
-            self.matrix.detach().cpu().numpy(),
-            self.bias.detach().cpu().numpy() if self.bias is not None else None,
-            self.idt.detach().cpu().numpy() if self.idt is not None else None,
+            to_numpy_array(self.matrix),
+            to_numpy_array(self.bias),
+            to_numpy_array(self.idt),
         )
         return nl.serialize()
 

--- a/deepmd/pt/model/network/mlp.py
+++ b/deepmd/pt/model/network/mlp.py
@@ -31,6 +31,7 @@ from deepmd.pt.utils.env import (
 from deepmd.pt.utils.utils import (
     ActivationFn,
     to_numpy_array,
+    to_torch_tensor,
 )
 
 try:
@@ -181,7 +182,7 @@ class MLPLayer(nn.Module):
 
         def check_load_param(ss):
             return (
-                nn.Parameter(data=torch.tensor(nl[ss], dtype=prec, device=device))
+                nn.Parameter(data=to_torch_tensor(nl[ss]))
                 if nl[ss] is not None
                 else None
             )

--- a/deepmd/pt/utils/env.py
+++ b/deepmd/pt/utils/env.py
@@ -4,6 +4,9 @@ import os
 import numpy as np
 import torch
 
+from deepmd.common import (
+    VALID_PRECISION,
+)
 from deepmd.env import (
     GLOBAL_ENER_FLOAT_PRECISION,
     GLOBAL_NP_FLOAT_PRECISION,
@@ -40,12 +43,14 @@ PRECISION_DICT = {
     "double": torch.float64,
     "int32": torch.int32,
     "int64": torch.int64,
+    "bfloat16": torch.bfloat16,
 }
 GLOBAL_PT_FLOAT_PRECISION = PRECISION_DICT[np.dtype(GLOBAL_NP_FLOAT_PRECISION).name]
 GLOBAL_PT_ENER_FLOAT_PRECISION = PRECISION_DICT[
     np.dtype(GLOBAL_ENER_FLOAT_PRECISION).name
 ]
 PRECISION_DICT["default"] = GLOBAL_PT_FLOAT_PRECISION
+assert VALID_PRECISION.issubset(PRECISION_DICT.keys())
 # cannot automatically generated
 RESERVED_PRECISON_DICT = {
     torch.float16: "float16",
@@ -53,7 +58,9 @@ RESERVED_PRECISON_DICT = {
     torch.float64: "float64",
     torch.int32: "int32",
     torch.int64: "int64",
+    torch.bfloat16: "bfloat16",
 }
+assert set(PRECISION_DICT.values()) == set(RESERVED_PRECISON_DICT.keys())
 DEFAULT_PRECISION = "float64"
 
 # throw warnings if threads not set

--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -88,6 +88,7 @@ def to_numpy_array(
     if prec is None:
         raise ValueError(f"unknown precision {xx.dtype}")
     if xx.dtype == torch.bfloat16:
+        # https://github.com/pytorch/pytorch/issues/109873
         xx = xx.float()
     return xx.detach().cpu().numpy().astype(prec)
 
@@ -116,6 +117,7 @@ def to_torch_tensor(
     if prec is None:
         raise ValueError(f"unknown precision {xx.dtype}")
     if xx.dtype == ml_dtypes.bfloat16:
+        # https://github.com/pytorch/pytorch/issues/109873
         xx = xx.astype(np.float32)
     return torch.tensor(xx, dtype=prec, device=DEVICE)
 

--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -5,6 +5,7 @@ from typing import (
     overload,
 )
 
+import ml_dtypes
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -114,6 +115,8 @@ def to_torch_tensor(
     prec = PT_PRECISION_DICT.get(prec, None)
     if prec is None:
         raise ValueError(f"unknown precision {xx.dtype}")
+    if xx.dtype == ml_dtypes.bfloat16:
+        xx = xx.astype(np.float32)
     return torch.tensor(xx, dtype=prec, device=DEVICE)
 
 

--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn.functional as F
 
 from deepmd.dpmodel.common import PRECISION_DICT as NP_PRECISION_DICT
+from deepmd.dpmodel.common import RESERVED_PRECISON_DICT as NP_RESERVED_PRECISON_DICT
 
 from .env import (
     DEVICE,
@@ -103,7 +104,9 @@ def to_torch_tensor(
         return None
     assert xx is not None
     # Create a reverse mapping of NP_PRECISION_DICT
-    reverse_precision_dict = {v: k for k, v in NP_PRECISION_DICT.items()}
+    # unsafe considering bfloat16:
+    # reverse_precision_dict = {v: k for k, v in NP_PRECISION_DICT.items()}
+    reverse_precision_dict = NP_RESERVED_PRECISON_DICT
     # Use the reverse mapping to find keys with the desired value
     prec = reverse_precision_dict.get(xx.dtype.type, None)
     prec = PT_PRECISION_DICT.get(prec, None)

--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -86,6 +86,8 @@ def to_numpy_array(
     prec = NP_PRECISION_DICT.get(prec, None)
     if prec is None:
         raise ValueError(f"unknown precision {xx.dtype}")
+    if xx.dtype == torch.bfloat16:
+        xx = xx.float()
     return xx.detach().cpu().numpy().astype(prec)
 
 

--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -11,7 +11,6 @@ import torch
 import torch.nn.functional as F
 
 from deepmd.dpmodel.common import PRECISION_DICT as NP_PRECISION_DICT
-from deepmd.dpmodel.common import RESERVED_PRECISON_DICT as NP_RESERVED_PRECISON_DICT
 
 from .env import (
     DEVICE,
@@ -108,9 +107,7 @@ def to_torch_tensor(
         return None
     assert xx is not None
     # Create a reverse mapping of NP_PRECISION_DICT
-    # unsafe considering bfloat16:
-    # reverse_precision_dict = {v: k for k, v in NP_PRECISION_DICT.items()}
-    reverse_precision_dict = NP_RESERVED_PRECISON_DICT
+    reverse_precision_dict = {v: k for k, v in NP_PRECISION_DICT.items()}
     # Use the reverse mapping to find keys with the desired value
     prec = reverse_precision_dict.get(xx.dtype.type, None)
     prec = PT_PRECISION_DICT.get(prec, None)

--- a/deepmd/tf/common.py
+++ b/deepmd/tf/common.py
@@ -18,6 +18,8 @@ from tensorflow.python.framework import (
 )
 
 from deepmd.common import (
+    VALID_ACTIVATION,
+    VALID_PRECISION,
     add_data_requirement,
     data_requirement,
     expand_sys_str,
@@ -69,6 +71,7 @@ PRECISION_DICT = {
     "float64": tf.float64,
     "bfloat16": tf.bfloat16,
 }
+assert VALID_PRECISION.issubset(PRECISION_DICT.keys())
 
 
 def gelu(x: tf.Tensor) -> tf.Tensor:
@@ -138,6 +141,7 @@ ACTIVATION_FN_DICT = {
     "linear": lambda x: x,
     "none": lambda x: x,
 }
+assert VALID_ACTIVATION.issubset(ACTIVATION_FN_DICT.keys())
 
 
 def get_activation_func(

--- a/deepmd/tf/utils/graph.py
+++ b/deepmd/tf/utils/graph.py
@@ -190,11 +190,10 @@ def get_embedding_net_variables_from_graph_def(
     Dict
         The embedding net variables within the given tf.GraphDef object
     """
-    embedding_net_variables = {}
     embedding_net_nodes = get_embedding_net_nodes_from_graph_def(
         graph_def, suffix=suffix
     )
-    return convert_tensor_to_ndarray_in_dict(embedding_net_variables)
+    return convert_tensor_to_ndarray_in_dict(embedding_net_nodes)
 
 
 def get_extra_embedding_net_suffix(type_one_side: bool):

--- a/deepmd/tf/utils/graph.py
+++ b/deepmd/tf/utils/graph.py
@@ -5,6 +5,7 @@ from typing import (
     Tuple,
 )
 
+import ml_dtypes
 import numpy as np
 
 from deepmd.tf.env import (
@@ -117,8 +118,12 @@ def get_tensor_by_type(node, data_type: np.dtype) -> tf.Tensor:
         tensor = np.array(node.double_val)
     elif data_type == np.float32:
         tensor = np.array(node.float_val)
+    elif data_type in (np.float16, ml_dtypes.bfloat16):
+        # https://github.com/tensorflow/tensorflow/blob/4c65498c773375c306640e3ccb80722aef72481a/tensorflow/python/framework/tensor_util.py#L681
+        tensor = np.fromiter(node.half_val, dtype=np.uint16)
+        tensor.dtype = data_type
     else:
-        raise RuntimeError("model compression does not support the half precision")
+        raise RuntimeError("Precision not supported!")
     return tensor
 
 

--- a/deepmd/tf/utils/graph.py
+++ b/deepmd/tf/utils/graph.py
@@ -5,7 +5,6 @@ from typing import (
     Tuple,
 )
 
-import ml_dtypes
 import numpy as np
 
 from deepmd.tf.env import (
@@ -97,34 +96,6 @@ def get_tensor_by_name(model_file: str, tensor_name: str) -> tf.Tensor:
     """
     graph, _ = load_graph_def(model_file)
     return get_tensor_by_name_from_graph(graph, tensor_name)
-
-
-def get_tensor_by_type(node, data_type: np.dtype) -> tf.Tensor:
-    """Get the tensor value within the given node according to the input data_type.
-
-    Parameters
-    ----------
-    node
-        The given tensorflow graph node
-    data_type
-        The data type of the node
-
-    Returns
-    -------
-    tf.Tensor
-        The tensor value of the given node
-    """
-    if data_type == np.float64:
-        tensor = np.array(node.double_val)
-    elif data_type == np.float32:
-        tensor = np.array(node.float_val)
-    elif data_type in (np.float16, ml_dtypes.bfloat16):
-        # https://github.com/tensorflow/tensorflow/blob/4c65498c773375c306640e3ccb80722aef72481a/tensorflow/python/framework/tensor_util.py#L681
-        tensor = np.fromiter(node.half_val, dtype=np.uint16)
-        tensor.dtype = data_type
-    else:
-        raise RuntimeError("Precision not supported!")
-    return tensor
 
 
 def get_pattern_nodes_from_graph_def(graph_def: tf.GraphDef, pattern: str) -> Dict:
@@ -223,18 +194,7 @@ def get_embedding_net_variables_from_graph_def(
     embedding_net_nodes = get_embedding_net_nodes_from_graph_def(
         graph_def, suffix=suffix
     )
-    for item in embedding_net_nodes:
-        node = embedding_net_nodes[item]
-        dtype = tf.as_dtype(node.dtype).as_numpy_dtype
-        tensor_shape = tf.TensorShape(node.tensor_shape).as_list()
-        if (len(tensor_shape) != 1) or (tensor_shape[0] != 1):
-            tensor_value = np.frombuffer(
-                node.tensor_content, dtype=tf.as_dtype(node.dtype).as_numpy_dtype
-            )
-        else:
-            tensor_value = get_tensor_by_type(node, dtype)
-        embedding_net_variables[item] = np.reshape(tensor_value, tensor_shape)
-    return embedding_net_variables
+    return convert_tensor_to_ndarray_in_dict(embedding_net_variables)
 
 
 def get_extra_embedding_net_suffix(type_one_side: bool):
@@ -273,16 +233,7 @@ def get_variables_from_graph_def_as_numpy_array(graph_def: tf.GraphDef, pattern:
         The numpy array of the variable
     """
     node = get_pattern_nodes_from_graph_def(graph_def, pattern)[pattern]
-    dtype = tf.as_dtype(node.dtype).as_numpy_dtype
-    tensor_shape = tf.TensorShape(node.tensor_shape).as_list()
-    if (len(tensor_shape) != 1) or (tensor_shape[0] != 1):
-        tensor_value = np.frombuffer(
-            node.tensor_content,
-            dtype=tf.as_dtype(node.dtype).as_numpy_dtype,
-        )
-    else:
-        tensor_value = get_tensor_by_type(node, dtype)
-    return np.reshape(tensor_value, tensor_shape)
+    return tf.make_ndarray(node)
 
 
 def get_extra_embedding_net_variables_from_graph_def(
@@ -408,20 +359,8 @@ def get_fitting_net_variables_from_graph_def(
     Dict
         The fitting net variables within the given tf.GraphDef object
     """
-    fitting_net_variables = {}
     fitting_net_nodes = get_fitting_net_nodes_from_graph_def(graph_def, suffix=suffix)
-    for item in fitting_net_nodes:
-        node = fitting_net_nodes[item]
-        dtype = tf.as_dtype(node.dtype).as_numpy_dtype
-        tensor_shape = tf.TensorShape(node.tensor_shape).as_list()
-        if (len(tensor_shape) != 1) or (tensor_shape[0] != 1):
-            tensor_value = np.frombuffer(
-                node.tensor_content, dtype=tf.as_dtype(node.dtype).as_numpy_dtype
-            )
-        else:
-            tensor_value = get_tensor_by_type(node, dtype)
-        fitting_net_variables[item] = np.reshape(tensor_value, tensor_shape)
-    return fitting_net_variables
+    return convert_tensor_to_ndarray_in_dict(fitting_net_nodes)
 
 
 def get_fitting_net_variables(model_file: str, suffix: str = "") -> Dict:
@@ -492,22 +431,10 @@ def get_type_embedding_net_variables_from_graph_def(
     Dict
         The embedding net variables within the given tf.GraphDef object
     """
-    type_embedding_net_variables = {}
     type_embedding_net_nodes = get_type_embedding_net_nodes_from_graph_def(
         graph_def, suffix=suffix
     )
-    for item in type_embedding_net_nodes:
-        node = type_embedding_net_nodes[item]
-        dtype = tf.as_dtype(node.dtype).as_numpy_dtype
-        tensor_shape = tf.TensorShape(node.tensor_shape).as_list()
-        if (len(tensor_shape) != 1) or (tensor_shape[0] != 1):
-            tensor_value = np.frombuffer(
-                node.tensor_content, dtype=tf.as_dtype(node.dtype).as_numpy_dtype
-            )
-        else:
-            tensor_value = get_tensor_by_type(node, dtype)
-        type_embedding_net_variables[item] = np.reshape(tensor_value, tensor_shape)
-    return type_embedding_net_variables
+    return convert_tensor_to_ndarray_in_dict(type_embedding_net_nodes)
 
 
 def get_attention_layer_nodes_from_graph_def(
@@ -561,19 +488,27 @@ def get_attention_layer_variables_from_graph_def(
     Dict
         The attention layer variables within the given tf.GraphDef object
     """
-    attention_layer_variables = {}
     attention_layer_net_nodes = get_attention_layer_nodes_from_graph_def(
         graph_def, suffix=suffix
     )
-    for item in attention_layer_net_nodes:
-        node = attention_layer_net_nodes[item]
-        dtype = tf.as_dtype(node.dtype).as_numpy_dtype
-        tensor_shape = tf.TensorShape(node.tensor_shape).as_list()
-        if (len(tensor_shape) != 1) or (tensor_shape[0] != 1):
-            tensor_value = np.frombuffer(
-                node.tensor_content, dtype=tf.as_dtype(node.dtype).as_numpy_dtype
-            )
-        else:
-            tensor_value = get_tensor_by_type(node, dtype)
-        attention_layer_variables[item] = np.reshape(tensor_value, tensor_shape)
-    return attention_layer_variables
+    return convert_tensor_to_ndarray_in_dict(attention_layer_net_nodes)
+
+
+def convert_tensor_to_ndarray_in_dict(
+    tensor_dict: Dict[str, tf.Tensor],
+) -> Dict[str, np.ndarray]:
+    """Convert tensor to ndarray in dict.
+
+    Parameters
+    ----------
+    tensor_dict : Dict[str, tf.Tensor]
+        The input tensor dict
+
+    Returns
+    -------
+    Dict[str, np.ndarray]
+        The converted tensor dict
+    """
+    for key in tensor_dict:
+        tensor_dict[key] = tf.make_ndarray(tensor_dict[key])
+    return tensor_dict

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -14,6 +14,10 @@ from dargs import (
     dargs,
 )
 
+from deepmd.common import (
+    VALID_ACTIVATION,
+    VALID_PRECISION,
+)
 from deepmd.utils.argcheck_nvnmd import (
     nvnmd_args,
 )
@@ -24,26 +28,8 @@ from deepmd.utils.plugin import (
 log = logging.getLogger(__name__)
 
 
-# TODO: import from a module outside tf/pt
-ACTIVATION_FN_DICT = {
-    "relu": None,
-    "relu6": None,
-    "softplus": None,
-    "sigmoid": None,
-    "tanh": None,
-    "gelu": None,
-    "gelu_tf": None,
-    "None": None,
-    "none": None,
-}
-# TODO: import from a module outside tf/pt
-PRECISION_DICT = {
-    "default": None,
-    "float16": None,
-    "float32": None,
-    "float64": None,
-    "bfloat16": None,
-}
+ACTIVATION_FN_DICT = dict.fromkeys(VALID_ACTIVATION)
+PRECISION_DICT = dict.fromkeys(VALID_PRECISION)
 
 doc_only_tf_supported = "(Supported Backend: TensorFlow) "
 doc_only_pt_supported = "(Supported Backend: PyTorch) "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     'h5py',
     'wcmatch',
     'packaging',
+    'ml_dtypes',
 ]
 requires-python = ">=3.8"
 keywords = ["deepmd"]

--- a/source/tests/consistent/fitting/test_ener.py
+++ b/source/tests/consistent/fitting/test_ener.py
@@ -40,7 +40,7 @@ from deepmd.utils.argcheck import (
 
 @parameterized(
     (True, False),  # resnet_dt
-    ("bfloat16",),  # precision
+    ("float64", "float32", "bfloat16"),  # precision
     (True, False),  # mixed_types
     (0, 1),  # numb_fparam
     ([], [-12345.6, None]),  # atom_ener

--- a/source/tests/consistent/fitting/test_ener.py
+++ b/source/tests/consistent/fitting/test_ener.py
@@ -40,7 +40,7 @@ from deepmd.utils.argcheck import (
 
 @parameterized(
     (True, False),  # resnet_dt
-    ("float64", "float32", "bfloat16"),  # precision
+    ("bfloat16",),  # precision
     (True, False),  # mixed_types
     (0, 1),  # numb_fparam
     ([], [-12345.6, None]),  # atom_ener

--- a/source/tests/consistent/fitting/test_ener.py
+++ b/source/tests/consistent/fitting/test_ener.py
@@ -40,7 +40,7 @@ from deepmd.utils.argcheck import (
 
 @parameterized(
     (True, False),  # resnet_dt
-    ("float64", "float32"),  # precision
+    ("float64", "float32", "bfloat16"),  # precision
     (True, False),  # mixed_types
     (0, 1),  # numb_fparam
     ([], [-12345.6, None]),  # atom_ener
@@ -178,6 +178,8 @@ class TestEner(CommonTest, FittingTest, unittest.TestCase):
             return 1e-10
         elif precision == "float32":
             return 1e-4
+        elif precision == "bfloat16":
+            return 1e-1
         else:
             raise ValueError(f"Unknown precision: {precision}")
 
@@ -195,5 +197,7 @@ class TestEner(CommonTest, FittingTest, unittest.TestCase):
             return 1e-10
         elif precision == "float32":
             return 1e-4
+        elif precision == "bfloat16":
+            return 1e-1
         else:
             raise ValueError(f"Unknown precision: {precision}")

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -3,6 +3,9 @@ import unittest
 
 import numpy as np
 
+from deepmd.common import (
+    VALID_ACTIVATION,
+)
 from deepmd.dpmodel.utils.network import get_activation_fn as get_activation_fn_dp
 
 from .common import (
@@ -25,17 +28,7 @@ if INSTALLED_TF:
 
 
 @parameterized(
-    (
-        "Relu",
-        "Relu6",
-        "Softplus",
-        "Sigmoid",
-        "Tanh",
-        "Gelu",
-        "Gelu_tf",
-        "Linear",
-        "None",
-    ),
+    tuple([x.capitalize() for x in VALID_ACTIVATION]),
 )
 class TestActivationFunctionConsistent(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fix #3553.

To support bfloat16,
- DP: As NumPy doesn't plan to support bfloat16, use `ml_dtypes.bfloat16`. The `ml_dtypes` package, developed by Google, is required.
- TF: use `tf.make_ndarray` instead of manually extracting information from a tensor node.
- PT: As ml_dtypes is not supported yet (https://github.com/pytorch/pytorch/issues/109873), use float32 as a bridge.