### PR TITLE
feat(C): add preprocessor define for C API version

### DIFF
--- a/source/api_c/include/c_api.h
+++ b/source/api_c/include/c_api.h
@@ -7,6 +7,13 @@ extern "C" {
 #include <stdbool.h>
 #endif
 
+/** @file */
+
+/** C API version. Bumped whenever the API is changed.
+ * @since API version 22
+ */
+#define DP_C_API_VERSION 22
+
 /**
  * @brief Neighbor list.
  */


### PR DESCRIPTION
It will be helpful for the downstream program to require a minimal version of the C API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the C API version to 22 in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->