### PR TITLE
feat: add `get_model` classmethod to `BaseModel`

### DIFF
--- a/deepmd/dpmodel/model/base_model.py
+++ b/deepmd/dpmodel/model/base_model.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import inspect
+import json
 from abc import (
     ABC,
     abstractmethod,
@@ -192,6 +193,30 @@ def make_base_model() -> Type[object]:
                 model_type = local_jdata.get("fitting", {}).get("type", "ener")
             cls = cls.get_class_by_type(model_type)
             return cls.update_sel(train_data, type_map, local_jdata)
+
+        @classmethod
+        def get_model(cls, model_params: dict) -> "BaseBaseModel":
+            """Get the model by the parameters.
+
+            By default, all the parameters are directly passed to the constructor.
+            If not, override this method.
+
+            Parameters
+            ----------
+            model_params : dict
+                The model parameters
+
+            Returns
+            -------
+            BaseBaseModel
+                The model
+            """
+            model_params_old = model_params.copy()
+            model_params = model_params.copy()
+            model_params.pop("type", None)
+            model = cls(**model_params)
+            model.model_def_script = json.dumps(model_params_old)
+            return model
 
     return BaseBaseModel
 

--- a/deepmd/dpmodel/model/model.py
+++ b/deepmd/dpmodel/model/model.py
@@ -5,6 +5,9 @@ from deepmd.dpmodel.descriptor.se_e2_a import (
 from deepmd.dpmodel.fitting.ener_fitting import (
     EnergyFittingNet,
 )
+from deepmd.dpmodel.model.base_model import (
+    BaseModel,
+)
 from deepmd.dpmodel.model.ener_model import (
     EnergyModel,
 )
@@ -93,7 +96,11 @@ def get_model(data: dict):
     data : dict
         The data to construct the model.
     """
-    if "spin" in data:
-        return get_spin_model(data)
+    model_type = data.get("type", "standard")
+    if model_type == "standard":
+        if "spin" in data:
+            return get_spin_model(data)
+        else:
+            return get_standard_model(data)
     else:
-        return get_standard_model(data)
+        return BaseModel.get_class_by_type(model_type).get_model(data)

--- a/deepmd/pt/model/model/__init__.py
+++ b/deepmd/pt/model/model/__init__.py
@@ -197,12 +197,16 @@ def get_standard_model(model_params):
 
 
 def get_model(model_params):
-    if "spin" in model_params:
-        return get_spin_model(model_params)
-    elif "use_srtab" in model_params:
-        return get_zbl_model(model_params)
+    model_type = model_params.get("type", "standard")
+    if model_type == "standard":
+        if "spin" in model_params:
+            return get_spin_model(model_params)
+        elif "use_srtab" in model_params:
+            return get_zbl_model(model_params)
+        else:
+            return get_standard_model(model_params)
     else:
-        return get_standard_model(model_params)
+        return BaseModel.get_class_by_type(model_type).get_model(model_params)
 
 
 __all__ = [


### PR DESCRIPTION
Fix #3968. External and new models can implement this method (if different from default) without changing the old `get_model` methods (which cannot be done by a plugin).

Note: I don't modify old `get_model` methods in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for model instantiation that enhances flexibility in parameter configuration.
  - Improved the model retrieval process to support dynamic model selection based on specified types.
  
- **Bug Fixes**
  - Enhanced control flow to ensure correct model type selection, addressing potential issues with model retrieval.

- **Refactor**
  - Updated existing model retrieval functions to streamline logic and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->