### PR TITLE
fix: fix `DPH5Path.glob` for new keys

### DIFF
--- a/deepmd/utils/path.py
+++ b/deepmd/utils/path.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import itertools
 import os
 from abc import (
     ABC,
@@ -373,7 +374,11 @@ class DPH5Path(DPPath):
             list of paths
         """
         # got paths starts with current path first, which is faster
-        subpaths = [ii for ii in self._keys if ii.startswith(self._name)]
+        subpaths = [
+            ii
+            for ii in itertools.chain(self._keys, self._new_keys)
+            if ii.startswith(self._name)
+        ]
         return [
             type(self)(f"{self.root_path}#{pp}", mode=self.mode)
             for pp in globfilter(subpaths, self._connect_path(pattern))


### PR DESCRIPTION
Fix #4151.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced path filtering logic to include a broader range of keys when generating subpaths.
  
- **Bug Fixes**
	- Improved the accuracy of path results returned by the `glob` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->