### PR TITLE
pt: fix typo in multitask finetune

### DIFF
--- a/deepmd/pt/utils/finetune.py
+++ b/deepmd/pt/utils/finetune.py
@@ -146,7 +146,9 @@ def change_finetune_model_params(finetune_model, model_config, model_branch=""):
             model_branch_from=model_branch,
         )
         finetune_links["Default"] = (
-            model_branch if finetune_from_multi_task else "Default"
+            model_config["model_branch_chosen"]
+            if finetune_from_multi_task
+            else "Default"
         )
     else:
         assert model_branch == "", (


### PR DESCRIPTION
fix #3604 , when doing single-task finetuning from multitask pretrained model and do not define the finetune model branch from command-line or input file.