### PR TITLE
Fix: tf dipole atomic key

### DIFF
--- a/deepmd/tf/loss/tensor.py
+++ b/deepmd/tf/loss/tensor.py
@@ -148,7 +148,7 @@ class TensorLoss(Loss):
         # data required
         data_requirements.append(
             DataRequirementItem(
-                "atomic_" + self.label_name,
+                "atom_" + self.label_name,
                 self.tensor_size,
                 atomic=True,
                 must=False,


### PR DESCRIPTION
I believe this should fix #3970 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated label naming convention from "atomic_" to "atom_" to ensure consistency in labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->