### PR TITLE
fix: fix nopbc in dpdata driver

### DIFF
--- a/deepmd/driver.py
+++ b/deepmd/driver.py
@@ -62,7 +62,8 @@ class DPDriver(dpdata.driver.Driver):
         atype = sorted_data["atom_types"]
 
         coord = data["coords"].reshape((nframes, natoms * 3))
-        if "nopbc" not in data:
+        # sometimes data["nopbc"] may be False
+        if not data.get("nopbc", False):
             cell = data["cells"].reshape((nframes, 9))
         else:
             cell = None


### PR DESCRIPTION
Sometimes dpdata data may contain `"nopbc": False` (from ase or n2p2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the "nopbc" key in the data processing logic, enhancing the accuracy of cell variable assignments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->