### PR TITLE
ci: limit downloaded files in build_docker

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -148,6 +148,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: source/install/docker/dist
+          pattern: cibw-*-manylinux_x86_64-cu${{ matrix.cuda_version }}*
           merge-multiple: true
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -180,6 +181,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist/packages
+          pattern: cibw-*
           merge-multiple: true
       - uses: actions/setup-python@v5
         name: Install Python


### PR DESCRIPTION
This download-artifact step fails randomly. Limiting the files to download should reduce the possibility of failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced artifact downloading patterns for improved specificity in the build process.
	- Expanded artifact access during the PyPI index build.

- **Improvements**
	- Maintained job structure and dependencies for consistent build and deployment processes.
	- Defined permissions for critical jobs to ensure secure operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->