### PR TITLE
fix(lmp): add pair_deepmd_index arg to fix dplr for multiple deepmd pairs

### DIFF
--- a/doc/model/dplr.md
+++ b/doc/model/dplr.md
@@ -198,7 +198,7 @@ fix ID group-ID style_name keyword value ...
 - three or more keyword/value pairs may be appended
 
 ```
-keyword = *model* or *type_associate* or *bond_type* or *efield*
+keyword = *model* or *type_associate* or *bond_type* or *efield* or *pair_deepmd_index*
   *model* value = name
     name = name of DPLR model file (e.g. frozen_model.pb) (not DW model)
   *type_associate* values = NR1 NW1 NR2 NW2 ...
@@ -208,6 +208,8 @@ keyword = *model* or *type_associate* or *bond_type* or *efield*
     NBi = bond type of i-th (real atom, Wannier centroid) pair
   *efield* (optional) values = Ex Ey Ez
     Ex/Ey/Ez = electric field along x/y/z direction
+  *pair_deepmd_index* (optional) values = idx
+    idx = The index of pair_style deepmd, starting from 1, if more than one is used
 ```
 
 **Examples**
@@ -223,6 +225,8 @@ fix_modify	0 virial yes
 ```
 
 The fix command `dplr` calculates the position of WCs by the DW model and back-propagates the long-range interaction on virtual atoms to real toms.
+The fix command must be used after [pair_style `deepmd`](../third-party/lammps-command.md#pair_style-deepmd).
+If there are more than 1 pair_style `deepmd`, `pair_deepmd_index` (starting from 1) must be set to assign the index of the pair_style `deepmd`.
 The atom names specified in [pair_style `deepmd`](../third-party/lammps-command.md#pair_style-deepmd) will be used to determine elements.
 If it is not set, the training parameter {ref}`type_map <model/type_map>` will be mapped to LAMMPS atom types.
 

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -62,6 +62,7 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
   size_vector = 3;
   qe2f = force->qe2f;
   xstyle = ystyle = zstyle = NONE;
+  pair_deepmd_index = 0;
 
   if (strcmp(update->unit_style, "lj") == 0) {
     error->all(FLERR,
@@ -125,6 +126,12 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
       }
       sort(bond_type.begin(), bond_type.end());
       iarg = iend;
+    } else if (string(arg[iarg]) == string("pair_deepmd_index")) {
+      if (iarg + 1 >= narg) {
+        error->all(FLERR, "Illegal pair_deepmd_index, not provided");
+      }
+      pair_deepmd_index = atoi(arg[iarg + 1]);
+      iarg += 2;
     } else {
       break;
     }
@@ -141,7 +148,7 @@ FixDPLR::FixDPLR(LAMMPS *lmp, int narg, char **arg)
     error->one(FLERR, e.what());
   }
 
-  pair_deepmd = (PairDeepMD *)force->pair_match("deepmd", 1);
+  pair_deepmd = (PairDeepMD *)force->pair_match("deepmd", 1, pair_deepmd_index);
   if (!pair_deepmd) {
     error->all(FLERR, "pair_style deepmd should be set before this fix\n");
   }

--- a/source/lmp/fix_dplr.h
+++ b/source/lmp/fix_dplr.h
@@ -80,6 +80,9 @@ class FixDPLR : public Fix {
   void update_efield_variables();
   enum { NONE, CONSTANT, EQUAL };
   std::vector<int> type_idx_map;
+  /* The index of deepmd pair index, which starts from 1. By default 0, which
+   * works only when there is one deepmd pair. */
+  int pair_deepmd_index;
 };
 }  // namespace LAMMPS_NS
 


### PR DESCRIPTION
Fix #4273.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional keyword `pair_deepmd_index` in the `fix dplr` command for enhanced control in simulations.
	- Updated documentation with clearer instructions and examples for the DPLR model, including training process and simulation setup.

- **Bug Fixes**
	- Improved error handling related to the new `pair_deepmd_index` parameter to ensure proper usage.

- **Documentation**
	- Enhanced descriptions and usability of the DPLR model documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->