### PR TITLE
fix(pt): remove deprecating torch.norm

### DIFF
--- a/deepmd/pt/utils/nlist.py
+++ b/deepmd/pt/utils/nlist.py
@@ -457,7 +457,7 @@ def extend_coord_with_ghosts(
         xyz = xyz.view(-1, 3)
         xyz = xyz.to(device=device, non_blocking=True)
         # ns x 3
-        shift_idx = xyz[torch.argsort(torch.norm(xyz, dim=1))]
+        shift_idx = xyz[torch.argsort(torch.linalg.norm(xyz, dim=-1))]
         ns, _ = shift_idx.shape
         nall = ns * nloc
         # nf x ns x 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the normalization method for improved consistency and potential optimization.
	- Minor code formatting adjustments for enhanced readability.
	- Ensured compatibility with existing function calls by preserving parameters and return types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->