### PR TITLE
chore: use `functools.cached_property` for cached properties

### DIFF
--- a/deepmd/tf/infer/deep_eval.py
+++ b/deepmd/tf/infer/deep_eval.py
@@ -263,8 +263,7 @@ class DeepEval(DeepEvalBackend):
         else:
             self.modifier_type = None
 
-    @property
-    @cache
+    @cached_property
     def model_type(self) -> type["DeepEvalWrapper"]:
         """Get type of model.
 
@@ -288,8 +287,7 @@ class DeepEval(DeepEvalBackend):
         else:
             raise RuntimeError(f"unknown model type {model_type}")
 
-    @property
-    @cache
+    @cached_property
     def model_version(self) -> str:
         """Get version of model.
 
@@ -307,8 +305,7 @@ class DeepEval(DeepEvalBackend):
             [mt] = run_sess(self.sess, [t_mt], feed_dict={})
             return mt.decode("utf-8")
 
-    @property
-    @cache
+    @cached_property
     def sess(self) -> tf.Session:
         """Get TF session."""
         # start a tf session associated to the graph
@@ -1192,8 +1189,7 @@ class DeepEvalOld:
 
         self.neighbor_list = neighbor_list
 
-    @property
-    @cache
+    @cached_property
     def model_type(self) -> str:
         """Get type of model.
 
@@ -1203,8 +1199,7 @@ class DeepEvalOld:
         [mt] = run_sess(self.sess, [t_mt], feed_dict={})
         return mt.decode("utf-8")
 
-    @property
-    @cache
+    @cached_property
     def model_version(self) -> str:
         """Get version of model.
 
@@ -1222,8 +1217,7 @@ class DeepEvalOld:
             [mt] = run_sess(self.sess, [t_mt], feed_dict={})
             return mt.decode("utf-8")
 
-    @property
-    @cache
+    @cached_property
     def sess(self) -> tf.Session:
         """Get TF session."""
         # start a tf session associated to the graph

--- a/deepmd/tf/infer/deep_eval.py
+++ b/deepmd/tf/infer/deep_eval.py
@@ -2,6 +2,7 @@
 import json
 from functools import (
     cache,
+    cached_property,
 )
 from typing import (
     TYPE_CHECKING,

--- a/deepmd/tf/infer/deep_eval.py
+++ b/deepmd/tf/infer/deep_eval.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import json
 from functools import (
-    cache,
     cached_property,
 )
 from typing import (

--- a/deepmd/tf/utils/tabulate.py
+++ b/deepmd/tf/utils/tabulate.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import logging
 from functools import (
+    cached_property,
     lru_cache,
 )
 from typing import (
@@ -770,8 +771,7 @@ class DPTabulate:
             raise RuntimeError("Unsupported descriptor")
         return layer_size
 
-    @property
-    @lru_cache
+    @cached_property
     def _n_all_excluded(self) -> int:
         """Then number of types excluding all types."""
         return sum(int(self._all_excluded(ii)) for ii in range(0, self.ntypes))

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -4,6 +4,7 @@ import logging
 import warnings
 from functools import (
     cache,
+    cached_property,
 )
 from typing import (
     Any,
@@ -238,8 +239,7 @@ class DeepmdDataSystem:
             for nn in test_system_data:
                 self.test_data[nn].append(test_system_data[nn])
 
-    @property
-    @cache
+    @cached_property
     def default_mesh(self) -> list[np.ndarray]:
         """Mesh for each system."""
         return [

--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -3,7 +3,6 @@ import collections
 import logging
 import warnings
 from functools import (
-    cache,
     cached_property,
 )
 from typing import (


### PR DESCRIPTION
`functools.cached_property` (new in Python 3.8) is more suitable for cached properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new parameter `neighbor_list` for enhanced neighbor list handling in model evaluation.
	- Added support for percentage strings in the `test_size` parameter for flexible test size configuration.
	- New method `_make_auto_ts` to facilitate test size calculations based on specified percentages.

- **Bug Fixes**
	- Improved caching mechanisms for properties, enhancing performance and memory management.

- **Documentation**
	- Added comments and clarifications in the code to improve understanding of batch and test size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->