### PR TITLE
Replacing long int type with int64_t

### DIFF
--- a/source/api_cc/src/DeepPotPT.cc
+++ b/source/api_cc/src/DeepPotPT.cc
@@ -2,9 +2,13 @@
 #ifdef BUILD_PYTORCH
 #include "DeepPotPT.h"
 
+#include <cstdint>
+
 #include "common.h"
 #include "device.h"
+
 using namespace deepmd;
+
 torch::Tensor createNlistTensor(const std::vector<std::vector<int>>& data) {
   std::vector<torch::Tensor> row_tensors;
 
@@ -155,7 +159,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
   at::Tensor coord_wrapped_Tensor =
       torch::from_blob(coord_wrapped.data(), {1, nall_real, 3}, options)
           .to(device);
-  std::vector<int64_t> atype_64(datype.begin(), datype.end());
+  std::vector<std::int64_t> atype_64(datype.begin(), datype.end());
   at::Tensor atype_Tensor =
       torch::from_blob(atype_64.data(), {1, nall_real}, int_option).to(device);
   if (ago == 0) {
@@ -199,16 +203,17 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
   if (!fparam.empty()) {
     fparam_tensor =
         torch::from_blob(const_cast<VALUETYPE*>(fparam.data()),
-                         {1, static_cast<int64_t>(fparam.size())}, options)
+                         {1, static_cast<std::int64_t>(fparam.size())}, options)
             .to(device);
   }
   c10::optional<torch::Tensor> aparam_tensor;
   if (!aparam_.empty()) {
     aparam_tensor =
-        torch::from_blob(const_cast<VALUETYPE*>(aparam_.data()),
-                         {1, lmp_list.inum,
-                          static_cast<int64_t>(aparam_.size()) / lmp_list.inum},
-                         options)
+        torch::from_blob(
+            const_cast<VALUETYPE*>(aparam_.data()),
+            {1, lmp_list.inum,
+             static_cast<std::int64_t>(aparam_.size()) / lmp_list.inum},
+            options)
             .to(device);
   }
   c10::Dict<c10::IValue, c10::IValue> outputs =
@@ -340,7 +345,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
       torch::from_blob(coord_wrapped.data(), {1, natoms, 3}, options)
           .to(device);
   inputs.push_back(coord_wrapped_Tensor);
-  std::vector<int64_t> atype_64(atype.begin(), atype.end());
+  std::vector<std::int64_t> atype_64(atype.begin(), atype.end());
   at::Tensor atype_Tensor =
       torch::from_blob(atype_64.data(), {1, natoms}, int_options).to(device);
   inputs.push_back(atype_Tensor);
@@ -355,7 +360,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
   if (!fparam.empty()) {
     fparam_tensor =
         torch::from_blob(const_cast<VALUETYPE*>(fparam.data()),
-                         {1, static_cast<int64_t>(fparam.size())}, options)
+                         {1, static_cast<std::int64_t>(fparam.size())}, options)
             .to(device);
   }
   inputs.push_back(fparam_tensor);
@@ -364,7 +369,8 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
     aparam_tensor =
         torch::from_blob(
             const_cast<VALUETYPE*>(aparam.data()),
-            {1, natoms, static_cast<int64_t>(aparam.size()) / natoms}, options)
+            {1, natoms, static_cast<std::int64_t>(aparam.size()) / natoms},
+            options)
             .to(device);
   }
   inputs.push_back(aparam_tensor);

--- a/source/api_cc/src/DeepPotPT.cc
+++ b/source/api_cc/src/DeepPotPT.cc
@@ -199,7 +199,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
   if (!fparam.empty()) {
     fparam_tensor =
         torch::from_blob(const_cast<VALUETYPE*>(fparam.data()),
-                         {1, static_cast<long int>(fparam.size())}, options)
+                         {1, static_cast<int64_t>(fparam.size())}, options)
             .to(device);
   }
   c10::optional<torch::Tensor> aparam_tensor;
@@ -207,7 +207,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
     aparam_tensor = torch::from_blob(
                         const_cast<VALUETYPE*>(aparam_.data()),
                         {1, lmp_list.inum,
-                         static_cast<long int>(aparam_.size()) / lmp_list.inum},
+                         static_cast<int64_t>(aparam_.size()) / lmp_list.inum},
                         options)
                         .to(device);
   }
@@ -355,7 +355,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
   if (!fparam.empty()) {
     fparam_tensor =
         torch::from_blob(const_cast<VALUETYPE*>(fparam.data()),
-                         {1, static_cast<long int>(fparam.size())}, options)
+                         {1, static_cast<int64_t>(fparam.size())}, options)
             .to(device);
   }
   inputs.push_back(fparam_tensor);
@@ -364,7 +364,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
     aparam_tensor =
         torch::from_blob(
             const_cast<VALUETYPE*>(aparam.data()),
-            {1, natoms, static_cast<long int>(aparam.size()) / natoms}, options)
+            {1, natoms, static_cast<int64_t>(aparam.size()) / natoms}, options)
             .to(device);
   }
   inputs.push_back(aparam_tensor);

--- a/source/api_cc/src/DeepPotPT.cc
+++ b/source/api_cc/src/DeepPotPT.cc
@@ -204,12 +204,12 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
   }
   c10::optional<torch::Tensor> aparam_tensor;
   if (!aparam_.empty()) {
-    aparam_tensor = torch::from_blob(
-                        const_cast<VALUETYPE*>(aparam_.data()),
-                        {1, lmp_list.inum,
-                         static_cast<int64_t>(aparam_.size()) / lmp_list.inum},
-                        options)
-                        .to(device);
+    aparam_tensor =
+        torch::from_blob(const_cast<VALUETYPE*>(aparam_.data()),
+                         {1, lmp_list.inum,
+                          static_cast<int64_t>(aparam_.size()) / lmp_list.inum},
+                         options)
+            .to(device);
   }
   c10::Dict<c10::IValue, c10::IValue> outputs =
       (do_message_passing == 1)

--- a/source/api_cc/src/DeepPotTF.cc
+++ b/source/api_cc/src/DeepPotTF.cc
@@ -2,6 +2,7 @@
 #ifdef BUILD_TENSORFLOW
 #include "DeepPotTF.h"
 
+#include <cstdint>
 #include <stdexcept>
 
 #include "AtomMap.h"
@@ -549,7 +550,7 @@ void DeepPotTF::tile_fparam_aparam(std::vector<VALUETYPE>& out_param,
     out_param.resize(static_cast<size_t>(nframes) * dparam);
     for (int ii = 0; ii < nframes; ++ii) {
       std::copy(param.begin(), param.end(),
-                out_param.begin() + static_cast<uint64_t>(ii) * dparam);
+                out_param.begin() + static_cast<std::uint64_t>(ii) * dparam);
     }
   } else if (param.size() == static_cast<size_t>(nframes) * dparam) {
     out_param = param;

--- a/source/api_cc/src/DeepPotTF.cc
+++ b/source/api_cc/src/DeepPotTF.cc
@@ -549,7 +549,7 @@ void DeepPotTF::tile_fparam_aparam(std::vector<VALUETYPE>& out_param,
     out_param.resize(static_cast<size_t>(nframes) * dparam);
     for (int ii = 0; ii < nframes; ++ii) {
       std::copy(param.begin(), param.end(),
-                out_param.begin() + static_cast<unsigned long>(ii) * dparam);
+                out_param.begin() + static_cast<uint64_t>(ii) * dparam);
     }
   } else if (param.size() == static_cast<size_t>(nframes) * dparam) {
     out_param = param;

--- a/source/op/pt/comm.cc
+++ b/source/op/pt/comm.cc
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
-#include "device.h"
-#endif
-#include <torch/torch.h>
+
 #ifdef USE_MPI
 #include <mpi.h>
 #ifdef OMPI_MPI_H
 #include <mpi-ext.h>
 #endif
+#include <torch/torch.h>
+
+#include <cstdint>
+
+#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
+#include "device.h"
+#endif
+
 template <typename T>
 static MPI_Datatype get_mpi_type();
 
@@ -321,9 +326,9 @@ class Border : public torch::autograd::Function<Border> {
   static void unpack_communicator(const torch::Tensor& communicator_tensor,
                                   MPI_Comm& mpi_comm) {
 #ifdef OMPI_MPI_H
-    int64_t* communicator = communicator_tensor.data_ptr<int64_t>();
+    std::int64_t* communicator = communicator_tensor.data_ptr<std::int64_t>();
 #else
-    int64_t* ptr = communicator_tensor.data_ptr<int64_t>();
+    std::int64_t* ptr = communicator_tensor.data_ptr<std::int64_t>();
     int* communicator = reinterpret_cast<int*>(ptr);
 #endif
     mpi_comm = reinterpret_cast<MPI_Comm>(*communicator);

--- a/source/op/pt/comm.cc
+++ b/source/op/pt/comm.cc
@@ -321,9 +321,9 @@ class Border : public torch::autograd::Function<Border> {
   static void unpack_communicator(const torch::Tensor& communicator_tensor,
                                   MPI_Comm& mpi_comm) {
 #ifdef OMPI_MPI_H
-    long int* communicator = communicator_tensor.data_ptr<long int>();
+    int64_t* communicator = communicator_tensor.data_ptr<int64_t>();
 #else
-    long int* ptr = communicator_tensor.data_ptr<long int>();
+    int64_t* ptr = communicator_tensor.data_ptr<int64_t>();
     int* communicator = reinterpret_cast<int*>(ptr);
 #endif
     mpi_comm = reinterpret_cast<MPI_Comm>(*communicator);

--- a/source/op/pt/comm.cc
+++ b/source/op/pt/comm.cc
@@ -5,6 +5,7 @@
 #ifdef OMPI_MPI_H
 #include <mpi-ext.h>
 #endif
+#endif
 #include <torch/torch.h>
 
 #include <cstdint>
@@ -13,6 +14,7 @@
 #include "device.h"
 #endif
 
+#ifdef USE_MPI
 template <typename T>
 static MPI_Datatype get_mpi_type();
 
@@ -26,6 +28,7 @@ MPI_Datatype get_mpi_type<double>() {
   return MPI_DOUBLE;
 }
 #endif
+
 class Border : public torch::autograd::Function<Border> {
  public:
   static torch::autograd::variable_list forward(


### PR DESCRIPTION
Following the discussion in #3657 this pull request addresses the usage of `long` or `long int` by replacing them with `int64_t` in multiple instances. This change aims to enhance code compatibility across different platforms and improve code clarity.

The `int64_t` type is a feature introduced in C++11, defined in the [`<cstdint>`](https://en.cppreference.com/w/cpp/header/cstdint) header. Due to historical reasons, the compilation behavior of `int64_t` is platform- and system-specific. On Linux, `int64_t` is compiled to `long`, whereas on macOS, it's compiled to `long long`.

In relevant codebases such as PyTorch and TensorFlow, `int64_t` is preferred over explicit declarations of `long` or `long long`. Consequently, for precompiled libraries, on Linux, symbols are defined exclusively to `long`, while on macOS, symbols are defined exclusively based on `long long`.

For these reasons, `data_ptr<long int>()` is unable to compile on macOS.

## References

* https://stackoverflow.com/questions/67584843/pytorch-tensordata-ptrlong-long-not-working-on-linux
* https://github.com/llvm/llvm-project/blob/c7910ee1f0af64501bf068cdfec154ea359ff832/clang/test/Preprocessor/init.c

## Examples

### Example 1

For the code used here, `torch::from_blob`, is defined using

```cpp
inline at::Tensor from_blob(
    void* data,
    at::IntArrayRef sizes,
    const at::TensorOptions& options = at::TensorOptions()) {
```
where `IntArrayRef` is defined as
```cpp
using IntArrayRef = c10::ArrayRef<int64_t>;
```

### Example 2

Dumping the symbols in `libtorch_cpu.dylib` on macOS

```
-> % nm -gU libtorch_cpu.dylib | llvm-cxxfilt | grep TensorBase | grep ::data_ptr
0000000002153398 T c10::Float8_e5m2* at::TensorBase::data_ptr<c10::Float8_e5m2>() const
0000000002153524 T c10::Float8_e4m3fn* at::TensorBase::data_ptr<c10::Float8_e4m3fn>() const
0000000002152738 T c10::Half* at::TensorBase::data_ptr<c10::Half>() const
00000000021536b0 T c10::qint8* at::TensorBase::data_ptr<c10::qint8>() const
00000000021539c8 T c10::qint32* at::TensorBase::data_ptr<c10::qint32>() const
000000000215383c T c10::quint8* at::TensorBase::data_ptr<c10::quint8>() const
0000000002152bdc T c10::complex<c10::Half>* at::TensorBase::data_ptr<c10::complex<c10::Half>>() const
0000000002152ef4 T c10::complex<double>* at::TensorBase::data_ptr<c10::complex<double>>() const
0000000002152d68 T c10::complex<float>* at::TensorBase::data_ptr<c10::complex<float>>() const
000000000215320c T c10::BFloat16* at::TensorBase::data_ptr<c10::BFloat16>() const
0000000002153ce0 T c10::quint2x4* at::TensorBase::data_ptr<c10::quint2x4>() const
0000000002153b54 T c10::quint4x2* at::TensorBase::data_ptr<c10::quint4x2>() const
0000000002152108 T signed char* at::TensorBase::data_ptr<signed char>() const
0000000002153080 T bool* at::TensorBase::data_ptr<bool>() const
0000000002152a50 T double* at::TensorBase::data_ptr<double>() const
00000000021528c4 T float* at::TensorBase::data_ptr<float>() const
0000000002151f7c T unsigned char* at::TensorBase::data_ptr<unsigned char>() const
0000000002152420 T int* at::TensorBase::data_ptr<int>() const
0000000002152294 T short* at::TensorBase::data_ptr<short>() const
00000000021525ac T long long* at::TensorBase::data_ptr<long long>() const
```

dumping symbols in `libtorch_cpu.dylib` on Linux

```
-> % nm -gU libtorch_cpu.so | c++filt | grep TensorBase | grep ::data_ptr 
00000000031ec0d0 T c10::Float8_e5m2* at::TensorBase::data_ptr<c10::Float8_e5m2>() const
00000000031ec2f0 T c10::Float8_e4m3fn* at::TensorBase::data_ptr<c10::Float8_e4m3fn>() const
00000000031ec730 T c10::Float8_e4m3fnuz* at::TensorBase::data_ptr<c10::Float8_e4m3fnuz>() const
00000000031ec510 T c10::Float8_e5m2fnuz* at::TensorBase::data_ptr<c10::Float8_e5m2fnuz>() const
00000000031eb030 T c10::Half* at::TensorBase::data_ptr<c10::Half>() const
00000000031ec950 T c10::qint8* at::TensorBase::data_ptr<c10::qint8>() const
00000000031ecd80 T c10::qint32* at::TensorBase::data_ptr<c10::qint32>() const
00000000031ecb70 T c10::quint8* at::TensorBase::data_ptr<c10::quint8>() const
00000000031eb660 T c10::complex<c10::Half>* at::TensorBase::data_ptr<c10::complex<c10::Half> >() const
00000000031eba80 T c10::complex<double>* at::TensorBase::data_ptr<c10::complex<double> >() const
00000000031eb870 T c10::complex<float>* at::TensorBase::data_ptr<c10::complex<float> >() const
00000000031ebeb0 T c10::BFloat16* at::TensorBase::data_ptr<c10::BFloat16>() const
00000000031ed1c0 T c10::quint2x4* at::TensorBase::data_ptr<c10::quint2x4>() const
00000000031ecfa0 T c10::quint4x2* at::TensorBase::data_ptr<c10::quint4x2>() const
00000000031ea7f0 T signed char* at::TensorBase::data_ptr<signed char>() const
00000000031ebca0 T bool* at::TensorBase::data_ptr<bool>() const
00000000031eb450 T double* at::TensorBase::data_ptr<double>() const
00000000031eb240 T float* at::TensorBase::data_ptr<float>() const
00000000031ea5d0 T unsigned char* at::TensorBase::data_ptr<unsigned char>() const
00000000031eac10 T int* at::TensorBase::data_ptr<int>() const
00000000031ed5e0 T unsigned int* at::TensorBase::data_ptr<unsigned int>() const
00000000031eae20 T long* at::TensorBase::data_ptr<long>() const
00000000031ed7f0 T unsigned long* at::TensorBase::data_ptr<unsigned long>() const
00000000031eaa00 T short* at::TensorBase::data_ptr<short>() const
00000000031ed3d0 T unsigned short* at::TensorBase::data_ptr<unsigned short>() const
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved data type consistency across various components for handling larger data sizes more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->