### PR TITLE
fix(cmake): fix PyTorch_LIBRARY_PATH

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -199,8 +199,9 @@ if(ENABLE_PYTORCH AND NOT DEEPMD_C_ROOT)
       add_definitions(-D_GLIBCXX_USE_CXX11_ABI=${OP_CXX_ABI})
     endif()
   endif()
-  # get torch directory
-  set(PyTorch_LIBRARY_PATH ${TORCH_INCLUDE_DIRS}/../lib)
+  # get torch directory get the directory of the target "torch"
+  get_target_property(_TORCH_LOCATION torch LOCATION)
+  get_filename_component(PyTorch_LIBRARY_PATH ${_TORCH_LOCATION} DIRECTORY)
   list(APPEND BACKEND_LIBRARY_PATH ${PyTorch_LIBRARY_PATH})
   list(APPEND BACKEND_INCLUDE_DIRS ${TORCH_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
The previous `PyTorch_LIBRARY_PATH` in #3636 is wrong: `BACKEND_INCLUDE_DIRS` is a list of paths instead of a single path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the method for retrieving the PyTorch library path during the build process to enhance configuration accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->