### PR TITLE
feat: compute output stat for a dict of labels.

### DIFF
--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -192,10 +192,6 @@ class BaseAtomicModel(BaseAtomicModel_):
 
     def get_forward_wrapper_func(self) -> Callable[..., torch.Tensor]:
         """Get a forward wrapper of the atomic model for output bias calculation."""
-        model_output_type = list(self.atomic_output_def().keys())
-        if "mask" in model_output_type:
-            model_output_type.pop(model_output_type.index("mask"))
-        out_name = model_output_type[0]
 
         def model_forward(coord, atype, box, fparam=None, aparam=None):
             with torch.no_grad():  # it's essential for pure torch forward function to use auto_batchsize
@@ -220,7 +216,7 @@ class BaseAtomicModel(BaseAtomicModel_):
                     fparam=fparam,
                     aparam=aparam,
                 )
-                return atomic_ret[out_name].detach()
+                return {kk: vv.detach() for kk, vv in atomic_ret.items()}
 
         return model_forward
 
@@ -287,14 +283,16 @@ class BaseAtomicModel(BaseAtomicModel_):
             delta_bias = compute_output_stats(
                 merged,
                 self.get_ntypes(),
+                keys=["energy"],
                 model_forward=self.get_forward_wrapper_func(),
-            )
+            )["energy"]
             self.set_out_bias(delta_bias, add=True)
         elif bias_adjust_mode == "set-by-statistic":
             bias_atom = compute_output_stats(
                 merged,
                 self.get_ntypes(),
-            )
+                keys=["energy"],
+            )["energy"]
             self.set_out_bias(bias_atom)
         else:
             raise RuntimeError("Unknown bias_adjust_mode mode: " + bias_adjust_mode)

--- a/deepmd/pt/model/atomic_model/pairtab_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/pairtab_atomic_model.py
@@ -228,8 +228,13 @@ class PairTabAtomicModel(torch.nn.Module, BaseAtomicModel):
 
         """
         bias_atom_e = compute_output_stats(
-            merged, self.ntypes, stat_file_path, self.rcond, self.atom_ener
-        )
+            merged,
+            self.ntypes,
+            keys=["energy"],
+            stat_file_path=stat_file_path,
+            rcond=self.rcond,
+            atom_ener=self.atom_ener,
+        )["energy"]
         self.bias_atom_e.copy_(
             torch.tensor(bias_atom_e, device=env.DEVICE).view([self.ntypes, 1])
         )

--- a/deepmd/pt/model/task/invar_fitting.py
+++ b/deepmd/pt/model/task/invar_fitting.py
@@ -165,8 +165,13 @@ class InvarFitting(GeneralFitting):
 
         """
         bias_atom_e = compute_output_stats(
-            merged, self.ntypes, stat_file_path, self.rcond, self.atom_ener
-        )
+            merged,
+            self.ntypes,
+            keys=["energy"],
+            stat_file_path=stat_file_path,
+            rcond=self.rcond,
+            atom_ener=self.atom_ener,
+        )["energy"]
         self.bias_atom_e.copy_(bias_atom_e.view([self.ntypes, self.dim_out]))
 
     def output_def(self) -> FittingOutputDef:

--- a/deepmd/pt/utils/stat.py
+++ b/deepmd/pt/utils/stat.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import logging
-from pathlib import (
-    Path,
-)
 from typing import (
     Callable,
     List,
@@ -82,32 +79,32 @@ def make_stat_input(datasets, dataloaders, nbatches):
 
 
 def restore_from_file(
-    stat_file_path: Path,
+    stat_file_path: DPPath,
     keys: List[str] = ["energy"],
 ) -> Optional[dict]:
     if stat_file_path is None:
         return None
-    stat_files = [stat_file_path / f"bias_atom_{kk}.npy" for kk in keys]
+    stat_files = [stat_file_path / f"bias_atom_{kk}" for kk in keys]
     if any(not (ii.is_file()) for ii in stat_files):
         return None
     ret = {}
 
     for kk in keys:
-        fp = stat_file_path / f"bias_atom_{kk}.npy"
+        fp = stat_file_path / f"bias_atom_{kk}"
         assert fp.is_file()
-        ret[kk] = np.load(fp)
+        ret[kk] = fp.load_numpy()
     return ret
 
 
 def save_to_file(
-    stat_file_path: Path,
+    stat_file_path: DPPath,
     results: dict,
 ):
     assert stat_file_path is not None
     stat_file_path.mkdir(exist_ok=True, parents=True)
     for kk, vv in results.items():
-        fp = stat_file_path / f"bias_atom_{kk}.npy"
-        np.save(fp, vv)
+        fp = stat_file_path / f"bias_atom_{kk}"
+        fp.save_numpy(vv)
 
 
 def compute_output_stats(

--- a/source/tests/pt/test_stat.py
+++ b/source/tests/pt/test_stat.py
@@ -55,6 +55,9 @@ from deepmd.tf.utils.data_system import (
 from deepmd.utils.data import (
     DataRequirementItem,
 )
+from deepmd.utils.path import (
+    DPPath,
+)
 
 CUR_DIR = os.path.dirname(__file__)
 
@@ -348,12 +351,13 @@ class TestOutputStat(unittest.TestCase):
             self.data.dataloaders,
             nbatches=1,
         )
-        stat_file_path = Path("my_output_stat")
-        stat_file_path.mkdir(exist_ok=True)
+        stat_file_name = "my_output_stat"
+        if os.path.isdir(stat_file_name):
+            shutil.rmtree(stat_file_name)
+        Path(stat_file_name).mkdir(exist_ok=True)
+        stat_file_path = DPPath(stat_file_name, "a")
         atom_ener = np.array([3.0, 5.0]).reshape(2, 1)
 
-        if stat_file_path.is_dir():
-            shutil.rmtree(stat_file_path)
         # compute from sample
         ret0 = compute_output_stats(
             self.sampled,
@@ -394,7 +398,7 @@ class TestOutputStat(unittest.TestCase):
         np.testing.assert_almost_equal(
             to_numpy_array(ret0["energy"]), to_numpy_array(ret1["energy"]), decimal=10
         )
-        shutil.rmtree(stat_file_path)
+        shutil.rmtree(stat_file_name)
 
         # from assigned atom_ener
         ret2 = compute_output_stats(
@@ -408,7 +412,7 @@ class TestOutputStat(unittest.TestCase):
         np.testing.assert_almost_equal(
             to_numpy_array(ret2["energy"]), atom_ener, decimal=10
         )
-        shutil.rmtree(stat_file_path)
+        shutil.rmtree(stat_file_name)
 
 
 if __name__ == "__main__":

--- a/source/tests/pt/test_stat.py
+++ b/source/tests/pt/test_stat.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import json
 import os
+import shutil
 import unittest
 from abc import (
     ABC,
@@ -29,7 +30,14 @@ from deepmd.pt.utils import (
 from deepmd.pt.utils.dataloader import (
     DpLoaderSet,
 )
+from deepmd.pt.utils.stat import (
+    compute_output_stats,
+)
+from deepmd.pt.utils.stat import make_stat_input
 from deepmd.pt.utils.stat import make_stat_input as my_make
+from deepmd.pt.utils.utils import (
+    to_numpy_array,
+)
 from deepmd.tf.common import (
     expand_sys_str,
 )
@@ -323,6 +331,84 @@ class TestDatasetMixed(DatasetTest, unittest.TestCase):
             mixed_type=True,
             real_natoms_vec=real_natoms_vec,
         )
+
+
+class TestOutputStat(unittest.TestCase):
+    def test(self):
+        self.data_file = [str(Path(__file__).parent / "water/data/data_0")]
+        type_map = ["O", "H"]  # by dataset
+        self.data = DpLoaderSet(
+            self.data_file,
+            batch_size=1,
+            type_map=type_map,
+        )
+        self.data.add_data_requirement(energy_data_requirement)
+        self.sampled = make_stat_input(
+            self.data.systems,
+            self.data.dataloaders,
+            nbatches=1,
+        )
+        stat_file_path = Path("my_output_stat")
+        stat_file_path.mkdir(exist_ok=True)
+        atom_ener = np.array([3.0, 5.0]).reshape(2, 1)
+
+        if stat_file_path.is_dir():
+            shutil.rmtree(stat_file_path)
+        # compute from sample
+        ret0 = compute_output_stats(
+            self.sampled,
+            len(type_map),
+            keys=["energy"],
+            stat_file_path=stat_file_path,
+            atom_ener=None,
+            model_forward=None,
+        )
+        # ground truth
+        ntest = 1
+        atom_nums = np.tile(
+            np.bincount(to_numpy_array(self.sampled[0]["atype"][0])),
+            (ntest, 1),
+        )
+        energy_diff = to_numpy_array(self.sampled[0]["energy"][:ntest])
+        ground_truth_shift = np.linalg.lstsq(atom_nums, energy_diff, rcond=None)[0]
+
+        # check values
+        np.testing.assert_almost_equal(
+            to_numpy_array(ret0["energy"]), ground_truth_shift, decimal=10
+        )
+        self.assertTrue(stat_file_path.is_dir())
+
+        def raise_error():
+            raise RuntimeError
+
+        # hack!!!
+        # suppose to load stat from file, if from sample, an error will raise.
+        ret1 = compute_output_stats(
+            raise_error,
+            len(type_map),
+            keys=["energy"],
+            stat_file_path=stat_file_path,
+            atom_ener=None,
+            model_forward=None,
+        )
+        np.testing.assert_almost_equal(
+            to_numpy_array(ret0["energy"]), to_numpy_array(ret1["energy"]), decimal=10
+        )
+        shutil.rmtree(stat_file_path)
+
+        # from assigned atom_ener
+        ret2 = compute_output_stats(
+            self.sampled,
+            len(type_map),
+            keys=["energy"],
+            stat_file_path=stat_file_path,
+            atom_ener=atom_ener,
+            model_forward=None,
+        )
+        np.testing.assert_almost_equal(
+            to_numpy_array(ret2["energy"]), atom_ener, decimal=10
+        )
+        shutil.rmtree(stat_file_path)
 
 
 if __name__ == "__main__":

--- a/source/tests/pt/test_stat.py
+++ b/source/tests/pt/test_stat.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import json
 import os
-import shutil
 import unittest
 from abc import (
     ABC,
@@ -56,7 +55,7 @@ from deepmd.utils.data import (
     DataRequirementItem,
 )
 from deepmd.utils.path import (
-    DPPath,
+    DPH5Path,
 )
 
 CUR_DIR = os.path.dirname(__file__)
@@ -352,10 +351,10 @@ class TestOutputStat(unittest.TestCase):
             nbatches=1,
         )
         stat_file_name = "my_output_stat"
-        if os.path.isdir(stat_file_name):
-            shutil.rmtree(stat_file_name)
-        Path(stat_file_name).mkdir(exist_ok=True)
-        stat_file_path = DPPath(stat_file_name, "a")
+        if os.path.isfile(stat_file_name):
+            os.remove(stat_file_name)
+        # Path(stat_file_name).mkdir(exist_ok=True)
+        stat_file_path = DPH5Path(stat_file_name, "a")
         atom_ener = np.array([3.0, 5.0]).reshape(2, 1)
 
         # compute from sample
@@ -398,7 +397,7 @@ class TestOutputStat(unittest.TestCase):
         np.testing.assert_almost_equal(
             to_numpy_array(ret0["energy"]), to_numpy_array(ret1["energy"]), decimal=10
         )
-        shutil.rmtree(stat_file_name)
+        os.remove(stat_file_name)
 
         # from assigned atom_ener
         ret2 = compute_output_stats(
@@ -412,7 +411,7 @@ class TestOutputStat(unittest.TestCase):
         np.testing.assert_almost_equal(
             to_numpy_array(ret2["energy"]), atom_ener, decimal=10
         )
-        shutil.rmtree(stat_file_name)
+        os.remove(stat_file_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- add UT for it.
- at the moment, only energy is supported in the `base_atomic_model`. handling of multiple output stat will be implemented in a future PR. 