### PR TITLE
docs: fix defination of `se_e3`

### DIFF
--- a/doc/model/train-se-e3.md
+++ b/doc/model/train-se-e3.md
@@ -4,7 +4,8 @@
 **Supported backends**: TensorFlow {{ tensorflow_icon }}, PyTorch {{ pytorch_icon }}, DP {{ dpmodel_icon }}
 :::
 
-The notation of `se_e3` is short for the Deep Potential Smooth Edition (DeepPot-SE) constructed from all information (both angular and radial) of atomic configurations. The embedding takes bond angles between a central atom and its two neighboring atoms as input (denoted by `e3`).
+The notation of `se_e3` is short for three-body embedding DeepPot-SE, which incorporates bond-angle information.
+The embedding takes bond angles between a central atom and its two neighboring atoms as input (denoted by `e3`).
 
 ## Theory
 

--- a/doc/model/train-se-e3.md
+++ b/doc/model/train-se-e3.md
@@ -4,7 +4,7 @@
 **Supported backends**: TensorFlow {{ tensorflow_icon }}, PyTorch {{ pytorch_icon }}, DP {{ dpmodel_icon }}
 :::
 
-The notation of `se_e3` is short for three-body embedding DeepPot-SE, which incorporates bond-angle information.
+The notation of `se_e3` is short for three-body embedding DeepPot-SE, which incorporates embedded bond-angle information.
 The embedding takes bond angles between a central atom and its two neighboring atoms as input (denoted by `e3`).
 
 ## Theory


### PR DESCRIPTION
As discussed in #4066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the description of the `se_e3` notation for improved clarity regarding its relation to three-body embedding in DeepPot-SE.
	- Enhanced explanation of bond-angle information in the context of the embedding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->