### PR TITLE
fix(tests): fix `skip_dp`

### DIFF
--- a/source/tests/consistent/descriptor/test_dpa1.py
+++ b/source/tests/consistent/descriptor/test_dpa1.py
@@ -177,7 +177,7 @@ class TestDPA1(CommonTest, DescriptorTest, unittest.TestCase):
             use_econf_tebd,
             use_tebd_bias,
         ) = self.param
-        return CommonTest.skip_pt or self.is_meaningless_zero_attention_layer_tests(
+        return CommonTest.skip_dp or self.is_meaningless_zero_attention_layer_tests(
             attn_layer,
             attn_dotr,
             normalize,

--- a/source/tests/consistent/descriptor/test_dpa2.py
+++ b/source/tests/consistent/descriptor/test_dpa2.py
@@ -235,7 +235,7 @@ class TestDPA2(CommonTest, DescriptorTest, unittest.TestCase):
             use_econf_tebd,
             use_tebd_bias,
         ) = self.param
-        return CommonTest.skip_pt
+        return CommonTest.skip_dp
 
     @property
     def skip_tf(self) -> bool:

--- a/source/tests/consistent/descriptor/test_se_atten_v2.py
+++ b/source/tests/consistent/descriptor/test_se_atten_v2.py
@@ -165,7 +165,7 @@ class TestSeAttenV2(CommonTest, DescriptorTest, unittest.TestCase):
             use_econf_tebd,
             use_tebd_bias,
         ) = self.param
-        return CommonTest.skip_pt or self.is_meaningless_zero_attention_layer_tests(
+        return CommonTest.skip_dp or self.is_meaningless_zero_attention_layer_tests(
             attn_layer,
             attn_dotr,
             normalize,

--- a/source/tests/consistent/descriptor/test_se_t_tebd.py
+++ b/source/tests/consistent/descriptor/test_se_t_tebd.py
@@ -116,7 +116,7 @@ class TestSeTTebd(CommonTest, DescriptorTest, unittest.TestCase):
             use_econf_tebd,
             use_tebd_bias,
         ) = self.param
-        return CommonTest.skip_pt
+        return CommonTest.skip_dp
 
     @property
     def skip_tf(self) -> bool:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the test skipping logic across multiple test files to reference the correct condition for skipping tests, enhancing the accuracy of test execution.
- **Tests**
	- Adjusted the `skip_dp` method in various test classes to improve the control flow and alignment with specific testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->