### PR TITLE
feat: make `dp neighbor-stat --type-map` optional

### DIFF
--- a/deepmd/entrypoints/neighbor_stat.py
+++ b/deepmd/entrypoints/neighbor_stat.py
@@ -2,6 +2,7 @@
 import logging
 from typing import (
     List,
+    Optional,
 )
 
 from deepmd.backend.backend import (
@@ -21,7 +22,7 @@ def neighbor_stat(
     *,
     system: str,
     rcut: float,
-    type_map: List[str],
+    type_map: Optional[List[str]],
     mixed_type: bool = False,
     backend: str = "tensorflow",
     **kwargs,
@@ -88,6 +89,8 @@ def neighbor_stat(
         rcut=rcut,
         type_map=type_map,
     )
+    if type_map is None:
+        log.info(f"type_map: {data.get_type_map()}")
     data.get_batch()
     nei = NeighborStat(data.get_ntypes(), rcut, mixed_type=mixed_type)
     min_nbor_dist, max_nbor_size = nei.get_stat(data)

--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -655,8 +655,8 @@ def main_parser() -> argparse.ArgumentParser:
         "--type-map",
         type=str,
         nargs="+",
-        required=True,
-        help="type map",
+        required=False,
+        help="Type map. If not provided, the type map of data will be used.",
     )
     parser_neighbor_stat.add_argument(
         "--mixed-type",


### PR DESCRIPTION
In most cases, we can directly read type map from data.