### PR TITLE
test(python): enable building PT OP

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -24,13 +24,18 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - run: python -m pip install -U uv
-    - run: uv pip install --system --only-binary=horovod -e .[cpu,test,torch] horovod[tensorflow-cpu] mpi4py mpich
+    - run: |
+        uv pip install mpich
+        uv pip install "torch==2.3.0+cpu.cxx11.abi" -i https://download.pytorch.org/whl/
+        export PYTORCH_ROOT=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')
+        uv pip install --system --only-binary=horovod -e .[cpu,test] horovod[tensorflow-cpu] mpi4py
       env:
         # Please note that uv has some issues with finding
         # existing TensorFlow package. Currently, it uses
         # TensorFlow in the build dependency, but if it
         # changes, setting `TENSORFLOW_ROOT`.
         TENSORFLOW_VERSION: ${{ matrix.python == '3.8' && '2.13.1' || '2.16.1' }}
+        DP_ENABLE_PYTORCH: 1
         DP_BUILD_TESTING: 1
         UV_EXTRA_INDEX_URL: "https://pypi.anaconda.org/njzjz/simple https://pypi.anaconda.org/mpi4py/simple"
     - run: dp --version

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -25,8 +25,8 @@ jobs:
         python-version: ${{ matrix.python }}
     - run: python -m pip install -U uv
     - run: |
-        uv pip install mpich
-        uv pip install "torch==2.3.0+cpu.cxx11.abi" -i https://download.pytorch.org/whl/
+        uv pip install --system mpich
+        uv pip install --system "torch==2.3.0+cpu.cxx11.abi" -i https://download.pytorch.org/whl/
         export PYTORCH_ROOT=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')
         uv pip install --system --only-binary=horovod -e .[cpu,test] horovod[tensorflow-cpu] mpi4py
       env:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -27,7 +27,7 @@ jobs:
     - run: |
         uv pip install --system mpich
         uv pip install --system "torch==2.3.0+cpu.cxx11.abi" -i https://download.pytorch.org/whl/
-        export PYTORCH_ROOT=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')
+        export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
         uv pip install --system --only-binary=horovod -e .[cpu,test] horovod[tensorflow-cpu] mpi4py
       env:
         # Please note that uv has some issues with finding


### PR DESCRIPTION
This enables building PyTorch customized OP in the Python tests for future usage. PyTorch provides undocumented cxx11 CPU-only wheels at https://download.pytorch.org/whl/torch_stable.html.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package installation commands for `mpich` and `torch` in the testing workflow.
  - Set `PYTORCH_ROOT` environment variable.
  - Added `DP_ENABLE_PYTORCH` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->