### PR TITLE
fix: fix git version detection in docker_package_c.sh

### DIFF
--- a/.github/workflows/package_c.yml
+++ b/.github/workflows/package_c.yml
@@ -26,6 +26,8 @@ jobs:
             filename: libdeepmd_c_cu11.tar.gz
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Package C library
         run: ./source/install/docker_package_c.sh
         env:

--- a/source/install/docker_package_c.sh
+++ b/source/install/docker_package_c.sh
@@ -5,6 +5,7 @@ SCRIPT_PATH=$(dirname $(realpath -s $0))
 docker run --rm -v ${SCRIPT_PATH}/../..:/root/deepmd-kit -w /root/deepmd-kit \
 	tensorflow/build:${TENSORFLOW_BUILD_VERSION:-2.15}-python3.11 \
 	/bin/sh -c "pip install \"tensorflow${TENSORFLOW_VERSION}\" cmake \
+            && git config --global --add safe.directory /root/deepmd-kit \
             && cd /root/deepmd-kit/source/install \
             && CC=/dt9/usr/bin/gcc \
                CXX=/dt9/usr/bin/g++ \


### PR DESCRIPTION
Fix the following error in docker_package_c.sh

```
-- Found Git: /usr/bin/git (found version "2.25.1")
fatal: detected dubious ownership in repository at '/root/deepmd-kit'
To add an exception for this directory, call:

	git config --global --add safe.directory /root/deepmd-kit
```

In addition, fetching git tags in actions/checkout.