### PR TITLE
ci: bump tensorflow/build image to 2.18

### DIFF
--- a/.github/workflows/package_c.yml
+++ b/.github/workflows/package_c.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - tensorflow_build_version: "2.15"
+          - tensorflow_build_version: "2.18"
             tensorflow_version: ""
             filename: libdeepmd_c.tar.gz
           - tensorflow_build_version: "2.14"


### PR DESCRIPTION
Fix the CI error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated TensorFlow build version from 2.15 to 2.18 in the C library build workflow. 

This change ensures compatibility with the latest TensorFlow features and improvements during the library's build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->