### PR TITLE
CI(codecov): do not notify until all reports are ready

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -44,3 +44,7 @@ component_management:
       name: i-PI
       paths:
         - source/ipi/**
+codecov:
+  notify:
+    # 12 Python + 2 C++
+    after_n_builds: 14


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the code coverage notification settings to trigger alerts after 14 builds, improving monitoring of code coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->