### PR TITLE
fix: remove `--input_script` from `dp test`

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -383,7 +383,7 @@ def main_parser() -> argparse.ArgumentParser:
         "--rand-seed",
         type=int,
         default=None,
-        help="(Supported backend: TensorFlow) The random seed",
+        help="The random seed",
     )
     parser_tst.add_argument(
         "--shuffle-test", action="store_true", default=False, help="Shuffle test data"
@@ -400,13 +400,7 @@ def main_parser() -> argparse.ArgumentParser:
         "--atomic",
         action="store_true",
         default=False,
-        help="(Supported backend: TensorFlow) Test the accuracy of atomic label, i.e. energy / tensor (dipole, polar)",
-    )
-    parser_tst.add_argument(
-        "-i",
-        "--input_script",
-        type=str,
-        help="(Supported backend: PyTorch) The input script of the model",
+        help="Test the accuracy of atomic label, i.e. energy / tensor (dipole, polar)",
     )
     parser_tst.add_argument(
         "--head",


### PR DESCRIPTION
`--input_script` is not used in the current code.

Also, mark `--rand-seed` and `--atomic` is supported in all backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified help messages by removing backend-specific information for random seed and atomic label testing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->