### PR TITLE
ci: skip `test_data_equal` on the GPU machine

### DIFF
--- a/source/tests/consistent/io/test_io.py
+++ b/source/tests/consistent/io/test_io.py
@@ -21,6 +21,11 @@ from deepmd.infer.deep_eval import (
     DeepEval,
 )
 
+from ...utils import (
+    CI,
+    TEST_DEVICE,
+)
+
 infer_path = Path(__file__).parent.parent.parent / "infer"
 
 
@@ -66,6 +71,7 @@ class IOTest:
             elif Path(ii).is_dir():
                 shutil.rmtree(ii)
 
+    @unittest.skipIf(TEST_DEVICE != "cpu" and CI, "Only test on CPU.")
     def test_data_equal(self):
         prefix = "test_consistent_io_" + self.__class__.__name__.lower()
         for backend_name in ("tensorflow", "pytorch", "dpmodel", "jax"):


### PR DESCRIPTION
This test crashes on the machine iZ0xih0eykcp6eddga4w5iZ with exit code 1: https://github.com/deepmodeling/deepmd-kit/actions/runs/11533273426/job/32106001782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced test execution control to ensure compatibility with CPU environments during continuous integration.

- **Tests**
	- Updated the `test_data_equal` method to conditionally skip tests based on the testing device and CI status.
	- Retained cleanup procedures in the `tearDown` method to ensure proper test environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->