### PR TITLE
fix: replace `datetime.datetime.utcnow` which is deprecated

### DIFF
--- a/deepmd/dpmodel/utils/serialization.py
+++ b/deepmd/dpmodel/utils/serialization.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import datetime
 import json
-from datetime import (
-    datetime,
-)
 from pathlib import (
     Path,
 )
@@ -90,7 +88,7 @@ def save_dp_model(filename: str, model_dict: dict) -> None:
         "software": "deepmd-kit",
         "version": __version__,
         # use UTC+0 time
-        "time": str(datetime.utcnow()),
+        "time": str(datetime.datetime.now(tz=datetime.timezone.utc)),
     }
     if filename_extension == ".dp":
         variable_counter = Counter()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,13 +7,14 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import datetime
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
 import sys
-import datetime
 
 from deepmd.utils.argcheck import (
     ACTIVATION_FN_DICT,
@@ -27,7 +28,9 @@ import sphinx_contrib_exhale_multiproject  # noqa: F401
 # -- Project information -----------------------------------------------------
 
 project = "DeePMD-kit"
-copyright = "2017-%d, DeepModeling" % datetime.datetime.now(tz=datetime.timezone.utc).year
+copyright = (
+    "2017-%d, DeepModeling" % datetime.datetime.now(tz=datetime.timezone.utc).year
+)
 author = "DeepModeling"
 
 autoapi_dirs = ["../deepmd"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,9 +13,7 @@
 #
 import os
 import sys
-from datetime import (
-    date,
-)
+import datetime
 
 from deepmd.utils.argcheck import (
     ACTIVATION_FN_DICT,
@@ -29,7 +27,7 @@ import sphinx_contrib_exhale_multiproject  # noqa: F401
 # -- Project information -----------------------------------------------------
 
 project = "DeePMD-kit"
-copyright = "2017-%d, DeepModeling" % date.today().year
+copyright = "2017-%d, DeepModeling" % datetime.datetime.now(tz=datetime.timezone.utc).year
 author = "DeepModeling"
 
 autoapi_dirs = ["../deepmd"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,7 @@ select = [
     "B904", # raise-without-from-inside-except
     "N804", # invalid-first-argument-name-for-class-method
     "N805", # invalid-first-argument-name-for-method
+    "DTZ", # datetime
 ]
 
 ignore = [


### PR DESCRIPTION
Fix #4063.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
  - Enhanced the accuracy and clarity of time representation in the model saving feature.
  - Updated copyright year retrieval to ensure timezone awareness for improved precision.
  - Expanded linting capabilities by adding datetime-related checks, which can improve code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->