### PR TITLE
feat(pt/tf): add bias changing param/interface

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -659,6 +659,61 @@ def main_parser() -> argparse.ArgumentParser:
         help="treat all types as a single type. Used with se_atten descriptor.",
     )
 
+    # change_bias
+    parser_change_bias = subparsers.add_parser(
+        "change-bias",
+        parents=[parser_log],
+        help="(Supported backend: PyTorch) Change model out bias according to the input data.",
+        formatter_class=RawTextArgumentDefaultsHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+        examples:
+            dp change-bias model.pt -s data -n 10 -m change
+        """
+        ),
+    )
+    parser_change_bias.add_argument(
+        "INPUT", help="The input checkpoint file or frozen model file"
+    )
+    parser_change_bias.add_argument(
+        "-s",
+        "--system",
+        default=".",
+        type=str,
+        help="The system dir. Recursively detect systems in this directory",
+    )
+    parser_change_bias.add_argument(
+        "-n",
+        "--numb-batch",
+        default=0,
+        type=int,
+        help="The number of frames for bias changing in one data system. 0 means all data.",
+    )
+    parser_change_bias.add_argument(
+        "-m",
+        "--mode",
+        type=str,
+        default="change",
+        choices=["change", "set"],
+        help="The mode for changing energy bias: \n"
+        "change (default) : perform predictions using input model on target dataset, "
+        "and do least square on the errors to obtain the target shift as bias.\n"
+        "set : directly use the statistic bias in the target dataset.",
+    )
+    parser_change_bias.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        type=str,
+        help="The model after changing bias.",
+    )
+    parser_change_bias.add_argument(
+        "--model-branch",
+        type=str,
+        default=None,
+        help="Model branch chosen for changing bias if multi-task model.",
+    )
+
     # --version
     parser.add_argument(
         "--version", action="version", version=f"DeePMD-kit v{__version__}"
@@ -831,6 +886,7 @@ def main():
         "convert-from",
         "train-nvnmd",
         "show",
+        "change-bias",
     ):
         deepmd_main = BACKENDS[args.backend]().entry_point_hook
     elif args.command is None:

--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -51,18 +51,6 @@ def get_ll(log_level: str) -> int:
     return int_level
 
 
-def float_list(value_str):
-    """Convert string to a list of float values."""
-    values = value_str.split(",")
-    try:
-        return [float(v) for v in values]
-    except ValueError:
-        raise argparse.ArgumentTypeError(
-            f"'{value_str}' cannot be converted to a list of floats, "
-            f"please use ',' to separate each float value."
-        )
-
-
 class RawTextArgumentDefaultsHelpFormatter(
     argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
 ):
@@ -699,8 +687,10 @@ def main_parser() -> argparse.ArgumentParser:
         "-b",
         "--bias-value",
         default=None,
-        type=float_list,
-        help="The user defined value for each type in the type_map of the model. "
+        type=float,
+        nargs="+",
+        help="The user defined value for each type in the type_map of the model, split with spaces.\n"
+        "For example, '-93.57 -187.1' for energy bias of two elements. "
         "Only supports energy bias changing.",
     )
     parser_change_bias.add_argument(

--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -51,6 +51,18 @@ def get_ll(log_level: str) -> int:
     return int_level
 
 
+def float_list(value_str):
+    """Convert string to a list of float values."""
+    values = value_str.split(",")
+    try:
+        return [float(v) for v in values]
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"'{value_str}' cannot be converted to a list of floats, "
+            f"please use ',' to separate each float value."
+        )
+
+
 class RawTextArgumentDefaultsHelpFormatter(
     argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
 ):
@@ -675,12 +687,21 @@ def main_parser() -> argparse.ArgumentParser:
     parser_change_bias.add_argument(
         "INPUT", help="The input checkpoint file or frozen model file"
     )
-    parser_change_bias.add_argument(
+    parser_change_bias_source = parser_change_bias.add_mutually_exclusive_group()
+    parser_change_bias_source.add_argument(
         "-s",
         "--system",
         default=".",
         type=str,
         help="The system dir. Recursively detect systems in this directory",
+    )
+    parser_change_bias_source.add_argument(
+        "-b",
+        "--bias-value",
+        default=None,
+        type=float_list,
+        help="The user defined value for each type in the type_map of the model. "
+        "Only supports energy bias changing.",
     )
     parser_change_bias.add_argument(
         "-n",

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import argparse
+import copy
 import json
 import logging
 import os
@@ -23,6 +24,9 @@ from torch.distributed.elastic.multiprocessing.errors import (
 from deepmd import (
     __version__,
 )
+from deepmd.common import (
+    expand_sys_str,
+)
 from deepmd.env import (
     GLOBAL_CONFIG,
 )
@@ -44,6 +48,9 @@ from deepmd.pt.model.model import (
 from deepmd.pt.train import (
     training,
 )
+from deepmd.pt.train.wrapper import (
+    ModelWrapper,
+)
 from deepmd.pt.utils import (
     env,
 )
@@ -58,6 +65,9 @@ from deepmd.pt.utils.finetune import (
 )
 from deepmd.pt.utils.multi_task import (
     preprocess_shared_params,
+)
+from deepmd.pt.utils.stat import (
+    make_stat_input,
 )
 from deepmd.utils.argcheck import (
     normalize,
@@ -377,6 +387,111 @@ def show(FLAGS):
             log.info(f"The fitting_net parameter is {fitting_net}")
 
 
+def change_bias(FLAGS):
+    if FLAGS.INPUT.split(".")[-1] == "pt":
+        old_state_dict = torch.load(FLAGS.INPUT, map_location=env.DEVICE)
+        model_state_dict = (
+            copy.deepcopy(old_state_dict["model"])
+            if "model" in old_state_dict
+            else copy.deepcopy(old_state_dict)
+        )
+        model_params = model_state_dict["_extra_state"]["model_params"]
+    elif FLAGS.INPUT.split(".")[-1] == "pth":
+        old_model = torch.jit.load(FLAGS.INPUT, map_location=env.DEVICE)
+        model_params_string = old_model.get_model_def_script()
+        model_params = json.loads(model_params_string)
+        old_state_dict = old_model.state_dict()
+        model_state_dict = old_state_dict
+    else:
+        raise RuntimeError(
+            "The model provided must be a checkpoint file with a .pt extension "
+            "or a frozen model with a .pth extension"
+        )
+    multi_task = "model_dict" in model_params
+    model_branch = FLAGS.model_branch
+    bias_adjust_mode = (
+        "change-by-statistic" if FLAGS.mode == "change" else "set-by-statistic"
+    )
+    if multi_task:
+        assert (
+            model_branch is not None
+        ), "For multitask model, the model branch must be set!"
+        assert model_branch in model_params["model_dict"], (
+            f"For multitask model, the model branch must be in the 'model_dict'! "
+            f"Available options are : {list(model_params['model_dict'].keys())}."
+        )
+        log.info(f"Changing out bias for model {model_branch}.")
+    model = training.get_model_for_wrapper(model_params)
+    data_systems = process_systems(expand_sys_str(FLAGS.system))
+    type_map = (
+        model_params["type_map"]
+        if not multi_task
+        else model_params["model_dict"][model_branch]["type_map"]
+    )
+    data_single = DpLoaderSet(
+        data_systems,
+        1,
+        type_map,
+    )
+    model_to_change = model if not multi_task else model[model_branch]
+    mock_loss = training.get_loss(
+        {"inference": True}, 1.0, len(type_map), model_to_change
+    )
+    data_requirement = mock_loss.label_requirement
+    data_requirement += training.get_additional_data_requirement(model_to_change)
+    data_single.add_data_requirement(data_requirement)
+    nbatches = FLAGS.numb_batch if FLAGS.numb_batch != 0 else float("inf")
+    sampled_data = make_stat_input(
+        data_single.systems,
+        data_single.dataloaders,
+        nbatches,
+    )
+    if FLAGS.INPUT.split(".")[-1] == "pt":
+        wrapper = ModelWrapper(model)
+        wrapper.load_state_dict(old_state_dict["model"])
+    else:
+        # for .pth
+        model.load_state_dict(old_state_dict)
+
+    if not multi_task:
+        model = training.model_change_out_bias(
+            model, sampled_data, _bias_adjust_mode=bias_adjust_mode
+        )
+    else:
+        model[model_branch] = training.model_change_out_bias(
+            model_to_change, sampled_data, _bias_adjust_mode=bias_adjust_mode
+        )
+
+    if FLAGS.INPUT.split(".")[-1] == "pt":
+        output_path = (
+            FLAGS.output
+            if FLAGS.output is not None
+            else FLAGS.INPUT.replace(".pt", "_updated.pt")
+        )
+        wrapper = ModelWrapper(model)
+        if "model" in old_state_dict:
+            old_state_dict["model"] = wrapper.state_dict()
+            old_state_dict["model"]["_extra_state"] = model_state_dict["_extra_state"]
+        else:
+            old_state_dict = wrapper.state_dict()
+            old_state_dict["_extra_state"] = model_state_dict["_extra_state"]
+        torch.save(old_state_dict, output_path)
+    else:
+        # for .pth
+        output_path = (
+            FLAGS.output
+            if FLAGS.output is not None
+            else FLAGS.INPUT.replace(".pth", "_updated.pth")
+        )
+        model = torch.jit.script(model)
+        torch.jit.save(
+            model,
+            output_path,
+            {},
+        )
+    log.info(f"Saved model to {output_path}")
+
+
 @record
 def main(args: Optional[Union[List[str], argparse.Namespace]] = None):
     if not isinstance(args, argparse.Namespace):
@@ -401,6 +516,8 @@ def main(args: Optional[Union[List[str], argparse.Namespace]] = None):
         freeze(FLAGS)
     elif FLAGS.command == "show":
         show(FLAGS)
+    elif FLAGS.command == "change-bias":
+        change_bias(FLAGS)
     else:
         raise RuntimeError(f"Invalid command {FLAGS.command}!")
 

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -393,11 +393,7 @@ def show(FLAGS):
 def change_bias(FLAGS):
     if FLAGS.INPUT.endswith(".pt"):
         old_state_dict = torch.load(FLAGS.INPUT, map_location=env.DEVICE)
-        model_state_dict = (
-            copy.deepcopy(old_state_dict["model"])
-            if "model" in old_state_dict
-            else copy.deepcopy(old_state_dict)
-        )
+        model_state_dict = copy.deepcopy(old_state_dict.get("model", old_state_dict))
         model_params = model_state_dict["_extra_state"]["model_params"]
     elif FLAGS.INPUT.endswith(".pth"):
         old_model = torch.jit.load(FLAGS.INPUT, map_location=env.DEVICE)

--- a/deepmd/pt/loss/ener.py
+++ b/deepmd/pt/loss/ener.py
@@ -96,7 +96,7 @@ class EnergyStdLoss(TaskLoss):
         self.has_v = (start_pref_v != 0.0 and limit_pref_v != 0.0) or inference
         self.has_ae = (start_pref_ae != 0.0 and limit_pref_ae != 0.0) or inference
         self.has_pf = (start_pref_pf != 0.0 and limit_pref_pf != 0.0) or inference
-        self.has_gf = (start_pref_gf != 0.0 and limit_pref_gf != 0.0) or inference
+        self.has_gf = start_pref_gf != 0.0 and limit_pref_gf != 0.0
 
         self.start_pref_e = start_pref_e
         self.limit_pref_e = limit_pref_e

--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -103,6 +103,9 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
         self.register_buffer("out_bias", out_bias_data)
         self.register_buffer("out_std", out_std_data)
 
+    def set_out_bias(self, out_bias: torch.Tensor) -> None:
+        self.out_bias = out_bias
+
     def __setitem__(self, key, value):
         if key in ["out_bias"]:
             self.out_bias = value

--- a/deepmd/pt/model/model/make_model.py
+++ b/deepmd/pt/model/model/make_model.py
@@ -175,6 +175,9 @@ def make_model(T_AtomicModel: Type[BaseAtomicModel]):
         def get_out_bias(self) -> torch.Tensor:
             return self.atomic_model.get_out_bias()
 
+        def set_out_bias(self, out_bias: torch.Tensor) -> None:
+            self.atomic_model.set_out_bias(out_bias)
+
         def change_out_bias(
             self,
             merged,

--- a/deepmd/pt/utils/stat.py
+++ b/deepmd/pt/utils/stat.py
@@ -53,7 +53,8 @@ def make_stat_input(datasets, dataloaders, nbatches):
         sys_stat = {}
         with torch.device("cpu"):
             iterator = iter(dataloaders[i])
-            for _ in range(nbatches):
+            numb_batches = min(nbatches, len(dataloaders[i]))
+            for _ in range(numb_batches):
                 try:
                     stat_data = next(iterator)
                 except StopIteration:

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -2337,6 +2337,11 @@ def training_args():  # ! modified by Ziyao: data configuration isolated.
         "The oldest checkpoints will be deleted once the number of checkpoints exceeds max_ckpt_keep. "
         "Defaults to 5."
     )
+    doc_change_bias_after_training = (
+        "Whether to change the output bias after the last training step, "
+        "by performing predictions using trained model on training data and "
+        "doing least square on the errors to add the target shift on the bias."
+    )
     doc_disp_training = "Displaying verbose information during training."
     doc_time_training = "Timing durining training."
     doc_profiling = "Export the profiling results to the Chrome JSON file for performance analysis, driven by the legacy TensorFlow profiling API or PyTorch Profiler. The output file will be saved to `profiling_file`."
@@ -2386,6 +2391,13 @@ def training_args():  # ! modified by Ziyao: data configuration isolated.
             "save_ckpt", str, optional=True, default="model.ckpt", doc=doc_save_ckpt
         ),
         Argument("max_ckpt_keep", int, optional=True, default=5, doc=doc_max_ckpt_keep),
+        Argument(
+            "change_bias_after_training",
+            bool,
+            optional=True,
+            default=False,
+            doc=doc_change_bias_after_training,
+        ),
         Argument(
             "disp_training", bool, optional=True, default=True, doc=doc_disp_training
         ),

--- a/doc/model/change-bias.md
+++ b/doc/model/change-bias.md
@@ -31,10 +31,10 @@ dp --pt change-bias multi_model.pt -s data_dir -o model_updated.pt --model-branc
 :::{tab-item} Changing bias using user input for **energy model**:
 
 ```sh
-dp --pt change-bias model.pt -b -92.523,-187.66 -o model_updated.pt
+dp --pt change-bias model.pt -b -92.523 -187.66 -o model_updated.pt
 ```
 
-Here, `-b` specifies user-defined energy bias for each type, separated by `,`,
+Here, `-b` specifies user-defined energy bias for each type, separated by space,
 in an order consistent with the `type_map` in the model.
 
 :::

--- a/doc/model/change-bias.md
+++ b/doc/model/change-bias.md
@@ -1,0 +1,42 @@
+# Change the model output bias for trained model {{ pytorch_icon }}
+
+:::{note}
+**Supported backends**: PyTorch {{ pytorch_icon }}
+:::
+
+The output bias of a trained model typically originates from the statistical results of the training dataset.
+
+There are several scenarios where one might want to adjust the output bias after the model is trained,
+such as zero-shot testing (similar to the procedure before the first step in fine-tuning)
+or manually setting the output bias.
+
+The `dp --pt change-bias` command supports the following methods for adjusting the bias:
+
+::::{tab-set}
+
+:::{tab-item} Changing bias using provided systems for trained `.pt`/`.pth` models:
+
+```sh
+dp --pt change-bias model.pt -s data_dir -o model_updated.pt
+```
+
+For multitask models, where `--model-branch` must be specified:
+
+```sh
+dp --pt change-bias multi_model.pt -s data_dir -o model_updated.pt --model-branch model_1
+```
+
+:::
+
+:::{tab-item} Changing bias using user input for **energy model**:
+
+```sh
+dp --pt change-bias model.pt -b -92.523,-187.66 -o model_updated.pt
+```
+
+Here, `-b` specifies user-defined energy bias for each type, separated by `,`,
+in an order consistent with the `type_map` in the model.
+
+:::
+
+::::

--- a/doc/model/index.rst
+++ b/doc/model/index.rst
@@ -12,7 +12,6 @@ Model
    dpa2
    train-hybrid
    sel
-   change-bias
    train-energy
    train-energy-spin
    train-fitting-tensor
@@ -23,3 +22,4 @@ Model
    dprc
    linear
    pairtab
+   change-bias

--- a/doc/model/index.rst
+++ b/doc/model/index.rst
@@ -12,6 +12,7 @@ Model
    dpa2
    train-hybrid
    sel
+   change-bias
    train-energy
    train-energy-spin
    train-fitting-tensor

--- a/source/tests/pt/test_change_bias.py
+++ b/source/tests/pt/test_change_bias.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+import json
+import os
+import shutil
+import unittest
+from copy import (
+    deepcopy,
+)
+from pathlib import (
+    Path,
+)
+
+import numpy as np
+import torch
+
+from deepmd.pt.entrypoints.main import (
+    get_trainer,
+)
+from deepmd.pt.train.training import (
+    get_model_for_wrapper,
+    model_change_out_bias,
+)
+from deepmd.pt.train.wrapper import (
+    ModelWrapper,
+)
+from deepmd.pt.utils.dataloader import (
+    DpLoaderSet,
+)
+from deepmd.pt.utils.env import (
+    DEVICE,
+)
+from deepmd.pt.utils.stat import (
+    make_stat_input,
+)
+from deepmd.pt.utils.utils import (
+    to_torch_tensor,
+)
+
+from .model.test_permutation import (
+    model_se_e2_a,
+)
+from .test_finetune import (
+    energy_data_requirement,
+)
+
+current_path = os.getcwd()
+
+
+class TestChangeBias(unittest.TestCase):
+    def setUp(self):
+        input_json = str(Path(__file__).parent / "water/se_atten.json")
+        with open(input_json) as f:
+            self.config = json.load(f)
+        model_name = "change-bias-model.ckpt"
+        self.data_file = [str(Path(__file__).parent / "water/data/single")]
+        self.config["training"]["training_data"]["systems"] = self.data_file
+        self.config["training"]["validation_data"]["systems"] = self.data_file
+        self.config["model"] = deepcopy(model_se_e2_a)
+        self.config["training"]["numb_steps"] = 1
+        self.config["training"]["save_freq"] = 1
+        self.config["training"]["save_ckpt"] = model_name
+        self.trainer = get_trainer(deepcopy(self.config))
+        self.trainer.run()
+        self.state_dict_trained = self.trainer.wrapper.model.state_dict()
+        data = DpLoaderSet(
+            self.data_file,
+            batch_size=1,
+            type_map=self.config["model"]["type_map"],
+        )
+        data.add_data_requirement(energy_data_requirement)
+        self.sampled = make_stat_input(
+            data.systems,
+            data.dataloaders,
+            nbatches=1,
+        )
+        self.model_path = Path(current_path) / (model_name + ".pt")
+        self.model_path_data_bias = Path(current_path) / (
+            model_name + "data_bias" + ".pt"
+        )
+        self.model_path_user_bias = Path(current_path) / (
+            model_name + "user_bias" + ".pt"
+        )
+
+    def test_change_bias_with_data(self):
+        os.system(
+            f"dp --pt change-bias {self.model_path!s} -s {self.data_file[0]} -o {self.model_path_data_bias!s}"
+        )
+        state_dict = torch.load(str(self.model_path_data_bias), map_location=DEVICE)
+        model_params = state_dict["model"]["_extra_state"]["model_params"]
+        model_for_wrapper = get_model_for_wrapper(model_params)
+        wrapper = ModelWrapper(model_for_wrapper)
+        wrapper.load_state_dict(state_dict["model"])
+        updated_bias = wrapper.model["Default"].get_out_bias()
+        expected_model = model_change_out_bias(
+            self.trainer.wrapper.model["Default"],
+            self.sampled,
+            _bias_adjust_mode="change-by-statistic",
+        )
+        expected_bias = expected_model.get_out_bias()
+        torch.testing.assert_close(updated_bias, expected_bias)
+
+    def test_change_bias_with_user_defined(self):
+        user_bias = [0.1, 3.2, -0.5]
+        os.system(
+            f"dp --pt change-bias {self.model_path!s} -b {' '.join([str(_) for _ in user_bias])} -o {self.model_path_user_bias!s}"
+        )
+        state_dict = torch.load(str(self.model_path_user_bias), map_location=DEVICE)
+        model_params = state_dict["model"]["_extra_state"]["model_params"]
+        model_for_wrapper = get_model_for_wrapper(model_params)
+        wrapper = ModelWrapper(model_for_wrapper)
+        wrapper.load_state_dict(state_dict["model"])
+        updated_bias = wrapper.model["Default"].get_out_bias()
+        expected_bias = to_torch_tensor(np.array(user_bias)).view(updated_bias.shape)
+        torch.testing.assert_close(updated_bias, expected_bias)
+
+    def tearDown(self):
+        for f in os.listdir("."):
+            if f.startswith("change-bias-model") and f.endswith(".pt"):
+                os.remove(f)
+            if f in ["lcurve.out"]:
+                os.remove(f)
+            if f in ["stat_files"]:
+                shutil.rmtree(f)


### PR DESCRIPTION
Add bias changing param/interface

For pt/tf, add `training/change_bias_after_training` to change out bias once after training.

For pt, add a separate command `change-bias` to change trained model(pt/pth, multi/single) out bias for specific data:

```
dp change-bias model.pt -s data -n 10 -m change
```

UTs for this feature are still in consideration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new subcommand `change-bias` to adjust model output bias in the PyTorch backend.
  - Introduced test cases for changing model biases via new test suite.
  
- **Documentation**
  - Added documentation for the new `change-bias` command, including usage and options.
  - Updated `index.rst` to include a new entry for `change-bias` under the `Model` section.

- **Bug Fixes**
  - Adjusted data handling in `make_stat_input` to limit processing to a specified number of batches.

- **Refactor**
  - Restructured training configuration to include the parameter `change_bias_after_training`.
  - Modularized data requirement handling and bias adjustment functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->