### PR TITLE
fix(tf): throw RuntimeError for se_a + type_embedding

### DIFF
--- a/deepmd/tf/descriptor/se_a.py
+++ b/deepmd/tf/descriptor/se_a.py
@@ -301,6 +301,7 @@ class DescrptSeA(DescrptSe):
                 self.stat_descrpt *= tf.reshape(mask, tf.shape(self.stat_descrpt))
         self.sub_sess = tf.Session(graph=sub_graph, config=default_tf_session_config)
         self.original_sel = None
+        self.use_tebd: Optional[bool] = None
 
     def get_rcut(self) -> float:
         """Returns the cut-off radius."""
@@ -746,8 +747,10 @@ class DescrptSeA(DescrptSe):
     ):
         if input_dict is not None:
             type_embedding = input_dict.get("type_embedding", None)
+            self.use_tebd = True
         else:
             type_embedding = None
+            self.use_tebd = False
         if self.stripped_type_embedding and type_embedding is None:
             raise RuntimeError("type_embedding is required for se_a_tebd_v2 model.")
         start_index = 0
@@ -1406,7 +1409,7 @@ class DescrptSeA(DescrptSe):
             raise NotImplementedError(
                 "Serialization is unsupported when tebd_input_mode is set to 'strip'"
             )
-        if (self.original_sel != self.sel_a).any():
+        if self.original_sel is not None and (self.original_sel != self.sel_a).any():
             raise NotImplementedError(
                 "Adjusting sel is unsupported by the native model"
             )
@@ -1416,9 +1419,11 @@ class DescrptSeA(DescrptSe):
             raise NotImplementedError("spin is unsupported")
         assert self.davg is not None
         assert self.dstd is not None
-        # TODO: tf: handle type embedding in DescrptSeA.serialize
-        # not sure how to handle type embedding - type embedding is not a model parameter,
-        # but instead a part of the input data. Maybe the interface should be refactored...
+        assert self.use_tebd is not None
+        if self.use_tebd:
+            raise RuntimeError(
+                "Serialization is unsupported when type_embedding is used."
+            )
 
         return {
             "@class": "Descriptor",

--- a/deepmd/tf/descriptor/se_a.py
+++ b/deepmd/tf/descriptor/se_a.py
@@ -301,7 +301,8 @@ class DescrptSeA(DescrptSe):
                 self.stat_descrpt *= tf.reshape(mask, tf.shape(self.stat_descrpt))
         self.sub_sess = tf.Session(graph=sub_graph, config=default_tf_session_config)
         self.original_sel = None
-        self.use_tebd: Optional[bool] = None
+        # Whether type embedding is used
+        self.use_tebd: bool = False
 
     def get_rcut(self) -> float:
         """Returns the cut-off radius."""
@@ -747,10 +748,10 @@ class DescrptSeA(DescrptSe):
     ):
         if input_dict is not None:
             type_embedding = input_dict.get("type_embedding", None)
-            self.use_tebd = True
+            if type_embedding is not None:
+                self.use_tebd = True
         else:
             type_embedding = None
-            self.use_tebd = False
         if self.stripped_type_embedding and type_embedding is None:
             raise RuntimeError("type_embedding is required for se_a_tebd_v2 model.")
         start_index = 0
@@ -1419,7 +1420,6 @@ class DescrptSeA(DescrptSe):
             raise NotImplementedError("spin is unsupported")
         assert self.davg is not None
         assert self.dstd is not None
-        assert self.use_tebd is not None
         if self.use_tebd:
             raise RuntimeError(
                 "Serialization is unsupported when type_embedding is used."

--- a/source/tests/tf/test_model_se_a_type.py
+++ b/source/tests/tf/test_model_se_a_type.py
@@ -179,3 +179,6 @@ class TestModel(tf.test.TestCase):
         np.testing.assert_almost_equal(e, refe, places)
         np.testing.assert_almost_equal(f, reff, places)
         np.testing.assert_almost_equal(v, refv, places)
+
+        with self.assertRaises(RuntimeError):
+            descrpt.serialize(suffix="se_a_type")


### PR DESCRIPTION
Fix #3541.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new attribute `use_tebd` to enhance serialization handling based on input conditions.

- **Tests**
  - Added new assertions to improve error handling in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->