### PR TITLE
docs: fix the default value of `DP_ENABLE_PYTORCH`

### DIFF
--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -167,7 +167,7 @@ The path to the ROCM toolkit directory.
 
 :::{envvar} DP_ENABLE_PYTORCH
 
-**Choices**: `0`, `1`; **Default**: `1`
+**Choices**: `0`, `1`; **Default**: `0`
 
 {{ pytorch_icon }} Enable customized C++ OPs for the PyTorch backend. PyTorch can still run without customized C++ OPs, but features will be limited.
 :::


### PR DESCRIPTION
It seems I made a typo before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the installation guide to reflect the change in the default value of the `DP_ENABLE_PYTORCH` environment variable from `1` to `0`, requiring users to explicitly enable customized C++ operations for the PyTorch backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->