### PR TITLE
fix: bugs in uts for polar and dipole fit

### DIFF
--- a/source/tests/pt/model/test_dipole_fitting.py
+++ b/source/tests/pt/model/test_dipole_fitting.py
@@ -194,7 +194,7 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz, atype, self.rcut, self.sel, False, box=self.cell
+                    xyz + self.shift, atype, self.rcut, self.sel, False, box=self.cell
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(

--- a/source/tests/pt/model/test_dipole_fitting.py
+++ b/source/tests/pt/model/test_dipole_fitting.py
@@ -194,7 +194,7 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz + self.shift, atype, self.rcut, self.sel, False, box=self.cell
+                    xyz, atype, self.rcut, self.sel, False, box=self.cell
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(

--- a/source/tests/pt/model/test_polarizability_fitting.py
+++ b/source/tests/pt/model/test_polarizability_fitting.py
@@ -205,7 +205,7 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz + self.shift, atype, self.rcut, self.sel, False, box=self.cell
+                    xyz, atype, self.rcut, self.sel, False, box=self.cell
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(

--- a/source/tests/pt/model/test_polarizability_fitting.py
+++ b/source/tests/pt/model/test_polarizability_fitting.py
@@ -59,8 +59,7 @@ class TestPolarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
             self.atype_ext[:, : self.nloc], dtype=int, device=env.DEVICE
         )
 
-        for mixed_types, nfp, nap, fit_diag, scale in itertools.product(
-            [True, False],
+        for nfp, nap, fit_diag, scale in itertools.product(
             [0, 3],
             [0, 4],
             [True, False],
@@ -72,7 +71,7 @@ class TestPolarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=nfp,
                 numb_aparam=nap,
-                mixed_types=mixed_types,
+                mixed_types=False,
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -167,8 +166,7 @@ class TestEquivalence(unittest.TestCase):
         rmat = torch.tensor(special_ortho_group.rvs(3), dtype=dtype, device=env.DEVICE)
         coord_rot = torch.matmul(self.coord, rmat)
 
-        for mixed_types, nfp, nap, fit_diag, scale in itertools.product(
-            [True, False],
+        for nfp, nap, fit_diag, scale in itertools.product(
             [0, 3],
             [0, 4],
             [True, False],
@@ -180,7 +178,7 @@ class TestEquivalence(unittest.TestCase):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=nfp,
                 numb_aparam=nap,
-                mixed_types=True,
+                mixed_types=False,
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -207,7 +205,7 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz + self.shift, atype, self.rcut, self.sel, mixed_types
+                    xyz + self.shift, atype, self.rcut, self.sel, False, box=self.cell
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(
@@ -216,7 +214,7 @@ class TestEquivalence(unittest.TestCase):
                     nlist,
                 )
 
-                ret0 = ft0(rd0, extended_atype, gr0, fparam=ifp, aparam=iap)
+                ret0 = ft0(rd0, atype, gr0, fparam=ifp, aparam=iap)
                 res.append(ret0["polarizability"])
             np.testing.assert_allclose(
                 to_numpy_array(res[1]),
@@ -237,7 +235,7 @@ class TestEquivalence(unittest.TestCase):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=0,
                 numb_aparam=0,
-                mixed_types=True,
+                mixed_types=False,
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -250,7 +248,7 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    coord[idx_perm], atype, self.rcut, self.sel, False
+                    coord[idx_perm], atype, self.rcut, self.sel, False, box=self.cell
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(
@@ -259,7 +257,7 @@ class TestEquivalence(unittest.TestCase):
                     nlist,
                 )
 
-                ret0 = ft0(rd0, extended_atype, gr0, fparam=None, aparam=None)
+                ret0 = ft0(rd0, atype, gr0, fparam=None, aparam=None)
                 res.append(ret0["polarizability"])
 
             np.testing.assert_allclose(
@@ -269,7 +267,12 @@ class TestEquivalence(unittest.TestCase):
 
     def test_trans(self):
         atype = self.atype.reshape(1, 5)
-        coord_s = self.coord + self.shift
+        coord_s = torch.matmul(
+            torch.remainder(
+                torch.matmul(self.coord + self.shift, torch.linalg.inv(self.cell)), 1.0
+            ),
+            self.cell,
+        )
         for fit_diag, scale in itertools.product([True, False], [None, self.scale]):
             ft0 = PolarFittingNet(
                 self.nt,
@@ -277,7 +280,7 @@ class TestEquivalence(unittest.TestCase):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=0,
                 numb_aparam=0,
-                mixed_types=True,
+                mixed_types=False,
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -289,7 +292,7 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz, atype, self.rcut, self.sel, False
+                    xyz, atype, self.rcut, self.sel, False, box=self.cell
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(
@@ -298,7 +301,7 @@ class TestEquivalence(unittest.TestCase):
                     nlist,
                 )
 
-                ret0 = ft0(rd0, extended_atype, gr0, fparam=0, aparam=0)
+                ret0 = ft0(rd0, atype, gr0, fparam=0, aparam=0)
                 res.append(ret0["polarizability"])
 
             np.testing.assert_allclose(to_numpy_array(res[0]), to_numpy_array(res[1]))
@@ -323,7 +326,7 @@ class TestPolarModel(unittest.TestCase):
             embedding_width=self.dd0.get_dim_emb(),
             numb_fparam=0,
             numb_aparam=0,
-            mixed_types=True,
+            mixed_types=False,
         ).to(env.DEVICE)
         self.type_mapping = ["O", "H", "B"]
         self.model = PolarModel(self.dd0, self.ft0, self.type_mapping)

--- a/source/tests/pt/model/test_polarizability_fitting.py
+++ b/source/tests/pt/model/test_polarizability_fitting.py
@@ -205,7 +205,7 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz, atype, self.rcut, self.sel, False, box=self.cell
+                    xyz + self.shift, atype, self.rcut, self.sel, False, box=self.cell
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(

--- a/source/tests/pt/model/test_polarizability_fitting.py
+++ b/source/tests/pt/model/test_polarizability_fitting.py
@@ -71,7 +71,7 @@ class TestPolarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=nfp,
                 numb_aparam=nap,
-                mixed_types=False,
+                mixed_types=self.dd0.mixed_types(),
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -165,6 +165,8 @@ class TestEquivalence(unittest.TestCase):
         atype = self.atype.reshape(1, 5)
         rmat = torch.tensor(special_ortho_group.rvs(3), dtype=dtype, device=env.DEVICE)
         coord_rot = torch.matmul(self.coord, rmat)
+        # use larger cell to rotate only coord and shift to the center of cell
+        cell_rot = 10.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
 
         for nfp, nap, fit_diag, scale in itertools.product(
             [0, 3],
@@ -178,7 +180,7 @@ class TestEquivalence(unittest.TestCase):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=nfp,
                 numb_aparam=nap,
-                mixed_types=False,
+                mixed_types=self.dd0.mixed_types(),
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -205,7 +207,12 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz + self.shift, atype, self.rcut, self.sel, False, box=self.cell
+                    xyz + self.shift,
+                    atype,
+                    self.rcut,
+                    self.sel,
+                    self.dd0.mixed_types(),
+                    box=cell_rot,
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(
@@ -235,7 +242,7 @@ class TestEquivalence(unittest.TestCase):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=0,
                 numb_aparam=0,
-                mixed_types=False,
+                mixed_types=self.dd0.mixed_types(),
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -248,7 +255,12 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    coord[idx_perm], atype, self.rcut, self.sel, False, box=self.cell
+                    coord[idx_perm],
+                    atype,
+                    self.rcut,
+                    self.sel,
+                    self.dd0.mixed_types(),
+                    box=self.cell,
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(
@@ -280,7 +292,7 @@ class TestEquivalence(unittest.TestCase):
                 embedding_width=self.dd0.get_dim_emb(),
                 numb_fparam=0,
                 numb_aparam=0,
-                mixed_types=False,
+                mixed_types=self.dd0.mixed_types(),
                 fit_diag=fit_diag,
                 scale=scale,
             ).to(env.DEVICE)
@@ -292,7 +304,12 @@ class TestEquivalence(unittest.TestCase):
                     _,
                     nlist,
                 ) = extend_input_and_build_neighbor_list(
-                    xyz, atype, self.rcut, self.sel, False, box=self.cell
+                    xyz,
+                    atype,
+                    self.rcut,
+                    self.sel,
+                    self.dd0.mixed_types(),
+                    box=self.cell,
                 )
 
                 rd0, gr0, _, _, _ = self.dd0(
@@ -326,7 +343,7 @@ class TestPolarModel(unittest.TestCase):
             embedding_width=self.dd0.get_dim_emb(),
             numb_fparam=0,
             numb_aparam=0,
-            mixed_types=False,
+            mixed_types=self.dd0.mixed_types(),
         ).to(env.DEVICE)
         self.type_mapping = ["O", "H", "B"]
         self.model = PolarModel(self.dd0, self.ft0, self.type_mapping)


### PR DESCRIPTION
Fix following trivial bugs in dipole and polar fit uts:
1. `box` was not used in `extend_input_and_build_neighbor_list` (which means they were all tested in nopbc mode, if shifted coord is outside the box (sometimes) and normalized explicitly, results are not the same.) Input for fitting also used extended_atype instead of atype. (Only same when nopbc.)
2. Using of `mixed_types` is disordered, mismatched with descriptor or sometimes with nlist. Now only use `mixed_types`==False since the descriptor output is not in mixed types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved consistency in parameter handling for various test methods.
  - Updated `mixed_types` parameter to dynamically use `self.dd0.mixed_types()` across multiple test functions for better flexibility and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->