### PR TITLE
chore: remove type embedding TODO from se_r serialize

### DIFF
--- a/deepmd/tf/descriptor/se_r.py
+++ b/deepmd/tf/descriptor/se_r.py
@@ -765,9 +765,6 @@ class DescrptSeR(DescrptSe):
             raise NotImplementedError("spin is unsupported")
         assert self.davg is not None
         assert self.dstd is not None
-        # TODO: tf: handle type embedding in DescrptSeR.serialize
-        # not sure how to handle type embedding - type embedding is not a model parameter,
-        # but instead a part of the input data. Maybe the interface should be refactored...
         return {
             "@class": "Descriptor",
             "type": "se_r",


### PR DESCRIPTION
Closes #3554. I just find `se_r` never supports type embedding. It's a mistake in #3338.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the serialization process by removing type embedding handling, leading to cleaner and more maintainable code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->