### PR TITLE
fix(pt/tf/dp): normalize the econf

### DIFF
--- a/deepmd/dpmodel/utils/type_embed.py
+++ b/deepmd/dpmodel/utils/type_embed.py
@@ -234,5 +234,6 @@ def get_econf_tebd(type_map, precision: str = "default"):
         [electronic_configuration_embedding[kk] for kk in type_map],
         dtype=PRECISION_DICT[precision],
     )
+    econf_tebd /= econf_tebd.sum(-1, keepdims=True)  # do normalization
     embed_input_dim = ECONF_DIM
     return econf_tebd, embed_input_dim


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced the accuracy of energy configuration embeddings by adding a normalization step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->