### PR TITLE
Revert "fix(ci): pin uv to 0.2.10"

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -75,7 +75,7 @@ jobs:
           # https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.2.10/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
         if: runner.os != 'Linux'
       - uses: docker/setup-qemu-action@v3
         name: Setup QEMU


### PR DESCRIPTION
Reverts deepmodeling/deepmd-kit#3870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build workflow to remove the specific version number from the `curl` command in the "Install uv" job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->