### PR TITLE
[Fix] Wrap log_path with Path

### DIFF
--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -555,7 +555,7 @@ def main(args: Optional[Union[List[str], argparse.Namespace]] = None):
     else:
         FLAGS = args
 
-    set_log_handles(FLAGS.log_level, FLAGS.log_path, mpi_log=None)
+    set_log_handles(FLAGS.log_level, Path(FLAGS.log_path), mpi_log=None)
     log.debug("Log handles were successfully set")
     log.info("DeePMD version: %s", __version__)
 

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -557,7 +557,7 @@ def main(args: Optional[Union[List[str], argparse.Namespace]] = None):
 
     set_log_handles(
         FLAGS.log_level,
-        Path(args.log_path) if args.log_path else None,
+        Path(FLAGS.log_path) if FLAGS.log_path else None,
         mpi_log=None,
     )
     log.debug("Log handles were successfully set")

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -555,7 +555,11 @@ def main(args: Optional[Union[List[str], argparse.Namespace]] = None):
     else:
         FLAGS = args
 
-    set_log_handles(FLAGS.log_level, Path(FLAGS.log_path), mpi_log=None)
+    set_log_handles(
+        FLAGS.log_level,
+        Path(args.log_path) if args.log_path else None,
+        mpi_log=None,
+    )
     log.debug("Log handles were successfully set")
     log.info("DeePMD version: %s", __version__)
 


### PR DESCRIPTION
`FLAGS.log_path` need to be wrapped into `Path` type, or will raise error when call `.parent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
	- Enhanced handling of log file paths for better compatibility and functionality in file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->