### PR TITLE
feat: add plugin entry point for PT

### DIFF
--- a/deepmd/backend/__init__.py
+++ b/deepmd/backend/__init__.py
@@ -7,10 +7,13 @@ Avoid directly importing third-party libraries in this module for performance.
 # copy from dpdata
 from importlib import (
     import_module,
-    metadata,
 )
 from pathlib import (
     Path,
+)
+
+from deepmd.utils.entry_point import (
+    load_entry_point,
 )
 
 PACKAGE_BASE = "deepmd.backend"
@@ -21,10 +24,4 @@ for module_file in Path(__file__).parent.glob("*.py"):
         module_name = f".{module_file.stem}"
         import_module(module_name, PACKAGE_BASE)
 
-# https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
-try:
-    eps = metadata.entry_points(group="deepmd.backend")
-except TypeError:
-    eps = metadata.entry_points().get("deepmd.backend", [])
-for ep in eps:
-    plugin = ep.load()
+load_entry_point("deepmd.backend")

--- a/deepmd/pt/model/__init__.py
+++ b/deepmd/pt/model/__init__.py
@@ -1,1 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.utils.entry_point import (
+    load_entry_point,
+)
+
+load_entry_point("deepmd.pt")

--- a/deepmd/tf/__init__.py
+++ b/deepmd/tf/__init__.py
@@ -1,14 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 """Root of the deepmd package, exposes all public classes and submodules."""
 
-try:
-    from importlib import (
-        metadata,
-    )
-except ImportError:  # for Python<3.8
-    import importlib_metadata as metadata
-
 import deepmd.tf.utils.network as network
+from deepmd.utils.entry_point import (
+    load_entry_point,
+)
 
 from . import (
     cluster,
@@ -39,12 +35,7 @@ except ImportError:
     )
 
 # load third-party plugins
-try:
-    eps = metadata.entry_points(group="deepmd")
-except TypeError:
-    eps = metadata.entry_points().get("deepmd", [])
-for ep in eps:
-    ep.load()
+load_entry_point("deepmd")
 
 __all__ = [
     "__version__",

--- a/deepmd/utils/entry_point.py
+++ b/deepmd/utils/entry_point.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from importlib import (
+    metadata,
+)
+
+
+def load_entry_point(group: str) -> list:
+    """Load entry points from a group.
+
+    Parameters
+    ----------
+    group : str
+        The group name.
+
+    Returns
+    -------
+    list
+        A list of loaded entry points.
+    """
+    # https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
+    try:
+        eps = metadata.entry_points(group=group)
+    except TypeError:
+        eps = metadata.entry_points().get(group, [])
+    return [ep.load() for ep in eps]

--- a/doc/development/create-a-model-pt.md
+++ b/doc/development/create-a-model-pt.md
@@ -168,6 +168,22 @@ allows one to use your new descriptor as below:
 
 The arguments here should be consistent with the class arguments of your new component.
 
+## Package new codes
+
+You may package new codes into a new Python package if you don't want to contribute it to the main DeePMD-kit repository.
+It's crucial to add your new component to `project.entry-points."deepmd.pt"` in `pyproject.toml`:
+
+```toml
+[project.entry-points."deepmd.pt"]
+some_descrpt = "deepmd_some_descrtpt:SomeDescript"
+```
+
+where `deepmd_some_descrtpt` is the module of your codes. It is equivalent to `from deepmd_some_descrtpt import SomeDescript`.
+
+If you place `SomeDescript` and `descrpt_some_args` into different modules, you are also expected to add `descrpt_some_args` to `entry_points`.
+
+After you install your new package, you can now use `dp train` to run your new model.
+
 ## Unit tests
 
 ### Universal tests

--- a/doc/development/create-a-model-tf.md
+++ b/doc/development/create-a-model-tf.md
@@ -58,16 +58,12 @@ The arguments here should be consistent with the class arguments of your new com
 
 ## Package new codes
 
-You may use `setuptools` to package new codes into a new Python package. It's crucial to add your new component to `entry_points['deepmd']` in `setup.py`:
+You may package new codes into a new Python package if you don't want to contribute it to the main DeePMD-kit repository.
+It's crucial to add your new component to `project.entry-points."deepmd"` in `pyproject.toml`:
 
-```py
-entry_points = (
-    {
-        "deepmd": [
-            "some_descrpt=deepmd_some_descrtpt:SomeDescript",
-        ],
-    },
-)
+```toml
+[project.entry-points."deepmd"]
+some_descrpt = "deepmd_some_descrtpt:SomeDescript"
 ```
 
 where `deepmd_some_descrtpt` is the module of your codes. It is equivalent to `from deepmd_some_descrtpt import SomeDescript`.


### PR DESCRIPTION
Currently, we have it for TF, for the backend, but not for PT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guidelines for packaging new codes into a Python package for DeePMD-kit, including changes to use `pyproject.toml` instead of `setup.py`.

- **Refactor**
  - Improved entry point loading by centralizing the logic into a new utility function, enhancing code maintainability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->