### PR TITLE
fix(pt): convert `torch.__version__` to `str` when serializing

### DIFF
--- a/deepmd/pt/utils/serialization.py
+++ b/deepmd/pt/utils/serialization.py
@@ -47,7 +47,7 @@ def serialize_from_file(model_file: str) -> dict:
     model_dict = model.serialize()
     data = {
         "backend": "PyTorch",
-        "pt_version": torch.__version__,
+        "pt_version": str(torch.__version__),
         "model": model_dict,
         "model_def_script": model_def_script,
         "@variables": {},


### PR DESCRIPTION
```py
>>> type(torch.__version__)
<class 'torch.torch_version.TorchVersion'>
```

This causes a YAML error:

```
  File "/home/jz748/anaconda3/lib/python3.10/site-packages/yaml/representer.py", line 231, in represent_undefined
    raise RepresenterError("cannot represent an object", data)
yaml.representer.RepresenterError: ('cannot represent an object', '2.3.1+cu121')
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the serialization of the PyTorch version by ensuring it is represented as a string, enhancing data clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->