### PR TITLE
fix(cmake): fix `set_if_higher`

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -11,7 +11,8 @@ set(DEEPMD_C_ROOT
 
 set(CMAKE_CXX_STANDARD 11)
 macro(set_if_higher VARIABLE VALUE)
-  if("${VARIABLE}" LESS "${VALUE}")
+  # ${VARIABLE} is a variable name, not a string
+  if(${VARIABLE} LESS "${VALUE}")
     set(${VARIABLE} ${VALUE})
   endif()
 endmacro()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `set_if_higher` macro to correctly interpret `${VARIABLE}` as a variable name rather than a string, enhancing variable comparison accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->