### PR TITLE
compute output stat for atomic model

### DIFF
--- a/deepmd/dpmodel/atomic_model/base_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/base_atomic_model.py
@@ -27,12 +27,18 @@ BaseAtomicModel_ = make_base_atomic_model(np.ndarray)
 class BaseAtomicModel(BaseAtomicModel_):
     def __init__(
         self,
+        type_map: List[str],
         atom_exclude_types: List[int] = [],
         pair_exclude_types: List[Tuple[int, int]] = [],
     ):
         super().__init__()
+        self.type_map = type_map
         self.reinit_atom_exclude(atom_exclude_types)
         self.reinit_pair_exclude(pair_exclude_types)
+
+    def get_type_map(self) -> List[str]:
+        """Get the type map."""
+        return self.type_map
 
     def reinit_atom_exclude(
         self,

--- a/deepmd/dpmodel/atomic_model/dp_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/dp_atomic_model.py
@@ -53,7 +53,7 @@ class DPAtomicModel(BaseAtomicModel):
         self.descriptor = descriptor
         self.fitting = fitting
         self.type_map = type_map
-        super().__init__(**kwargs)
+        super().__init__(type_map, **kwargs)
 
     def fitting_output_def(self) -> FittingOutputDef:
         """Get the output def of the fitting net."""
@@ -66,10 +66,6 @@ class DPAtomicModel(BaseAtomicModel):
     def get_sel(self) -> List[int]:
         """Get the neighbor selection."""
         return self.descriptor.get_sel()
-
-    def get_type_map(self) -> List[str]:
-        """Get the type map."""
-        return self.type_map
 
     def mixed_types(self) -> bool:
         """If true, the model

--- a/deepmd/dpmodel/atomic_model/linear_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/linear_atomic_model.py
@@ -66,7 +66,7 @@ class LinearEnergyAtomicModel(BaseAtomicModel):
             self.mapping_list.append(self.remap_atype(tpmp, self.type_map))
         assert len(err_msg) == 0, "\n".join(err_msg)
         self.mixed_types_list = [model.mixed_types() for model in self.models]
-        super().__init__(**kwargs)
+        super().__init__(type_map, **kwargs)
 
     def mixed_types(self) -> bool:
         """If true, the model

--- a/deepmd/dpmodel/atomic_model/make_base_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/make_base_atomic_model.py
@@ -51,9 +51,6 @@ def make_base_atomic_model(
             """
             return self.fitting_output_def()
 
-        def get_output_keys(self) -> List[str]:
-            return list(self.atomic_output_def().keys())
-
         @abstractmethod
         def get_rcut(self) -> float:
             """Get the cut-off radius."""

--- a/deepmd/dpmodel/atomic_model/pairtab_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/pairtab_atomic_model.py
@@ -61,7 +61,7 @@ class PairTabAtomicModel(BaseAtomicModel):
         type_map: List[str],
         **kwargs,
     ):
-        super().__init__()
+        super().__init__(type_map, **kwargs)
         self.tab_file = tab_file
         self.rcut = rcut
         self.type_map = type_map

--- a/deepmd/dpmodel/atomic_model/pairtab_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/pairtab_atomic_model.py
@@ -59,6 +59,8 @@ class PairTabAtomicModel(BaseAtomicModel):
         rcut: float,
         sel: Union[int, List[int]],
         type_map: List[str],
+        rcond: Optional[float] = None,
+        atom_ener: Optional[List[float]] = None,
         **kwargs,
     ):
         super().__init__(type_map, **kwargs)
@@ -69,6 +71,8 @@ class PairTabAtomicModel(BaseAtomicModel):
         self.tab = PairTab(self.tab_file, rcut=rcut)
         self.type_map = type_map
         self.ntypes = len(type_map)
+        self.rcond = rcond
+        self.atom_ener = atom_ener
 
         if self.tab_file is not None:
             self.tab_info, self.tab_data = self.tab.get()

--- a/deepmd/dpmodel/output_def.py
+++ b/deepmd/dpmodel/output_def.py
@@ -224,6 +224,10 @@ class OutputVariableDef:
             if not self.r_differentiable:
                 raise ValueError("only r_differentiable variable can calculate hessian")
 
+    @property
+    def size(self):
+        return self.output_size
+
 
 class FittingOutputDef:
     """Defines the shapes and other properties of the fitting network outputs.

--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -79,7 +79,7 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
         self.reinit_atom_exclude(atom_exclude_types)
         self.reinit_pair_exclude(pair_exclude_types)
         self.rcond = rcond
-        self.atom_ener = preset_out_bias
+        self.preset_out_bias = preset_out_bias
 
     def init_out_stat(self):
         """Initialize the output bias."""
@@ -235,7 +235,7 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
             fparam=fparam,
             aparam=aparam,
         )
-        ret_dict = self.apply_out_bias(ret_dict, atype)
+        ret_dict = self.apply_out_stat(ret_dict, atype)
 
         # nf x nloc
         atom_mask = ext_atom_mask[:, :nloc].to(torch.int32)
@@ -308,12 +308,12 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
             bias_adjust_mode="set-by-statistic",
         )
 
-    def apply_out_bias(
+    def apply_out_stat(
         self,
         ret: Dict[str, torch.Tensor],
         atype: torch.Tensor,
     ):
-        """Apply the bias to each atomic output.
+        """Apply the stat to each atomic output.
         The developer may override the method to define how the bias is applied
         to the atomic output of the model.
 
@@ -362,7 +362,7 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
                 stat_file_path=stat_file_path,
                 model_forward=self._get_forward_wrapper_func(),
                 rcond=self.rcond,
-                preset_bias=self.atom_ener,
+                preset_bias=self.preset_out_bias,
             )
             # self.set_out_bias(delta_bias, add=True)
             self._store_out_stat(delta_bias, out_std, add=True)
@@ -373,7 +373,7 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
                 keys=list(self.atomic_output_def().keys()),
                 stat_file_path=stat_file_path,
                 rcond=self.rcond,
-                preset_bias=self.atom_ener,
+                preset_bias=self.preset_out_bias,
             )
             # self.set_out_bias(bias_out)
             self._store_out_stat(bias_out, std_out)

--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -45,7 +45,7 @@ BaseAtomicModel_ = make_base_atomic_model(torch.Tensor)
 class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
     def __init__(
         self,
-        type_map,
+        type_map: List[str],
         atom_exclude_types: List[int] = [],
         pair_exclude_types: List[Tuple[int, int]] = [],
     ):

--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -65,14 +65,30 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
             [self.atomic_output_def()[kk].size for kk in self.bias_keys]
         )
         self.n_out = len(self.bias_keys)
-        self.out_bias_data = torch.zeros(
+        out_bias_data = torch.zeros(
             [self.n_out, ntypes, self.max_out_size], dtype=dtype, device=device
         )
-        self.out_std_data = torch.ones(
+        out_std_data = torch.ones(
             [self.n_out, ntypes, self.max_out_size], dtype=dtype, device=device
         )
-        self.register_buffer("out_bias", self.out_bias_data)
-        self.register_buffer("out_std", self.out_std_data)
+        self.register_buffer("out_bias", out_bias_data)
+        self.register_buffer("out_std", out_std_data)
+
+    def __setitem__(self, key, value):
+        if key in ["out_bias"]:
+            self.out_bias = value
+        elif key in ["out_std"]:
+            self.out_std = value
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        if key in ["out_bias"]:
+            return self.out_bias
+        elif key in ["out_std"]:
+            return self.out_std
+        else:
+            raise KeyError(key)
 
     @torch.jit.export
     def get_type_map(self) -> List[str]:

--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -324,7 +324,7 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
                 rcond=self.rcond,
                 atom_ener=self.atom_ener,
             )
-            self.set_out_bias(delta_bias, add=True)
+            # self.set_out_bias(delta_bias, add=True)
             self._store_out_stat(delta_bias, out_std, add=True)
         elif bias_adjust_mode == "set-by-statistic":
             bias_out, std_out = compute_output_stats(
@@ -335,7 +335,7 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
                 rcond=self.rcond,
                 atom_ener=self.atom_ener,
             )
-            self.set_out_bias(bias_out)
+            # self.set_out_bias(bias_out)
             self._store_out_stat(bias_out, std_out)
         else:
             raise RuntimeError("Unknown bias_adjust_mode mode: " + bias_adjust_mode)

--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -353,6 +353,8 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
             'change-by-statistic' : perform predictions on labels of target dataset,
                     and do least square on the errors to obtain the target shift as bias.
             'set-by-statistic' : directly use the statistic output bias in the target dataset.
+        stat_file_path : Optional[DPPath]
+            The path to the stat file.
         """
         if bias_adjust_mode == "change-by-statistic":
             delta_bias, out_std = compute_output_stats(

--- a/deepmd/pt/model/atomic_model/dp_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/dp_atomic_model.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 
 @BaseAtomicModel.register("standard")
-class DPAtomicModel(torch.nn.Module, BaseAtomicModel):
+class DPAtomicModel(BaseAtomicModel):
     """Model give atomic prediction of some physical property.
 
     Parameters
@@ -55,7 +55,7 @@ class DPAtomicModel(torch.nn.Module, BaseAtomicModel):
         type_map: List[str],
         **kwargs,
     ):
-        torch.nn.Module.__init__(self)
+        super().__init__(type_map, **kwargs)
         ntypes = len(type_map)
         self.type_map = type_map
         self.ntypes = ntypes
@@ -63,9 +63,9 @@ class DPAtomicModel(torch.nn.Module, BaseAtomicModel):
         self.rcut = self.descriptor.get_rcut()
         self.sel = self.descriptor.get_sel()
         self.fitting_net = fitting
-        # order matters ntypes and type_map should be initialized first.
-        BaseAtomicModel.__init__(self, **kwargs)
+        super().init_out_stat()
 
+    @torch.jit.export
     def fitting_output_def(self) -> FittingOutputDef:
         """Get the output def of the fitting net."""
         return (
@@ -78,11 +78,6 @@ class DPAtomicModel(torch.nn.Module, BaseAtomicModel):
     def get_rcut(self) -> float:
         """Get the cut-off radius."""
         return self.rcut
-
-    @torch.jit.export
-    def get_type_map(self) -> List[str]:
-        """Get the type map."""
-        return self.type_map
 
     def get_sel(self) -> List[int]:
         """Get the neighbor selection."""

--- a/deepmd/pt/model/atomic_model/dp_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/dp_atomic_model.py
@@ -215,8 +215,7 @@ class DPAtomicModel(BaseAtomicModel):
             return sampled
 
         self.descriptor.compute_input_stats(wrapped_sampler, stat_file_path)
-        if self.fitting_net is not None:
-            self.fitting_net.compute_output_stats(wrapped_sampler, stat_file_path)
+        self.compute_or_load_out_stat(wrapped_sampler, stat_file_path)
 
     def set_out_bias(self, out_bias: torch.Tensor, add=False) -> None:
         """

--- a/deepmd/pt/model/atomic_model/linear_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/linear_atomic_model.py
@@ -39,7 +39,7 @@ from .pairtab_atomic_model import (
 )
 
 
-class LinearEnergyAtomicModel(torch.nn.Module, BaseAtomicModel):
+class LinearEnergyAtomicModel(BaseAtomicModel):
     """Linear model make linear combinations of several existing models.
 
     Parameters
@@ -57,7 +57,8 @@ class LinearEnergyAtomicModel(torch.nn.Module, BaseAtomicModel):
         type_map: List[str],
         **kwargs,
     ):
-        torch.nn.Module.__init__(self)
+        super().__init__(type_map, **kwargs)
+        super().init_out_stat()
         self.models = torch.nn.ModuleList(models)
         sub_model_type_maps = [md.get_type_map() for md in models]
         err_msg = []
@@ -78,7 +79,6 @@ class LinearEnergyAtomicModel(torch.nn.Module, BaseAtomicModel):
             self.get_model_rcuts(), dtype=torch.float64, device=env.DEVICE
         )
         self.nsels = torch.tensor(self.get_model_nsels(), device=env.DEVICE)
-        BaseAtomicModel.__init__(self, **kwargs)
 
     def mixed_types(self) -> bool:
         """If true, the model

--- a/deepmd/pt/model/atomic_model/pairtab_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/pairtab_atomic_model.py
@@ -17,9 +17,6 @@ from deepmd.dpmodel import (
 from deepmd.pt.utils import (
     env,
 )
-from deepmd.pt.utils.stat import (
-    compute_output_stats,
-)
 from deepmd.utils.pair_tab import (
     PairTab,
 )
@@ -227,18 +224,7 @@ class PairTabAtomicModel(BaseAtomicModel):
             The path to the stat file.
 
         """
-        # [0] to get the mean (bias)
-        bias_atom_e = compute_output_stats(
-            merged,
-            self.ntypes,
-            keys=["energy"],
-            stat_file_path=stat_file_path,
-            rcond=self.rcond,
-            atom_ener=self.atom_ener,
-        )[0]["energy"]
-        self.bias_atom_e.copy_(
-            torch.tensor(bias_atom_e, device=env.DEVICE).view([self.ntypes, 1])
-        )
+        self.compute_or_load_out_stat(merged, stat_file_path)
 
     def set_out_bias(self, out_bias: torch.Tensor, add=False) -> None:
         """

--- a/deepmd/pt/model/task/invar_fitting.py
+++ b/deepmd/pt/model/task/invar_fitting.py
@@ -78,8 +78,11 @@ class InvarFitting(GeneralFitting):
         Random seed.
     exclude_types: List[int]
         Atomic contributions of the excluded atom types are set zero.
-    atom_ener: List[float], optional
-        Specifying atomic energy contribution in vacuum. The `set_davg_zero` key in the descrptor should be set.
+    atom_ener: List[Optional[torch.Tensor]], optional
+        Specifying atomic energy contribution in vacuum.
+        The value is a list specifying the bias. the elements can be None or np.array of output shape.
+        For example: [None, [2.]] means type 0 is not set, type 1 is set to [2.]
+        The `set_davg_zero` key in the descrptor should be set.
 
     """
 
@@ -100,7 +103,7 @@ class InvarFitting(GeneralFitting):
         rcond: Optional[float] = None,
         seed: Optional[int] = None,
         exclude_types: List[int] = [],
-        atom_ener: Optional[List[float]] = None,
+        atom_ener: Optional[List[Optional[torch.Tensor]]] = None,
         **kwargs,
     ):
         self.dim_out = dim_out
@@ -171,7 +174,9 @@ class InvarFitting(GeneralFitting):
             keys=[self.var_name],
             stat_file_path=stat_file_path,
             rcond=self.rcond,
-            atom_ener=self.atom_ener,
+            preset_bias={self.var_name: self.atom_ener}
+            if self.atom_ener is not None
+            else None,
         )[0][self.var_name]
         self.bias_atom_e.copy_(bias_atom_e.view([self.ntypes, self.dim_out]))
 

--- a/deepmd/pt/model/task/invar_fitting.py
+++ b/deepmd/pt/model/task/invar_fitting.py
@@ -164,6 +164,7 @@ class InvarFitting(GeneralFitting):
             The path to the stat file.
 
         """
+        # [0] to get the mean (bias)
         bias_atom_e = compute_output_stats(
             merged,
             self.ntypes,
@@ -171,7 +172,7 @@ class InvarFitting(GeneralFitting):
             stat_file_path=stat_file_path,
             rcond=self.rcond,
             atom_ener=self.atom_ener,
-        )[self.var_name]
+        )[0][self.var_name]
         self.bias_atom_e.copy_(bias_atom_e.view([self.ntypes, self.dim_out]))
 
     def output_def(self) -> FittingOutputDef:

--- a/deepmd/pt/utils/stat.py
+++ b/deepmd/pt/utils/stat.py
@@ -83,28 +83,58 @@ def _restore_from_file(
     keys: List[str] = ["energy"],
 ) -> Optional[dict]:
     if stat_file_path is None:
-        return None
+        return None, None
     stat_files = [stat_file_path / f"bias_atom_{kk}" for kk in keys]
-    if any(not (ii.is_file()) for ii in stat_files):
-        return None
-    ret = {}
+    if all(not (ii.is_file()) for ii in stat_files):
+        return None, None
+    stat_files = [stat_file_path / f"std_atom_{kk}" for kk in keys]
+    if all(not (ii.is_file()) for ii in stat_files):
+        return None, None
 
+    ret_bias = {}
+    ret_std = {}
     for kk in keys:
         fp = stat_file_path / f"bias_atom_{kk}"
-        assert fp.is_file()
-        ret[kk] = fp.load_numpy()
-    return ret
+        # only read the key that exists
+        if fp.is_file():
+            ret_bias[kk] = fp.load_numpy()
+    for kk in keys:
+        fp = stat_file_path / f"std_atom_{kk}"
+        # only read the key that exists
+        if fp.is_file():
+            ret_std[kk] = fp.load_numpy()
+    return ret_bias, ret_std
 
 
 def _save_to_file(
     stat_file_path: DPPath,
-    results: dict,
+    bias_out: dict,
+    std_out: dict,
 ):
     assert stat_file_path is not None
     stat_file_path.mkdir(exist_ok=True, parents=True)
-    for kk, vv in results.items():
+    for kk, vv in bias_out.items():
         fp = stat_file_path / f"bias_atom_{kk}"
         fp.save_numpy(vv)
+    for kk, vv in std_out.items():
+        fp = stat_file_path / f"std_atom_{kk}"
+        fp.save_numpy(vv)
+
+
+def _post_process_stat(
+    out_bias,
+    out_std,
+):
+    """Post process the statistics.
+
+    For global statistics, we do not have the std for each type of atoms,
+    thus fake the output std by ones for all the types.
+
+    """
+    new_std = {}
+    for kk, vv in out_bias.items():
+        new_std[kk] = np.ones_like(vv)
+    return out_bias, new_std
 
 
 def _compute_model_predict(
@@ -183,7 +213,7 @@ def compute_output_stats(
         The difference will then be used to calculate the delta complement energy bias for each type.
     """
     # try to restore the bias from stat file
-    bias_atom_e = _restore_from_file(stat_file_path, keys)
+    bias_atom_e, std_atom_e = _restore_from_file(stat_file_path, keys)
 
     # failed to restore the bias from stat file. compute
     if bias_atom_e is None:
@@ -210,6 +240,7 @@ def compute_output_stats(
         merged_output = {kk: to_numpy_array(torch.cat(outputs[kk])) for kk in keys}
         # shape: (nframes, ntypes)
         merged_natoms = to_numpy_array(torch.cat(input_natoms)[:, 2:])
+        nf = merged_natoms.shape[0]
         if atom_ener is not None and len(atom_ener) > 0:
             assigned_atom_ener = np.array(
                 [ee if ee is not None else np.nan for ee in atom_ener]
@@ -224,39 +255,46 @@ def compute_output_stats(
             model_predict = _compute_model_predict(sampled, keys, model_forward)
             stats_input = {kk: merged_output[kk] - model_predict[kk] for kk in keys}
 
-        # [0]: take the first otuput (mean) of compute_stats_from_redu
-        bias_atom_e = {
-            kk: compute_stats_from_redu(
+        bias_atom_e = {}
+        std_atom_e = {}
+        for kk in keys:
+            bias_atom_e[kk], std_atom_e[kk] = compute_stats_from_redu(
                 stats_input[kk],
                 merged_natoms,
                 assigned_bias=assigned_atom_ener,
                 rcond=rcond,
-            )[0]
-            for kk in keys
-        }
+            )
+        bias_atom_e, std_atom_e = _post_process_stat(bias_atom_e, std_atom_e)
 
+        # unbias_e is only used for print rmse
         if model_forward is None:
-            unbias_e = {kk: merged_natoms @ bias_atom_e[kk] for kk in keys}
+            unbias_e = {
+                kk: merged_natoms @ bias_atom_e[kk].reshape(ntypes, -1) for kk in keys
+            }
         else:
             unbias_e = {
-                kk: model_predict[kk] + merged_natoms @ bias_atom_e[kk] for kk in keys
+                kk: model_predict[kk].reshape(ntypes, -1)
+                + merged_natoms @ bias_atom_e[kk].reshape(ntypes, -1)
+                for kk in keys
             }
         atom_numbs = merged_natoms.sum(-1)
+
+        def rmse(x):
+            return np.sqrt(np.mean(np.square(x)))
+
         for kk in keys:
-            rmse_ae = np.sqrt(
-                np.mean(
-                    np.square(
-                        (unbias_e[kk].ravel() - merged_output[kk].ravel()) / atom_numbs
-                    )
-                )
+            rmse_ae = rmse(
+                (unbias_e[kk].reshape(nf, -1) - merged_output[kk].reshape(nf, -1))
+                / atom_numbs[:, None]
             )
             log.info(
                 f"RMSE of {kk} per atom after linear regression is: {rmse_ae} in the unit of {kk}."
             )
 
         if stat_file_path is not None:
-            _save_to_file(stat_file_path, bias_atom_e)
+            _save_to_file(stat_file_path, bias_atom_e, std_atom_e)
 
-    ret = {kk: to_torch_tensor(bias_atom_e[kk]) for kk in keys}
+    ret_bias = {kk: to_torch_tensor(vv) for kk, vv in bias_atom_e.items()}
+    ret_std = {kk: to_torch_tensor(vv) for kk, vv in std_atom_e.items()}
 
-    return ret
+    return ret_bias, ret_std

--- a/deepmd/pt/utils/stat.py
+++ b/deepmd/pt/utils/stat.py
@@ -273,7 +273,7 @@ def compute_output_stats(
             }
         else:
             unbias_e = {
-                kk: model_predict[kk].reshape(ntypes, -1)
+                kk: model_predict[kk].reshape(nf, -1)
                 + merged_natoms @ bias_atom_e[kk].reshape(ntypes, -1)
                 for kk in keys
             }

--- a/deepmd/utils/out_stat.py
+++ b/deepmd/utils/out_stat.py
@@ -27,8 +27,9 @@ def compute_stats_from_redu(
     natoms
         The number of atoms for each atom, shape is [nframes, ntypes].
     assigned_bias
-        The assigned output bias, shape is [ntypes, *(odim0, odim1, ...)]. Set to nan
-        if not assigned.
+        The assigned output bias, shape is [ntypes, *(odim0, odim1, ...)].
+        Set to a tensor of shape (odim0, odim1, ...) filled with nan if the bias
+        of the type is not assigned.
     rcond
         Cut-off ratio for small singular values of a.
 

--- a/source/tests/common/dpmodel/test_dp_atomic_model.py
+++ b/source/tests/common/dpmodel/test_dp_atomic_model.py
@@ -41,7 +41,7 @@ class TestDPAtomicModel(unittest.TestCase, TestCaseSingleFrameWithNlist):
 
         md0 = DPAtomicModel(ds, ft, type_map=type_map)
 
-        self.assertEqual(md0.get_output_keys(), ["energy", "mask"])
+        self.assertEqual(list(md0.atomic_output_def().keys()), ["energy", "mask"])
         self.assertEqual(md0.get_type_map(), ["foo", "bar"])
         self.assertEqual(md0.get_ntypes(), 2)
         self.assertAlmostEqual(md0.get_rcut(), self.rcut)

--- a/source/tests/pt/model/test_atomic_model_stat.py
+++ b/source/tests/pt/model/test_atomic_model_stat.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+import tempfile
+import unittest
+from pathlib import (
+    Path,
+)
+from typing import (
+    Optional,
+)
+
+import h5py
+import numpy as np
+import torch
+
+from deepmd.dpmodel.output_def import (
+    FittingOutputDef,
+    OutputVariableDef,
+)
+from deepmd.pt.model.atomic_model import (
+    BaseAtomicModel,
+    DPAtomicModel,
+)
+from deepmd.pt.model.descriptor.dpa1 import (
+    DescrptDPA1,
+)
+from deepmd.pt.model.task.base_fitting import (
+    BaseFitting,
+)
+from deepmd.pt.utils import (
+    env,
+)
+from deepmd.pt.utils.utils import (
+    to_numpy_array,
+    to_torch_tensor,
+)
+from deepmd.utils.path import (
+    DPPath,
+)
+
+from .test_env_mat import (
+    TestCaseSingleFrameWithNlist,
+)
+
+dtype = env.GLOBAL_PT_FLOAT_PRECISION
+
+
+class FooFitting(torch.nn.Module, BaseFitting):
+    def output_def(self):
+        return FittingOutputDef(
+            [
+                OutputVariableDef(
+                    "foo",
+                    [1],
+                    reduciable=True,
+                    r_differentiable=True,
+                    c_differentiable=True,
+                ),
+                OutputVariableDef(
+                    "pix",
+                    [1],
+                    reduciable=True,
+                    r_differentiable=True,
+                    c_differentiable=True,
+                ),
+                OutputVariableDef(
+                    "bar",
+                    [1, 2],
+                    reduciable=True,
+                    r_differentiable=True,
+                    c_differentiable=True,
+                ),
+            ]
+        )
+
+    def serialize(self) -> dict:
+        raise NotImplementedError
+
+    def forward(
+        self,
+        descriptor: torch.Tensor,
+        atype: torch.Tensor,
+        gr: Optional[torch.Tensor] = None,
+        g2: Optional[torch.Tensor] = None,
+        h2: Optional[torch.Tensor] = None,
+        fparam: Optional[torch.Tensor] = None,
+        aparam: Optional[torch.Tensor] = None,
+    ):
+        nf, nloc, _ = descriptor.shape
+        ret = {}
+        ret["foo"] = (
+            torch.Tensor(
+                [
+                    [1.0, 2.0, 3.0],
+                    [4.0, 5.0, 6.0],
+                ]
+            )
+            .view([nf, nloc] + self.output_def()["foo"].shape)  # noqa: RUF005
+            .to(env.GLOBAL_PT_FLOAT_PRECISION)
+            .to(env.DEVICE)
+        )
+        ret["pix"] = (
+            torch.Tensor(
+                [
+                    [3.0, 2.0, 1.0],
+                    [6.0, 5.0, 4.0],
+                ]
+            )
+            .view([nf, nloc] + self.output_def()["pix"].shape)  # noqa: RUF005
+            .to(env.GLOBAL_PT_FLOAT_PRECISION)
+            .to(env.DEVICE)
+        )
+        ret["bar"] = (
+            torch.Tensor(
+                [
+                    [1.0, 2.0, 3.0, 7.0, 8.0, 9.0],
+                    [4.0, 5.0, 6.0, 10.0, 11.0, 12.0],
+                ]
+            )
+            .view([nf, nloc] + self.output_def()["bar"].shape)  # noqa: RUF005
+            .to(env.GLOBAL_PT_FLOAT_PRECISION)
+            .to(env.DEVICE)
+        )
+        return ret
+
+
+class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def setUp(self):
+        TestCaseSingleFrameWithNlist.setUp(self)
+        nf, nloc, nnei = self.nlist.shape
+        self.merged_output_stat = [
+            {
+                "coord": to_torch_tensor(np.zeros([2, 3, 3])),
+                "atype": to_torch_tensor(
+                    np.array([[0, 0, 1], [0, 1, 1]], dtype=np.int32)
+                ),
+                "atype_ext": to_torch_tensor(
+                    np.array([[0, 0, 1, 0], [0, 1, 1, 0]], dtype=np.int32)
+                ),
+                "box": to_torch_tensor(np.zeros([2, 3, 3])),
+                "natoms": to_torch_tensor(
+                    np.array([[3, 3, 2, 1], [3, 3, 1, 2]], dtype=np.int32)
+                ),
+                # bias of foo: 1, 3
+                "foo": to_torch_tensor(np.array([5.0, 7.0]).reshape(2, 1)),
+                # no bias of pix
+                # bias of bar: [1, 5], [3, 2]
+                "bar": to_torch_tensor(
+                    np.array([5.0, 12.0, 7.0, 9.0]).reshape(2, 1, 2)
+                ),
+            }
+        ]
+        self.tempdir = tempfile.TemporaryDirectory()
+        h5file = str((Path(self.tempdir.name) / "testcase.h5").resolve())
+        with h5py.File(h5file, "w") as f:
+            pass
+        self.stat_file_path = DPPath(h5file, "a")
+
+    def test_output_stat(self):
+        nf, nloc, nnei = self.nlist.shape
+        ds = DescrptDPA1(
+            self.rcut,
+            self.rcut_smth,
+            sum(self.sel),
+            self.nt,
+        ).to(env.DEVICE)
+        ft = FooFitting().to(env.DEVICE)
+        type_map = ["foo", "bar"]
+        md0 = DPAtomicModel(
+            ds,
+            ft,
+            type_map=type_map,
+        ).to(env.DEVICE)
+        args = [
+            to_torch_tensor(ii) for ii in [self.coord_ext, self.atype_ext, self.nlist]
+        ]
+        # nf x nloc
+        at = self.atype_ext[:, :nloc]
+
+        # 1. test run without bias
+        # nf x na x odim
+        ret0 = md0.forward_common_atomic(*args)
+        expected_ret0 = {}
+        expected_ret0["foo"] = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0],
+            ]
+        ).reshape([nf, nloc] + md0.fitting_output_def()["foo"].shape)  # noqa: RUF005
+        expected_ret0["pix"] = np.array(
+            [
+                [3.0, 2.0, 1.0],
+                [6.0, 5.0, 4.0],
+            ]
+        ).reshape([nf, nloc] + md0.fitting_output_def()["pix"].shape)  # noqa: RUF005
+        expected_ret0["bar"] = np.array(
+            [
+                [1.0, 2.0, 3.0, 7.0, 8.0, 9.0],
+                [4.0, 5.0, 6.0, 10.0, 11.0, 12.0],
+            ]
+        ).reshape([nf, nloc] + md0.fitting_output_def()["bar"].shape)  # noqa: RUF005
+        for kk in ["foo", "pix", "bar"]:
+            np.testing.assert_almost_equal(to_numpy_array(ret0[kk]), expected_ret0[kk])
+
+        # 2. test bias is applied
+        md0.compute_or_load_out_stat(
+            self.merged_output_stat, stat_file_path=self.stat_file_path
+        )
+        ret1 = md0.forward_common_atomic(*args)
+        # nt x odim
+        foo_bias = np.array([1.0, 3.0]).reshape(2, 1)
+        bar_bias = np.array([1.0, 5.0, 3.0, 2.0]).reshape(2, 1, 2)
+        expected_ret1 = {}
+        expected_ret1["foo"] = ret0["foo"] + foo_bias[at]
+        expected_ret1["pix"] = ret0["pix"]
+        expected_ret1["bar"] = ret0["bar"] + bar_bias[at]
+        for kk in ["foo", "pix", "bar"]:
+            np.testing.assert_almost_equal(to_numpy_array(ret1[kk]), expected_ret1[kk])
+
+        # 3. test bias load from file
+        def raise_error():
+            raise RuntimeError
+
+        md0.compute_or_load_out_stat(raise_error, stat_file_path=self.stat_file_path)
+        ret2 = md0.forward_common_atomic(*args)
+        for kk in ["foo", "pix", "bar"]:
+            np.testing.assert_almost_equal(to_numpy_array(ret1[kk]), ret2[kk])
+
+        # 4. test change bias
+        BaseAtomicModel.change_out_bias(
+            md0, self.merged_output_stat, bias_adjust_mode="change-by-statistic"
+        )
+        args = [
+            to_torch_tensor(ii)
+            for ii in [
+                self.coord_ext,
+                to_numpy_array(self.merged_output_stat[0]["atype_ext"]),
+                self.nlist,
+            ]
+        ]
+        ret3 = md0.forward_common_atomic(*args)
+        ## model output on foo: [[2, 3, 6], [5, 8, 9]] given bias [1, 3]
+        ## foo sumed: [11, 22] compared with [5, 7], fit target is [-6, -15]
+        ## fit bias is [1, -8]
+        ## old bias + fit bias [2, -5]
+        ## new model output is [[3, 4, -2], [6, 0, 1]], which sumed to [5, 7]
+        expected_ret3 = {}
+        expected_ret3["foo"] = np.array([[3, 4, -2], [6, 0, 1]]).reshape(2, 3, 1)
+        expected_ret3["pix"] = ret0["pix"]
+        for kk in ["foo", "pix"]:
+            np.testing.assert_almost_equal(to_numpy_array(ret3[kk]), expected_ret3[kk])
+        # bar is too complicated to be manually computed.

--- a/source/tests/pt/model/test_atomic_model_stat.py
+++ b/source/tests/pt/model/test_atomic_model_stat.py
@@ -179,9 +179,13 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         # nf x nloc
         at = self.atype_ext[:, :nloc]
 
+        def cvt_ret(x):
+            return {kk: to_numpy_array(vv) for kk, vv in x.items()}
+
         # 1. test run without bias
         # nf x na x odim
         ret0 = md0.forward_common_atomic(*args)
+        ret0 = cvt_ret(ret0)
         expected_ret0 = {}
         expected_ret0["foo"] = np.array(
             [
@@ -202,13 +206,14 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
             ]
         ).reshape([nf, nloc] + md0.fitting_output_def()["bar"].shape)  # noqa: RUF005
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret0[kk]), expected_ret0[kk])
+            np.testing.assert_almost_equal(ret0[kk], expected_ret0[kk])
 
         # 2. test bias is applied
         md0.compute_or_load_out_stat(
             self.merged_output_stat, stat_file_path=self.stat_file_path
         )
         ret1 = md0.forward_common_atomic(*args)
+        ret1 = cvt_ret(ret1)
         # nt x odim
         foo_bias = np.array([1.0, 3.0]).reshape(2, 1)
         bar_bias = np.array([1.0, 5.0, 3.0, 2.0]).reshape(2, 1, 2)
@@ -217,7 +222,7 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         expected_ret1["pix"] = ret0["pix"]
         expected_ret1["bar"] = ret0["bar"] + bar_bias[at]
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret1[kk]), expected_ret1[kk])
+            np.testing.assert_almost_equal(ret1[kk], expected_ret1[kk])
 
         # 3. test bias load from file
         def raise_error():
@@ -225,8 +230,9 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
 
         md0.compute_or_load_out_stat(raise_error, stat_file_path=self.stat_file_path)
         ret2 = md0.forward_common_atomic(*args)
+        ret2 = cvt_ret(ret2)
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret1[kk]), ret2[kk])
+            np.testing.assert_almost_equal(ret1[kk], ret2[kk])
 
         # 4. test change bias
         BaseAtomicModel.change_out_bias(
@@ -241,6 +247,7 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
             ]
         ]
         ret3 = md0.forward_common_atomic(*args)
+        ret3 = cvt_ret(ret3)
         ## model output on foo: [[2, 3, 6], [5, 8, 9]] given bias [1, 3]
         ## foo sumed: [11, 22] compared with [5, 7], fit target is [-6, -15]
         ## fit bias is [1, -8]
@@ -250,7 +257,7 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         expected_ret3["foo"] = np.array([[3, 4, -2], [6, 0, 1]]).reshape(2, 3, 1)
         expected_ret3["pix"] = ret0["pix"]
         for kk in ["foo", "pix"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret3[kk]), expected_ret3[kk])
+            np.testing.assert_almost_equal(ret3[kk], expected_ret3[kk])
         # bar is too complicated to be manually computed.
 
     def test_preset_bias(self):
@@ -280,9 +287,13 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         # nf x nloc
         at = self.atype_ext[:, :nloc]
 
+        def cvt_ret(x):
+            return {kk: to_numpy_array(vv) for kk, vv in x.items()}
+
         # 1. test run without bias
         # nf x na x odim
         ret0 = md0.forward_common_atomic(*args)
+        ret0 = cvt_ret(ret0)
         expected_ret0 = {}
         expected_ret0["foo"] = np.array(
             [
@@ -303,13 +314,14 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
             ]
         ).reshape([nf, nloc] + md0.fitting_output_def()["bar"].shape)  # noqa: RUF005
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret0[kk]), expected_ret0[kk])
+            np.testing.assert_almost_equal(ret0[kk], expected_ret0[kk])
 
         # 2. test bias is applied
         md0.compute_or_load_out_stat(
             self.merged_output_stat, stat_file_path=self.stat_file_path
         )
         ret1 = md0.forward_common_atomic(*args)
+        ret1 = cvt_ret(ret1)
         # foo sums: [5, 7],
         # given bias of type 1 being 2, the bias left for type 0 is [5-2*1, 7-2*2] = [3,3]
         # the solution of type 0 is 1.8
@@ -320,7 +332,7 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         expected_ret1["pix"] = ret0["pix"]
         expected_ret1["bar"] = ret0["bar"] + bar_bias[at]
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret1[kk]), expected_ret1[kk])
+            np.testing.assert_almost_equal(ret1[kk], expected_ret1[kk])
 
         # 3. test bias load from file
         def raise_error():
@@ -328,8 +340,9 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
 
         md0.compute_or_load_out_stat(raise_error, stat_file_path=self.stat_file_path)
         ret2 = md0.forward_common_atomic(*args)
+        ret2 = cvt_ret(ret2)
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret1[kk]), ret2[kk])
+            np.testing.assert_almost_equal(ret1[kk], ret2[kk])
 
         # 4. test change bias
         BaseAtomicModel.change_out_bias(
@@ -344,6 +357,7 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
             ]
         ]
         ret3 = md0.forward_common_atomic(*args)
+        ret3 = cvt_ret(ret3)
         ## model output on foo: [[2.8, 3.8, 5], [5.8, 7., 8.]] given bias [1.8, 2]
         ## foo sumed: [11.6, 20.8] compared with [5, 7], fit target is [-6.6, -13.8]
         ## fit bias is [-7, 2] (2 is assigned. -7 is fit to [-8.6, -17.8])
@@ -355,7 +369,7 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         )
         expected_ret3["pix"] = ret0["pix"]
         for kk in ["foo", "pix"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret3[kk]), expected_ret3[kk])
+            np.testing.assert_almost_equal(ret3[kk], expected_ret3[kk])
         # bar is too complicated to be manually computed.
 
     def test_preset_bias_all_none(self):
@@ -383,9 +397,13 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         # nf x nloc
         at = self.atype_ext[:, :nloc]
 
+        def cvt_ret(x):
+            return {kk: to_numpy_array(vv) for kk, vv in x.items()}
+
         # 1. test run without bias
         # nf x na x odim
         ret0 = md0.forward_common_atomic(*args)
+        ret0 = cvt_ret(ret0)
         expected_ret0 = {}
         expected_ret0["foo"] = np.array(
             [
@@ -406,13 +424,14 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
             ]
         ).reshape([nf, nloc] + md0.fitting_output_def()["bar"].shape)  # noqa: RUF005
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret0[kk]), expected_ret0[kk])
+            np.testing.assert_almost_equal(ret0[kk], expected_ret0[kk])
 
         # 2. test bias is applied
         md0.compute_or_load_out_stat(
             self.merged_output_stat, stat_file_path=self.stat_file_path
         )
         ret1 = md0.forward_common_atomic(*args)
+        ret1 = cvt_ret(ret1)
         # nt x odim
         foo_bias = np.array([1.0, 3.0]).reshape(2, 1)
         bar_bias = np.array([1.0, 5.0, 3.0, 2.0]).reshape(2, 1, 2)
@@ -421,4 +440,4 @@ class TestAtomicModelStat(unittest.TestCase, TestCaseSingleFrameWithNlist):
         expected_ret1["pix"] = ret0["pix"]
         expected_ret1["bar"] = ret0["bar"] + bar_bias[at]
         for kk in ["foo", "pix", "bar"]:
-            np.testing.assert_almost_equal(to_numpy_array(ret1[kk]), expected_ret1[kk])
+            np.testing.assert_almost_equal(ret1[kk], expected_ret1[kk])

--- a/source/tests/pt/test_finetune.py
+++ b/source/tests/pt/test_finetune.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import tempfile
 import unittest
-from copy import (
-    deepcopy,
-)
 from pathlib import (
     Path,
 )
@@ -41,11 +38,9 @@ class FinetuneTest:
     def test_finetune_change_out_bias(self):
         # get model
         model = get_model(self.model_config)
-        fitting_net = model.get_fitting_net()
-        fitting_net["bias_atom_e"] = torch.rand_like(fitting_net["bias_atom_e"])
-        energy_bias_before = deepcopy(
-            to_numpy_array(fitting_net["bias_atom_e"]).reshape(-1)
-        )
+        atomic_model = model.atomic_model
+        atomic_model["out_bias"] = torch.rand_like(atomic_model["out_bias"])
+        energy_bias_before = to_numpy_array(atomic_model["out_bias"])[0].ravel()
 
         # prepare original model for test
         dp = torch.jit.script(model)
@@ -60,9 +55,7 @@ class FinetuneTest:
             self.sampled,
             bias_adjust_mode="change-by-statistic",
         )
-        energy_bias_after = deepcopy(
-            to_numpy_array(fitting_net["bias_atom_e"]).reshape(-1)
-        )
+        energy_bias_after = to_numpy_array(atomic_model["out_bias"])[0].ravel()
 
         # get ground-truth energy bias change
         sorter = np.argsort(full_type_map)

--- a/source/tests/pt/test_multitask.py
+++ b/source/tests/pt/test_multitask.py
@@ -138,7 +138,7 @@ class MultiTaskTrainTest:
                     multi_state_dict[state_key.replace("model_3", "model_2")],
                     multi_state_dict_finetuned[state_key],
                 )
-            elif "model_4" in state_key and "atomic_model" not in state_key:
+            elif "model_4" in state_key and "fitting_net" not in state_key and "out_bias" not in state_key:
                 torch.testing.assert_close(
                     multi_state_dict[state_key.replace("model_4", "model_2")],
                     multi_state_dict_finetuned[state_key],

--- a/source/tests/pt/test_multitask.py
+++ b/source/tests/pt/test_multitask.py
@@ -138,7 +138,11 @@ class MultiTaskTrainTest:
                     multi_state_dict[state_key.replace("model_3", "model_2")],
                     multi_state_dict_finetuned[state_key],
                 )
-            elif "model_4" in state_key and "fitting_net" not in state_key and "out_bias" not in state_key:
+            elif (
+                "model_4" in state_key
+                and "fitting_net" not in state_key
+                and "out_bias" not in state_key
+            ):
                 torch.testing.assert_close(
                     multi_state_dict[state_key.replace("model_4", "model_2")],
                     multi_state_dict_finetuned[state_key],

--- a/source/tests/pt/test_multitask.py
+++ b/source/tests/pt/test_multitask.py
@@ -128,17 +128,17 @@ class MultiTaskTrainTest:
                     multi_state_dict[state_key],
                     multi_state_dict_finetuned[state_key],
                 )
-            elif "model_2" in state_key and "bias_atom_e" not in state_key:
+            elif "model_2" in state_key and "out_bias" not in state_key:
                 torch.testing.assert_close(
                     multi_state_dict[state_key],
                     multi_state_dict_finetuned[state_key],
                 )
-            elif "model_3" in state_key and "bias_atom_e" not in state_key:
+            elif "model_3" in state_key and "out_bias" not in state_key:
                 torch.testing.assert_close(
                     multi_state_dict[state_key.replace("model_3", "model_2")],
                     multi_state_dict_finetuned[state_key],
                 )
-            elif "model_4" in state_key and "fitting_net" not in state_key:
+            elif "model_4" in state_key and "atomic_model" not in state_key:
                 torch.testing.assert_close(
                     multi_state_dict[state_key.replace("model_4", "model_2")],
                     multi_state_dict_finetuned[state_key],

--- a/source/tests/pt/test_stat.py
+++ b/source/tests/pt/test_stat.py
@@ -371,7 +371,7 @@ class TestOutputStat(unittest.TestCase):
             len(type_map),
             keys=["energy"],
             stat_file_path=stat_file_path,
-            atom_ener=None,
+            preset_bias=None,
             model_forward=None,
         )
         # ground truth
@@ -399,7 +399,7 @@ class TestOutputStat(unittest.TestCase):
             len(type_map),
             keys=["energy"],
             stat_file_path=stat_file_path,
-            atom_ener=None,
+            preset_bias=None,
             model_forward=None,
         )
         np.testing.assert_almost_equal(
@@ -407,7 +407,7 @@ class TestOutputStat(unittest.TestCase):
         )
 
     def test_assigned(self):
-        atom_ener = np.array([3.0, 5.0]).reshape(2, 1)
+        atom_ener = {"energy": np.array([3.0, 5.0]).reshape(2, 1)}
         stat_file_path = self.stat_file_path
         type_map = self.type_map
 
@@ -417,11 +417,11 @@ class TestOutputStat(unittest.TestCase):
             len(type_map),
             keys=["energy"],
             stat_file_path=stat_file_path,
-            atom_ener=atom_ener,
+            preset_bias=atom_ener,
             model_forward=None,
         )
         np.testing.assert_almost_equal(
-            to_numpy_array(ret2["energy"]), atom_ener, decimal=10
+            to_numpy_array(ret2["energy"]), atom_ener["energy"], decimal=10
         )
 
 

--- a/source/tests/pt/test_stat.py
+++ b/source/tests/pt/test_stat.py
@@ -366,7 +366,7 @@ class TestOutputStat(unittest.TestCase):
         type_map = self.type_map
 
         # compute from sample
-        ret0 = compute_output_stats(
+        ret0, _ = compute_output_stats(
             self.sampled,
             len(type_map),
             keys=["energy"],
@@ -394,7 +394,7 @@ class TestOutputStat(unittest.TestCase):
 
         # hack!!!
         # suppose to load stat from file, if from sample, an error will raise.
-        ret1 = compute_output_stats(
+        ret1, _ = compute_output_stats(
             raise_error,
             len(type_map),
             keys=["energy"],
@@ -412,7 +412,7 @@ class TestOutputStat(unittest.TestCase):
         type_map = self.type_map
 
         # from assigned atom_ener
-        ret2 = compute_output_stats(
+        ret2, _ = compute_output_stats(
             self.sampled,
             len(type_map),
             keys=["energy"],


### PR DESCRIPTION
This PR:
- breaking change: the base atomic model is now a module. 
  - reason: the out stat is a data attribute of the base atomic model. 
- implement the `compute_or_load_output_stat` for the base atomic model. the method computes both bias and std. 
- the derived atomic models call the `compute_or_load_output_stat`  method for computing output stat. 
- atomic model provides the `apply_out_stat`, the derived class may override the method to define how the statistics is applied to an atomic model's output. @anyangml may need. 
- `out_stat` support statistics of output tensor of any shape. 

@iProzd  please check if i took it correctly in [ce7ec1f](https://github.com/deepmodeling/deepmd-kit/pull/3642/commits/ce7ec1f39be669fcc63a05e9474bc248d9a54d8a)

To be done:
- atomic statistics of the bias and std. @anyangml 
- erialization and deserialization. 

