### PR TITLE
fix: add mendeleev to dependencies; remove dpdata; remove catching ImportError

### DIFF
--- a/deepmd/utils/econf_embd.py
+++ b/deepmd/utils/econf_embd.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import dpdata
 import numpy as np
 from mendeleev import (
     element,
@@ -169,7 +168,7 @@ maxn = 7
 maxl = maxn
 maxm = 2 * maxl + 1
 
-type_map = dpdata.periodic_table.ELEMENTS
+type_map = list(electronic_configuration_embedding.keys())
 ECONF_DIM = electronic_configuration_embedding[type_map[0]].shape[0]
 
 

--- a/deepmd/utils/econf_embd.py
+++ b/deepmd/utils/econf_embd.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import numpy as np
-
-
 import dpdata
+import numpy as np
 from mendeleev import (
     element,
 )

--- a/deepmd/utils/econf_embd.py
+++ b/deepmd/utils/econf_embd.py
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import numpy as np
 
-try:
-    import dpdata
-    from mendeleev import (
-        element,
-    )
-except ImportError:
-    pass
+
+import dpdata
+from mendeleev import (
+    element,
+)
 
 ###
 # made by command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     'wcmatch',
     'packaging',
     'ml_dtypes',
+    'mendeleev',
 ]
 requires-python = ">=3.8"
 keywords = ["deepmd"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ test = [
     "pytest-sugar",
     "pytest-split",
     "dpgui",
-    "mendeleev",
 ]
 docs = [
     "sphinx>=3.1.1",

--- a/source/tests/common/test_econf_embd.py
+++ b/source/tests/common/test_econf_embd.py
@@ -6,15 +6,7 @@ from deepmd.utils.econf_embd import (
     make_econf_embedding,
 )
 
-try:
-    import mendeleev  # noqa: F401
 
-    has_mendeleev = True
-except ImportError:
-    has_mendeleev = False
-
-
-@unittest.skipIf(not has_mendeleev, "does not have mendeleev installed, skip the UTs.")
 class TestEConfEmbd(unittest.TestCase):
     def test_fe(self):
         res = make_econf_embedding(["Fe"], flatten=False)["Fe"]


### PR DESCRIPTION
Fix #3743.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Consolidated imports and removed redundant exception handling for `dpdata` and `mendeleev`.
  - Updated dependencies in `pyproject.toml` to include `mendeleev` in the main section and update packages for testing and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->