### PR TITLE
feat: allow model arguments to be registered outside

### DIFF
--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -167,8 +167,8 @@ class ArgsPlugin:
     def register(
         self, name: str, alias: Optional[List[str]] = None, doc: str = ""
     ) -> Callable[
-        [Callable[[], Union[Argument, List[Argument]]]],
-        Callable[[], Union[Argument, List[Argument]]],
+        [Union[Callable[[], Argument], Callable[[], List[Argument]]]],
+        Union[Callable[[], Argument], Callable[[], List[Argument]]],
     ]:
         """Register a descriptor argument plugin.
 
@@ -181,7 +181,7 @@ class ArgsPlugin:
 
         Returns
         -------
-        Callable[[Callable[[], Union[Argument, List[Argument]]]], Callable[[], Union[Argument, List[Argument]]]]
+        Callable[[Union[Callable[[], Argument], Callable[[], List[Argument]]]], Union[Callable[[], Argument], Callable[[], List[Argument]]]]
             decorator to return the registered descriptor argument method
 
         Examples


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new plugins for handling model arguments, including `standard`, `frozen`, `pairtab`, `pairwise_dprc`, and `linear_ener` models.
  - Added support for hybrid models that require another model as input.

- **Improvements**
  - Enhanced argument-checking mechanisms to accommodate complex return types and nested structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->