### PR TITLE
fix(dptest): Wrong dptest results except for energy head

### DIFF
--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -124,7 +124,7 @@ def test(
         log.info(f"# testing system : {system}")
 
         # create data class
-        tmap = dp.get_type_map() if isinstance(dp, DeepPot) else None
+        tmap = dp.get_type_map()
         data = DeepmdData(
             system,
             set_prefix="set",

--- a/source/tests/pt/test_dp_test.py
+++ b/source/tests/pt/test_dp_test.py
@@ -152,7 +152,9 @@ class TestDPTestPropertySeA(unittest.TestCase):
         self.config["training"]["training_data"]["systems"] = data_file
         self.config["training"]["validation_data"]["systems"] = data_file
         self.config["model"] = deepcopy(model_property)
-        self.config["model"]["type_map"] = [self.config["model"]["type_map"][i] for i in [1,0,3,2]]
+        self.config["model"]["type_map"] = [
+            self.config["model"]["type_map"][i] for i in [1, 0, 3, 2]
+        ]
         self.input_json = "test_dp_test_property.json"
         with open(self.input_json, "w") as fp:
             json.dump(self.config, fp, indent=4)

--- a/source/tests/pt/test_dp_test.py
+++ b/source/tests/pt/test_dp_test.py
@@ -152,6 +152,7 @@ class TestDPTestPropertySeA(unittest.TestCase):
         self.config["training"]["training_data"]["systems"] = data_file
         self.config["training"]["validation_data"]["systems"] = data_file
         self.config["model"] = deepcopy(model_property)
+        self.config["model"]["type_map"] = [self.config["model"]["type_map"][i] for i in [1,0,3,2]]
         self.input_json = "test_dp_test_property.json"
         with open(self.input_json, "w") as fp:
             json.dump(self.config, fp, indent=4)


### PR DESCRIPTION
Solve issue #4249

In `/deepmd/entrypoints/test.py`  line 127 `tmap = dp.get_type_map() if isinstance(dp, DeepPot) else None`. If we use `DeepProperty` or `DeepPolar` or `DeepDOS`..... `tmap` is None. So  `type_map` is not modified again according to `type_map` in `input.json`. So `atype` is wrong in the model forward process. The model prediction value is wrong.

According to @njzjz , It seems that in the `r2` branch, `get_type_map()` is only available in `DeepPot`. After we refactor `DeepEval` in v3, this should not be a problem anymore.

I also change the order of `type_map` in UT to ensure that when `type_map` of `input.json` doesn't match the `type_map ` of data, the result of the dptest is still correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced warning logs for unsupported `DeepGlobalPolar` model usage, recommending the `DeepPolar` model instead.
  
- **Bug Fixes**
	- Simplified logic for obtaining the type map, ensuring consistent retrieval from the updated source.
	- Adjusted model configuration in tests to influence type interpretation.

- **Documentation**
	- Improved clarity of comments and logging statements for better understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->