### PR TITLE
fix(ci): pin uv to 0.2.10

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -75,7 +75,7 @@ jobs:
           # https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.2.6/install.sh | sh
         if: runner.os != 'Linux'
       - uses: docker/setup-qemu-action@v3
         name: Setup QEMU

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -75,7 +75,7 @@ jobs:
           # https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.2.6/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.2.10/install.sh | sh
         if: runner.os != 'Linux'
       - uses: docker/setup-qemu-action@v3
         name: Setup QEMU


### PR DESCRIPTION
xref: https://github.com/pypa/cibuildwheel/issues/1877#issuecomment-2163744243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated installation script URL in build workflow to ensure compatibility with version 0.2.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->