### PR TITLE
fix(cmake): fix OP_CXX_ABI_PT on macos/windows

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -221,7 +221,10 @@ if(ENABLE_PYTORCH AND NOT DEEPMD_C_ROOT)
     endif()
   else()
     # Maybe in macos/windows
-    set(OP_CXX_ABI_PT ${OP_CXX_ABI})
+    if(NOT DEFINED OP_CXX_ABI)
+      set(OP_CXX_ABI 0)
+    endif()
+    set(OP_CXX_ABI_PT "${OP_CXX_ABI}")
   endif()
   # get torch directory get the directory of the target "torch"
   get_target_property(_TORCH_LOCATION torch LOCATION)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -219,6 +219,9 @@ if(ENABLE_PYTORCH AND NOT DEEPMD_C_ROOT)
       set(OP_CXX_ABI ${CMAKE_MATCH_1})
       add_definitions(-D_GLIBCXX_USE_CXX11_ABI=${OP_CXX_ABI})
     endif()
+  else()
+    # Maybe in macos/windows
+    set(OP_CXX_ABI_PT ${OP_CXX_ABI})
   endif()
   # get torch directory get the directory of the target "torch"
   get_target_property(_TORCH_LOCATION torch LOCATION)


### PR DESCRIPTION
`TORCH_CXX_FLAGS` on macOS and Windows doesn't have `_GLIBCXX_USE_CXX11_ABI`. This PR sets `OP_CXX_ABI_PT` to a default value to fix the error introduced in #3891.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to set `OP_CXX_ABI_PT` conditionally for improved compatibility with macOS and Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->