### PR TITLE
Clarifiy se_atten_v2 compression doc

### DIFF
--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -424,7 +424,7 @@ def descrpt_se_atten_common_args():
         + "The excluded pairs of types which have no interaction with each other. For example, `[[0, 1]]` means no interaction between type 0 and type 1."
     )
     doc_attn = "The length of hidden vectors in attention layers"
-    doc_attn_layer = "The number of attention layers. Note that model compression of `se_atten` is only enabled when attn_layer==0 and stripped_type_embedding is True"
+    doc_attn_layer = "The number of attention layers."
     doc_attn_dotr = "Whether to do dot product with the normalized relative coordinates"
     doc_attn_mask = "Whether to do mask on the diagonal in the attention matrix"
 

--- a/doc/freeze/compress.md
+++ b/doc/freeze/compress.md
@@ -152,6 +152,8 @@ The model compression interface requires the version of DeePMD-kit used in the o
 
 Descriptors with `se_e2_a`, `se_e3`, `se_e2_r` and `se_atten_v2` types are supported by the model compression feature. `Hybrid` mixed with the above descriptors is also supported.
 
+Notice: Model compression for the `se_atten_v2` descriptor is exclusively designed for models with the training parameter `attn_layer` set to 0.
+
 **Available activation functions for descriptor:**
 
 - tanh

--- a/doc/freeze/compress.md
+++ b/doc/freeze/compress.md
@@ -152,7 +152,7 @@ The model compression interface requires the version of DeePMD-kit used in the o
 
 Descriptors with `se_e2_a`, `se_e3`, `se_e2_r` and `se_atten_v2` types are supported by the model compression feature. `Hybrid` mixed with the above descriptors is also supported.
 
-Notice: Model compression for the `se_atten_v2` descriptor is exclusively designed for models with the training parameter `attn_layer` set to 0.
+Notice: Model compression for the `se_atten_v2` descriptor is exclusively designed for models with the training parameter {ref}`attn_layer <model/descriptor[se_atten_v2]/attn_layer>` set to 0.
 
 **Available activation functions for descriptor:**
 

--- a/doc/model/train-se-atten.md
+++ b/doc/model/train-se-atten.md
@@ -163,6 +163,8 @@ We highly recommend using the version 2.0 of the attention-based descriptor `"se
 
 Practical evidence demonstrates that `"se_atten_v2"` offers better and more stable performance compared to `"se_atten"`.
 
+Notice: Model compression for the `se_atten_v2` descriptor is exclusively designed for models with the training parameter `attn_layer` set to 0.
+
 ### Fitting `"ener"`
 
 DPA-1 only supports `"ener"` fitting type, and you can refer [here](train-energy.md) for detailed information.

--- a/doc/model/train-se-atten.md
+++ b/doc/model/train-se-atten.md
@@ -163,7 +163,7 @@ We highly recommend using the version 2.0 of the attention-based descriptor `"se
 
 Practical evidence demonstrates that `"se_atten_v2"` offers better and more stable performance compared to `"se_atten"`.
 
-Notice: Model compression for the `se_atten_v2` descriptor is exclusively designed for models with the training parameter `attn_layer` set to 0.
+Notice: Model compression for the `se_atten_v2` descriptor is exclusively designed for models with the training parameter {ref}`attn_layer <model/descriptor[se_atten_v2]/attn_layer>` set to 0.
 
 ### Fitting `"ener"`
 


### PR DESCRIPTION
https://github.com/deepmodeling/deepmd-kit/issues/3643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Simplified the description for the number of attention layers in the code documentation.
	- Added a notice about model compression compatibility for `se_atten_v2` descriptor in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->