### PR TITLE
pin nvidia-cudnn-cu{11,12} to <9

### DIFF
--- a/backend/dynamic_metadata.py
+++ b/backend/dynamic_metadata.py
@@ -76,7 +76,7 @@ def dynamic_metadata(
                 "nvidia-curand-cu11",
                 "nvidia-cusolver-cu11",
                 "nvidia-cusparse-cu11",
-                "nvidia-cudnn-cu11",
+                "nvidia-cudnn-cu11<9",
                 "nvidia-cuda-nvcc-cu11",
             ],
             "cu12": [
@@ -86,7 +86,7 @@ def dynamic_metadata(
                 "nvidia-curand-cu12",
                 "nvidia-cusolver-cu12",
                 "nvidia-cusparse-cu12",
-                "nvidia-cudnn-cu12",
+                "nvidia-cudnn-cu12<9",
                 "nvidia-cuda-nvcc-cu12",
             ],
             "torch": [


### PR DESCRIPTION
`nvidia-cudnn-cu12` 9.0.0.312 seems broken (and might not be compatible)