### PR TITLE
fix(pt): move entry point from `deepmd.pt.model` to `deepmd.pt`

### DIFF
--- a/deepmd/pt/__init__.py
+++ b/deepmd/pt/__init__.py
@@ -4,6 +4,11 @@
 from deepmd.pt.cxx_op import (
     ENABLE_CUSTOMIZED_OP,
 )
+from deepmd.utils.entry_point import (
+    load_entry_point,
+)
+
+load_entry_point("deepmd.pt")
 
 __all__ = [
     "ENABLE_CUSTOMIZED_OP",

--- a/deepmd/pt/model/__init__.py
+++ b/deepmd/pt/model/__init__.py
@@ -1,6 +1,1 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-from deepmd.utils.entry_point import (
-    load_entry_point,
-)
-
-load_entry_point("deepmd.pt")


### PR DESCRIPTION
`deepmd.pt` should be a more reasonable one to load the plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization process for the `deepmd.pt` module, allowing for improved dynamic loading and configuration.
  
- **Refactor**
	- Removed unnecessary imports and function calls related to entry point loading in the `deepmd.pt.model` module, streamlining the module's initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->