### PR TITLE
fix(tf): make `se_atten_v2` masking smooth when davg is not zero

### DIFF
--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -683,7 +683,7 @@ class DescrptSeAtten(DescrptSeA):
             )
             if self.smooth:
                 inputs_i = tf.where(
-                    tf.cast(mask, tf.bool), inputs_i, self.avg_looked_up
+                    tf.cast(mask, tf.bool), inputs_i, tf.reshape(tf.tile(self.avg_looked_up, [1, 1, 4]), tf.shape(inputs_i))
                 )
             else:
                 inputs_i *= mask

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -681,7 +681,10 @@ class DescrptSeAtten(DescrptSeA):
                 tf.shape(inputs_i)[0],
                 self.nei_type_vec,  # extra input for atten
             )
-            inputs_i *= mask
+            if self.smooth:
+                inputs_i = tf.where(mask, inputs_i, self.avg_looked_up)
+            else:
+                inputs_i *= mask
         if nvnmd_cfg.enable and nvnmd_cfg.quantize_descriptor:
             inputs_i = descrpt2r4(inputs_i, atype)
         layer, qmat = self._filter(

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -686,9 +686,7 @@ class DescrptSeAtten(DescrptSeA):
                     tf.cast(mask, tf.bool),
                     inputs_i,
                     # broadcast is available: (nframes * nloc, 1) -> (nframes * nloc, ndescrpt)
-                    tf.reshape(
-                        self.avg_looked_up, [-1, 1]
-                    ),
+                    tf.reshape(self.avg_looked_up, [-1, 1]),
                 )
             else:
                 inputs_i *= mask

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -685,8 +685,8 @@ class DescrptSeAtten(DescrptSeA):
                 inputs_i = tf.where(
                     tf.cast(mask, tf.bool),
                     inputs_i,
-                    # broadcast is available: (nframes * nloc, 1) -> (nframes * nloc, ndescrpt)
-                    tf.reshape(self.avg_looked_up, [-1, 1]),
+                    # (nframes * nloc, 1) -> (nframes * nloc, ndescrpt)
+                    tf.tile(tf.reshape(self.avg_looked_up, [-1, 1]), [1, self.ndescrpt]),
                 )
             else:
                 inputs_i *= mask

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -683,7 +683,11 @@ class DescrptSeAtten(DescrptSeA):
             )
             if self.smooth:
                 inputs_i = tf.where(
-                    tf.cast(mask, tf.bool), inputs_i, tf.reshape(tf.tile(self.avg_looked_up, [1, 1, 4]), tf.shape(inputs_i))
+                    tf.cast(mask, tf.bool),
+                    inputs_i,
+                    tf.reshape(
+                        tf.tile(self.avg_looked_up, [1, 1, 4]), tf.shape(inputs_i)
+                    ),
                 )
             else:
                 inputs_i *= mask

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -686,7 +686,9 @@ class DescrptSeAtten(DescrptSeA):
                     tf.cast(mask, tf.bool),
                     inputs_i,
                     # (nframes * nloc, 1) -> (nframes * nloc, ndescrpt)
-                    tf.tile(tf.reshape(self.avg_looked_up, [-1, 1]), [1, self.ndescrpt]),
+                    tf.tile(
+                        tf.reshape(self.avg_looked_up, [-1, 1]), [1, self.ndescrpt]
+                    ),
                 )
             else:
                 inputs_i *= mask

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -682,7 +682,9 @@ class DescrptSeAtten(DescrptSeA):
                 self.nei_type_vec,  # extra input for atten
             )
             if self.smooth:
-                inputs_i = tf.where(tf.cast(mask, tf.bool), inputs_i, self.avg_looked_up)
+                inputs_i = tf.where(
+                    tf.cast(mask, tf.bool), inputs_i, self.avg_looked_up
+                )
             else:
                 inputs_i *= mask
         if nvnmd_cfg.enable and nvnmd_cfg.quantize_descriptor:

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -682,7 +682,7 @@ class DescrptSeAtten(DescrptSeA):
                 self.nei_type_vec,  # extra input for atten
             )
             if self.smooth:
-                inputs_i = tf.where(mask, inputs_i, self.avg_looked_up)
+                inputs_i = tf.where(tf.cast(mask, tf.bool), inputs_i, self.avg_looked_up)
             else:
                 inputs_i *= mask
         if nvnmd_cfg.enable and nvnmd_cfg.quantize_descriptor:

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -685,8 +685,9 @@ class DescrptSeAtten(DescrptSeA):
                 inputs_i = tf.where(
                     tf.cast(mask, tf.bool),
                     inputs_i,
+                    # broadcast is available: (nframes * nloc, 1) -> (nframes * nloc, ndescrpt)
                     tf.reshape(
-                        tf.tile(self.avg_looked_up, [1, 1, 4]), tf.shape(inputs_i)
+                        self.avg_looked_up, [-1, 1]
                     ),
                 )
             else:


### PR DESCRIPTION
Currently, `se_atten_v2` is always masked to zero when `exclude_types` is given. However, for the no neighbor case, the placeholder for a virtual neighbor is `davg`. This causes discontinuity when `set_davg_zero` is not set.

This PR uses `davg` for masking.

In production, we usually use `set_davg_zero` along with `exclude_types`, so it hasn't caused a real problem.

I notice PT hasn't implemented `se_atten_v2` or `exclude_types`, but we need attention in the future.