### PR TITLE
ci(deps): bump uv to 0.2.24

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -75,7 +75,7 @@ jobs:
           # https://github.com/pypa/setuptools_scm/issues/480
           fetch-depth: 0
       - name: Install uv
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.2.18/uv-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.2.24/uv-installer.sh | sh
         if: runner.os != 'Linux'
       - uses: docker/setup-qemu-action@v3
         name: Setup QEMU


### PR DESCRIPTION
Bump uv to [0.2.24](https://github.com/astral-sh/uv/releases/tag/0.2.24), which adds retry on connection reset network errors.

Let's see if this fixes the network issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build configuration to download the latest version (0.2.24) of `uv`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->