### PR TITLE
[r2] fix: move resnet_dt checking from graph to tabulate

### DIFF
--- a/deepmd/utils/graph.py
+++ b/deepmd/utils/graph.py
@@ -176,10 +176,6 @@ def get_embedding_net_nodes_from_graph_def(
     embedding_net_nodes = get_pattern_nodes_from_graph_def(
         graph_def, embedding_net_pattern
     )
-    for key in embedding_net_nodes.keys():
-        assert (
-            key.find("bias") > 0 or key.find("matrix") > 0
-        ), "currently, only support weight matrix and bias matrix at the tabulation op!"
     return embedding_net_nodes
 
 

--- a/deepmd/utils/tabulate.py
+++ b/deepmd/utils/tabulate.py
@@ -133,6 +133,10 @@ class DPTabulate:
         self.embedding_net_nodes = get_embedding_net_nodes_from_graph_def(
             self.graph_def, suffix=self.suffix
         )
+        for key in self.embedding_net_nodes.keys():
+            assert (
+                key.find("bias") > 0 or key.find("matrix") > 0
+            ), "currently, only support weight matrix and bias matrix at the tabulation op!"
 
         # move it to the descriptor class
         # for tt in self.exclude_types:


### PR DESCRIPTION
Fix #3950. Backport a part of #3263 to r2 (the whole of #3263 is not likely to be backported).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new checks to ensure only weight and bias matrices are supported during tabulation operations.

- **Refactor**
	- Removed redundant loop enforcing constraints on node keys related to weight and bias matrices to streamline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->