### PR TITLE
Set ROCM_ROOT to ROCM_PATH when it exist

### DIFF
--- a/backend/read_env.py
+++ b/backend/read_env.py
@@ -60,6 +60,8 @@ def get_argument_from_env() -> Tuple[str, list, list, dict, str, str]:
         cmake_minimum_required_version = "3.21"
         cmake_args.append("-DUSE_ROCM_TOOLKIT:BOOL=TRUE")
         rocm_root = os.environ.get("ROCM_ROOT")
+        if not rocm_root:
+            rocm_root = os.environ.get("ROCM_PATH")
         if rocm_root:
             cmake_args.append(f"-DCMAKE_HIP_COMPILER_ROCM_ROOT:STRING={rocm_root}")
         hipcc_flags = os.environ.get("HIP_HIPCC_FLAGS")

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -155,7 +155,8 @@ The path to the CUDA toolkit directory. CUDA 9.0 or later is supported. NVCC is 
 
 **Type**: Path; **Default**: Detected automatically
 
-The path to the ROCM toolkit directory.
+The path to the ROCM toolkit directory. If `ROCM_ROOT` is not set, it will look for `ROCM_PATH`; if `ROCM_PATH` is also not set, it will be detected using `hipconfig --rocmpath`.
+
 :::
 
 :::{envvar} DP_ENABLE_TENSORFLOW


### PR DESCRIPTION
This small commit closes issue #4149 by checking if `rocm_root` is not set, and then inferring it from `rocm_path`, if it exists. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in retrieving the ROCM root directory by checking both `ROCM_ROOT` and `ROCM_PATH` environment variables. 
	- Updated installation documentation to clarify the fallback mechanism for locating the ROCM toolkit, ensuring users have clear guidance on configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->