### PR TITLE
[r2] docs: pin sphinx-argparse to < 0.5.0 (#3988)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ docs = [
     "ase",
     "deepmodeling-sphinx>=0.1.0",
     "dargs>=0.3.4",
-    "sphinx-argparse",
+    "sphinx-argparse<0.5.0",
     "pygments-lammps",
     "sphinxcontrib-bibtex",
 ]


### PR DESCRIPTION
Cherry-pick from #3988. The doc on the `r2` branch needs a rebuild, but the build failed due to sphinx-argparse.

----

Pin sphinx-argparse to <0.5.0 due to sphinx-doc/sphinx-argparse#56.

Generated by the task: https://github.com/njzjz-bot/njzjz-bot/issues/7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated `sphinx-argparse` dependency to ensure compatibility by restricting it to versions below `0.5.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->