### PR TITLE
ci(test): split each pytest job into 6 separated jobs

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -47,17 +47,17 @@ jobs:
         # the key must never match, even when restarting workflows, as that
         # will cause durations to get out of sync between groups, the
         # combined durations will be loaded if available
-        key: test-durations-split-${{ github.run_id }}-${{ github.run_number}}-${{ matrix.group }}
+        key: test-durations-split-${{ github.run_id }}-${{ github.run_number}}-${{ matrix.python }}-${{ matrix.group }}
         restore-keys: |
-          test-durations-combined-${{ github.sha }}
-          test-durations-combined
+          test-durations-combined-${{ matrix.python }}-${{ github.sha }}
+          test-durations-combined-${{ matrix.python }}
     - run: pytest --cov=deepmd source/tests --durations=0 --splits 6 --group ${{ matrix.group }} --store-durations --durations-path=.test_durations_${{ matrix.group }}
       env:
         NUM_WORKERS: 0
     - name: Upload partial durations
       uses: actions/upload-artifact@v4
       with:
-        name: split-${{ matrix.group }}
+        name: split-${{ matrix.python }}-${{ matrix.group }}
         path: .test_durations_${{ matrix.group }}
     - uses: codecov/codecov-action@v4
       env:
@@ -65,6 +65,9 @@ jobs:
   update_durations:
     name: Combine and update integration test durations
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python: ["3.8", "3.11"]
     needs: testpython
     steps:
     - name: Get durations from cache
@@ -74,12 +77,12 @@ jobs:
         # key won't match during the first run for the given commit, but
         # restore-key will if there's a previous stored durations file,
         # so cache will both be loaded and stored
-        key: test-durations-combined-${{ github.sha }}
-        restore-keys: test-durations-combined
+        key: test-durations-combined-${{ matrix.python }}-${{ github.sha }}
+        restore-keys: test-durations-combined-${{ matrix.python }}
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: split-*
+        pattern: split-${{ matrix.python }}-*
         merge-multiple: true
     - name: Combine test durations
       run: jq '. + input' .test_durations_* > .test_durations

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -14,13 +14,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        include:
-          - python: 3.8
-            tf:
-            torch:
-          - python: "3.11"
-            tf:
-            torch:
+        group: [1, 2, 3, 4, 5, 6]
+        python: ["3.8", "3.11"]
 
     steps:
     - uses: actions/checkout@v4
@@ -45,15 +40,52 @@ jobs:
         HOROVOD_WITHOUT_PYTORCH: 1
         HOROVOD_WITHOUT_GLOO: 1
     - run: dp --version
-    - run: pytest --cov=deepmd source/tests --durations=0
+    - name: Get durations from cache
+      uses: actions/cache@v4
+      with:
+        path: test_durations
+        # the key must never match, even when restarting workflows, as that
+        # will cause durations to get out of sync between groups, the
+        # combined durations will be loaded if available
+        key: test-durations-split-${{ github.run_id }}-${{ github.run_number}}-${{ matrix.group }}
+        restore-keys: |
+          test-durations-combined-${{ github.sha }}
+          test-durations-combined
+    - run: pytest --cov=deepmd source/tests --durations=0 --splits 6 --group ${{ matrix.group }} --store-durations --durations-path=.test_durations_${{ matrix.group }}
       env:
         NUM_WORKERS: 0
+    - name: Upload partial durations
+      uses: actions/upload-artifact@v4
+      with:
+        name: split-${{ matrix.group }}
+        path: .test_durations_${{ matrix.group }}
     - uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  update_durations:
+    name: Combine and update integration test durations
+    runs-on: ubuntu-22.04
+    needs: testpython
+    steps:
+    - name: Get durations from cache
+      uses: actions/cache@v4
+      with:
+        path: .test_durations
+        # key won't match during the first run for the given commit, but
+        # restore-key will if there's a previous stored durations file,
+        # so cache will both be loaded and stored
+        key: test-durations-combined-${{ github.sha }}
+        restore-keys: test-durations-combined
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: split-*
+        merge-multiple: true
+    - name: Combine test durations
+      run: jq '. + input' .test_durations_* > .test_durations
   pass:
     name: Pass testing Python
-    needs: [testpython]
+    needs: [testpython, update_durations]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -51,7 +51,7 @@ jobs:
         restore-keys: |
           test-durations-combined-${{ matrix.python }}-${{ github.sha }}
           test-durations-combined-${{ matrix.python }}
-    - run: pytest --cov=deepmd source/tests --durations=0 --splits 6 --group ${{ matrix.group }} --store-durations --durations-path=.test_durations_${{ matrix.group }}
+    - run: pytest --cov=deepmd source/tests --durations=0 --splits 6 --group ${{ matrix.group }} --store-durations --durations-path=.test_durations_${{ matrix.group }} --splitting-algorithm least_duration
       env:
         NUM_WORKERS: 0
     - name: Upload partial durations

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -13,6 +13,7 @@ jobs:
     name: Test Python
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5, 6]
         python: ["3.8", "3.11"]
@@ -66,6 +67,7 @@ jobs:
     name: Combine and update integration test durations
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.8", "3.11"]
     needs: testpython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-sugar",
+    "pytest-split",
     "dpgui",
     "mendeleev",
 ]

--- a/source/tests/tf/test_nvnmd_entrypoints.py
+++ b/source/tests/tf/test_nvnmd_entrypoints.py
@@ -847,8 +847,8 @@ class TestNvnmdEntrypointsV1(tf.test.TestCase):
 
     @pytest.mark.run(order=2)
     def test_wrap_qnn_v1(self):
-        # without calling test_model_qnn_v1, this test will fail when running individually
-        self.test_model_qnn_v1()
+        # without calling test_mapt_cnn_v1, this test will fail when running individually
+        self.test_mapt_cnn_v1()
 
         tf.reset_default_graph()
         jdata = {}

--- a/source/tests/tf/test_nvnmd_entrypoints.py
+++ b/source/tests/tf/test_nvnmd_entrypoints.py
@@ -847,6 +847,9 @@ class TestNvnmdEntrypointsV1(tf.test.TestCase):
 
     @pytest.mark.run(order=2)
     def test_wrap_qnn_v1(self):
+        # without calling test_model_qnn_v1, this test will fail when running individually
+        self.test_model_qnn_v1()
+
         tf.reset_default_graph()
         jdata = {}
         jdata["nvnmd_config"] = str(tests_path / "nvnmd" / "ref" / "config_v1_cnn.npy")

--- a/source/tests/tf/test_nvnmd_entrypoints.py
+++ b/source/tests/tf/test_nvnmd_entrypoints.py
@@ -391,8 +391,6 @@ class TestNvnmdEntrypointsV0(tf.test.TestCase):
             2.24079704,
         ]
         np.testing.assert_almost_equal(pred, ref_dout, 8)
-        # close
-        nvnmd_cfg.enable = False
 
     @pytest.mark.run(order=1)
     def test_model_qnn_v0(self):
@@ -510,6 +508,8 @@ class TestNvnmdEntrypointsV0(tf.test.TestCase):
         pred = valuedic["o_energy"]
         ref_dout = -62.60181403
         np.testing.assert_almost_equal(pred, ref_dout, 8)
+
+    def tearDown(self):
         # close
         nvnmd_cfg.enable = False
 
@@ -700,8 +700,6 @@ class TestNvnmdEntrypointsV1(tf.test.TestCase):
             3.24079514,
         ]
         np.testing.assert_almost_equal(pred, ref_dout, 8)
-        # close
-        nvnmd_cfg.enable = False
 
     @pytest.mark.run(order=1)
     def test_model_qnn_v1(self):
@@ -846,8 +844,6 @@ class TestNvnmdEntrypointsV1(tf.test.TestCase):
             pred = d2[key]
             ref_dout = d1[key]
             np.testing.assert_almost_equal(pred, ref_dout, 8)
-        # close
-        nvnmd_cfg.enable = False
 
     @pytest.mark.run(order=2)
     def test_wrap_qnn_v1(self):
@@ -865,6 +861,8 @@ class TestNvnmdEntrypointsV1(tf.test.TestCase):
         pred = [data[i] for i in idx]
         red_dout = [249, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 95, 24, 176]
         np.testing.assert_equal(pred, red_dout)
+
+    def tearDown(self):
         # close
         nvnmd_cfg.enable = False
 


### PR DESCRIPTION
Split each pytest job into 6 separated jobs in GHA.

Currently, each separated job takes:
- ~2.5 min for installation, which may need to be optimized in the future;
- ~2 min for setup, which may be a defect and should be resolved in #3715;
-  4~5 min for tests (expected).