### PR TITLE
build(tf): remove keras from dependencies

### DIFF
--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -139,10 +139,8 @@ def get_tf_requirement(tf_version: str = "") -> dict:
     if not (tf_version == "" or tf_version in SpecifierSet(">=2.12", prereleases=True)):
         extra_requires.append("protobuf<3.20")
     # keras 3 is not compatible with tf.compat.v1
-    if tf_version == "" or tf_version in SpecifierSet(">=2.15.0rc0", prereleases=True):
-        extra_requires.append("tf-keras; python_version>='3.9'")
-        # only TF>=2.16 is compatible with Python 3.12
-        extra_requires.append("tf-keras>=2.16.0rc0; python_version>='3.12'")
+    # 2024/04/24: deepmd.tf doesn't import tf.keras any more
+
     if tf_version == "" or tf_version in SpecifierSet(">=1.15", prereleases=True):
         extra_select["mpi"] = [
             "horovod",

--- a/deepmd/tf/env.py
+++ b/deepmd/tf/env.py
@@ -77,7 +77,8 @@ if platform.system() == "Linux":
 
 # keras 3 is incompatible with tf.compat.v1
 # https://keras.io/getting_started/#tensorflow--keras-2-backwards-compatibility
-os.environ["TF_USE_LEGACY_KERAS"] = "1"
+# 2024/04/24: deepmd.tf doesn't import tf.keras any more
+
 # import tensorflow v1 compatability
 try:
     import tensorflow.compat.v1 as tf


### PR DESCRIPTION
After #3696, we don't need keras anymore.