### PR TITLE
feat(pt/tf): init-(frz)-model use pretrain script

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -258,7 +258,9 @@ def main_parser() -> argparse.ArgumentParser:
     parser_train.add_argument(
         "--use-pretrain-script",
         action="store_true",
-        help="Use model parameters from the script of the pretrained model instead of user input when doing finetuning. Note: This behavior is default and unchangeable in TensorFlow.",
+        help="When performing fine-tuning or init-model, "
+        "utilize the model parameters provided by the script of the pretrained model rather than relying on user input. "
+        "It is important to note that in TensorFlow, this behavior is the default and cannot be modified for fine-tuning. ",
     )
     parser_train.add_argument(
         "-o",

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -239,6 +239,21 @@ def train(FLAGS):
             model_branch=FLAGS.model_branch,
             change_model_params=FLAGS.use_pretrain_script,
         )
+    # update init_model or init_frz_model config if necessary
+    if (
+        FLAGS.init_model is not None or FLAGS.init_frz_model is not None
+    ) and FLAGS.use_pretrain_script:
+        if FLAGS.init_model is not None:
+            init_state_dict = torch.load(FLAGS.init_model, map_location=DEVICE)
+            if "model" in init_state_dict:
+                init_state_dict = init_state_dict["model"]
+            config["model"] = init_state_dict["_extra_state"]["model_params"]
+        else:
+            config["model"] = json.loads(
+                torch.jit.load(
+                    FLAGS.init_frz_model, map_location=DEVICE
+                ).get_model_def_script()
+            )
 
     # argcheck
     if not multi_task:


### PR DESCRIPTION
Support `--use-pretrain-script` for pt&tf when doing init-(frz)-model.