### PR TITLE
ci: bump ase to 3.23.0

### DIFF
--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -47,11 +47,9 @@ jobs:
         CMAKE_GENERATOR: Ninja
         CXXFLAGS: ${{ matrix.check_memleak && '-fsanitize=leak' || '' }}
     # test lammps
-    # ASE issue: https://gitlab.com/ase/ase/-/merge_requests/2843
-    # TODO: remove ase version when ase has new release
     - run: |
         export TENSORFLOW_ROOT=$(python -c 'import importlib,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
-        python -m uv pip install --system -e .[cpu,test,lmp] mpi4py "ase @ https://gitlab.com/ase/ase/-/archive/8c5aa5fd6448c5cfb517a014dccf2b214a9dfa8f/ase-8c5aa5fd6448c5cfb517a014dccf2b214a9dfa8f.tar.gz"
+        python -m uv pip install --system -e .[cpu,test,lmp] mpi4py
       env:
         DP_BUILD_TESTING: 1
       if: ${{ !matrix.check_memleak }}

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -50,7 +50,7 @@ jobs:
     - run: python -m uv pip install --system "tensorflow>=2.15.0rc0" "torch>=2.2.0"
     - run: |
         export TENSORFLOW_ROOT=$(python -c 'import importlib,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
-        python -m uv pip install --system -v -e .[gpu,test,lmp,cu12,torch] mpi4py "ase @ https://gitlab.com/ase/ase/-/archive/8c5aa5fd6448c5cfb517a014dccf2b214a9dfa8f/ase-8c5aa5fd6448c5cfb517a014dccf2b214a9dfa8f.tar.gz"
+        python -m uv pip install --system -v -e .[gpu,test,lmp,cu12,torch] mpi4py
       env:
         DP_VARIANT: cuda
         DP_ENABLE_NATIVE_OPTIMIZATION: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ repository = "https://github.com/deepmodeling/deepmd-kit"
 [tool.deepmd_build_backend.optional-dependencies]
 test = [
     "dpdata>=0.2.7",
-    "ase",
+    # ASE issue: https://gitlab.com/ase/ase/-/merge_requests/2843
+    # fixed in 3.23.0
+    "ase>=3.23.0",
     "pytest",
     "pytest-cov",
     "pytest-sugar",


### PR DESCRIPTION
Fix #3520.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the installation process by removing specific version references for the `ase` package in workflow files.
  - Updated the dependency version of "ase" to `>=3.23.0` in `pyproject.toml` to ensure compatibility and resolve previous issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->