### PR TITLE
docs: fix RTD timeout issue

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,4 +10,5 @@ build:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install -r doc/requirements.txt
   apt_packages:
     - inkscape
-formats: all
+formats:
+  - pdf

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,7 +32,6 @@ project = "DeePMD-kit"
 copyright = "2017-%d, DeepModeling" % date.today().year
 author = "DeepModeling"
 
-extensions = ["autoapi.extension"]
 autoapi_dirs = ["../deepmd"]
 autoapi_add_toctree_entry = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,36 +32,9 @@ project = "DeePMD-kit"
 copyright = "2017-%d, DeepModeling" % date.today().year
 author = "DeepModeling"
 
-
-def run_apidoc(_):
-    import sys
-
-    from sphinx.ext.apidoc import (
-        main,
-    )
-
-    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
-    module = os.path.join(cur_dir, "..")
-    main(
-        [
-            "-M",
-            "--tocfile",
-            "api_py",
-            "-H",
-            "Python API",
-            "-o",
-            os.path.join(cur_dir, "api_py"),
-            module,
-            "source/*",
-            "--force",
-        ]
-    )
-
-
-def setup(app):
-    # Add hook for building doxygen xml when needed
-    app.connect("builder-inited", run_apidoc)
+extensions = ["autoapi.extension"]
+autoapi_dirs = ["../deepmd"]
+autoapi_add_toctree_entry = False
 
 
 # -- General configuration ---------------------------------------------------
@@ -94,6 +67,7 @@ extensions = [
     "exhale",
     "sphinxcontrib.bibtex",
     "sphinx_design",
+    "autoapi.extension",
 ]
 
 # breathe_domain_by_extension = {

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,7 +69,7 @@ DeePMD-kit is a package written in Python/C++, designed to minimize the effort r
    development/type-embedding
    development/coding-conventions
    development/cicd
-   api_py/api_py
+   autoapi/deepmd/index
    api_op
    API_CC/api_cc
    api_c/api_c

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,7 +69,7 @@ DeePMD-kit is a package written in Python/C++, designed to minimize the effort r
    development/type-embedding
    development/coding-conventions
    development/cicd
-   autoapi/deepmd/index
+   Python API <autoapi/deepmd/index>
    api_op
    API_CC/api_cc
    api_c/api_c

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,3 @@
 .[docs,cpu,torch]
-exhale @ https://github.com/svenevs/exhale/archive/2759a394268307b88f5440487ae0920ee4ebf81e.zip
 # https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/309
 docutils!=0.18.*,!=0.19.*

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 .[docs,cpu,torch]
 # https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/309
 docutils!=0.18.*,!=0.19.*
+sphinx>=7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ docs = [
     "sphinx-argparse",
     "pygments-lammps",
     "sphinxcontrib-bibtex",
+    "sphinx-autoapi",
 ]
 lmp = [
     "lammps~=2023.8.2.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ docs = [
     "sphinx-argparse",
     "pygments-lammps",
     "sphinxcontrib-bibtex",
-    "sphinx-autoapi",
+    "sphinx-autoapi>=3.0.0",
 ]
 lmp = [
     "lammps~=2023.8.2.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ docs = [
     "myst-parser>=0.19.2",
     "sphinx-design",
     "breathe",
-    "exhale",
+    "exhale>=0.3.7",
     "numpydoc",
     "ase",
     "deepmodeling-sphinx>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ test = [
 docs = [
     "sphinx>=3.1.1",
     "sphinx_rtd_theme>=1.0.0rc1",
-    "sphinx_markdown_tables",
     "myst-nb>=1.0.0rc0",
     "myst-parser>=0.19.2",
     "sphinx-design",


### PR DESCRIPTION
Currently, the readthedocs build is terminated due to time out after 30 minutes on the devel branch, since it also builds other formats

1. Per https://docs.readthedocs.io/en/stable/guides/build-using-too-many-resources.html#document-python-modules-api-statically, autoapi might be faster.
2. Turn off epub and htmlzip. I don't think some one uses them.

![image](https://github.com/deepmodeling/deepmd-kit/assets/9496702/00274d6d-99c4-41cf-ba02-52cf287ea3a3)
