### PR TITLE
fix(pt): ensure suffix of `--init_model` and `--restart` is `.pt`

### DIFF
--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -236,6 +236,11 @@ def train(FLAGS):
     SummaryPrinter()()
     with open(FLAGS.INPUT) as fin:
         config = json.load(fin)
+    # ensure suffix, as in the command line help, we say "path prefix of checkpoint files"
+    if FLAGS.init_model is not None and not FLAGS.init_model.endswith(".pt"):
+        FLAGS.init_model += ".pt"
+    if FLAGS.restart is not None and not FLAGS.restart.endswith(".pt"):
+        FLAGS.restart += ".pt"
 
     # update multitask config
     multi_task = "model_dict" in config["model"]


### PR DESCRIPTION
... as in the command line help, we say "path prefix of checkpoint files". This will be compatible with the current DP-GEN code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Ensured that the `.pt` suffix is automatically appended to `init_model` and `restart` file paths if not already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->