### PR TITLE
ci: add `include-hidden-files` to `actions/upload-artifact`

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -59,6 +59,7 @@ jobs:
       with:
         name: split-${{ matrix.python }}-${{ matrix.group }}
         path: .test_durations_${{ matrix.group }}
+        include-hidden-files: true
     - uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Due to a breaking change introduced in https://github.com/actions/upload-artifact/issues/602.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced file handling in the workflow by including hidden files during job execution, improving output granularity.
  
- **Bug Fixes**
	- Adjusted job configuration to ensure accurate test duration reporting by considering hidden files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->