### PR TITLE
docs: fix convert svg error on RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,6 @@ build:
       - pip install uv
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install -r doc/requirements.txt
+  apt_packages:
+    - inkscape
 formats: all


### PR DESCRIPTION
Per https://github.com/readthedocs/readthedocs-docker-images/issues/131#issuecomment-613624239, the solution is to install inkscape in the RTD environment.

See error in the log: https://readthedocs.org/projects/deepmd/builds/24116201/
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/ext/imgconverter.py", line 59, in convert
    subprocess.run(args, stdout=PIPE, stderr=PIPE, check=True)
  File "/home/docs/.asdf/installs/python/3.11.6/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['convert', '/home/docs/checkouts/readthedocs.org/user_builds/deepmd/checkouts/latest/doc/_static/pytorch.svg[0]', '/home/docs/checkouts/readthedocs.org/user_builds/deepmd/checkouts/latest/doc/_build/doctrees/images/pytorch.png']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/cmd/build.py", line 281, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 347, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 307, in build_update
    self.build(['__all__'], to_build)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 376, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/builders/latex/__init__.py", line 285, in write
    doctree = self.assemble_doctree(
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/builders/latex/__init__.py", line 349, in assemble_doctree
    self.env.resolve_references(largetree, indexfile, self)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/environment/__init__.py", line 625, in resolve_references
    self.apply_post_transforms(doctree, fromdocname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/environment/__init__.py", line 637, in apply_post_transforms
    transformer.apply_transforms()
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/transforms/__init__.py", line 80, in apply_transforms
    super().apply_transforms()
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/docutils/transforms/__init__.py", line 171, in apply_transforms
    transform.apply(**kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/transforms/post_transforms/images.py", line 27, in apply
    self.handle(node)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/transforms/post_transforms/images.py", line 244, in handle
    if self.convert(abs_srcpath, destpath):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepmd/envs/latest/lib/python3.11/site-packages/sphinx/ext/imgconverter.py", line 67, in convert
    raise ExtensionError(__('convert exited with error:\n'
sphinx.errors.ExtensionError: convert exited with error:
[stderr]
b"convert-im6.q16: non-conforming drawing primitive definition `l-1.744' @ error/draw.c/TracePath/6288.\nconvert-im6.q16: non-conforming drawing primitive definition `path' @ error/draw.c/RenderMVGContent/4301.\n"
[stdout]
b''

Extension error:
convert exited with error:
[stderr]
b"convert-im6.q16: non-conforming drawing primitive definition `l-1.744' @ error/draw.c/TracePath/6288.\nconvert-im6.q16: non-conforming drawing primitive definition `path' @ error/draw.c/RenderMVGContent/4301.\n"
[stdout]
b''
```