### PR TITLE
fix(pt): make 'find_' to be float in get data

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -184,6 +184,7 @@ class Trainer:
                     if dist.is_available()
                     else 0,  # setting to 0 diverges the behavior of its iterator; should be >=1
                     drop_last=False,
+                    collate_fn=lambda batch: batch,  # prevent extra conversion
                     pin_memory=True,
                 )
                 with torch.device("cpu"):
@@ -1093,7 +1094,7 @@ class Trainer:
                     batch_data = next(iter(self.validation_data[task_key]))
 
         for key in batch_data.keys():
-            if key == "sid" or key == "fid" or key == "box":
+            if key == "sid" or key == "fid" or key == "box" or "find_" in key:
                 continue
             elif not isinstance(batch_data[key], list):
                 if batch_data[key] is not None:


### PR DESCRIPTION
make 'find_' to be float in get data, fix #3991 .

On my device, the profiler indicates that `cudaStreamSynchronize` takes negligible time, resulting in minimal speedup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced data loading by adding a `collate_fn` parameter for more flexible data collation.
    - Improved data filtering by excluding keys containing "find_" in addition to existing filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->