### PR TITLE
fix(pt): fix model_def_script

### DIFF
--- a/deepmd/pt/model/model/__init__.py
+++ b/deepmd/pt/model/model/__init__.py
@@ -138,6 +138,7 @@ def get_zbl_model(model_params):
 
 
 def get_standard_model(model_params):
+    model_params_old = model_params
     model_params = copy.deepcopy(model_params)
     ntypes = len(model_params["type_map"])
     # descriptor
@@ -167,7 +168,7 @@ def get_standard_model(model_params):
         atom_exclude_types=atom_exclude_types,
         pair_exclude_types=pair_exclude_types,
     )
-    model.model_def_script = json.dumps(model_params)
+    model.model_def_script = json.dumps(model_params_old)
     return model
 
 


### PR DESCRIPTION
When executing

```sh
cd examples/water/se_e2_a
dp --pt train input.json
dp --pt freeze
dp convert-backend fromzen_model.pth frozen_model.pb
dp convert-backend fromzen_model.pb frozen_model.pth
```

An error throws in the last step:

```
TypeError: deepmd.tf.descriptor.descriptor.Descriptor() got multiple values for keyword argument 'ntypes'
```

The reason is that `model_def_script` is modified and further saved

https://github.com/deepmodeling/deepmd-kit/blob/3b230c2cceea40db3b03a017c063e4c7a78bbb6a/deepmd/pt/model/model/__init__.py#L145

