### PR TITLE
feat(jax): energy model (no grad support)

### DIFF
--- a/deepmd/dpmodel/atomic_model/base_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/base_atomic_model.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import copy
+import math
 from typing import (
     Optional,
 )
 
+import array_api_compat
 import numpy as np
 
 from deepmd.dpmodel.common import (
     NativeOP,
+    to_numpy_array,
 )
 from deepmd.dpmodel.output_def import (
     FittingOutputDef,
@@ -172,17 +175,18 @@ class BaseAtomicModel(BaseAtomicModel_, NativeOP):
             ret_dict["mask"][ff,ii] == 0 indicating the ii-th atom of the ff-th frame is virtual.
 
         """
+        xp = array_api_compat.array_namespace(extended_coord, extended_atype, nlist)
         _, nloc, _ = nlist.shape
         atype = extended_atype[:, :nloc]
         if self.pair_excl is not None:
             pair_mask = self.pair_excl.build_type_exclude_mask(nlist, extended_atype)
             # exclude neighbors in the nlist
-            nlist = np.where(pair_mask == 1, nlist, -1)
+            nlist = xp.where(pair_mask == 1, nlist, -1)
 
         ext_atom_mask = self.make_atom_mask(extended_atype)
         ret_dict = self.forward_atomic(
             extended_coord,
-            np.where(ext_atom_mask, extended_atype, 0),
+            xp.where(ext_atom_mask, extended_atype, 0),
             nlist,
             mapping=mapping,
             fparam=fparam,
@@ -191,13 +195,13 @@ class BaseAtomicModel(BaseAtomicModel_, NativeOP):
         ret_dict = self.apply_out_stat(ret_dict, atype)
 
         # nf x nloc
-        atom_mask = ext_atom_mask[:, :nloc].astype(np.int32)
+        atom_mask = ext_atom_mask[:, :nloc].astype(xp.int32)
         if self.atom_excl is not None:
             atom_mask *= self.atom_excl.build_type_exclude_mask(atype)
 
         for kk in ret_dict.keys():
             out_shape = ret_dict[kk].shape
-            out_shape2 = np.prod(out_shape[2:])
+            out_shape2 = math.prod(out_shape[2:])
             ret_dict[kk] = (
                 ret_dict[kk].reshape([out_shape[0], out_shape[1], out_shape2])
                 * atom_mask[:, :, None]
@@ -232,8 +236,8 @@ class BaseAtomicModel(BaseAtomicModel_, NativeOP):
             "rcond": self.rcond,
             "preset_out_bias": self.preset_out_bias,
             "@variables": {
-                "out_bias": self.out_bias,
-                "out_std": self.out_std,
+                "out_bias": to_numpy_array(self.out_bias),
+                "out_std": to_numpy_array(self.out_std),
             },
         }
 

--- a/deepmd/dpmodel/atomic_model/base_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/base_atomic_model.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import copy
 import math
 from typing import (
     Optional,
@@ -243,7 +242,8 @@ class BaseAtomicModel(BaseAtomicModel_, NativeOP):
 
     @classmethod
     def deserialize(cls, data: dict) -> "BaseAtomicModel":
-        data = copy.deepcopy(data)
+        # do not deep copy Descriptor and Fitting class
+        data = data.copy()
         variables = data.pop("@variables")
         obj = cls(**data)
         for kk in variables.keys():

--- a/deepmd/dpmodel/atomic_model/dp_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/dp_atomic_model.py
@@ -169,14 +169,20 @@ class DPAtomicModel(BaseAtomicModel):
         )
         return dd
 
+    # for subclass overriden
+    base_descriptor_cls = BaseDescriptor
+    """The base descriptor class."""
+    base_fitting_cls = BaseFitting
+    """The base fitting class."""
+
     @classmethod
     def deserialize(cls, data) -> "DPAtomicModel":
         data = copy.deepcopy(data)
         check_version_compatibility(data.pop("@version", 1), 2, 2)
         data.pop("@class")
         data.pop("type")
-        descriptor_obj = BaseDescriptor.deserialize(data.pop("descriptor"))
-        fitting_obj = BaseFitting.deserialize(data.pop("fitting"))
+        descriptor_obj = cls.base_descriptor_cls.deserialize(data.pop("descriptor"))
+        fitting_obj = cls.base_fitting_cls.deserialize(data.pop("fitting"))
         data["descriptor"] = descriptor_obj
         data["fitting"] = fitting_obj
         obj = super().deserialize(data)

--- a/deepmd/dpmodel/model/make_model.py
+++ b/deepmd/dpmodel/model/make_model.py
@@ -76,7 +76,8 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
             else:
                 self.atomic_model: T_AtomicModel = T_AtomicModel(*args, **kwargs)
             self.precision_dict = PRECISION_DICT
-            self.reverse_precision_dict = RESERVED_PRECISON_DICT
+            # not supported by flax
+            # self.reverse_precision_dict = RESERVED_PRECISON_DICT
             self.global_np_float_precision = GLOBAL_NP_FLOAT_PRECISION
             self.global_ener_float_precision = GLOBAL_ENER_FLOAT_PRECISION
 
@@ -254,9 +255,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
             str,
         ]:
             """Cast the input data to global float type."""
-            input_prec = self.reverse_precision_dict[
-                self.precision_dict[coord.dtype.name]
-            ]
+            input_prec = RESERVED_PRECISON_DICT[self.precision_dict[coord.dtype.name]]
             ###
             ### type checking would not pass jit, convert to coord prec anyway
             ###
@@ -265,10 +264,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
                 for vv in [box, fparam, aparam]
             ]
             box, fparam, aparam = _lst
-            if (
-                input_prec
-                == self.reverse_precision_dict[self.global_np_float_precision]
-            ):
+            if input_prec == RESERVED_PRECISON_DICT[self.global_np_float_precision]:
                 return coord, box, fparam, aparam, input_prec
             else:
                 pp = self.global_np_float_precision
@@ -287,8 +283,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
         ) -> dict[str, np.ndarray]:
             """Convert the model output to the input prec."""
             do_cast = (
-                input_prec
-                != self.reverse_precision_dict[self.global_np_float_precision]
+                input_prec != RESERVED_PRECISON_DICT[self.global_np_float_precision]
             )
             pp = self.precision_dict[input_prec]
             odef = self.model_output_def()

--- a/deepmd/dpmodel/model/transform_output.py
+++ b/deepmd/dpmodel/model/transform_output.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
+import array_api_compat
 import numpy as np
 
 from deepmd.dpmodel.common import (
@@ -23,6 +24,7 @@ def fit_output_to_model_output(
     the model output.
 
     """
+    xp = array_api_compat.get_namespace(coord_ext)
     model_ret = dict(fit_ret.items())
     for kk, vv in fit_ret.items():
         vdef = fit_output_def[kk]
@@ -31,7 +33,7 @@ def fit_output_to_model_output(
         if vdef.reducible:
             kk_redu = get_reduce_name(kk)
             # cast to energy prec brefore reduction
-            model_ret[kk_redu] = np.sum(
+            model_ret[kk_redu] = xp.sum(
                 vv.astype(GLOBAL_ENER_FLOAT_PRECISION), axis=atom_axis
             )
             if vdef.r_differentiable:

--- a/deepmd/jax/atomic_model/__init__.py
+++ b/deepmd/jax/atomic_model/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/deepmd/jax/atomic_model/base_atomic_model.py
+++ b/deepmd/jax/atomic_model/base_atomic_model.py
@@ -11,10 +11,8 @@ from deepmd.jax.utils.exclude_mask import (
 def base_atomic_model_set_attr(name, value):
     if name in {"out_bias", "out_std"}:
         value = to_jax_array(value)
-    elif name == "pair_excl":
-        if value is not None:
-            value = PairExcludeMask(value.ntypes, value.exclude_types)
-    elif name == "atom_excl":
-        if value is not None:
-            value = AtomExcludeMask(value.ntypes, value.exclude_types)
+    elif name == "pair_excl" and value is not None:
+        value = PairExcludeMask(value.ntypes, value.exclude_types)
+    elif name == "atom_excl" and value is not None:
+        value = AtomExcludeMask(value.ntypes, value.exclude_types)
     return value

--- a/deepmd/jax/atomic_model/base_atomic_model.py
+++ b/deepmd/jax/atomic_model/base_atomic_model.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.jax.common import (
+    to_jax_array,
+)
+from deepmd.jax.utils.exclude_mask import (
+    AtomExcludeMask,
+    PairExcludeMask,
+)
+
+
+def base_atomic_model_set_attr(name, value):
+    if name in {"out_bias", "out_std"}:
+        value = to_jax_array(value)
+    elif name == "pair_excl":
+        if value is not None:
+            value = PairExcludeMask(value.ntypes, value.exclude_types)
+    elif name == "atom_excl":
+        if value is not None:
+            value = AtomExcludeMask(value.ntypes, value.exclude_types)
+    return value

--- a/deepmd/jax/atomic_model/dp_atomic_model.py
+++ b/deepmd/jax/atomic_model/dp_atomic_model.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
+
+from deepmd.dpmodel.atomic_model.dp_atomic_model import DPAtomicModel as DPAtomicModelDP
+from deepmd.jax.atomic_model.base_atomic_model import (
+    base_atomic_model_set_attr,
+)
+from deepmd.jax.descriptor.base_descriptor import (
+    BaseDescriptor,
+)
+from deepmd.jax.fitting.base_fitting import (
+    BaseFitting,
+)
+
+
+class DPAtomicModel(DPAtomicModelDP):
+    base_descriptor_cls = BaseDescriptor
+    """The base descriptor class."""
+    base_fitting_cls = BaseFitting
+    """The base fitting class."""
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        value = base_atomic_model_set_attr(name, value)
+        return super().__setattr__(name, value)

--- a/deepmd/jax/atomic_model/dp_atomic_model.py
+++ b/deepmd/jax/atomic_model/dp_atomic_model.py
@@ -7,6 +7,9 @@ from deepmd.dpmodel.atomic_model.dp_atomic_model import DPAtomicModel as DPAtomi
 from deepmd.jax.atomic_model.base_atomic_model import (
     base_atomic_model_set_attr,
 )
+from deepmd.jax.common import (
+    flax_module,
+)
 from deepmd.jax.descriptor.base_descriptor import (
     BaseDescriptor,
 )
@@ -15,6 +18,7 @@ from deepmd.jax.fitting.base_fitting import (
 )
 
 
+@flax_module
 class DPAtomicModel(DPAtomicModelDP):
     base_descriptor_cls = BaseDescriptor
     """The base descriptor class."""

--- a/deepmd/jax/descriptor/__init__.py
+++ b/deepmd/jax/descriptor/__init__.py
@@ -1,1 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.jax.descriptor.dpa1 import (
+    DescrptDPA1,
+)
+from deepmd.jax.descriptor.se_e2_a import (
+    DescrptSeA,
+)
+
+__all__ = [
+    "DescrptSeA",
+    "DescrptDPA1",
+]

--- a/deepmd/jax/descriptor/base_descriptor.py
+++ b/deepmd/jax/descriptor/base_descriptor.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.dpmodel.descriptor.make_base_descriptor import (
+    make_base_descriptor,
+)
+from deepmd.jax.env import (
+    jnp,
+)
+
+BaseDescriptor = make_base_descriptor(jnp.ndarray)

--- a/deepmd/jax/descriptor/dpa1.py
+++ b/deepmd/jax/descriptor/dpa1.py
@@ -16,6 +16,9 @@ from deepmd.jax.common import (
     flax_module,
     to_jax_array,
 )
+from deepmd.jax.descriptor.base_descriptor import (
+    BaseDescriptor,
+)
 from deepmd.jax.utils.exclude_mask import (
     PairExcludeMask,
 )
@@ -76,6 +79,8 @@ class DescrptBlockSeAtten(DescrptBlockSeAttenDP):
         return super().__setattr__(name, value)
 
 
+@BaseDescriptor.register("dpa1")
+@BaseDescriptor.register("se_atten")
 @flax_module
 class DescrptDPA1(DescrptDPA1DP):
     def __setattr__(self, name: str, value: Any) -> None:

--- a/deepmd/jax/descriptor/se_e2_a.py
+++ b/deepmd/jax/descriptor/se_e2_a.py
@@ -8,6 +8,9 @@ from deepmd.jax.common import (
     flax_module,
     to_jax_array,
 )
+from deepmd.jax.descriptor.base_descriptor import (
+    BaseDescriptor,
+)
 from deepmd.jax.utils.exclude_mask import (
     PairExcludeMask,
 )
@@ -16,6 +19,8 @@ from deepmd.jax.utils.network import (
 )
 
 
+@BaseDescriptor.register("se_e2_a")
+@BaseDescriptor.register("se_a")
 @flax_module
 class DescrptSeA(DescrptSeADP):
     def __setattr__(self, name: str, value: Any) -> None:

--- a/deepmd/jax/fitting/__init__.py
+++ b/deepmd/jax/fitting/__init__.py
@@ -1,1 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.jax.fitting.fitting import (
+    DOSFittingNet,
+    EnergyFittingNet,
+)
+
+__all__ = [
+    "EnergyFittingNet",
+    "DOSFittingNet",
+]

--- a/deepmd/jax/fitting/base_fitting.py
+++ b/deepmd/jax/fitting/base_fitting.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.dpmodel.fitting.make_base_fitting import (
+    make_base_fitting,
+)
+from deepmd.jax.env import (
+    jnp,
+)
+
+BaseFitting = make_base_fitting(jnp.ndarray)

--- a/deepmd/jax/fitting/fitting.py
+++ b/deepmd/jax/fitting/fitting.py
@@ -9,6 +9,9 @@ from deepmd.jax.common import (
     flax_module,
     to_jax_array,
 )
+from deepmd.jax.fitting.base_fitting import (
+    BaseFitting,
+)
 from deepmd.jax.utils.exclude_mask import (
     AtomExcludeMask,
 )
@@ -33,6 +36,7 @@ def setattr_for_general_fitting(name: str, value: Any) -> Any:
     return value
 
 
+@BaseFitting.register("ener")
 @flax_module
 class EnergyFittingNet(EnergyFittingNetDP):
     def __setattr__(self, name: str, value: Any) -> None:
@@ -40,6 +44,7 @@ class EnergyFittingNet(EnergyFittingNetDP):
         return super().__setattr__(name, value)
 
 
+@BaseFitting.register("dos")
 @flax_module
 class DOSFittingNet(DOSFittingNetDP):
     def __setattr__(self, name: str, value: Any) -> None:

--- a/deepmd/jax/model/__init__.py
+++ b/deepmd/jax/model/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/deepmd/jax/model/__init__.py
+++ b/deepmd/jax/model/__init__.py
@@ -1,1 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from .ener_model import (
+    EnergyModel,
+)
+
+__all__ = ["EnergyModel"]

--- a/deepmd/jax/model/base_model.py
+++ b/deepmd/jax/model/base_model.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.dpmodel.model.base_model import (
+    make_base_model,
+)
+
+BaseModel = make_base_model()

--- a/deepmd/jax/model/ener_model.py
+++ b/deepmd/jax/model/ener_model.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
+
+from deepmd.dpmodel.model import EnergyModel as EnergyModelDP
+from deepmd.jax.atomic_model.dp_atomic_model import (
+    DPAtomicModel,
+)
+from deepmd.jax.model.base_model import (
+    BaseModel,
+)
+
+
+@BaseModel.register("ener")
+class EnergyModel(EnergyModelDP):
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "atomic_model":
+            value = DPAtomicModel.deserialize(value.serialize())
+        return super().__setattr__(name, value)

--- a/deepmd/jax/model/ener_model.py
+++ b/deepmd/jax/model/ener_model.py
@@ -7,12 +7,16 @@ from deepmd.dpmodel.model import EnergyModel as EnergyModelDP
 from deepmd.jax.atomic_model.dp_atomic_model import (
     DPAtomicModel,
 )
+from deepmd.jax.common import (
+    flax_module,
+)
 from deepmd.jax.model.base_model import (
     BaseModel,
 )
 
 
 @BaseModel.register("ener")
+@flax_module
 class EnergyModel(EnergyModelDP):
     def __setattr__(self, name: str, value: Any) -> None:
         if name == "atomic_model":

--- a/deepmd/jax/model/model.py
+++ b/deepmd/jax/model/model.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.jax.descriptor.base_descriptor import (
+    BaseDescriptor,
+)
+from deepmd.jax.fitting.base_fitting import (
+    BaseFitting,
+)
+from deepmd.jax.model.base_model import (
+    BaseModel,
+)
+
+
+def get_standard_model(data: dict):
+    """Get a Model from a dictionary.
+
+    Parameters
+    ----------
+    data : dict
+        The data to construct the model.
+    """
+    descriptor_type = data["descriptor"].pop("type")
+    data["descriptor"]["type_map"] = data["type_map"]
+    fitting_type = data["fitting_net"].pop("type")
+    data["fitting_net"]["type_map"] = data["type_map"]
+    descriptor = BaseDescriptor.get_class_by_type(descriptor_type)(
+        **data["descriptor"],
+    )
+    fitting = BaseFitting.get_class_by_type(fitting_type)(
+        ntypes=descriptor.get_ntypes(),
+        dim_descrpt=descriptor.get_dim_out(),
+        mixed_types=descriptor.mixed_types(),
+        **data["fitting_net"],
+    )
+    return BaseModel.get_class_by_type(fitting_type)(
+        descriptor=descriptor,
+        fitting=fitting,
+        type_map=data["type_map"],
+        atom_exclude_types=data.get("atom_exclude_types", []),
+        pair_exclude_types=data.get("pair_exclude_types", []),
+    )
+
+
+def get_model(data: dict):
+    """Get a model from a dictionary.
+
+    Parameters
+    ----------
+    data : dict
+        The data to construct the model.
+    """
+    model_type = data.get("type", "standard")
+    if model_type == "standard":
+        if "spin" in data:
+            raise NotImplementedError("Spin model is not implemented yet.")
+        else:
+            return get_standard_model(data)
+    else:
+        return BaseModel.get_class_by_type(model_type).get_model(data)

--- a/deepmd/jax/model/model.py
+++ b/deepmd/jax/model/model.py
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from copy import (
+    deepcopy,
+)
+
 from deepmd.jax.descriptor.base_descriptor import (
     BaseDescriptor,
 )
@@ -18,6 +22,7 @@ def get_standard_model(data: dict):
     data : dict
         The data to construct the model.
     """
+    data = deepcopy(data)
     descriptor_type = data["descriptor"].pop("type")
     data["descriptor"]["type_map"] = data["type_map"]
     fitting_type = data["fitting_net"].pop("type")

--- a/source/tests/consistent/model/common.py
+++ b/source/tests/consistent/model/common.py
@@ -6,8 +6,12 @@ from typing import (
 from deepmd.common import (
     make_default_mesh,
 )
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 
 from ..common import (
+    INSTALLED_JAX,
     INSTALLED_PT,
     INSTALLED_TF,
 )
@@ -19,6 +23,11 @@ if INSTALLED_TF:
     from deepmd.tf.env import (
         GLOBAL_TF_FLOAT_PRECISION,
         tf,
+    )
+if INSTALLED_JAX:
+    from deepmd.jax.common import to_jax_array as numpy_to_jax
+    from deepmd.jax.env import (
+        jnp,
     )
 
 
@@ -60,5 +69,19 @@ class ModelTest:
                 numpy_to_torch(coords),
                 numpy_to_torch(atype),
                 box=numpy_to_torch(box),
+            ).items()
+        }
+
+    def eval_jax_model(self, jax_obj: Any, natoms, coords, atype, box) -> Any:
+        def assert_jax_array(arr):
+            assert isinstance(arr, jnp.ndarray) or arr is None
+            return arr
+
+        return {
+            kk: to_numpy_array(assert_jax_array(vv))
+            for kk, vv in jax_obj(
+                numpy_to_jax(coords),
+                numpy_to_jax(atype),
+                box=numpy_to_jax(box),
             ).items()
         }


### PR DESCRIPTION
Add JAX energy model without grad support. The grad support needs discussion.
Array API is not supported in this PR as it needs more effort. (JAX has more APIs than Array API)
This PR also fixes a `skip_tf` bug introduced in #3357. When no `@property` was added, `xx.skip_tf` is always cast to `True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced `BaseAtomicModel` and `DPAtomicModel` classes with improved array compatibility and new output definitions.
	- Introduced new classes and attributes for better model flexibility and customization.
	- Added `EnergyFittingNet` and `DOSFittingNet` for advanced fitting capabilities.
	- New functions `get_standard_model` and `get_model` for flexible model creation based on input data.
	- Added `BaseDescriptor` and `BaseFitting` classes to streamline descriptor and fitting processes.
	- Introduced `EnergyModel` class for improved atomic model handling.

- **Bug Fixes**
	- Updated serialization logic for consistency across models.

- **Tests**
	- Enhanced testing framework to support JAX operations and added methods for JAX model evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->