### PR TITLE
breaking: drop C++ 11

### DIFF
--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -108,7 +108,8 @@ Check the compiler version on your machine
 gcc --version
 ```
 
-The compiler GCC 4.8 or later is supported in the DeePMD-kit.
+By default, DeePMD-kit uses C++ 14, so the compiler needs to support C++ 14 (GCC 5 or later).
+The backend package may use a higher C++ standard version, and thus require a higher compiler version (for example, GCC 7 for C++ 17). 
 
 ::::{tab-set}
 

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -109,7 +109,7 @@ gcc --version
 ```
 
 By default, DeePMD-kit uses C++ 14, so the compiler needs to support C++ 14 (GCC 5 or later).
-The backend package may use a higher C++ standard version, and thus require a higher compiler version (for example, GCC 7 for C++ 17). 
+The backend package may use a higher C++ standard version, and thus require a higher compiler version (for example, GCC 7 for C++ 17).
 
 ::::{tab-set}
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -16,7 +16,7 @@ macro(set_if_higher VARIABLE VALUE)
     set(${VARIABLE} ${VALUE})
   endif()
 endmacro()
-if (NOT DEEPMD_C_ROOT)
+if(NOT DEEPMD_C_ROOT)
   # we can still allow C++ 11 for programs linked to the C library
   set_if_higher(CMAKE_CXX_STANDARD 14)
 endif()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -16,6 +16,10 @@ macro(set_if_higher VARIABLE VALUE)
     set(${VARIABLE} ${VALUE})
   endif()
 endmacro()
+if (NOT DEEPMD_C_ROOT)
+  # we can still allow C++ 11 for programs linked to the C library
+  set_if_higher(CMAKE_CXX_STANDARD 14)
+endif()
 
 if(BUILD_TESTING)
   enable_testing()


### PR DESCRIPTION
Fix #4060.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation documentation to clarify C++ compiler requirements, specifying that GCC 5 or higher is necessary for C++ 14 and potentially GCC 7 for C++ 17.
  
- **Chores**
	- Enhanced CMake configuration to support C++ 14 in specific scenarios, improving compatibility with older codebases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->