### PR TITLE
fix: rm unused import of `__version__`

### DIFF
--- a/deepmd/dpmodel/descriptor/dpa1.py
+++ b/deepmd/dpmodel/descriptor/dpa1.py
@@ -1,6 +1,26 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
 import numpy as np
 
+from deepmd.dpmodel import (
+    DEFAULT_PRECISION,
+    PRECISION_DICT,
+    NativeOP,
+)
+from deepmd.dpmodel.utils import (
+    EmbeddingNet,
+    EnvMat,
+    NetworkCollection,
+    PairExcludeMask,
+)
 from deepmd.dpmodel.utils.network import (
     LayerNorm,
     NativeLayer,
@@ -22,32 +42,6 @@ from deepmd.utils.path import (
 )
 from deepmd.utils.version import (
     check_version_compatibility,
-)
-
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
-from typing import (
-    Any,
-    Callable,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
-
-from deepmd.dpmodel import (
-    DEFAULT_PRECISION,
-    PRECISION_DICT,
-    NativeOP,
-)
-from deepmd.dpmodel.utils import (
-    EmbeddingNet,
-    EnvMat,
-    NetworkCollection,
-    PairExcludeMask,
 )
 
 from .base_descriptor import (

--- a/deepmd/dpmodel/descriptor/dpa2.py
+++ b/deepmd/dpmodel/descriptor/dpa2.py
@@ -1,6 +1,20 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
 import numpy as np
 
+from deepmd.dpmodel import (
+    NativeOP,
+)
+from deepmd.dpmodel.utils import (
+    EnvMat,
+    NetworkCollection,
+)
 from deepmd.dpmodel.utils.network import (
     Identity,
     NativeLayer,
@@ -23,26 +37,6 @@ from deepmd.utils.path import (
 )
 from deepmd.utils.version import (
     check_version_compatibility,
-)
-
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
-from typing import (
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
-
-from deepmd.dpmodel import (
-    NativeOP,
-)
-from deepmd.dpmodel.utils import (
-    EnvMat,
-    NetworkCollection,
 )
 
 from .base_descriptor import (

--- a/deepmd/dpmodel/descriptor/repformers.py
+++ b/deepmd/dpmodel/descriptor/repformers.py
@@ -1,22 +1,4 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import numpy as np
-
-from deepmd.dpmodel.utils.network import (
-    LayerNorm,
-    NativeLayer,
-)
-from deepmd.utils.path import (
-    DPPath,
-)
-from deepmd.utils.version import (
-    check_version_compatibility,
-)
-
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
 from typing import (
     Callable,
     List,
@@ -24,6 +6,8 @@ from typing import (
     Tuple,
     Union,
 )
+
+import numpy as np
 
 from deepmd.dpmodel import (
     PRECISION_DICT,
@@ -34,7 +18,15 @@ from deepmd.dpmodel.utils import (
     PairExcludeMask,
 )
 from deepmd.dpmodel.utils.network import (
+    LayerNorm,
+    NativeLayer,
     get_activation_fn,
+)
+from deepmd.utils.path import (
+    DPPath,
+)
+from deepmd.utils.version import (
+    check_version_compatibility,
 )
 
 from .descriptor import (

--- a/deepmd/dpmodel/descriptor/se_e2_a.py
+++ b/deepmd/dpmodel/descriptor/se_e2_a.py
@@ -1,8 +1,26 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import copy
 import itertools
+from typing import (
+    Any,
+    List,
+    Optional,
+    Tuple,
+)
 
 import numpy as np
 
+from deepmd.dpmodel import (
+    DEFAULT_PRECISION,
+    PRECISION_DICT,
+    NativeOP,
+)
+from deepmd.dpmodel.utils import (
+    EmbeddingNet,
+    EnvMat,
+    NetworkCollection,
+    PairExcludeMask,
+)
 from deepmd.dpmodel.utils.update_sel import (
     UpdateSel,
 )
@@ -17,31 +35,6 @@ from deepmd.utils.path import (
 )
 from deepmd.utils.version import (
     check_version_compatibility,
-)
-
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
-import copy
-from typing import (
-    Any,
-    List,
-    Optional,
-    Tuple,
-)
-
-from deepmd.dpmodel import (
-    DEFAULT_PRECISION,
-    PRECISION_DICT,
-    NativeOP,
-)
-from deepmd.dpmodel.utils import (
-    EmbeddingNet,
-    EnvMat,
-    NetworkCollection,
-    PairExcludeMask,
 )
 
 from .base_descriptor import (

--- a/deepmd/dpmodel/descriptor/se_r.py
+++ b/deepmd/dpmodel/descriptor/se_r.py
@@ -1,24 +1,4 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import numpy as np
-
-from deepmd.dpmodel.utils.update_sel import (
-    UpdateSel,
-)
-from deepmd.utils.data_system import (
-    DeepmdDataSystem,
-)
-from deepmd.utils.path import (
-    DPPath,
-)
-from deepmd.utils.version import (
-    check_version_compatibility,
-)
-
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
 import copy
 from typing import (
     Any,
@@ -26,6 +6,8 @@ from typing import (
     Optional,
     Tuple,
 )
+
+import numpy as np
 
 from deepmd.dpmodel import (
     DEFAULT_PRECISION,
@@ -38,8 +20,20 @@ from deepmd.dpmodel.utils import (
     NetworkCollection,
     PairExcludeMask,
 )
+from deepmd.dpmodel.utils.update_sel import (
+    UpdateSel,
+)
 from deepmd.env import (
     GLOBAL_NP_FLOAT_PRECISION,
+)
+from deepmd.utils.data_system import (
+    DeepmdDataSystem,
+)
+from deepmd.utils.path import (
+    DPPath,
+)
+from deepmd.utils.version import (
+    check_version_compatibility,
 )
 
 from .base_descriptor import (

--- a/deepmd/dpmodel/descriptor/se_t.py
+++ b/deepmd/dpmodel/descriptor/se_t.py
@@ -1,8 +1,25 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import copy
 import itertools
+from typing import (
+    List,
+    Optional,
+    Tuple,
+)
 
 import numpy as np
 
+from deepmd.dpmodel import (
+    DEFAULT_PRECISION,
+    PRECISION_DICT,
+    NativeOP,
+)
+from deepmd.dpmodel.utils import (
+    EmbeddingNet,
+    EnvMat,
+    NetworkCollection,
+    PairExcludeMask,
+)
 from deepmd.dpmodel.utils.update_sel import (
     UpdateSel,
 )
@@ -17,30 +34,6 @@ from deepmd.utils.path import (
 )
 from deepmd.utils.version import (
     check_version_compatibility,
-)
-
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
-import copy
-from typing import (
-    List,
-    Optional,
-    Tuple,
-)
-
-from deepmd.dpmodel import (
-    DEFAULT_PRECISION,
-    PRECISION_DICT,
-    NativeOP,
-)
-from deepmd.dpmodel.utils import (
-    EmbeddingNet,
-    EnvMat,
-    NetworkCollection,
-    PairExcludeMask,
 )
 
 from .base_descriptor import (

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -17,19 +17,13 @@ from typing import (
 
 import numpy as np
 
-from deepmd.utils.version import (
-    check_version_compatibility,
-)
-
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
 from deepmd.dpmodel import (
     DEFAULT_PRECISION,
     PRECISION_DICT,
     NativeOP,
+)
+from deepmd.utils.version import (
+    check_version_compatibility,
 )
 
 

--- a/deepmd/pt/model/network/mlp.py
+++ b/deepmd/pt/model/network/mlp.py
@@ -41,11 +41,6 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
-try:
-    from deepmd._version import version as __version__
-except ImportError:
-    __version__ = "unknown"
-
 
 def empty_t(shape, precision):
     return torch.empty(shape, dtype=precision, device=device)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reorganized and cleaned up import statements across multiple files for improved readability and maintainability.
  - Simplified version handling logic by removing unnecessary imports and setting default version values.

- **Chores**
  - Removed duplicate imports and restructured import order to enhance code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->