### PR TITLE
chore(pt): lower the atol for dpa2 test

### DIFF
--- a/source/tests/consistent/descriptor/test_dpa2.py
+++ b/source/tests/consistent/descriptor/test_dpa2.py
@@ -385,7 +385,7 @@ class TestDPA2(CommonTest, DescriptorTest, unittest.TestCase):
             add_tebd_to_repinit_out,
         ) = self.param
         if precision == "float64":
-            return 1e-10
+            return 1e-8
         elif precision == "float32":
             return 1e-4
         else:

--- a/source/tests/pt/model/test_dpa2.py
+++ b/source/tests/pt/model/test_dpa2.py
@@ -86,7 +86,7 @@ class TestDescrptDPA2(unittest.TestCase, TestCaseSingleFrameWithNlist):
             dtype = PRECISION_DICT[prec]
             rtol, atol = get_tols(prec)
             if prec == "float64":
-                atol = 1e-11  # marginal GPU test cases...
+                atol = 1e-8  # marginal GPU test cases...
 
             repinit = RepinitArgs(
                 rcut=self.rcut,


### PR DESCRIPTION
Opened an issue about this: https://github.com/deepmodeling/deepmd-kit/issues/3786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted tolerance values to improve the precision consistency for specific tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->