### PR TITLE
Feat: output logs on freezing models

### DIFF
--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -354,6 +354,7 @@ def freeze(FLAGS):
         FLAGS.output,
         extra_files,
     )
+    log.info(f"Saved frozen model to {FLAGS.output}")
 
 
 def change_bias(FLAGS):


### PR DESCRIPTION
`dp --pt freeze` does not output whether the operation finishes successfully. This PR adds a log message on it.