### PR TITLE
fix: pin uv version to 0.2.18

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -75,7 +75,7 @@ jobs:
           # https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.2.18/uv-installer.sh | sh
         if: runner.os != 'Linux'
       - uses: docker/setup-qemu-action@v3
         name: Setup QEMU


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the URL for downloading the `uv` installer script in the build workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->