### PR TITLE
test: skip test of electronic_configuration_embedding if mendeleev is not installed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         exclude: ^source/3rdparty
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.2
+    rev: v0.4.3
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/source/tests/common/test_econf_embd.py
+++ b/source/tests/common/test_econf_embd.py
@@ -6,7 +6,15 @@ from deepmd.utils.econf_embd import (
     make_econf_embedding,
 )
 
+try:
+    import mendeleev  # noqa: F401
 
+    has_mendeleev = True
+except ImportError:
+    has_mendeleev = False
+
+
+@unittest.skipIf(not has_mendeleev, "does not have mendeleev installed, skip the UTs.")
 class TestEConfEmbd(unittest.TestCase):
     def test_fe(self):
         res = make_econf_embedding(["Fe"], flatten=False)["Fe"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the pre-commit hooks to a newer version for improved performance and bug fixes.
  
- **Tests**
	- Enhanced test reliability by skipping certain tests if the required `mendeleev` module is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->