### PR TITLE
fix(pt): add `finetune_head` to argcheck

### DIFF
--- a/deepmd/pt/utils/finetune.py
+++ b/deepmd/pt/utils/finetune.py
@@ -155,7 +155,6 @@ def get_finetune_rules(
             change_model_params=change_model_params,
         )
         finetune_links["Default"] = finetune_rule
-        model_config.pop("finetune_head", None)  # for argcheck
     else:
         assert model_branch == "", (
             "Multi-task fine-tuning does not support command-line branches chosen!"
@@ -201,7 +200,4 @@ def get_finetune_rules(
             )
             finetune_links[model_key] = finetune_rule
             finetune_links[model_key].resuming = resuming
-            model_config["model_dict"][model_key].pop(
-                "finetune_head", None
-            )  # for argcheck
     return model_config, finetune_links

--- a/deepmd/pt/utils/finetune.py
+++ b/deepmd/pt/utils/finetune.py
@@ -155,6 +155,7 @@ def get_finetune_rules(
             change_model_params=change_model_params,
         )
         finetune_links["Default"] = finetune_rule
+        model_config.pop("finetune_head", None)  # for argcheck
     else:
         assert model_branch == "", (
             "Multi-task fine-tuning does not support command-line branches chosen!"
@@ -200,4 +201,7 @@ def get_finetune_rules(
             )
             finetune_links[model_key] = finetune_rule
             finetune_links[model_key].resuming = resuming
+            model_config["model_dict"][model_key].pop(
+                "finetune_head", None
+            )  # for argcheck
     return model_config, finetune_links

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -1533,6 +1533,10 @@ def model_args(exclude_hybrid=False):
     doc_spin = "The settings for systems with spin."
     doc_atom_exclude_types = "Exclude the atomic contribution of the listed atom types"
     doc_pair_exclude_types = "The atom pairs of the listed types are not treated to be neighbors, i.e. they do not see each other."
+    doc_finetune_head = (
+        "The chosen fitting net to fine-tune on, when doing multi-task fine-tuning. "
+        "If not set or set to 'RANDOM', the fitting net will be randomly initialized."
+    )
 
     hybrid_models = []
     if not exclude_hybrid:
@@ -1629,6 +1633,12 @@ def model_args(exclude_hybrid=False):
                 fold_subdoc=True,
             ),
             Argument("spin", dict, spin_args(), [], optional=True, doc=doc_spin),
+            Argument(
+                "finetune_head",
+                str,
+                optional=True,
+                doc=doc_only_pt_supported + doc_finetune_head,
+            ),
         ],
         [
             Variant(

--- a/source/tests/pt/model/water/multitask.json
+++ b/source/tests/pt/model/water/multitask.json
@@ -68,7 +68,6 @@
     "_comment": "that's all"
   },
   "loss_dict": {
-    "_comment": " that's all",
     "model_1": {
       "type": "ener",
       "start_pref_e": 0.02,

--- a/source/tests/pt/test_multitask.py
+++ b/source/tests/pt/test_multitask.py
@@ -21,6 +21,12 @@ from deepmd.pt.utils.finetune import (
 from deepmd.pt.utils.multi_task import (
     preprocess_shared_params,
 )
+from deepmd.utils.argcheck import (
+    normalize,
+)
+from deepmd.utils.compat import (
+    update_deepmd_input,
+)
 
 from .model.test_permutation import (
     model_dpa1,
@@ -39,6 +45,8 @@ def setUpModule():
 class MultiTaskTrainTest:
     def test_multitask_train(self):
         # test multitask training
+        self.config = update_deepmd_input(self.config, warning=True)
+        self.config = normalize(self.config, multi_task=True)
         trainer = get_trainer(deepcopy(self.config), shared_links=self.shared_links)
         trainer.run()
         # check model keys
@@ -124,6 +132,8 @@ class MultiTaskTrainTest:
             finetune_model,
             self.origin_config["model"],
         )
+        self.origin_config = update_deepmd_input(self.origin_config, warning=True)
+        self.origin_config = normalize(self.origin_config, multi_task=True)
         trainer_finetune = get_trainer(
             deepcopy(self.origin_config),
             finetune_model=finetune_model,


### PR DESCRIPTION
 Add `finetune_head`  to argcheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `finetune_head` argument for specifying the fitting net during multi-task fine-tuning, with optional random initialization if not set.
  
- **Bug Fixes**
  - Improved handling for specific conditions by automatically removing the "finetune_head" key from the configuration.

- **Tests**
  - Updated multitask training and finetuning tests to include new configuration manipulations.
  - Removed the `_comment` field from test configuration files to ensure cleaner test setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->