### PR TITLE
fix(test): make unit tests deterministic

### DIFF
--- a/source/tests/common/dpmodel/test_descriptor_dpa1.py
+++ b/source/tests/common/dpmodel/test_descriptor_dpa1.py
@@ -7,6 +7,9 @@ from deepmd.dpmodel.descriptor import (
     DescrptDPA1,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -19,7 +22,7 @@ class TestDescrptDPA1(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_dpa1.py
+++ b/source/tests/common/dpmodel/test_descriptor_dpa1.py
@@ -19,7 +19,7 @@ class TestDescrptDPA1(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_dpa2.py
+++ b/source/tests/common/dpmodel/test_descriptor_dpa2.py
@@ -11,6 +11,9 @@ from deepmd.dpmodel.descriptor.dpa2 import (
     RepinitArgs,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -23,7 +26,7 @@ class TestDescrptDPA2(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_dpa2.py
+++ b/source/tests/common/dpmodel/test_descriptor_dpa2.py
@@ -23,7 +23,7 @@ class TestDescrptDPA2(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_hybrid.py
+++ b/source/tests/common/dpmodel/test_descriptor_hybrid.py
@@ -16,6 +16,9 @@ from deepmd.dpmodel.descriptor.se_r import (
     DescrptSeR,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -29,7 +32,7 @@ class TestDescrptHybrid(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_get_parameters(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))
@@ -72,7 +75,7 @@ class TestDescrptHybrid(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_hybrid.py
+++ b/source/tests/common/dpmodel/test_descriptor_hybrid.py
@@ -29,7 +29,7 @@ class TestDescrptHybrid(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_get_parameters(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))
@@ -72,7 +72,7 @@ class TestDescrptHybrid(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_se_e2_a.py
+++ b/source/tests/common/dpmodel/test_descriptor_se_e2_a.py
@@ -7,6 +7,9 @@ from deepmd.dpmodel.descriptor import (
     DescrptSeA,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -19,7 +22,7 @@ class TestDescrptSeA(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_se_e2_a.py
+++ b/source/tests/common/dpmodel/test_descriptor_se_e2_a.py
@@ -19,7 +19,7 @@ class TestDescrptSeA(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_se_r.py
+++ b/source/tests/common/dpmodel/test_descriptor_se_r.py
@@ -7,6 +7,9 @@ from deepmd.dpmodel.descriptor import (
     DescrptSeR,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -19,7 +22,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))

--- a/source/tests/common/dpmodel/test_descriptor_se_r.py
+++ b/source/tests/common/dpmodel/test_descriptor_se_r.py
@@ -19,7 +19,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))

--- a/source/tests/common/dpmodel/test_descriptor_se_t.py
+++ b/source/tests/common/dpmodel/test_descriptor_se_t.py
@@ -7,6 +7,9 @@ from deepmd.dpmodel.descriptor import (
     DescrptSeT,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -19,7 +22,7 @@ class TestDescrptSeT(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_descriptor_se_t.py
+++ b/source/tests/common/dpmodel/test_descriptor_se_t.py
@@ -19,7 +19,7 @@ class TestDescrptSeT(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_dp_model.py
+++ b/source/tests/common/dpmodel/test_dp_model.py
@@ -50,7 +50,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         np.testing.assert_allclose(ret0["energy_redu"], ret1["energy_redu"])
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         ds = DescrptSeA(
             self.rcut,
@@ -102,7 +102,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         TestCaseSingleFrameWithoutNlist.setUp(self)
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc = self.atype.shape
         ds = DescrptSeA(
             self.rcut,

--- a/source/tests/common/dpmodel/test_dp_model.py
+++ b/source/tests/common/dpmodel/test_dp_model.py
@@ -13,6 +13,9 @@ from deepmd.dpmodel.model.ener_model import (
     EnergyModel,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
     TestCaseSingleFrameWithoutNlist,
@@ -50,7 +53,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         np.testing.assert_allclose(ret0["energy_redu"], ret1["energy_redu"])
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DescrptSeA(
             self.rcut,
@@ -102,7 +105,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         TestCaseSingleFrameWithoutNlist.setUp(self)
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc = self.atype.shape
         ds = DescrptSeA(
             self.rcut,

--- a/source/tests/common/dpmodel/test_env_mat.py
+++ b/source/tests/common/dpmodel/test_env_mat.py
@@ -7,6 +7,9 @@ from deepmd.dpmodel.utils import (
     EnvMat,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -19,7 +22,7 @@ class TestEnvMat(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_env_mat.py
+++ b/source/tests/common/dpmodel/test_env_mat.py
@@ -19,7 +19,7 @@ class TestEnvMat(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/common/dpmodel/test_fitting_invar_fitting.py
+++ b/source/tests/common/dpmodel/test_fitting_invar_fitting.py
@@ -23,7 +23,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         ds = DescrptSeA(self.rcut, self.rcut_smth, self.sel)
         dd = ds.call(self.coord_ext, self.atype_ext, self.nlist)
@@ -102,7 +102,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_exception(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         ds = DescrptSeA(self.rcut, self.rcut_smth, self.sel)
         dd = ds.call(self.coord_ext, self.atype_ext, self.nlist)
@@ -160,7 +160,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
             3,
             1,
         )
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         foo = rng.normal([3, 4])
         for ii in [
             "bias_atom_e",

--- a/source/tests/common/dpmodel/test_fitting_invar_fitting.py
+++ b/source/tests/common/dpmodel/test_fitting_invar_fitting.py
@@ -11,6 +11,9 @@ from deepmd.dpmodel.fitting import (
     InvarFitting,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .case_single_frame_with_nlist import (
     TestCaseSingleFrameWithNlist,
 )
@@ -23,7 +26,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DescrptSeA(self.rcut, self.rcut_smth, self.sel)
         dd = ds.call(self.coord_ext, self.atype_ext, self.nlist)
@@ -102,7 +105,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_self_exception(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DescrptSeA(self.rcut, self.rcut_smth, self.sel)
         dd = ds.call(self.coord_ext, self.atype_ext, self.nlist)
@@ -160,7 +163,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
             3,
             1,
         )
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         foo = rng.normal([3, 4])
         for ii in [
             "bias_atom_e",

--- a/source/tests/common/dpmodel/test_neighbor_stat.py
+++ b/source/tests/common/dpmodel/test_neighbor_stat.py
@@ -11,16 +11,17 @@ from deepmd.entrypoints.neighbor_stat import (
 
 
 def gen_sys(nframes):
+    rng = np.random.default_rng(20240604)
     natoms = 1000
     data = {}
     X, Y, Z = np.mgrid[0:2:3j, 0:2:3j, 0:2:3j]
     positions = np.vstack([X.ravel(), Y.ravel(), Z.ravel()]).T  # + 0.1
     data["coords"] = np.repeat(positions[np.newaxis, :, :], nframes, axis=0)
-    data["forces"] = np.random.default_rng().random([nframes, natoms, 3])
+    data["forces"] = rng.random([nframes, natoms, 3])
     data["cells"] = np.array([3.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 3.0]).reshape(
         1, 3, 3
     )
-    data["energies"] = np.random.default_rng().random([nframes, 1])
+    data["energies"] = rng.random([nframes, 1])
     data["atom_names"] = ["TYPE"]
     data["atom_numbs"] = [27]
     data["atom_types"] = np.repeat(0, 27)

--- a/source/tests/common/dpmodel/test_neighbor_stat.py
+++ b/source/tests/common/dpmodel/test_neighbor_stat.py
@@ -9,9 +9,13 @@ from deepmd.entrypoints.neighbor_stat import (
     neighbor_stat,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 
 def gen_sys(nframes):
-    rng = np.random.default_rng(20240604)
+    rng = np.random.default_rng(GLOBAL_SEED)
     natoms = 1000
     data = {}
     X, Y, Z = np.mgrid[0:2:3j, 0:2:3j, 0:2:3j]

--- a/source/tests/common/dpmodel/test_region.py
+++ b/source/tests/common/dpmodel/test_region.py
@@ -19,7 +19,7 @@ class TestRegion(unittest.TestCase):
         self.prec = 1e-8
 
     def test_inter_to_phys(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         inter = rng.normal(size=[4, 5, 3, 3])
         phys = inter2phys(inter, self.cell)
         for ii in range(4):

--- a/source/tests/common/dpmodel/test_region.py
+++ b/source/tests/common/dpmodel/test_region.py
@@ -8,6 +8,10 @@ from deepmd.dpmodel.utils import (
     to_face_distance,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 
 class TestRegion(unittest.TestCase):
     def setUp(self):
@@ -19,7 +23,7 @@ class TestRegion(unittest.TestCase):
         self.prec = 1e-8
 
     def test_inter_to_phys(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         inter = rng.normal(size=[4, 5, 3, 3])
         phys = inter2phys(inter, self.cell)
         for ii in range(4):

--- a/source/tests/common/dpmodel/test_update_sel.py
+++ b/source/tests/common/dpmodel/test_update_sel.py
@@ -12,6 +12,10 @@ from deepmd.dpmodel.utils.update_sel import (
     UpdateSel,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 
 def update_sel(jdata):
     type_map = jdata["model"].get("type_map")
@@ -23,7 +27,7 @@ def update_sel(jdata):
 class TestTrain(unittest.TestCase):
     def setUp(self) -> None:
         self.update_sel = UpdateSel()
-        self.mock_min_nbor_dist = random.Random(20240604).random()
+        self.mock_min_nbor_dist = random.Random(GLOBAL_SEED).random()
         return super().setUp()
 
     @patch("deepmd.dpmodel.utils.update_sel.UpdateSel.get_nbor_stat")

--- a/source/tests/common/dpmodel/test_update_sel.py
+++ b/source/tests/common/dpmodel/test_update_sel.py
@@ -23,7 +23,7 @@ def update_sel(jdata):
 class TestTrain(unittest.TestCase):
     def setUp(self) -> None:
         self.update_sel = UpdateSel()
-        self.mock_min_nbor_dist = random.random()
+        self.mock_min_nbor_dist = random.Random(20240604).random()
         return super().setUp()
 
     @patch("deepmd.dpmodel.utils.update_sel.UpdateSel.get_nbor_stat")

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -33,7 +33,9 @@ if INSTALLED_TF:
 class TestActivationFunctionConsistent(unittest.TestCase):
     def setUp(self):
         (self.activation,) = self.param
-        self.random_input = np.random.default_rng().normal(scale=10, size=(10, 10))
+        self.random_input = np.random.default_rng(20240604).normal(
+            scale=10, size=(10, 10)
+        )
         self.ref = get_activation_fn_dp(self.activation)(self.random_input)
 
     @unittest.skipUnless(INSTALLED_TF, "TensorFlow is not installed")

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -8,6 +8,9 @@ from deepmd.common import (
 )
 from deepmd.dpmodel.utils.network import get_activation_fn as get_activation_fn_dp
 
+from ..seed import (
+    GLOBAL_SEED,
+)
 from .common import (
     INSTALLED_PT,
     INSTALLED_TF,
@@ -33,7 +36,7 @@ if INSTALLED_TF:
 class TestActivationFunctionConsistent(unittest.TestCase):
     def setUp(self):
         (self.activation,) = self.param
-        self.random_input = np.random.default_rng(20240604).normal(
+        self.random_input = np.random.default_rng(GLOBAL_SEED).normal(
             scale=10, size=(10, 10)
         )
         self.ref = get_activation_fn_dp(self.activation)(self.random_input)

--- a/source/tests/pt/model/test_autodiff.py
+++ b/source/tests/pt/model/test_autodiff.py
@@ -15,6 +15,10 @@ from deepmd.pt.utils.utils import (
     to_numpy_array,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 dtype = torch.float64
 
 from .test_permutation import (
@@ -58,7 +62,7 @@ class ForceTest:
         places = 5
         delta = 1e-5
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device="cpu", generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device="cpu")
         coord = torch.rand([natoms, 3], dtype=dtype, device="cpu", generator=generator)
@@ -130,7 +134,7 @@ class VirialTest:
         places = 5
         delta = 1e-4
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device="cpu", generator=generator)
         cell = (cell) + 5.0 * torch.eye(3, device="cpu")
         coord = torch.rand([natoms, 3], dtype=dtype, device="cpu", generator=generator)

--- a/source/tests/pt/model/test_autodiff.py
+++ b/source/tests/pt/model/test_autodiff.py
@@ -58,11 +58,12 @@ class ForceTest:
         places = 5
         delta = 1e-5
         natoms = 5
-        cell = torch.rand([3, 3], dtype=dtype, device="cpu")
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell = torch.rand([3, 3], dtype=dtype, device="cpu", generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device="cpu")
-        coord = torch.rand([natoms, 3], dtype=dtype, device="cpu")
+        coord = torch.rand([natoms, 3], dtype=dtype, device="cpu", generator=generator)
         coord = torch.matmul(coord, cell)
-        spin = torch.rand([natoms, 3], dtype=dtype, device="cpu")
+        spin = torch.rand([natoms, 3], dtype=dtype, device="cpu", generator=generator)
         atype = torch.IntTensor([0, 0, 0, 1, 1])
         # assumes input to be numpy tensor
         coord = coord.numpy()
@@ -129,9 +130,10 @@ class VirialTest:
         places = 5
         delta = 1e-4
         natoms = 5
-        cell = torch.rand([3, 3], dtype=dtype, device="cpu")
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell = torch.rand([3, 3], dtype=dtype, device="cpu", generator=generator)
         cell = (cell) + 5.0 * torch.eye(3, device="cpu")
-        coord = torch.rand([natoms, 3], dtype=dtype, device="cpu")
+        coord = torch.rand([natoms, 3], dtype=dtype, device="cpu", generator=generator)
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1])
         # assumes input to be numpy tensor

--- a/source/tests/pt/model/test_descriptor_hybrid.py
+++ b/source/tests/pt/model/test_descriptor_hybrid.py
@@ -23,6 +23,9 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -56,7 +59,7 @@ class TestDescrptHybrid(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_get_parameters(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ddsub0 = DescrptSeA(
             rcut=self.rcut,

--- a/source/tests/pt/model/test_descriptor_hybrid.py
+++ b/source/tests/pt/model/test_descriptor_hybrid.py
@@ -23,9 +23,6 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
-from ...seed import (
-    GLOBAL_SEED,
-)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -59,7 +56,6 @@ class TestDescrptHybrid(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_get_parameters(
         self,
     ):
-        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ddsub0 = DescrptSeA(
             rcut=self.rcut,

--- a/source/tests/pt/model/test_descriptor_hybrid.py
+++ b/source/tests/pt/model/test_descriptor_hybrid.py
@@ -56,7 +56,7 @@ class TestDescrptHybrid(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_get_parameters(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         ddsub0 = DescrptSeA(
             rcut=self.rcut,

--- a/source/tests/pt/model/test_descriptor_se_r.py
+++ b/source/tests/pt/model/test_descriptor_se_r.py
@@ -37,7 +37,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         _, _, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))
@@ -107,7 +107,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
                 )
 
     def test_load_stat(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         _, _, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))
@@ -157,7 +157,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         _, _, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))

--- a/source/tests/pt/model/test_descriptor_se_r.py
+++ b/source/tests/pt/model/test_descriptor_se_r.py
@@ -19,6 +19,9 @@ from deepmd.pt.utils.env_mat_stat import (
     EnvMatStatSe,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -37,7 +40,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         _, _, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))
@@ -107,7 +110,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
                 )
 
     def test_load_stat(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         _, _, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))
@@ -157,7 +160,7 @@ class TestDescrptSeR(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         _, _, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 1))
         dstd = rng.normal(size=(self.nt, nnei, 1))

--- a/source/tests/pt/model/test_dipole_fitting.py
+++ b/source/tests/pt/model/test_dipole_fitting.py
@@ -150,7 +150,7 @@ class TestEquivalence(unittest.TestCase):
         self.rcut_smth = 0.5
         self.sel = [46, 92, 4]
         self.nf = 1
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         self.coord = 2 * torch.rand(
             [self.natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         )
@@ -312,7 +312,7 @@ class TestDipoleModel(unittest.TestCase):
         self.rcut_smth = 0.5
         self.sel = [46, 92, 4]
         self.nf = 1
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         self.coord = 2 * torch.rand(
             [self.natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         )

--- a/source/tests/pt/model/test_dipole_fitting.py
+++ b/source/tests/pt/model/test_dipole_fitting.py
@@ -33,6 +33,9 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -57,7 +60,7 @@ def finite_difference(f, x, a, delta=1e-6):
 class TestDipoleFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def setUp(self):
         TestCaseSingleFrameWithNlist.setUp(self)
-        self.rng = np.random.default_rng(20240604)
+        self.rng = np.random.default_rng(GLOBAL_SEED)
         self.nf, self.nloc, _ = self.nlist.shape
         self.dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
 
@@ -147,7 +150,7 @@ class TestEquivalence(unittest.TestCase):
         self.rcut_smth = 0.5
         self.sel = [46, 92, 4]
         self.nf = 1
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         self.coord = 2 * torch.rand(
             [self.natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         )
@@ -165,7 +168,7 @@ class TestEquivalence(unittest.TestCase):
         coord_rot = torch.matmul(self.coord, rmat)
         # use larger cell to rotate only coord and shift to the center of cell
         cell_rot = 10.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         for nfp, nap in itertools.product(
             [0, 3],
             [0, 4],
@@ -309,7 +312,7 @@ class TestDipoleModel(unittest.TestCase):
         self.rcut_smth = 0.5
         self.sel = [46, 92, 4]
         self.nf = 1
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         self.coord = 2 * torch.rand(
             [self.natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         )

--- a/source/tests/pt/model/test_dipole_fitting.py
+++ b/source/tests/pt/model/test_dipole_fitting.py
@@ -57,7 +57,7 @@ def finite_difference(f, x, a, delta=1e-6):
 class TestDipoleFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def setUp(self):
         TestCaseSingleFrameWithNlist.setUp(self)
-        self.rng = np.random.default_rng()
+        self.rng = np.random.default_rng(20240604)
         self.nf, self.nloc, _ = self.nlist.shape
         self.dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
 
@@ -147,11 +147,16 @@ class TestEquivalence(unittest.TestCase):
         self.rcut_smth = 0.5
         self.sel = [46, 92, 4]
         self.nf = 1
-        self.coord = 2 * torch.rand([self.natoms, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        self.coord = 2 * torch.rand(
+            [self.natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         self.shift = torch.tensor([4, 4, 4], dtype=dtype, device=env.DEVICE)
         self.atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32, device=env.DEVICE)
         self.dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
-        self.cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        self.cell = torch.rand(
+            [3, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         self.cell = (self.cell + self.cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
 
     def test_rot(self):
@@ -160,7 +165,7 @@ class TestEquivalence(unittest.TestCase):
         coord_rot = torch.matmul(self.coord, rmat)
         # use larger cell to rotate only coord and shift to the center of cell
         cell_rot = 10.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         for nfp, nap in itertools.product(
             [0, 3],
             [0, 4],
@@ -304,8 +309,11 @@ class TestDipoleModel(unittest.TestCase):
         self.rcut_smth = 0.5
         self.sel = [46, 92, 4]
         self.nf = 1
-        self.coord = 2 * torch.rand([self.natoms, 3], dtype=dtype, device=env.DEVICE)
-        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        self.coord = 2 * torch.rand(
+            [self.natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
+        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         self.cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         self.atype = torch.IntTensor([0, 0, 0, 1, 1], device="cpu").to(env.DEVICE)
         self.dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)

--- a/source/tests/pt/model/test_dp_atomic_model.py
+++ b/source/tests/pt/model/test_dp_atomic_model.py
@@ -75,7 +75,7 @@ class TestDPAtomicModel(unittest.TestCase, TestCaseSingleFrameWithNlist):
             )
 
     def test_dp_consistency(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,

--- a/source/tests/pt/model/test_dp_atomic_model.py
+++ b/source/tests/pt/model/test_dp_atomic_model.py
@@ -25,9 +25,6 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
-from ...seed import (
-    GLOBAL_SEED,
-)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
     TestCaseSingleFrameWithNlistWithVirtual,
@@ -78,7 +75,6 @@ class TestDPAtomicModel(unittest.TestCase, TestCaseSingleFrameWithNlist):
             )
 
     def test_dp_consistency(self):
-        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,

--- a/source/tests/pt/model/test_dp_atomic_model.py
+++ b/source/tests/pt/model/test_dp_atomic_model.py
@@ -25,6 +25,9 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
     TestCaseSingleFrameWithNlistWithVirtual,
@@ -75,7 +78,7 @@ class TestDPAtomicModel(unittest.TestCase, TestCaseSingleFrameWithNlist):
             )
 
     def test_dp_consistency(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,

--- a/source/tests/pt/model/test_dp_model.py
+++ b/source/tests/pt/model/test_dp_model.py
@@ -29,6 +29,9 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
     TestCaseSingleFrameWithoutNlist,
@@ -130,7 +133,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         md0 = DPEnergyModel(ds, ft, type_map=type_map)
         md1 = EnergyModel.deserialize(md0.serialize()).to(env.DEVICE)
 
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         fparam = rng.normal(size=[self.nf, nfp])
         aparam = rng.normal(size=[self.nf, nloc, nap])
         args0 = [self.coord, self.atype, self.cell]
@@ -169,7 +172,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         md0 = DPEnergyModel(ds, ft, type_map=type_map)
         md1 = EnergyModel.deserialize(md0.serialize()).to(env.DEVICE)
 
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         fparam = rng.normal(size=[self.nf, nfp])
         aparam = rng.normal(size=[self.nf, self.nloc, nap])
         args0 = [self.coord, self.atype]
@@ -190,7 +193,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         )
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc = self.atype.shape
         ds = DPDescrptSeA(
             self.rcut,
@@ -292,7 +295,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         )
 
     def test_dp_consistency(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,
@@ -325,7 +328,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         )
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,

--- a/source/tests/pt/model/test_dp_model.py
+++ b/source/tests/pt/model/test_dp_model.py
@@ -130,7 +130,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         md0 = DPEnergyModel(ds, ft, type_map=type_map)
         md1 = EnergyModel.deserialize(md0.serialize()).to(env.DEVICE)
 
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         fparam = rng.normal(size=[self.nf, nfp])
         aparam = rng.normal(size=[self.nf, nloc, nap])
         args0 = [self.coord, self.atype, self.cell]
@@ -169,7 +169,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         md0 = DPEnergyModel(ds, ft, type_map=type_map)
         md1 = EnergyModel.deserialize(md0.serialize()).to(env.DEVICE)
 
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         fparam = rng.normal(size=[self.nf, nfp])
         aparam = rng.normal(size=[self.nf, self.nloc, nap])
         args0 = [self.coord, self.atype]
@@ -190,7 +190,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         )
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc = self.atype.shape
         ds = DPDescrptSeA(
             self.rcut,
@@ -292,7 +292,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         )
 
     def test_dp_consistency(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,
@@ -325,7 +325,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         )
 
     def test_prec_consistency(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,

--- a/source/tests/pt/model/test_dp_model.py
+++ b/source/tests/pt/model/test_dp_model.py
@@ -295,7 +295,6 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         )
 
     def test_dp_consistency(self):
-        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         ds = DPDescrptSeA(
             self.rcut,

--- a/source/tests/pt/model/test_dpa1.py
+++ b/source/tests/pt/model/test_dpa1.py
@@ -170,7 +170,7 @@ class TestDescrptSeAtten(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_dpa1.py
+++ b/source/tests/pt/model/test_dpa1.py
@@ -16,6 +16,9 @@ from deepmd.pt.utils.env import (
     PRECISION_DICT,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -170,7 +173,7 @@ class TestDescrptSeAtten(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_ener_fitting.py
+++ b/source/tests/pt/model/test_ener_fitting.py
@@ -34,7 +34,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
         rd0, _, _, _, _ = dd0(
@@ -102,7 +102,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_new_old(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         dd = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
         rd0, _, _, _, _ = dd(
@@ -176,7 +176,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
             3,
             1,
         )
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         foo = rng.normal([3, 4])
         for ii in [
             "bias_atom_e",

--- a/source/tests/pt/model/test_ener_fitting.py
+++ b/source/tests/pt/model/test_ener_fitting.py
@@ -20,6 +20,9 @@ from deepmd.pt.utils.utils import (
     to_numpy_array,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -34,7 +37,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
         rd0, _, _, _, _ = dd0(
@@ -102,7 +105,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_new_old(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         dd = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
         rd0, _, _, _, _ = dd(
@@ -176,7 +179,7 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
             3,
             1,
         )
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         foo = rng.normal([3, 4])
         for ii in [
             "bias_atom_e",

--- a/source/tests/pt/model/test_ener_fitting.py
+++ b/source/tests/pt/model/test_ener_fitting.py
@@ -105,7 +105,6 @@ class TestInvarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_new_old(
         self,
     ):
-        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         dd = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
         rd0, _, _, _, _ = dd(

--- a/source/tests/pt/model/test_ener_spin_model.py
+++ b/source/tests/pt/model/test_ener_spin_model.py
@@ -59,11 +59,12 @@ class SpinTest:
         natoms = 5
         self.ntypes = 3  # ["O", "H", "B"] for test
         self.cell = 4.0 * torch.eye(3, dtype=dtype, device=env.DEVICE).unsqueeze(0)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
         self.coord = 3.0 * torch.rand(
-            [natoms, 3], dtype=dtype, device=env.DEVICE
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         ).unsqueeze(0)
         self.spin = 0.5 * torch.rand(
-            [natoms, 3], dtype=dtype, device=env.DEVICE
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         ).unsqueeze(0)
         self.atype = torch.tensor(
             [0, 0, 0, 1, 1], dtype=torch.int64, device=env.DEVICE

--- a/source/tests/pt/model/test_ener_spin_model.py
+++ b/source/tests/pt/model/test_ener_spin_model.py
@@ -20,6 +20,9 @@ from deepmd.pt.utils.utils import (
     to_numpy_array,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (
     model_dpa1,
     model_dpa2,
@@ -59,7 +62,7 @@ class SpinTest:
         natoms = 5
         self.ntypes = 3  # ["O", "H", "B"] for test
         self.cell = 4.0 * torch.eye(3, dtype=dtype, device=env.DEVICE).unsqueeze(0)
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         self.coord = 3.0 * torch.rand(
             [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         ).unsqueeze(0)

--- a/source/tests/pt/model/test_ener_spin_model.py
+++ b/source/tests/pt/model/test_ener_spin_model.py
@@ -62,7 +62,7 @@ class SpinTest:
         natoms = 5
         self.ntypes = 3  # ["O", "H", "B"] for test
         self.cell = 4.0 * torch.eye(3, dtype=dtype, device=env.DEVICE).unsqueeze(0)
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         self.coord = 3.0 * torch.rand(
             [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         ).unsqueeze(0)

--- a/source/tests/pt/model/test_env_mat.py
+++ b/source/tests/pt/model/test_env_mat.py
@@ -14,6 +14,10 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 dtype = env.GLOBAL_PT_FLOAT_PRECISION
 
 
@@ -155,7 +159,7 @@ class TestEnvMat(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_env_mat.py
+++ b/source/tests/pt/model/test_env_mat.py
@@ -155,7 +155,7 @@ class TestEnvMat(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_fitting_net.py
+++ b/source/tests/pt/model/test_fitting_net.py
@@ -84,7 +84,7 @@ class TestFittingNet(unittest.TestCase):
         nloc = 7
         self.embedding_width = 30
         self.natoms = np.array([nloc, nloc, 2, 5], dtype=np.int32)
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         self.embedding = rng.uniform(size=[4, nloc * self.embedding_width])
         self.ntypes = self.natoms.size - 2
         self.n_neuron = [32, 32, 32]

--- a/source/tests/pt/model/test_fitting_net.py
+++ b/source/tests/pt/model/test_fitting_net.py
@@ -21,6 +21,10 @@ from deepmd.tf.fit.ener import (
     EnerFitting,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 
 class FakeDescriptor:
     def __init__(self, ntypes, embedding_width):
@@ -84,7 +88,7 @@ class TestFittingNet(unittest.TestCase):
         nloc = 7
         self.embedding_width = 30
         self.natoms = np.array([nloc, nloc, 2, 5], dtype=np.int32)
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         self.embedding = rng.uniform(size=[4, nloc * self.embedding_width])
         self.ntypes = self.natoms.size - 2
         self.n_neuron = [32, 32, 32]

--- a/source/tests/pt/model/test_force_grad.py
+++ b/source/tests/pt/model/test_force_grad.py
@@ -23,6 +23,10 @@ from deepmd.utils.data import (
     DeepmdData,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 
 class CheckSymmetry(DeepmdData):
     def __init__(
@@ -85,7 +89,7 @@ class TestForceGrad(unittest.TestCase):
 
     @unittest.skip("it can be replaced by autodiff")
     def test_force_grad(self, threshold=1e-2, delta0=1e-6, seed=20):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         result0 = self.model(**get_data(self.origin_batch))
         np.random.default_rng(seed)
         errors = np.zeros((self.dpdatasystem.natoms, 3))

--- a/source/tests/pt/model/test_force_grad.py
+++ b/source/tests/pt/model/test_force_grad.py
@@ -85,12 +85,13 @@ class TestForceGrad(unittest.TestCase):
 
     @unittest.skip("it can be replaced by autodiff")
     def test_force_grad(self, threshold=1e-2, delta0=1e-6, seed=20):
+        rng = np.random.default_rng(20240604)
         result0 = self.model(**get_data(self.origin_batch))
         np.random.default_rng(seed)
         errors = np.zeros((self.dpdatasystem.natoms, 3))
         for atom_index in range(self.dpdatasystem.natoms):
             for axis_index in range(3):
-                delta = np.random.default_rng().random() * delta0
+                delta = rng.random() * delta0
                 disturb_batch = self.dpdatasystem.get_disturb(
                     self.batch_index, atom_index, axis_index, delta
                 )

--- a/source/tests/pt/model/test_forward_lower.py
+++ b/source/tests/pt/model/test_forward_lower.py
@@ -61,7 +61,7 @@ class ForwardLowerTest:
         prec = self.prec
         natoms = 5
         cell = 4.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         coord = 3.0 * torch.rand(
             [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         )

--- a/source/tests/pt/model/test_forward_lower.py
+++ b/source/tests/pt/model/test_forward_lower.py
@@ -17,6 +17,9 @@ from deepmd.pt.utils.nlist import (
     extend_input_and_build_neighbor_list,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (  # model_dpau,
     model_dpa1,
     model_dpa2,
@@ -58,7 +61,7 @@ class ForwardLowerTest:
         prec = self.prec
         natoms = 5
         cell = 4.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         coord = 3.0 * torch.rand(
             [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
         )

--- a/source/tests/pt/model/test_forward_lower.py
+++ b/source/tests/pt/model/test_forward_lower.py
@@ -58,8 +58,13 @@ class ForwardLowerTest:
         prec = self.prec
         natoms = 5
         cell = 4.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
-        coord = 3.0 * torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
-        spin = 0.5 * torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        coord = 3.0 * torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
+        spin = 0.5 * torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int64, device=env.DEVICE)
         test_spin = getattr(self, "test_spin", False)
         if not test_spin:

--- a/source/tests/pt/model/test_linear_atomic_model.py
+++ b/source/tests/pt/model/test_linear_atomic_model.py
@@ -32,6 +32,9 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -191,7 +194,8 @@ class TestIntegration(unittest.TestCase, TestCaseSingleFrameWithNlist):
 
 class TestRemmapMethod(unittest.TestCase):
     def test_valid(self):
-        atype = torch.randint(0, 3, (4, 20), device=env.DEVICE)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
+        atype = torch.randint(0, 3, (4, 20), device=env.DEVICE, generator=generator)
         commonl = ["H", "O", "S"]
         originl = ["Si", "H", "O", "S"]
         mapping = DPZBLLinearEnergyAtomicModel.remap_atype(originl, commonl)

--- a/source/tests/pt/model/test_make_hessian_model.py
+++ b/source/tests/pt/model/test_make_hessian_model.py
@@ -66,12 +66,15 @@ class HessianTest:
         natoms = self.nloc
         nf = self.nf
         nv = self.nv
-        cell0 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell0 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell0 = 1.0 * (cell0 + cell0.T) + 5.0 * torch.eye(3, device=env.DEVICE)
-        cell1 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        cell1 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell1 = 1.0 * (cell1 + cell1.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         cell = torch.stack([cell0, cell1])
-        coord = torch.rand([nf, natoms, 3], dtype=dtype, device=env.DEVICE)
+        coord = torch.rand(
+            [nf, natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         coord = torch.matmul(coord, cell)
         cell = cell.view([nf, 9])
         coord = coord.view([nf, natoms * 3])
@@ -86,8 +89,12 @@ class HessianTest:
             .to(env.DEVICE)
         )
         nfp, nap = 2, 3
-        fparam = torch.rand([nf, nfp], dtype=dtype, device=env.DEVICE)
-        aparam = torch.rand([nf, natoms * nap], dtype=dtype, device=env.DEVICE)
+        fparam = torch.rand(
+            [nf, nfp], dtype=dtype, device=env.DEVICE, generator=generator
+        )
+        aparam = torch.rand(
+            [nf, natoms * nap], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         # forward hess and valu models
         ret_dict0 = self.model_hess.forward_common(
             coord, atype, box=cell, fparam=fparam, aparam=aparam

--- a/source/tests/pt/model/test_make_hessian_model.py
+++ b/source/tests/pt/model/test_make_hessian_model.py
@@ -25,6 +25,10 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 dtype = torch.float64
 
 
@@ -66,7 +70,7 @@ class HessianTest:
         natoms = self.nloc
         nf = self.nf
         nv = self.nv
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell0 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell0 = 1.0 * (cell0 + cell0.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         cell1 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)

--- a/source/tests/pt/model/test_make_hessian_model.py
+++ b/source/tests/pt/model/test_make_hessian_model.py
@@ -70,7 +70,7 @@ class HessianTest:
         natoms = self.nloc
         nf = self.nf
         nv = self.nv
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         cell0 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell0 = 1.0 * (cell0 + cell0.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         cell1 = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)

--- a/source/tests/pt/model/test_null_input.py
+++ b/source/tests/pt/model/test_null_input.py
@@ -35,11 +35,14 @@ class NullTest:
         self,
     ):
         natoms = 1
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
         # torch.manual_seed(1000)
-        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         # large box to exclude images
         cell = (cell + cell.T) + 100.0 * torch.eye(3, device=env.DEVICE)
-        coord = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        coord = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         atype = torch.tensor([0], dtype=torch.int32, device=env.DEVICE)
         test_keys = ["energy", "force", "virial"]
         result = eval_model(self.model, coord.unsqueeze(0), cell.unsqueeze(0), atype)
@@ -58,10 +61,11 @@ class NullTest:
         self,
     ):
         natoms = 2
-        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         # large box to exclude images
         cell = (cell + cell.T) + 3000.0 * torch.eye(3, device=env.DEVICE)
-        coord = torch.rand([1, 3], dtype=dtype, device=env.DEVICE)
+        coord = torch.rand([1, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         # 2 far-away atoms
         coord = torch.cat([coord, coord + 100.0], dim=0)
         atype = torch.tensor([0, 2], dtype=torch.int32, device=env.DEVICE)

--- a/source/tests/pt/model/test_null_input.py
+++ b/source/tests/pt/model/test_null_input.py
@@ -19,6 +19,9 @@ from deepmd.pt.utils.utils import (
     to_numpy_array,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (
     model_dpa1,
     model_dpa2,
@@ -35,7 +38,7 @@ class NullTest:
         self,
     ):
         natoms = 1
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         # torch.manual_seed(1000)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         # large box to exclude images
@@ -61,7 +64,7 @@ class NullTest:
         self,
     ):
         natoms = 2
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         # large box to exclude images
         cell = (cell + cell.T) + 3000.0 * torch.eye(3, device=env.DEVICE)

--- a/source/tests/pt/model/test_null_input.py
+++ b/source/tests/pt/model/test_null_input.py
@@ -38,7 +38,7 @@ class NullTest:
         self,
     ):
         natoms = 1
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         # torch.manual_seed(1000)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         # large box to exclude images
@@ -64,7 +64,7 @@ class NullTest:
         self,
     ):
         natoms = 2
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         # large box to exclude images
         cell = (cell + cell.T) + 3000.0 * torch.eye(3, device=env.DEVICE)

--- a/source/tests/pt/model/test_permutation.py
+++ b/source/tests/pt/model/test_permutation.py
@@ -15,6 +15,10 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 CUR_DIR = os.path.dirname(__file__)
 
 dtype = torch.float64
@@ -259,7 +263,7 @@ class PermutationTest:
         self,
     ):
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         coord = torch.rand(

--- a/source/tests/pt/model/test_permutation.py
+++ b/source/tests/pt/model/test_permutation.py
@@ -259,10 +259,15 @@ class PermutationTest:
         self,
     ):
         natoms = 5
-        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
-        coord = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
-        spin = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        coord = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
+        spin = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         coord = torch.matmul(coord, cell)
         atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32, device=env.DEVICE)
         idx_perm = [1, 0, 4, 3, 2]

--- a/source/tests/pt/model/test_permutation.py
+++ b/source/tests/pt/model/test_permutation.py
@@ -263,7 +263,7 @@ class PermutationTest:
         self,
     ):
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         coord = torch.rand(

--- a/source/tests/pt/model/test_permutation_denoise.py
+++ b/source/tests/pt/model/test_permutation_denoise.py
@@ -40,7 +40,7 @@ class PermutationDenoiseTest:
     def test(
         self,
     ):
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         natoms = 5
         cell = torch.rand([3, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         cell = (cell + cell.T) + 5.0 * torch.eye(3).to(env.DEVICE)

--- a/source/tests/pt/model/test_permutation_denoise.py
+++ b/source/tests/pt/model/test_permutation_denoise.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (  # model_dpau,
     model_dpa1,
     model_dpa2,
@@ -37,7 +40,7 @@ class PermutationDenoiseTest:
     def test(
         self,
     ):
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         natoms = 5
         cell = torch.rand([3, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         cell = (cell + cell.T) + 5.0 * torch.eye(3).to(env.DEVICE)

--- a/source/tests/pt/model/test_permutation_denoise.py
+++ b/source/tests/pt/model/test_permutation_denoise.py
@@ -37,10 +37,11 @@ class PermutationDenoiseTest:
     def test(
         self,
     ):
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
         natoms = 5
-        cell = torch.rand([3, 3], dtype=dtype).to(env.DEVICE)
+        cell = torch.rand([3, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         cell = (cell + cell.T) + 5.0 * torch.eye(3).to(env.DEVICE)
-        coord = torch.rand([natoms, 3], dtype=dtype).to(env.DEVICE)
+        coord = torch.rand([natoms, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1]).to(env.DEVICE)
         idx_perm = [1, 0, 4, 3, 2]

--- a/source/tests/pt/model/test_polarizability_fitting.py
+++ b/source/tests/pt/model/test_polarizability_fitting.py
@@ -32,6 +32,9 @@ from deepmd.pt.utils.utils import (
     to_numpy_array,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -42,7 +45,7 @@ dtype = env.GLOBAL_PT_FLOAT_PRECISION
 class TestPolarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def setUp(self):
         TestCaseSingleFrameWithNlist.setUp(self)
-        self.rng = np.random.default_rng(20240604)
+        self.rng = np.random.default_rng(GLOBAL_SEED)
         self.nf, self.nloc, _ = self.nlist.shape
         self.dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
         self.scale = self.rng.uniform(0, 1, self.nt).tolist()
@@ -152,7 +155,7 @@ class TestEquivalence(unittest.TestCase):
         self.sel = [46, 92, 4]
         self.nf = 1
         self.nt = 3
-        self.rng = np.random.default_rng(20240604)
+        self.rng = np.random.default_rng(GLOBAL_SEED)
         self.coord = 2 * torch.rand([self.natoms, 3], dtype=dtype, device=env.DEVICE)
         self.shift = torch.tensor([4, 4, 4], dtype=dtype, device=env.DEVICE)
         self.atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32, device=env.DEVICE)

--- a/source/tests/pt/model/test_polarizability_fitting.py
+++ b/source/tests/pt/model/test_polarizability_fitting.py
@@ -42,7 +42,7 @@ dtype = env.GLOBAL_PT_FLOAT_PRECISION
 class TestPolarFitting(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def setUp(self):
         TestCaseSingleFrameWithNlist.setUp(self)
-        self.rng = np.random.default_rng()
+        self.rng = np.random.default_rng(20240604)
         self.nf, self.nloc, _ = self.nlist.shape
         self.dd0 = DescrptSeA(self.rcut, self.rcut_smth, self.sel).to(env.DEVICE)
         self.scale = self.rng.uniform(0, 1, self.nt).tolist()
@@ -152,7 +152,7 @@ class TestEquivalence(unittest.TestCase):
         self.sel = [46, 92, 4]
         self.nf = 1
         self.nt = 3
-        self.rng = np.random.default_rng()
+        self.rng = np.random.default_rng(20240604)
         self.coord = 2 * torch.rand([self.natoms, 3], dtype=dtype, device=env.DEVICE)
         self.shift = torch.tensor([4, 4, 4], dtype=dtype, device=env.DEVICE)
         self.atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32, device=env.DEVICE)

--- a/source/tests/pt/model/test_region.py
+++ b/source/tests/pt/model/test_region.py
@@ -28,7 +28,8 @@ class TestRegion(unittest.TestCase):
         self.prec = 1e-8
 
     def test_inter_to_phys(self):
-        inter = torch.rand([4, 5, 3, 3], dtype=dtype, device="cpu")
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        inter = torch.rand([4, 5, 3, 3], dtype=dtype, device="cpu", generator=generator)
         phys = inter2phys(inter, self.cell)
         for ii in range(4):
             for jj in range(5):
@@ -65,14 +66,16 @@ class TestLegacyRegion(unittest.TestCase):
         self.prec = 1e-6
 
     def test_inter_to_phys(self):
-        inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         reg = Region3D(self.cell)
         phys = reg.inter2phys(inter)
         expected_phys = torch.matmul(inter, self.cell)
         torch.testing.assert_close(phys, expected_phys, rtol=self.prec, atol=self.prec)
 
     def test_inter_to_inter(self):
-        inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         reg = Region3D(self.cell)
         new_inter = reg.phys2inter(reg.inter2phys(inter))
         torch.testing.assert_close(inter, new_inter, rtol=self.prec, atol=self.prec)

--- a/source/tests/pt/model/test_region.py
+++ b/source/tests/pt/model/test_region.py
@@ -15,6 +15,10 @@ from deepmd.pt.utils.region import (
     to_face_distance,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
+
 dtype = torch.float64
 
 
@@ -28,7 +32,7 @@ class TestRegion(unittest.TestCase):
         self.prec = 1e-8
 
     def test_inter_to_phys(self):
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         inter = torch.rand([4, 5, 3, 3], dtype=dtype, device="cpu", generator=generator)
         phys = inter2phys(inter, self.cell)
         for ii in range(4):
@@ -66,7 +70,7 @@ class TestLegacyRegion(unittest.TestCase):
         self.prec = 1e-6
 
     def test_inter_to_phys(self):
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         reg = Region3D(self.cell)
         phys = reg.inter2phys(inter)
@@ -74,7 +78,7 @@ class TestLegacyRegion(unittest.TestCase):
         torch.testing.assert_close(phys, expected_phys, rtol=self.prec, atol=self.prec)
 
     def test_inter_to_inter(self):
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         reg = Region3D(self.cell)
         new_inter = reg.phys2inter(reg.inter2phys(inter))

--- a/source/tests/pt/model/test_region.py
+++ b/source/tests/pt/model/test_region.py
@@ -70,7 +70,7 @@ class TestLegacyRegion(unittest.TestCase):
         self.prec = 1e-6
 
     def test_inter_to_phys(self):
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         reg = Region3D(self.cell)
         phys = reg.inter2phys(inter)
@@ -78,7 +78,7 @@ class TestLegacyRegion(unittest.TestCase):
         torch.testing.assert_close(phys, expected_phys, rtol=self.prec, atol=self.prec)
 
     def test_inter_to_inter(self):
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         inter = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         reg = Region3D(self.cell)
         new_inter = reg.phys2inter(reg.inter2phys(inter))

--- a/source/tests/pt/model/test_rot.py
+++ b/source/tests/pt/model/test_rot.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (  # model_dpau,
     model_dos,
     model_dpa1,
@@ -31,7 +34,7 @@ class RotTest:
     def test(
         self,
     ):
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         prec = 1e-10
         natoms = 5
         cell = 10.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)

--- a/source/tests/pt/model/test_rot.py
+++ b/source/tests/pt/model/test_rot.py
@@ -31,11 +31,16 @@ class RotTest:
     def test(
         self,
     ):
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
         prec = 1e-10
         natoms = 5
         cell = 10.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
-        coord = 2 * torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
-        spin = 2 * torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        coord = 2 * torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
+        spin = 2 * torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         shift = torch.tensor([4, 4, 4], dtype=dtype, device=env.DEVICE)
         atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32, device=env.DEVICE)
         from scipy.stats import (
@@ -89,11 +94,15 @@ class RotTest:
                 raise RuntimeError(f"Unexpected test key {key}")
         # rotate coord and cell
         torch.manual_seed(0)
-        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
-        coord = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        coord = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         coord = torch.matmul(coord, cell)
-        spin = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        spin = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32, device=env.DEVICE)
         coord_rot = torch.matmul(coord, rmat)
         spin_rot = torch.matmul(spin, rmat)

--- a/source/tests/pt/model/test_rot.py
+++ b/source/tests/pt/model/test_rot.py
@@ -34,7 +34,7 @@ class RotTest:
     def test(
         self,
     ):
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         prec = 1e-10
         natoms = 5
         cell = 10.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)

--- a/source/tests/pt/model/test_rot_denoise.py
+++ b/source/tests/pt/model/test_rot_denoise.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation_denoise import (
     model_dpa1,
     model_dpa2,
@@ -26,7 +29,7 @@ class RotDenoiseTest:
     def test(
         self,
     ):
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         prec = 1e-10
         natoms = 5
         cell = 10.0 * torch.eye(3, dtype=dtype).to(env.DEVICE)

--- a/source/tests/pt/model/test_rot_denoise.py
+++ b/source/tests/pt/model/test_rot_denoise.py
@@ -29,12 +29,12 @@ class RotDenoiseTest:
     def test(
         self,
     ):
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         prec = 1e-10
         natoms = 5
         cell = 10.0 * torch.eye(3, dtype=dtype).to(env.DEVICE)
-        coord = 2 * torch.rand([natoms, 3], dtype=dtype, generator=generator).to(
-            env.DEVICE
+        coord = 2 * torch.rand(
+            [natoms, 3], dtype=dtype, generator=generator, device=env.DEVICE
         )
         shift = torch.tensor([4, 4, 4], dtype=dtype).to(env.DEVICE)
         atype = torch.IntTensor([0, 0, 0, 1, 1]).to(env.DEVICE)

--- a/source/tests/pt/model/test_rot_denoise.py
+++ b/source/tests/pt/model/test_rot_denoise.py
@@ -26,10 +26,13 @@ class RotDenoiseTest:
     def test(
         self,
     ):
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
         prec = 1e-10
         natoms = 5
         cell = 10.0 * torch.eye(3, dtype=dtype).to(env.DEVICE)
-        coord = 2 * torch.rand([natoms, 3], dtype=dtype).to(env.DEVICE)
+        coord = 2 * torch.rand([natoms, 3], dtype=dtype, generator=generator).to(
+            env.DEVICE
+        )
         shift = torch.tensor([4, 4, 4], dtype=dtype).to(env.DEVICE)
         atype = torch.IntTensor([0, 0, 0, 1, 1]).to(env.DEVICE)
         from scipy.stats import (
@@ -68,9 +71,9 @@ class RotDenoiseTest:
 
         # rotate coord and cell
         torch.manual_seed(0)
-        cell = torch.rand([3, 3], dtype=dtype).to(env.DEVICE)
+        cell = torch.rand([3, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         cell = (cell + cell.T) + 5.0 * torch.eye(3).to(env.DEVICE)
-        coord = torch.rand([natoms, 3], dtype=dtype).to(env.DEVICE)
+        coord = torch.rand([natoms, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1]).to(env.DEVICE)
         coord_rot = torch.matmul(coord, rmat)

--- a/source/tests/pt/model/test_se_e2_a.py
+++ b/source/tests/pt/model/test_se_e2_a.py
@@ -34,7 +34,7 @@ class TestDescrptSeA(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))
@@ -144,7 +144,7 @@ class TestDescrptSeA(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_se_e2_a.py
+++ b/source/tests/pt/model/test_se_e2_a.py
@@ -16,6 +16,9 @@ from deepmd.pt.utils.env import (
     PRECISION_DICT,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -34,7 +37,7 @@ class TestDescrptSeA(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))
@@ -144,7 +147,7 @@ class TestDescrptSeA(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_se_t.py
+++ b/source/tests/pt/model/test_se_t.py
@@ -16,6 +16,9 @@ from deepmd.pt.utils.env import (
     PRECISION_DICT,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_env_mat import (
     TestCaseSingleFrameWithNlist,
 )
@@ -34,7 +37,7 @@ class TestDescrptSeT(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))
@@ -108,7 +111,7 @@ class TestDescrptSeT(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_se_t.py
+++ b/source/tests/pt/model/test_se_t.py
@@ -34,7 +34,7 @@ class TestDescrptSeT(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_consistency(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))
@@ -108,7 +108,7 @@ class TestDescrptSeT(unittest.TestCase, TestCaseSingleFrameWithNlist):
     def test_jit(
         self,
     ):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         nf, nloc, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))

--- a/source/tests/pt/model/test_smooth.py
+++ b/source/tests/pt/model/test_smooth.py
@@ -35,7 +35,7 @@ class SmoothTest:
         self,
     ):
         # displacement of atoms
-        epsilon = 1e-5 if self.epsilon is None else self.epsilon
+        epsilon = 1e-6 if self.epsilon is None else self.epsilon
         # required prec. relative prec is not checked.
         rprec = 0
         aprec = 1e-5 if self.aprec is None else self.aprec
@@ -166,7 +166,7 @@ class TestEnergyModelDPA1(unittest.TestCase, SmoothTest):
         self.model = get_model(model_params).to(env.DEVICE)
         # less degree of smoothness,
         # error can be systematically removed by reducing epsilon
-        self.epsilon = 1e-5
+        self.epsilon = 1e-6
         self.aprec = 1e-5
 
 
@@ -178,7 +178,7 @@ class TestEnergyModelDPA1Excl1(unittest.TestCase, SmoothTest):
         self.model = get_model(model_params).to(env.DEVICE)
         # less degree of smoothness,
         # error can be systematically removed by reducing epsilon
-        self.epsilon = 1e-5
+        self.epsilon = 1e-6
         self.aprec = 1e-5
 
 
@@ -190,7 +190,7 @@ class TestEnergyModelDPA1Excl12(unittest.TestCase, SmoothTest):
         self.model = get_model(model_params).to(env.DEVICE)
         # less degree of smoothness,
         # error can be systematically removed by reducing epsilon
-        self.epsilon = 1e-5
+        self.epsilon = 1e-6
         self.aprec = 1e-5
 
 
@@ -201,7 +201,7 @@ class TestEnergyModelDPA2(unittest.TestCase, SmoothTest):
         model_params["descriptor"]["repinit"]["rcut_smth"] = 3.5
         self.type_split = True
         self.model = get_model(model_params).to(env.DEVICE)
-        self.epsilon, self.aprec = 1e-5, 1e-4
+        self.epsilon, self.aprec = 1e-6, 1e-4
 
 
 class TestEnergyModelDPA2_1(unittest.TestCase, SmoothTest):

--- a/source/tests/pt/model/test_smooth.py
+++ b/source/tests/pt/model/test_smooth.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (  # model_dpau,
     model_dos,
     model_dpa1,
@@ -57,7 +60,7 @@ class SmoothTest:
             dtype=dtype,
             device=env.DEVICE,
         ).view([-1, 3])
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         coord1 = torch.rand(
             [natoms - coord0.shape[0], 3],
             dtype=dtype,

--- a/source/tests/pt/model/test_smooth.py
+++ b/source/tests/pt/model/test_smooth.py
@@ -36,7 +36,7 @@ class SmoothTest:
     ):
         generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         # displacement of atoms
-        epsilon = 1e-6 if self.epsilon is None else self.epsilon
+        epsilon = 1e-5 if self.epsilon is None else self.epsilon
         # required prec. relative prec is not checked.
         rprec = 0
         aprec = 1e-5 if self.aprec is None else self.aprec
@@ -168,7 +168,7 @@ class TestEnergyModelDPA1(unittest.TestCase, SmoothTest):
         self.model = get_model(model_params).to(env.DEVICE)
         # less degree of smoothness,
         # error can be systematically removed by reducing epsilon
-        self.epsilon = 1e-6
+        self.epsilon = 1e-5
         self.aprec = 1e-5
 
 
@@ -180,7 +180,7 @@ class TestEnergyModelDPA1Excl1(unittest.TestCase, SmoothTest):
         self.model = get_model(model_params).to(env.DEVICE)
         # less degree of smoothness,
         # error can be systematically removed by reducing epsilon
-        self.epsilon = 1e-6
+        self.epsilon = 1e-5
         self.aprec = 1e-5
 
 
@@ -192,7 +192,7 @@ class TestEnergyModelDPA1Excl12(unittest.TestCase, SmoothTest):
         self.model = get_model(model_params).to(env.DEVICE)
         # less degree of smoothness,
         # error can be systematically removed by reducing epsilon
-        self.epsilon = 1e-6
+        self.epsilon = 1e-5
         self.aprec = 1e-5
 
 
@@ -203,7 +203,7 @@ class TestEnergyModelDPA2(unittest.TestCase, SmoothTest):
         model_params["descriptor"]["repinit"]["rcut_smth"] = 3.5
         self.type_split = True
         self.model = get_model(model_params).to(env.DEVICE)
-        self.epsilon, self.aprec = 1e-6, 1e-4
+        self.epsilon, self.aprec = 1e-5, 1e-4
 
 
 class TestEnergyModelDPA2_1(unittest.TestCase, SmoothTest):

--- a/source/tests/pt/model/test_smooth.py
+++ b/source/tests/pt/model/test_smooth.py
@@ -34,6 +34,7 @@ class SmoothTest:
     def test(
         self,
     ):
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         # displacement of atoms
         epsilon = 1e-6 if self.epsilon is None else self.epsilon
         # required prec. relative prec is not checked.
@@ -43,7 +44,9 @@ class SmoothTest:
         natoms = 10
         cell = 8.6 * torch.eye(3, dtype=dtype, device=env.DEVICE)
         atype0 = torch.arange(3, dtype=dtype, device=env.DEVICE)
-        atype1 = torch.randint(0, 3, [natoms - 3], device=env.DEVICE)
+        atype1 = torch.randint(
+            0, 3, [natoms - 3], device=env.DEVICE, generator=generator
+        )
         atype = torch.cat([atype0, atype1]).view([natoms])
         coord0 = torch.tensor(
             [
@@ -60,7 +63,6 @@ class SmoothTest:
             dtype=dtype,
             device=env.DEVICE,
         ).view([-1, 3])
-        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         coord1 = torch.rand(
             [natoms - coord0.shape[0], 3],
             dtype=dtype,

--- a/source/tests/pt/model/test_smooth.py
+++ b/source/tests/pt/model/test_smooth.py
@@ -57,12 +57,18 @@ class SmoothTest:
             dtype=dtype,
             device=env.DEVICE,
         ).view([-1, 3])
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
         coord1 = torch.rand(
-            [natoms - coord0.shape[0], 3], dtype=dtype, device=env.DEVICE
+            [natoms - coord0.shape[0], 3],
+            dtype=dtype,
+            device=env.DEVICE,
+            generator=generator,
         )
         coord1 = torch.matmul(coord1, cell)
         coord = torch.concat([coord0, coord1], dim=0)
-        spin = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        spin = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         coord0 = torch.clone(coord)
         coord1 = torch.clone(coord)
         coord1[1][0] += epsilon

--- a/source/tests/pt/model/test_smooth.py
+++ b/source/tests/pt/model/test_smooth.py
@@ -60,7 +60,7 @@ class SmoothTest:
             dtype=dtype,
             device=env.DEVICE,
         ).view([-1, 3])
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         coord1 = torch.rand(
             [natoms - coord0.shape[0], 3],
             dtype=dtype,

--- a/source/tests/pt/model/test_smooth_denoise.py
+++ b/source/tests/pt/model/test_smooth_denoise.py
@@ -52,7 +52,10 @@ class SmoothDenoiseTest:
             .view([-1, 3])
             .to(env.DEVICE)
         )
-        coord1 = torch.rand([natoms - coord0.shape[0], 3], dtype=dtype).to(env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        coord1 = torch.rand(
+            [natoms - coord0.shape[0], 3], dtype=dtype, genreator=generator
+        ).to(env.DEVICE)
         coord1 = torch.matmul(coord1, cell)
         coord = torch.concat([coord0, coord1], dim=0)
 

--- a/source/tests/pt/model/test_smooth_denoise.py
+++ b/source/tests/pt/model/test_smooth_denoise.py
@@ -57,7 +57,7 @@ class SmoothDenoiseTest:
         )
         generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         coord1 = torch.rand(
-            [natoms - coord0.shape[0], 3], dtype=dtype, genreator=generator
+            [natoms - coord0.shape[0], 3], dtype=dtype, generator=generator
         ).to(env.DEVICE)
         coord1 = torch.matmul(coord1, cell)
         coord = torch.concat([coord0, coord1], dim=0)

--- a/source/tests/pt/model/test_smooth_denoise.py
+++ b/source/tests/pt/model/test_smooth_denoise.py
@@ -55,7 +55,7 @@ class SmoothDenoiseTest:
             .view([-1, 3])
             .to(env.DEVICE)
         )
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         coord1 = torch.rand(
             [natoms - coord0.shape[0], 3], dtype=dtype, generator=generator
         ).to(env.DEVICE)

--- a/source/tests/pt/model/test_smooth_denoise.py
+++ b/source/tests/pt/model/test_smooth_denoise.py
@@ -36,7 +36,8 @@ class SmoothDenoiseTest:
 
         natoms = 10
         cell = 8.6 * torch.eye(3, dtype=dtype).to(env.DEVICE)
-        atype = torch.randint(0, 3, [natoms])
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
+        atype = torch.randint(0, 3, [natoms], generator=generator, device=env.DEVICE)
         coord0 = (
             torch.tensor(
                 [
@@ -55,7 +56,6 @@ class SmoothDenoiseTest:
             .view([-1, 3])
             .to(env.DEVICE)
         )
-        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         coord1 = torch.rand(
             [natoms - coord0.shape[0], 3], dtype=dtype, generator=generator
         ).to(env.DEVICE)

--- a/source/tests/pt/model/test_smooth_denoise.py
+++ b/source/tests/pt/model/test_smooth_denoise.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation_denoise import (
     model_dpa2,
 )
@@ -52,7 +55,7 @@ class SmoothDenoiseTest:
             .view([-1, 3])
             .to(env.DEVICE)
         )
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         coord1 = torch.rand(
             [natoms - coord0.shape[0], 3], dtype=dtype, genreator=generator
         ).to(env.DEVICE)

--- a/source/tests/pt/model/test_trans.py
+++ b/source/tests/pt/model/test_trans.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (  # model_dpau,
     model_dos,
     model_dpa1,
@@ -32,7 +35,7 @@ class TransTest:
         self,
     ):
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         coord = torch.rand(

--- a/source/tests/pt/model/test_trans.py
+++ b/source/tests/pt/model/test_trans.py
@@ -32,13 +32,20 @@ class TransTest:
         self,
     ):
         natoms = 5
-        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
-        coord = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        coord = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         coord = torch.matmul(coord, cell)
-        spin = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        spin = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         atype = torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32, device=env.DEVICE)
-        shift = (torch.rand([3], dtype=dtype, device=env.DEVICE) - 0.5) * 2.0
+        shift = (
+            torch.rand([3], dtype=dtype, device=env.DEVICE, generator=generator) - 0.5
+        ) * 2.0
         coord_s = torch.matmul(
             torch.remainder(torch.matmul(coord + shift, torch.linalg.inv(cell)), 1.0),
             cell,

--- a/source/tests/pt/model/test_trans.py
+++ b/source/tests/pt/model/test_trans.py
@@ -35,7 +35,7 @@ class TransTest:
         self,
     ):
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         coord = torch.rand(

--- a/source/tests/pt/model/test_trans_denoise.py
+++ b/source/tests/pt/model/test_trans_denoise.py
@@ -28,12 +28,15 @@ class TransDenoiseTest:
         self,
     ):
         natoms = 5
-        cell = torch.rand([3, 3], dtype=dtype).to(env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell = torch.rand([3, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         cell = (cell + cell.T) + 5.0 * torch.eye(3).to(env.DEVICE)
         coord = torch.rand([natoms, 3], dtype=dtype).to(env.DEVICE)
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1]).to(env.DEVICE)
-        shift = (torch.rand([3], dtype=dtype) - 0.5).to(env.DEVICE) * 2.0
+        shift = (torch.rand([3], dtype=dtype, generaotr=generator) - 0.5).to(
+            env.DEVICE
+        ) * 2.0
         coord_s = torch.matmul(
             torch.remainder(torch.matmul(coord + shift, torch.linalg.inv(cell)), 1.0),
             cell,

--- a/source/tests/pt/model/test_trans_denoise.py
+++ b/source/tests/pt/model/test_trans_denoise.py
@@ -31,7 +31,7 @@ class TransDenoiseTest:
         self,
     ):
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         cell = (cell + cell.T) + 5.0 * torch.eye(3).to(env.DEVICE)
         coord = torch.rand([natoms, 3], dtype=dtype).to(env.DEVICE)

--- a/source/tests/pt/model/test_trans_denoise.py
+++ b/source/tests/pt/model/test_trans_denoise.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation_denoise import (
     model_dpa1,
     model_dpa2,
@@ -28,7 +31,7 @@ class TransDenoiseTest:
         self,
     ):
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, generator=generator).to(env.DEVICE)
         cell = (cell + cell.T) + 5.0 * torch.eye(3).to(env.DEVICE)
         coord = torch.rand([natoms, 3], dtype=dtype).to(env.DEVICE)

--- a/source/tests/pt/model/test_trans_denoise.py
+++ b/source/tests/pt/model/test_trans_denoise.py
@@ -37,7 +37,7 @@ class TransDenoiseTest:
         coord = torch.rand([natoms, 3], dtype=dtype).to(env.DEVICE)
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1]).to(env.DEVICE)
-        shift = (torch.rand([3], dtype=dtype, generaotr=generator) - 0.5).to(
+        shift = (torch.rand([3], dtype=dtype, generator=generator) - 0.5).to(
             env.DEVICE
         ) * 2.0
         coord_s = torch.matmul(

--- a/source/tests/pt/model/test_unused_params.py
+++ b/source/tests/pt/model/test_unused_params.py
@@ -56,9 +56,12 @@ class TestUnusedParamsDPA2(unittest.TestCase):
     def _test_unused(self, model_params):
         self.model = get_model(model_params).to(env.DEVICE)
         natoms = 5
-        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
-        coord = torch.rand([natoms, 3], dtype=dtype, device=env.DEVICE)
+        coord = torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1]).to(env.DEVICE)
         idx_perm = [1, 0, 4, 3, 2]

--- a/source/tests/pt/model/test_unused_params.py
+++ b/source/tests/pt/model/test_unused_params.py
@@ -14,6 +14,9 @@ from deepmd.pt.utils import (
     env,
 )
 
+from ...seed import (
+    GLOBAL_SEED,
+)
 from .test_permutation import (
     model_dpa2,
 )
@@ -56,7 +59,7 @@ class TestUnusedParamsDPA2(unittest.TestCase):
     def _test_unused(self, model_params):
         self.model = get_model(model_params).to(env.DEVICE)
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         coord = torch.rand(

--- a/source/tests/pt/model/test_unused_params.py
+++ b/source/tests/pt/model/test_unused_params.py
@@ -59,7 +59,7 @@ class TestUnusedParamsDPA2(unittest.TestCase):
     def _test_unused(self, model_params):
         self.model = get_model(model_params).to(env.DEVICE)
         natoms = 5
-        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
         cell = torch.rand([3, 3], dtype=dtype, device=env.DEVICE, generator=generator)
         cell = (cell + cell.T) + 5.0 * torch.eye(3, device=env.DEVICE)
         coord = torch.rand(

--- a/source/tests/pt/test_calculator.py
+++ b/source/tests/pt/test_calculator.py
@@ -18,6 +18,10 @@ from deepmd.pt.utils.ase_calc import (
     DPCalculator,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 dtype = torch.float64
 
 
@@ -53,7 +57,7 @@ class TestCalculator(unittest.TestCase):
 
         natoms = 5
         cell = torch.eye(3, dtype=dtype, device="cpu") * 10
-        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        generator = torch.Generator(device="cpu").manual_seed(GLOBAL_SEED)
         coord = torch.rand([natoms, 3], dtype=dtype, device="cpu", generator=generator)
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1])

--- a/source/tests/pt/test_calculator.py
+++ b/source/tests/pt/test_calculator.py
@@ -53,7 +53,8 @@ class TestCalculator(unittest.TestCase):
 
         natoms = 5
         cell = torch.eye(3, dtype=dtype, device="cpu") * 10
-        coord = torch.rand([natoms, 3], dtype=dtype, device="cpu")
+        generator = torch.Generator(device="cpu").manual_seed(20240604)
+        coord = torch.rand([natoms, 3], dtype=dtype, device="cpu", generator=generator)
         coord = torch.matmul(coord, cell)
         atype = torch.IntTensor([0, 0, 0, 1, 1])
         atomic_numbers = [1, 1, 1, 8, 8]

--- a/source/tests/pt/test_loss.py
+++ b/source/tests/pt/test_loss.py
@@ -68,7 +68,7 @@ class LossCommonTest(unittest.TestCase):
         natoms = np_batch["natoms"]
         self.nloc = natoms[0]
         nframes = np_batch["energy"].shape[0]
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
 
         if not self.spin:
             l_energy, l_force, l_virial = (

--- a/source/tests/pt/test_loss.py
+++ b/source/tests/pt/test_loss.py
@@ -26,6 +26,9 @@ from deepmd.utils.data import (
     DataRequirementItem,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
 from .model.test_embedding_net import (
     get_single_batch,
 )
@@ -68,7 +71,7 @@ class LossCommonTest(unittest.TestCase):
         natoms = np_batch["natoms"]
         self.nloc = natoms[0]
         nframes = np_batch["energy"].shape[0]
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
 
         if not self.spin:
             l_energy, l_force, l_virial = (

--- a/source/tests/pt/test_neighbor_stat.py
+++ b/source/tests/pt/test_neighbor_stat.py
@@ -11,16 +11,17 @@ from deepmd.entrypoints.neighbor_stat import (
 
 
 def gen_sys(nframes):
+    rng = np.random.default_rng(20240604)
     natoms = 1000
     data = {}
     X, Y, Z = np.mgrid[0:2:3j, 0:2:3j, 0:2:3j]
     positions = np.vstack([X.ravel(), Y.ravel(), Z.ravel()]).T  # + 0.1
     data["coords"] = np.repeat(positions[np.newaxis, :, :], nframes, axis=0)
-    data["forces"] = np.random.default_rng().random([nframes, natoms, 3])
+    data["forces"] = rng.random([nframes, natoms, 3])
     data["cells"] = np.array([3.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 3.0]).reshape(
         1, 3, 3
     )
-    data["energies"] = np.random.default_rng().random([nframes, 1])
+    data["energies"] = rng.random([nframes, 1])
     data["atom_names"] = ["TYPE"]
     data["atom_numbs"] = [27]
     data["atom_types"] = np.repeat(0, 27)

--- a/source/tests/pt/test_neighbor_stat.py
+++ b/source/tests/pt/test_neighbor_stat.py
@@ -9,9 +9,13 @@ from deepmd.entrypoints.neighbor_stat import (
     neighbor_stat,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 
 def gen_sys(nframes):
-    rng = np.random.default_rng(20240604)
+    rng = np.random.default_rng(GLOBAL_SEED)
     natoms = 1000
     data = {}
     X, Y, Z = np.mgrid[0:2:3j, 0:2:3j, 0:2:3j]

--- a/source/tests/pt/test_update_sel.py
+++ b/source/tests/pt/test_update_sel.py
@@ -12,6 +12,10 @@ from deepmd.pt.utils.update_sel import (
     UpdateSel,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 
 def update_sel(jdata):
     type_map = jdata["model"].get("type_map")
@@ -23,7 +27,7 @@ def update_sel(jdata):
 class TestTrain(unittest.TestCase):
     def setUp(self) -> None:
         self.update_sel = UpdateSel()
-        self.mock_min_nbor_dist = random.Random(20240604).random()
+        self.mock_min_nbor_dist = random.Random(GLOBAL_SEED).random()
         return super().setUp()
 
     @patch("deepmd.pt.utils.update_sel.UpdateSel.get_nbor_stat")

--- a/source/tests/pt/test_update_sel.py
+++ b/source/tests/pt/test_update_sel.py
@@ -23,7 +23,7 @@ def update_sel(jdata):
 class TestTrain(unittest.TestCase):
     def setUp(self) -> None:
         self.update_sel = UpdateSel()
-        self.mock_min_nbor_dist = random.random()
+        self.mock_min_nbor_dist = random.Random(20240604).random()
         return super().setUp()
 
     @patch("deepmd.pt.utils.update_sel.UpdateSel.get_nbor_stat")

--- a/source/tests/pt/test_utils.py
+++ b/source/tests/pt/test_utils.py
@@ -9,10 +9,14 @@ from deepmd.pt.utils.utils import (
     to_torch_tensor,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 
 class TestCvt(unittest.TestCase):
     def test_to_numpy(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         foo = rng.normal([3, 4])
         for ptp, npp in zip(
             [torch.float16, torch.float32, torch.float64],

--- a/source/tests/pt/test_utils.py
+++ b/source/tests/pt/test_utils.py
@@ -12,7 +12,7 @@ from deepmd.pt.utils.utils import (
 
 class TestCvt(unittest.TestCase):
     def test_to_numpy(self):
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(20240604)
         foo = rng.normal([3, 4])
         for ptp, npp in zip(
             [torch.float16, torch.float32, torch.float64],

--- a/source/tests/seed.py
+++ b/source/tests/seed.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+import os
+
+GLOBAL_SEED = int(os.environ.get("DP_UT_GLOBAL_SEED", 20240604))

--- a/source/tests/tf/test_data_modifier_shuffle.py
+++ b/source/tests/tf/test_data_modifier_shuffle.py
@@ -91,6 +91,7 @@ class TestDataModifier(tf.test.TestCase):
                 f.write(output_graph_def.SerializeToString())
 
     def _setUp_data(self):
+        rng = np.random.default_rng(20240604)
         jdata = self._setUp_jdata()
         # sys0
         self.atom_types0 = np.array([0, 3, 2, 1, 3, 4, 1, 4], dtype=int)
@@ -101,10 +102,8 @@ class TestDataModifier(tf.test.TestCase):
         self.nsel = 0
         for ii in self.sel_type:
             self.nsel += np.sum(self.atom_types0 == ii)
-        self.coords0 = (
-            np.random.default_rng().random([self.nframes, self.natoms * 3]) * scale
-        )
-        self.dipoles0 = np.random.default_rng().random([self.nframes, self.nsel * 3])
+        self.coords0 = rng.random([self.nframes, self.natoms * 3]) * scale
+        self.dipoles0 = rng.random([self.nframes, self.nsel * 3])
         self.box0 = np.reshape(np.eye(3) * scale, [-1, 9])
         self.box0 = np.tile(self.box0, [self.nframes, 1])
         self._write_sys_data(

--- a/source/tests/tf/test_data_modifier_shuffle.py
+++ b/source/tests/tf/test_data_modifier_shuffle.py
@@ -24,6 +24,10 @@ from deepmd.tf.utils.data_system import (
     DeepmdDataSystem,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 if GLOBAL_NP_FLOAT_PRECISION == np.float32:
     global_default_fv_hh = 1e-2
     global_default_dw_hh = 1e-2
@@ -91,7 +95,7 @@ class TestDataModifier(tf.test.TestCase):
                 f.write(output_graph_def.SerializeToString())
 
     def _setUp_data(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         jdata = self._setUp_jdata()
         # sys0
         self.atom_types0 = np.array([0, 3, 2, 1, 3, 4, 1, 4], dtype=int)

--- a/source/tests/tf/test_deepmd_data.py
+++ b/source/tests/tf/test_deepmd_data.py
@@ -25,6 +25,7 @@ else:
 
 class TestDataTypeSel(unittest.TestCase):
     def setUp(self):
+        rng = np.random.default_rng(20240604)
         self.data_name = "test_data"
         os.makedirs(self.data_name, exist_ok=True)
         os.makedirs(os.path.join(self.data_name, "set.foo"), exist_ok=True)
@@ -37,13 +38,13 @@ class TestDataTypeSel(unittest.TestCase):
         self.natoms = 6
         # coord
         path = os.path.join(self.data_name, "set.foo", "coord.npy")
-        self.coord = np.random.default_rng().random([self.nframes, self.natoms, 3])
+        self.coord = rng.random([self.nframes, self.natoms, 3])
         np.save(path, np.reshape(self.coord, [self.nframes, -1]))
         self.coord = self.coord[:, [0, 3, 1, 2, 4, 5], :]
         self.coord = self.coord.reshape([self.nframes, -1])
         # box
         path = os.path.join(self.data_name, "set.foo", "box.npy")
-        self.box = np.random.default_rng().random([self.nframes, 9])
+        self.box = rng.random([self.nframes, 9])
         np.save(path, self.box)
         # value
         path = os.path.join(self.data_name, "set.foo", "value_1.npy")
@@ -78,6 +79,7 @@ class TestDataTypeSel(unittest.TestCase):
 
 class TestData(unittest.TestCase):
     def setUp(self):
+        rng = np.random.default_rng(20240604)
         self.data_name = "test_data"
         os.makedirs(self.data_name, exist_ok=True)
         os.makedirs(os.path.join(self.data_name, "set.foo"), exist_ok=True)
@@ -94,59 +96,55 @@ class TestData(unittest.TestCase):
         self.natoms = 2
         # coord
         path = os.path.join(self.data_name, "set.foo", "coord.npy")
-        self.coord = np.random.default_rng().random([self.nframes, self.natoms, 3])
+        self.coord = rng.random([self.nframes, self.natoms, 3])
         np.save(path, np.reshape(self.coord, [self.nframes, -1]))
         self.coord = self.coord[:, [1, 0], :]
         self.coord = self.coord.reshape([self.nframes, -1])
         # coord bar
         path = os.path.join(self.data_name, "set.bar", "coord.npy")
-        self.coord_bar = np.random.default_rng().random([self.nframes, 3 * self.natoms])
+        self.coord_bar = rng.random([self.nframes, 3 * self.natoms])
         np.save(path, self.coord_bar)
         self.coord_bar = self.coord_bar.reshape([self.nframes, self.natoms, 3])
         self.coord_bar = self.coord_bar[:, [1, 0], :]
         self.coord_bar = self.coord_bar.reshape([self.nframes, -1])
         # coord tar
         path = os.path.join(self.data_name, "set.tar", "coord.npy")
-        self.coord_tar = np.random.default_rng().random([2, 3 * self.natoms])
+        self.coord_tar = rng.random([2, 3 * self.natoms])
         np.save(path, self.coord_tar)
         self.coord_tar = self.coord_tar.reshape([2, self.natoms, 3])
         self.coord_tar = self.coord_tar[:, [1, 0], :]
         self.coord_tar = self.coord_tar.reshape([2, -1])
         # box
         path = os.path.join(self.data_name, "set.foo", "box.npy")
-        self.box = np.random.default_rng().random([self.nframes, 9])
+        self.box = rng.random([self.nframes, 9])
         np.save(path, self.box)
         # box bar
         path = os.path.join(self.data_name, "set.bar", "box.npy")
-        self.box_bar = np.random.default_rng().random([self.nframes, 9])
+        self.box_bar = rng.random([self.nframes, 9])
         np.save(path, self.box_bar)
         # box tar
         path = os.path.join(self.data_name, "set.tar", "box.npy")
-        self.box_tar = np.random.default_rng().random([2, 9])
+        self.box_tar = rng.random([2, 9])
         np.save(path, self.box_tar)
         # t a
         path = os.path.join(self.data_name, "set.foo", "test_atomic.npy")
-        self.test_atomic = np.random.default_rng().random(
-            [self.nframes, self.natoms, 7]
-        )
+        self.test_atomic = rng.random([self.nframes, self.natoms, 7])
         self.redu_atomic = np.sum(self.test_atomic, axis=1)
         np.save(path, np.reshape(self.test_atomic, [self.nframes, -1]))
         self.test_atomic = self.test_atomic[:, [1, 0], :]
         self.test_atomic = self.test_atomic.reshape([self.nframes, -1])
         # t f
         path = os.path.join(self.data_name, "set.foo", "test_frame.npy")
-        self.test_frame = np.random.default_rng().random([self.nframes, 5])
+        self.test_frame = rng.random([self.nframes, 5])
         np.save(path, self.test_frame)
         path = os.path.join(self.data_name, "set.bar", "test_frame.npy")
-        self.test_frame_bar = np.random.default_rng().random([self.nframes, 5])
+        self.test_frame_bar = rng.random([self.nframes, 5])
         np.save(path, self.test_frame_bar)
         # t n
         self.test_null = np.zeros([self.nframes, 2 * self.natoms])
         # tensor shape
         path = os.path.join(self.data_name, "set.foo", "tensor_natoms.npy")
-        self.tensor_natoms = np.random.default_rng().random(
-            [self.nframes, self.natoms, 6]
-        )
+        self.tensor_natoms = rng.random([self.nframes, self.natoms, 6])
         self.tensor_natoms[:, 0, :] = 0
         np.save(path, self.tensor_natoms)
         path = os.path.join(self.data_name, "set.foo", "tensor_nsel.npy")

--- a/source/tests/tf/test_deepmd_data.py
+++ b/source/tests/tf/test_deepmd_data.py
@@ -13,6 +13,9 @@ from deepmd.tf.utils.data import (
     DeepmdData,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
 from .common import (
     tests_path,
 )
@@ -25,7 +28,7 @@ else:
 
 class TestDataTypeSel(unittest.TestCase):
     def setUp(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         self.data_name = "test_data"
         os.makedirs(self.data_name, exist_ok=True)
         os.makedirs(os.path.join(self.data_name, "set.foo"), exist_ok=True)
@@ -79,7 +82,7 @@ class TestDataTypeSel(unittest.TestCase):
 
 class TestData(unittest.TestCase):
     def setUp(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         self.data_name = "test_data"
         os.makedirs(self.data_name, exist_ok=True)
         os.makedirs(os.path.join(self.data_name, "set.foo"), exist_ok=True)

--- a/source/tests/tf/test_deepmd_data_sys.py
+++ b/source/tests/tf/test_deepmd_data_sys.py
@@ -24,6 +24,7 @@ else:
 
 class TestDataSystem(unittest.TestCase):
     def setUp(self):
+        rng = np.random.default_rng(20240604)
         self.nsys = 4
         self.nframes = [3, 6, 5, 4]
         self.natoms = [3, 4, 6, 5]
@@ -40,15 +41,13 @@ class TestDataSystem(unittest.TestCase):
                 set_name = os.path.join(sys_name, "set.%03d" % jj)
                 os.makedirs(set_name, exist_ok=True)
                 path = os.path.join(set_name, "coord.npy")
-                val = np.random.default_rng().random(
-                    [self.nframes[ii] + jj, self.natoms[ii] * 3]
-                )
+                val = rng.random([self.nframes[ii] + jj, self.natoms[ii] * 3])
                 np.save(path, val)
                 path = os.path.join(set_name, "box.npy")
-                val = np.random.default_rng().random([self.nframes[ii] + jj, 9]) * 10
+                val = rng.random([self.nframes[ii] + jj, 9]) * 10
                 np.save(path, val)
                 path = os.path.join(set_name, "test.npy")
-                val = np.random.default_rng().random(
+                val = rng.random(
                     [self.nframes[ii] + jj, self.natoms[ii] * self.test_ndof]
                 )
                 np.save(path, val)

--- a/source/tests/tf/test_deepmd_data_sys.py
+++ b/source/tests/tf/test_deepmd_data_sys.py
@@ -16,6 +16,10 @@ from deepmd.tf.utils.data_system import (
     prob_sys_size_ext,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 if GLOBAL_NP_FLOAT_PRECISION == np.float32:
     places = 6
 else:
@@ -24,7 +28,7 @@ else:
 
 class TestDataSystem(unittest.TestCase):
     def setUp(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         self.nsys = 4
         self.nframes = [3, 6, 5, 4]
         self.natoms = [3, 4, 6, 5]

--- a/source/tests/tf/test_descrpt_sea_ef_rot.py
+++ b/source/tests/tf/test_descrpt_sea_ef_rot.py
@@ -14,6 +14,10 @@ from deepmd.tf.env import (
     tf,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 
 class TestEfRot(tf.test.TestCase):
     def setUp(self):
@@ -97,7 +101,7 @@ class TestEfRot(tf.test.TestCase):
         return energy, force, virial, atom_ener, atom_vir
 
     def make_test_data(self, nframes):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         dcoord = rng.random([nframes, self.natoms[0], 3])
         for ii in range(nframes):
             dcoord[ii, :, :] = dcoord[ii, :, :] - np.tile(

--- a/source/tests/tf/test_descrpt_sea_ef_rot.py
+++ b/source/tests/tf/test_descrpt_sea_ef_rot.py
@@ -97,7 +97,8 @@ class TestEfRot(tf.test.TestCase):
         return energy, force, virial, atom_ener, atom_vir
 
     def make_test_data(self, nframes):
-        dcoord = np.random.default_rng().random([nframes, self.natoms[0], 3])
+        rng = np.random.default_rng(20240604)
+        dcoord = rng.random([nframes, self.natoms[0], 3])
         for ii in range(nframes):
             dcoord[ii, :, :] = dcoord[ii, :, :] - np.tile(
                 dcoord[ii, 0, :], [self.natoms[0], 1]
@@ -111,7 +112,7 @@ class TestEfRot(tf.test.TestCase):
         np.random.shuffle(one_type)  # noqa: NPY002
         one_type = np.array(one_type, dtype=int).reshape([1, -1])
         dtype = np.tile(one_type, [nframes, 1])
-        defield = np.random.default_rng().random(dcoord.shape)
+        defield = rng.random(dcoord.shape)
         return dcoord, dbox, dtype, defield
 
     def rotate_mat(self, axis_, theta):

--- a/source/tests/tf/test_ewald.py
+++ b/source/tests/tf/test_ewald.py
@@ -11,6 +11,10 @@ from deepmd.tf.infer.ewald_recp import (
     op_module,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 if GLOBAL_NP_FLOAT_PRECISION == np.float32:
     global_default_fv_hh = 1e-2
     global_default_dw_hh = 1e-2
@@ -23,7 +27,7 @@ else:
 
 class TestEwaldRecp(tf.test.TestCase):
     def setUp(self):
-        rng = np.random.default_rng(20240604)
+        rng = np.random.default_rng(GLOBAL_SEED)
         boxl = 4.5  # NOTICE grid should not change before and after box pert...
         box_pert = 0.2
         self.natoms = 16

--- a/source/tests/tf/test_ewald.py
+++ b/source/tests/tf/test_ewald.py
@@ -23,6 +23,7 @@ else:
 
 class TestEwaldRecp(tf.test.TestCase):
     def setUp(self):
+        rng = np.random.default_rng(20240604)
         boxl = 4.5  # NOTICE grid should not change before and after box pert...
         box_pert = 0.2
         self.natoms = 16
@@ -38,16 +39,16 @@ class TestEwaldRecp(tf.test.TestCase):
             box = np.eye(3) * boxl
             box[1][1] += 1
             box[2][2] += 2
-            box += np.random.default_rng().random([3, 3]) * box_pert
+            box += rng.random([3, 3]) * box_pert
             box = 0.5 * (box + box.T)
             self.dbox.append(box)
             # scaled
-            coord = np.random.default_rng().random([self.natoms, 3])
+            coord = rng.random([self.natoms, 3])
             self.rcoord.append(coord)
             # real coords
             self.dcoord.append(np.matmul(coord, box))
             # charge
-            dcharge = np.random.default_rng().random([self.natoms])
+            dcharge = rng.random([self.natoms])
             dcharge -= np.average(dcharge)
             assert np.abs(np.sum(self.dcharge) - 0) < 1e-12
             self.dcharge.append(dcharge)

--- a/source/tests/tf/test_gen_stat_data.py
+++ b/source/tests/tf/test_gen_stat_data.py
@@ -21,9 +21,13 @@ from deepmd.tf.utils.data_system import (
     DeepmdDataSystem,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 
 def gen_sys(nframes, atom_types):
-    rng = np.random.default_rng(20240604)
+    rng = np.random.default_rng(GLOBAL_SEED)
     natoms = len(atom_types)
     data = {}
     data["coords"] = rng.random([nframes, natoms, 3])

--- a/source/tests/tf/test_gen_stat_data.py
+++ b/source/tests/tf/test_gen_stat_data.py
@@ -23,12 +23,13 @@ from deepmd.tf.utils.data_system import (
 
 
 def gen_sys(nframes, atom_types):
+    rng = np.random.default_rng(20240604)
     natoms = len(atom_types)
     data = {}
-    data["coords"] = np.random.default_rng().random([nframes, natoms, 3])
-    data["forces"] = np.random.default_rng().random([nframes, natoms, 3])
-    data["cells"] = np.random.default_rng().random([nframes, 9])
-    data["energies"] = np.random.default_rng().random([nframes, 1])
+    data["coords"] = rng.random([nframes, natoms, 3])
+    data["forces"] = rng.random([nframes, natoms, 3])
+    data["cells"] = rng.random([nframes, 9])
+    data["energies"] = rng.random([nframes, 1])
     types = list(set(atom_types))
     types.sort()
     data["atom_names"] = []

--- a/source/tests/tf/test_neighbor_stat.py
+++ b/source/tests/tf/test_neighbor_stat.py
@@ -11,16 +11,17 @@ from deepmd.tf.entrypoints.neighbor_stat import (
 
 
 def gen_sys(nframes):
+    rng = np.random.default_rng(20240604)
     natoms = 1000
     data = {}
     X, Y, Z = np.mgrid[0:2:3j, 0:2:3j, 0:2:3j]
     positions = np.vstack([X.ravel(), Y.ravel(), Z.ravel()]).T  # + 0.1
     data["coords"] = np.repeat(positions[np.newaxis, :, :], nframes, axis=0)
-    data["forces"] = np.random.default_rng().random([nframes, natoms, 3])
+    data["forces"] = rng.random([nframes, natoms, 3])
     data["cells"] = np.array([3.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 3.0]).reshape(
         1, 3, 3
     )
-    data["energies"] = np.random.default_rng().random([nframes, 1])
+    data["energies"] = rng.random([nframes, 1])
     data["atom_names"] = ["TYPE"]
     data["atom_numbs"] = [27]
     data["atom_types"] = np.repeat(0, 27)

--- a/source/tests/tf/test_neighbor_stat.py
+++ b/source/tests/tf/test_neighbor_stat.py
@@ -9,9 +9,13 @@ from deepmd.tf.entrypoints.neighbor_stat import (
     neighbor_stat,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 
 def gen_sys(nframes):
-    rng = np.random.default_rng(20240604)
+    rng = np.random.default_rng(GLOBAL_SEED)
     natoms = 1000
     data = {}
     X, Y, Z = np.mgrid[0:2:3j, 0:2:3j, 0:2:3j]

--- a/source/tests/tf/test_train.py
+++ b/source/tests/tf/test_train.py
@@ -16,7 +16,7 @@ from deepmd.tf.utils.update_sel import (
 class TestTrain(unittest.TestCase):
     def setUp(self) -> None:
         self.update_sel = UpdateSel()
-        self.mock_min_nbor_dist = random.random()
+        self.mock_min_nbor_dist = random.Random(20240604).random()
         return super().setUp()
 
     def test_train_parse_auto_sel(self):

--- a/source/tests/tf/test_train.py
+++ b/source/tests/tf/test_train.py
@@ -12,11 +12,15 @@ from deepmd.tf.utils.update_sel import (
     UpdateSel,
 )
 
+from ..seed import (
+    GLOBAL_SEED,
+)
+
 
 class TestTrain(unittest.TestCase):
     def setUp(self) -> None:
         self.update_sel = UpdateSel()
-        self.mock_min_nbor_dist = random.Random(20240604).random()
+        self.mock_min_nbor_dist = random.Random(GLOBAL_SEED).random()
         return super().setUp()
 
     def test_train_parse_auto_sel(self):


### PR DESCRIPTION
Fix #3847.
This PR makes all unit tests deterministic. We have found non-deterministic unit tests have more disadvantages than advantages.
Read more: https://softwareengineering.stackexchange.com/questions/221632/testing-deterministic-or-non-deterministic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a global seed for consistent random number generation across various test files.
  - Updated the initialization of random tensors to include a generator parameter seeded with the global seed.
  - Adjusted epsilon values and setup methods in specific test cases for accuracy and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->