### PR TITLE
chore: rename j_must_have to j_deprecated and only warn about deprecated keys

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -40,7 +40,6 @@ from deepmd.utils.path import (
 __all__ = [
     "select_idx_map",
     "make_default_mesh",
-    "j_must_have",
     "j_loader",
     "expand_sys_str",
     "get_np_precision",
@@ -127,14 +126,19 @@ def make_default_mesh(pbc: bool, mixed_type: bool) -> np.ndarray:
     return default_mesh
 
 
-# TODO: rename j_must_have to j_deprecated and only warn about deprecated keys
-# maybe rename this to j_deprecated and only warn about deprecated keys,
-# if the deprecated_key argument is left empty function puppose is only custom
-# error since dict[key] already raises KeyError when the key is missing
-def j_must_have(
+def j_deprecated(
     jdata: Dict[str, "_DICT_VAL"], key: str, deprecated_key: List[str] = []
 ) -> "_DICT_VAL":
     """Assert that supplied dictionary conaines specified key.
+
+    Parameters
+    ----------
+    jdata : Dict[str, _DICT_VAL]
+        dictionary to check
+    key : str
+        key to check
+    deprecated_key : List[str], optional
+        list of deprecated keys, by default []
 
     Returns
     -------

--- a/deepmd/tf/common.py
+++ b/deepmd/tf/common.py
@@ -26,7 +26,6 @@ from deepmd.common import (
     expand_sys_str,
     get_np_precision,
     j_loader,
-    j_must_have,
     make_default_mesh,
     select_idx_map,
 )
@@ -47,7 +46,6 @@ __all__ = [
     # from deepmd.common
     "select_idx_map",
     "make_default_mesh",
-    "j_must_have",
     "j_loader",
     "expand_sys_str",
     "get_np_precision",

--- a/deepmd/tf/entrypoints/train.py
+++ b/deepmd/tf/entrypoints/train.py
@@ -15,7 +15,6 @@ from typing import (
 
 from deepmd.tf.common import (
     j_loader,
-    j_must_have,
 )
 from deepmd.tf.env import (
     reset_default_tf_session_config,
@@ -211,7 +210,7 @@ def _do_work(jdata: Dict[str, Any], run_opt: RunOptions, is_compress: bool = Fal
             modifier.build_fv_graph()
 
     # get training info
-    stop_batch = j_must_have(jdata["training"], "numb_steps")
+    stop_batch = jdata["training"]["numb_steps"]
     origin_type_map = jdata["model"].get("origin_type_map", None)
     if (
         origin_type_map is not None and not origin_type_map

--- a/deepmd/tf/train/trainer.py
+++ b/deepmd/tf/train/trainer.py
@@ -29,7 +29,6 @@ from deepmd.loggers.training import (
 )
 from deepmd.tf.common import (
     get_precision,
-    j_must_have,
 )
 from deepmd.tf.env import (
     GLOBAL_ENER_FLOAT_PRECISION,
@@ -91,7 +90,7 @@ class DPTrainer:
 
     def _init_param(self, jdata):
         # model config
-        model_param = j_must_have(jdata, "model")
+        model_param = jdata["model"]
 
         # nvnmd
         self.nvnmd_param = jdata.get("nvnmd", {})
@@ -123,7 +122,7 @@ class DPTrainer:
             return lr, scale_lr_coef
 
         # learning rate
-        lr_param = j_must_have(jdata, "learning_rate")
+        lr_param = jdata["learning_rate"]
         self.lr, self.scale_lr_coef = get_lr_and_coef(lr_param)
         # loss
         # infer loss type by fitting_type

--- a/deepmd/utils/compat.py
+++ b/deepmd/utils/compat.py
@@ -17,7 +17,7 @@ from typing import (
 import numpy as np
 
 from deepmd.common import (
-    j_must_have,
+    j_deprecated,
 )
 
 
@@ -127,8 +127,8 @@ def _smth_descriptor(jdata: Dict[str, Any]) -> Dict[str, Any]:
     descriptor["sel"] = jdata["sel_a"]
     _jcopy(jdata, descriptor, ("rcut",))
     descriptor["rcut_smth"] = jdata.get("rcut_smth", descriptor["rcut"])
-    descriptor["neuron"] = j_must_have(jdata, "filter_neuron")
-    descriptor["axis_neuron"] = j_must_have(jdata, "axis_neuron", ["n_axis_neuron"])
+    descriptor["neuron"] = jdata["filter_neuron"]
+    descriptor["axis_neuron"] = j_deprecated(jdata, "axis_neuron", ["n_axis_neuron"])
     descriptor["resnet_dt"] = False
     if "resnet_dt" in jdata:
         descriptor["resnet_dt"] = jdata["filter_resnet_dt"]
@@ -154,7 +154,7 @@ def _fitting_net(jdata: Dict[str, Any]) -> Dict[str, Any]:
     seed = jdata.get("seed", None)
     if seed is not None:
         fitting_net["seed"] = seed
-    fitting_net["neuron"] = j_must_have(jdata, "fitting_neuron", ["n_neuron"])
+    fitting_net["neuron"] = j_deprecated(jdata, "fitting_neuron", ["n_neuron"])
     fitting_net["resnet_dt"] = True
     if "resnet_dt" in jdata:
         fitting_net["resnet_dt"] = jdata["resnet_dt"]
@@ -237,16 +237,16 @@ def _training(jdata: Dict[str, Any]) -> Dict[str, Any]:
     training["disp_file"] = "lcurve.out"
     if "disp_file" in jdata:
         training["disp_file"] = jdata["disp_file"]
-    training["disp_freq"] = j_must_have(jdata, "disp_freq")
-    training["numb_test"] = j_must_have(jdata, "numb_test")
-    training["save_freq"] = j_must_have(jdata, "save_freq")
-    training["save_ckpt"] = j_must_have(jdata, "save_ckpt")
-    training["disp_training"] = j_must_have(jdata, "disp_training")
-    training["time_training"] = j_must_have(jdata, "time_training")
+    training["disp_freq"] = jdata["disp_freq"]
+    training["numb_test"] = jdata["numb_test"]
+    training["save_freq"] = jdata["save_freq"]
+    training["save_ckpt"] = jdata["save_ckpt"]
+    training["disp_training"] = jdata["disp_training"]
+    training["time_training"] = jdata["time_training"]
     if "profiling" in jdata:
         training["profiling"] = jdata["profiling"]
         if training["profiling"]:
-            training["profiling_file"] = j_must_have(jdata, "profiling_file")
+            training["profiling_file"] = jdata["profiling_file"]
     return training
 
 
@@ -378,7 +378,7 @@ def update_deepmd_input(
         return "model" not in jdata.keys()
 
     def is_deepmd_v1_input(jdata):
-        return "systems" in j_must_have(jdata, "training").keys()
+        return "systems" in jdata, ["training"].keys()
 
     if is_deepmd_v0_input(jdata):
         jdata = convert_input_v0_v1(jdata, warning, None)

--- a/deepmd/utils/compat.py
+++ b/deepmd/utils/compat.py
@@ -378,7 +378,7 @@ def update_deepmd_input(
         return "model" not in jdata.keys()
 
     def is_deepmd_v1_input(jdata):
-        return "systems" in jdata, ["training"].keys()
+        return "systems" in jdata["training"].keys()
 
     if is_deepmd_v0_input(jdata):
         jdata = convert_input_v0_v1(jdata, warning, None)

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -18,7 +18,6 @@ import numpy as np
 import deepmd.utils.random as dp_random
 from deepmd.common import (
     expand_sys_str,
-    j_must_have,
     make_default_mesh,
 )
 from deepmd.env import (
@@ -792,10 +791,10 @@ def get_data(
     DeepmdDataSystem
         The data system
     """
-    systems = j_must_have(jdata, "systems")
+    systems = jdata["systems"]
     systems = process_systems(systems)
 
-    batch_size = j_must_have(jdata, "batch_size")
+    batch_size = jdata["batch_size"]
     sys_probs = jdata.get("sys_probs", None)
     auto_prob = jdata.get("auto_prob", "prob_sys_size")
     optional_type_map = not multi_task_mode

--- a/source/tests/tf/test_data_large_batch.py
+++ b/source/tests/tf/test_data_large_batch.py
@@ -5,9 +5,6 @@ import unittest
 import numpy as np
 from packaging.version import parse as parse_version
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeAtten,
 )
@@ -50,11 +47,11 @@ class TestDataLargeBatch(tf.test.TestCase):
         jfile = "water_se_atten_mixed_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        type_map = j_must_have(jdata["model"], "type_map")
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        type_map = jdata["model"]["type_map"]
 
         data = DeepmdDataSystem(systems, batch_size, test_size, rcut, type_map=type_map)
         data_requirement = {
@@ -248,11 +245,11 @@ class TestDataLargeBatch(tf.test.TestCase):
         jfile = "water_se_atten_mixed_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        type_map = j_must_have(jdata["model"], "type_map")
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        type_map = jdata["model"]["type_map"]
 
         data = DeepmdDataSystem(systems, batch_size, test_size, rcut, type_map=type_map)
         data_requirement = {
@@ -446,11 +443,11 @@ class TestDataLargeBatch(tf.test.TestCase):
         jfile = "water_se_atten_mixed_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        type_map = j_must_have(jdata["model"], "type_map")
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        type_map = jdata["model"]["type_map"]
 
         data = DeepmdDataSystem(systems, batch_size, test_size, rcut, type_map=type_map)
         data_requirement = {

--- a/source/tests/tf/test_data_modifier.py
+++ b/source/tests/tf/test_data_modifier.py
@@ -3,9 +3,6 @@ import os
 
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.env import (
     GLOBAL_NP_FLOAT_PRECISION,
     tf,
@@ -61,12 +58,12 @@ class TestDataModifier(tf.test.TestCase):
         rcut = model.model.get_rcut()
 
         # init data system
-        systems = j_must_have(jdata["training"], "systems")
+        systems = jdata["training"]["systems"]
         # systems[0] = tests_path / systems[0]
         systems = [tests_path / ii for ii in systems]
         set_pfx = "set"
-        batch_size = j_must_have(jdata["training"], "batch_size")
-        test_size = j_must_have(jdata["training"], "numb_test")
+        batch_size = jdata["training"]["batch_size"]
+        test_size = jdata["training"]["numb_test"]
         data = DeepmdDataSystem(
             systems, batch_size, test_size, rcut, set_prefix=set_pfx
         )

--- a/source/tests/tf/test_data_modifier_shuffle.py
+++ b/source/tests/tf/test_data_modifier_shuffle.py
@@ -4,9 +4,6 @@ import shutil
 
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.env import (
     GLOBAL_NP_FLOAT_PRECISION,
     tf,
@@ -64,10 +61,10 @@ class TestDataModifier(tf.test.TestCase):
         rcut = model.model.get_rcut()
 
         # init data system
-        systems = j_must_have(jdata["training"], "systems")
+        systems = jdata["training"]["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata["training"], "batch_size")
-        test_size = j_must_have(jdata["training"], "numb_test")
+        batch_size = jdata["training"]["batch_size"]
+        test_size = jdata["training"]["numb_test"]
         data = DeepmdDataSystem(
             systems, batch_size, test_size, rcut, set_prefix=set_pfx
         )

--- a/source/tests/tf/test_descrpt_hybrid.py
+++ b/source/tests/tf/test_descrpt_hybrid.py
@@ -39,8 +39,6 @@ class TestHybrid(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
         rcut = 6

--- a/source/tests/tf/test_descrpt_hybrid.py
+++ b/source/tests/tf/test_descrpt_hybrid.py
@@ -4,9 +4,6 @@ import unittest
 import numpy as np
 from packaging.version import parse as parse_version
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptHybrid,
 )
@@ -40,10 +37,10 @@ class TestHybrid(tf.test.TestCase):
         jfile = "water_hybrid.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
         rcut = 6

--- a/source/tests/tf/test_descrpt_se_a_mask.py
+++ b/source/tests/tf/test_descrpt_se_a_mask.py
@@ -3,9 +3,6 @@ import os
 
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeAMask,
 )
@@ -231,12 +228,12 @@ class TestModel(tf.test.TestCase):
         jdata["training"]["validation_data"]["systems"] = [
             str(tests_path / "data_dp_mask")
         ]
-        systems = j_must_have(jdata["training"]["validation_data"], "systems")
+        systems = jdata["training"]["validation_data"]["systems"]
         set_pfx = "set"
         batch_size = 2
         test_size = 1
         rcut = 20.0  # For DataSystem interface compatibility, not used in this test.
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)
         total_atom_num = np.cumsum(sel)[-1]
 

--- a/source/tests/tf/test_descrpt_se_a_type.py
+++ b/source/tests/tf/test_descrpt_se_a_type.py
@@ -32,8 +32,6 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
         stop_batch = jdata["stop_batch"]

--- a/source/tests/tf/test_descrpt_se_a_type.py
+++ b/source/tests/tf/test_descrpt_se_a_type.py
@@ -34,7 +34,6 @@ class TestModel(tf.test.TestCase):
         set_pfx = "set"
         batch_size = 2
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)

--- a/source/tests/tf/test_descrpt_se_a_type.py
+++ b/source/tests/tf/test_descrpt_se_a_type.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -33,15 +30,15 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -197,15 +194,15 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_descrpt_se_a_type.py
+++ b/source/tests/tf/test_descrpt_se_a_type.py
@@ -197,7 +197,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)

--- a/source/tests/tf/test_descrpt_se_atten.py
+++ b/source/tests/tf/test_descrpt_se_atten.py
@@ -5,9 +5,6 @@ import unittest
 import numpy as np
 from packaging.version import parse as parse_version
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeAtten,
 )
@@ -42,15 +39,15 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -219,15 +216,15 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -397,15 +394,15 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -568,15 +565,15 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_descrpt_se_atten.py
+++ b/source/tests/tf/test_descrpt_se_atten.py
@@ -45,7 +45,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])
@@ -222,7 +221,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])
@@ -400,7 +398,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])
@@ -571,7 +568,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 2
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(jdata["model"]["type_map"])

--- a/source/tests/tf/test_dipole_se_a.py
+++ b/source/tests/tf/test_dipole_se_a.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -38,14 +35,14 @@ class TestModel(tf.test.TestCase):
         jfile = "polar_se_a.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_dipole_se_a.py
+++ b/source/tests/tf/test_dipole_se_a.py
@@ -41,7 +41,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_dipole_se_a_tebd.py
+++ b/source/tests/tf/test_dipole_se_a_tebd.py
@@ -51,7 +51,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_dipole_se_a_tebd.py
+++ b/source/tests/tf/test_dipole_se_a_tebd.py
@@ -4,9 +4,6 @@ import unittest
 import numpy as np
 from packaging.version import parse as parse_version
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -48,14 +45,14 @@ class TestModel(tf.test.TestCase):
         jfile = "polar_se_a_tebd.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_fitting_dos.py
+++ b/source/tests/tf/test_fitting_dos.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -33,15 +30,15 @@ class TestModel(tf.test.TestCase):
         jfile = "train_dos.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata["training"], "systems")
+        systems = jdata["training"]["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata["training"], "batch_size")
-        test_size = j_must_have(jdata["training"], "numb_test")
+        batch_size = jdata["training"]["batch_size"]
+        test_size = jdata["training"]["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata["training"], "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["training"]["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_fitting_dos.py
+++ b/source/tests/tf/test_fitting_dos.py
@@ -36,7 +36,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["training"]["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["training"]["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)

--- a/source/tests/tf/test_fitting_ener_type.py
+++ b/source/tests/tf/test_fitting_ener_type.py
@@ -36,7 +36,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)

--- a/source/tests/tf/test_fitting_ener_type.py
+++ b/source/tests/tf/test_fitting_ener_type.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -33,15 +30,15 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_dos.py
+++ b/source/tests/tf/test_model_dos.py
@@ -43,7 +43,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["training"]["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["training"]["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_dos.py
+++ b/source/tests/tf/test_model_dos.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -40,14 +37,14 @@ class TestModel(tf.test.TestCase):
         jfile = "train_dos.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata["training"], "systems")
+        systems = jdata["training"]["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata["training"], "batch_size")
-        test_size = j_must_have(jdata["training"], "numb_test")
+        batch_size = jdata["training"]["batch_size"]
+        test_size = jdata["training"]["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata["training"], "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["training"]["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_loc_frame.py
+++ b/source/tests/tf/test_model_loc_frame.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptLocFrame,
 )
@@ -35,14 +32,14 @@ class TestModel(tf.test.TestCase):
     def test_model(self):
         jfile = "water.json"
         jdata = j_loader(jfile)
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_pairtab.py
+++ b/source/tests/tf/test_model_pairtab.py
@@ -2,9 +2,6 @@
 import numpy as np
 import scipy.spatial.distance
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.env import (
     tf,
 )
@@ -30,7 +27,7 @@ class TestModel(tf.test.TestCase):
     def test_model(self):
         jfile = "water.json"
         jdata = j_loader(jfile)
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
         batch_size = 1
         test_size = 1
@@ -42,7 +39,7 @@ class TestModel(tf.test.TestCase):
             "rcut": 6,
             "sel": [6],
         }
-        rcut = j_must_have(jdata["model"], "rcut")
+        rcut = jdata["model"]["rcut"]
 
         def pair_pot(r: float):
             # LJ, as exmaple

--- a/source/tests/tf/test_model_se_a.py
+++ b/source/tests/tf/test_model_se_a.py
@@ -2,9 +2,6 @@
 import dpdata
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -59,14 +56,14 @@ class TestModel(tf.test.TestCase):
         sys.data["forces"] = np.zeros([nframes, natoms, 3])
         sys.to_deepmd_npy("system", prec=np.float64)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
         test_data = data.get_test()
@@ -140,14 +137,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 
@@ -289,14 +286,14 @@ class TestModel(tf.test.TestCase):
         sys.data["forces"] = np.zeros([nframes, natoms, 3])
         sys.to_deepmd_npy("system", prec=np.float64)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
         test_data = data.get_test()

--- a/source/tests/tf/test_model_se_a.py
+++ b/source/tests/tf/test_model_se_a.py
@@ -62,7 +62,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -143,7 +142,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -292,7 +290,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_a_aparam.py
+++ b/source/tests/tf/test_model_se_a_aparam.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -38,14 +35,14 @@ class TestModel(tf.test.TestCase):
     def test_model(self):
         jfile = "water_se_a_aparam.json"
         jdata = j_loader(jfile)
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_a_aparam.py
+++ b/source/tests/tf/test_model_se_a_aparam.py
@@ -41,7 +41,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_a_ebd.py
+++ b/source/tests/tf/test_model_se_a_ebd.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor.se_a_ebd import (
     DescrptSeAEbd,
 )
@@ -36,14 +33,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_ebd.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_a_ebd_v2.py
+++ b/source/tests/tf/test_model_se_a_ebd_v2.py
@@ -42,7 +42,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_a_ebd_v2.py
+++ b/source/tests/tf/test_model_se_a_ebd_v2.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor.se_a_ebd_v2 import (
     DescrptSeAEbdV2,
 )
@@ -39,14 +36,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_ebd.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_a_fparam.py
+++ b/source/tests/tf/test_model_se_a_fparam.py
@@ -42,7 +42,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_a_fparam.py
+++ b/source/tests/tf/test_model_se_a_fparam.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -39,14 +36,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_fparam.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_a_srtab.py
+++ b/source/tests/tf/test_model_se_a_srtab.py
@@ -3,9 +3,6 @@ import os
 
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -53,14 +50,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_srtab.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_a_srtab.py
+++ b/source/tests/tf/test_model_se_a_srtab.py
@@ -56,7 +56,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_a_type.py
+++ b/source/tests/tf/test_model_se_a_type.py
@@ -42,7 +42,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_a_type.py
+++ b/source/tests/tf/test_model_se_a_type.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -39,14 +36,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_atten.py
+++ b/source/tests/tf/test_model_se_atten.py
@@ -5,9 +5,6 @@ import unittest
 import numpy as np
 from packaging.version import parse as parse_version
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeAtten,
 )
@@ -50,14 +47,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 
@@ -204,13 +201,13 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        rcut = jdata["model"]["descriptor"]["rcut"]
         ntypes = 2
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -277,14 +274,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 
@@ -433,13 +430,13 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        rcut = jdata["model"]["descriptor"]["rcut"]
         ntypes = 2
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -508,14 +505,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 
@@ -667,13 +664,13 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        rcut = jdata["model"]["descriptor"]["rcut"]
         ntypes = 2
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -747,14 +744,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 
@@ -896,11 +893,11 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_atten.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_atten.py
+++ b/source/tests/tf/test_model_se_atten.py
@@ -49,7 +49,6 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
@@ -202,8 +201,6 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
         rcut = jdata["model"]["descriptor"]["rcut"]
@@ -275,8 +272,6 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
         rcut = jdata["model"]["descriptor"]["rcut"]
@@ -431,7 +426,6 @@ class TestModel(tf.test.TestCase):
         systems = jdata["systems"]
         set_pfx = "set"
         batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
         rcut = jdata["model"]["descriptor"]["rcut"]
@@ -505,11 +499,9 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -744,11 +736,8 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_atten.py
+++ b/source/tests/tf/test_model_se_atten.py
@@ -53,7 +53,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_atten.py
+++ b/source/tests/tf/test_model_se_atten.py
@@ -279,7 +279,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_r.py
+++ b/source/tests/tf/test_model_se_r.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeR,
 )
@@ -36,14 +33,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_r.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_se_t.py
+++ b/source/tests/tf/test_model_se_t.py
@@ -35,8 +35,6 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
         stop_batch = jdata["stop_batch"]

--- a/source/tests/tf/test_model_se_t.py
+++ b/source/tests/tf/test_model_se_t.py
@@ -37,7 +37,6 @@ class TestModel(tf.test.TestCase):
         set_pfx = "set"
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_model_se_t.py
+++ b/source/tests/tf/test_model_se_t.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeT,
 )
@@ -36,14 +33,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_t.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_model_spin.py
+++ b/source/tests/tf/test_model_spin.py
@@ -45,7 +45,6 @@ class TestModelSpin(tf.test.TestCase):
 
         # set system information
         set_pfx = "set"
-        batch_size = jdata["training"]["training_data"]["batch_size"]
         batch_size = 2
         test_size = jdata["training"]["validation_data"]["numb_btch"]
         stop_batch = jdata["training"]["numb_steps"]

--- a/source/tests/tf/test_model_spin.py
+++ b/source/tests/tf/test_model_spin.py
@@ -3,9 +3,6 @@ import unittest
 
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -48,18 +45,18 @@ class TestModelSpin(tf.test.TestCase):
 
         # set system information
         set_pfx = "set"
-        batch_size = j_must_have(jdata["training"]["training_data"], "batch_size")
+        batch_size = jdata["training"]["training_data"]["batch_size"]
         batch_size = 2
-        test_size = j_must_have(jdata["training"]["validation_data"], "numb_btch")
-        stop_batch = j_must_have(jdata["training"], "numb_steps")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        test_size = jdata["training"]["validation_data"]["numb_btch"]
+        stop_batch = jdata["training"]["numb_steps"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
         jdata["training"]["training_data"]["systems"] = [
             str(tests_path / "model_spin/")
         ]
         jdata["training"]["validation_data"]["systems"] = [
             str(tests_path / "model_spin/")
         ]
-        systems = j_must_have(jdata["training"]["training_data"], "systems")
+        systems = jdata["training"]["training_data"]["systems"]
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
         test_data = data.get_test()
 

--- a/source/tests/tf/test_model_spin.py
+++ b/source/tests/tf/test_model_spin.py
@@ -47,7 +47,6 @@ class TestModelSpin(tf.test.TestCase):
         set_pfx = "set"
         batch_size = 2
         test_size = jdata["training"]["validation_data"]["numb_btch"]
-        stop_batch = jdata["training"]["numb_steps"]
         rcut = jdata["model"]["descriptor"]["rcut"]
         jdata["training"]["training_data"]["systems"] = [
             str(tests_path / "model_spin/")

--- a/source/tests/tf/test_pairwise_dprc.py
+++ b/source/tests/tf/test_pairwise_dprc.py
@@ -13,7 +13,6 @@ from deepmd.tf import (
 )
 from deepmd.tf.common import (
     j_loader,
-    j_must_have,
 )
 from deepmd.tf.env import (
     GLOBAL_ENER_FLOAT_PRECISION,
@@ -437,7 +436,7 @@ class TestPairwiseModel(tf.test.TestCase):
         idxs = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3])
         np.save("system/set.000/aparam.npy", idxs)
 
-        systems = j_must_have(jdata["training"]["training_data"], "systems")
+        systems = jdata["training"]["training_data"]["systems"]
         batch_size = 1
         test_size = 1
         rcut = model.get_rcut()
@@ -625,7 +624,7 @@ class TestPairwiseModel(tf.test.TestCase):
         idxs = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3])
         np.save("system/set.000/aparam.npy", idxs)
 
-        systems = j_must_have(jdata["training"]["training_data"], "systems")
+        systems = jdata["training"]["training_data"]["systems"]
         batch_size = 1
         test_size = 1
         rcut = model.get_rcut()

--- a/source/tests/tf/test_polar_se_a.py
+++ b/source/tests/tf/test_polar_se_a.py
@@ -5,9 +5,6 @@ from pathlib import (
 
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -45,14 +42,14 @@ class TestModel(tf.test.TestCase):
         jfile = "polar_se_a.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 
@@ -229,7 +226,7 @@ class TestModel(tf.test.TestCase):
 
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DeepmdDataSystem(systems, batch_size, test_size, rcut)
         data.add(

--- a/source/tests/tf/test_polar_se_a.py
+++ b/source/tests/tf/test_polar_se_a.py
@@ -46,7 +46,6 @@ class TestModel(tf.test.TestCase):
         set_pfx = "set"
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_polar_se_a.py
+++ b/source/tests/tf/test_polar_se_a.py
@@ -44,8 +44,6 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
-        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
         stop_batch = jdata["stop_batch"]

--- a/source/tests/tf/test_polar_se_a_tebd.py
+++ b/source/tests/tf/test_polar_se_a_tebd.py
@@ -47,7 +47,6 @@ class TestModel(tf.test.TestCase):
 
         systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = jdata["batch_size"]
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1

--- a/source/tests/tf/test_polar_se_a_tebd.py
+++ b/source/tests/tf/test_polar_se_a_tebd.py
@@ -50,7 +50,6 @@ class TestModel(tf.test.TestCase):
         test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = jdata["stop_batch"]
         rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_polar_se_a_tebd.py
+++ b/source/tests/tf/test_polar_se_a_tebd.py
@@ -4,9 +4,6 @@ import unittest
 import numpy as np
 from packaging.version import parse as parse_version
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     DescrptSeA,
 )
@@ -48,14 +45,14 @@ class TestModel(tf.test.TestCase):
         jfile = "polar_se_a_tebd.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        stop_batch = j_must_have(jdata, "stop_batch")
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
+        stop_batch = jdata["stop_batch"]
+        rcut = jdata["model"]["descriptor"]["rcut"]
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
 

--- a/source/tests/tf/test_type_one_side.py
+++ b/source/tests/tf/test_type_one_side.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.descriptor import (
     Descriptor,
 )
@@ -41,14 +38,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_a.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)
@@ -148,14 +145,14 @@ class TestModel(tf.test.TestCase):
         jfile = "water_se_r.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         set_pfx = "set"
-        batch_size = j_must_have(jdata, "batch_size")
-        test_size = j_must_have(jdata, "numb_test")
+        batch_size = jdata["batch_size"]
+        test_size = jdata["numb_test"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        sel = j_must_have(jdata["model"]["descriptor"], "sel")
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        sel = jdata["model"]["descriptor"]["sel"]
         ntypes = len(sel)
 
         data = DataSystem(systems, set_pfx, batch_size, test_size, rcut, run_opt=None)

--- a/source/tests/tf/test_virtual_type.py
+++ b/source/tests/tf/test_virtual_type.py
@@ -6,9 +6,6 @@ import unittest
 
 import numpy as np
 
-from deepmd.tf.common import (
-    j_must_have,
-)
 from deepmd.tf.infer import (
     DeepPot,
 )
@@ -130,11 +127,11 @@ class TestTrainVirtualType(unittest.TestCase):
         jfile = "water_se_atten_mixed_type.json"
         jdata = j_loader(jfile)
 
-        systems = j_must_have(jdata, "systems")
+        systems = jdata["systems"]
         batch_size = 1
         test_size = 1
-        rcut = j_must_have(jdata["model"]["descriptor"], "rcut")
-        type_map = j_must_have(jdata["model"], "type_map")
+        rcut = jdata["model"]["descriptor"]["rcut"]
+        type_map = jdata["model"]["type_map"]
 
         data = DeepmdDataSystem(systems, batch_size, test_size, rcut, type_map=type_map)
         data.get_batch()


### PR DESCRIPTION
Fix #3523.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Simplified code by removing the `j_must_have` function and directly accessing dictionary keys in various test files.
  - Replaced `j_must_have` with direct dictionary access for improved code readability and maintenance.

- **Chores**
  - Updated test files to directly access dictionary values, enhancing code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->