### PR TITLE
fix:fix LAMMPS MPI tests with mpi4py 4.0.0

### DIFF
--- a/source/lmp/tests/run_mpi_pair_deepmd.py
+++ b/source/lmp/tests/run_mpi_pair_deepmd.py
@@ -54,8 +54,8 @@ lammps.pair_style(
 )
 lammps.pair_coeff("* *")
 lammps.run(0)
-pe = lammps.eval("pe")
 if rank == 0:
+    pe = lammps.eval("pe")
     arr = [pe]
     np.savetxt(output, np.array(arr))
 MPI.Finalize()


### PR DESCRIPTION
The previous code works with mpi4py<4 but fails with mpi4py 4.0.0. I don't know what breaking change was made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Optimized potential energy calculation in the LAMMPS simulation by restricting evaluation to the master process, reducing unnecessary computations.

- **Chores**
	- Improved control flow for better performance in parallel execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->