### PR TITLE
Enable Hybrid Descriptor to be compressed

### DIFF
--- a/deepmd/dpmodel/descriptor/hybrid.py
+++ b/deepmd/dpmodel/descriptor/hybrid.py
@@ -209,6 +209,38 @@ class DescrptHybrid(BaseDescriptor, NativeOP):
             mean_list.append(mean_item)
             stddev_list.append(stddev_item)
         return mean_list, stddev_list
+    
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        """Receive the statisitcs (distance, max_nbor_size and env_mat_range) of the training data.
+
+        Parameters
+        ----------
+        min_nbor_dist
+            The nearest distance between atoms
+        table_extrapolate
+            The scale of model extrapolation
+        table_stride_1
+            The uniform stride of the first table
+        table_stride_2
+            The uniform stride of the second table
+        check_frequency
+            The overflow check frequency
+        """
+        for descrpt in self.descrpt_list:
+            descrpt.enable_compression(
+                min_nbor_dist,
+                table_extrapolate,
+                table_stride_1,
+                table_stride_2,
+                check_frequency,
+            )
 
     def call(
         self,

--- a/deepmd/dpmodel/descriptor/hybrid.py
+++ b/deepmd/dpmodel/descriptor/hybrid.py
@@ -209,7 +209,7 @@ class DescrptHybrid(BaseDescriptor, NativeOP):
             mean_list.append(mean_item)
             stddev_list.append(stddev_item)
         return mean_list, stddev_list
-    
+
     def enable_compression(
         self,
         min_nbor_dist: float,

--- a/deepmd/pt/model/descriptor/hybrid.py
+++ b/deepmd/pt/model/descriptor/hybrid.py
@@ -223,7 +223,7 @@ class DescrptHybrid(BaseDescriptor, torch.nn.Module):
             mean_list.append(mean_item)
             stddev_list.append(stddev_item)
         return mean_list, stddev_list
-    
+
     def enable_compression(
         self,
         min_nbor_dist: float,

--- a/deepmd/pt/model/descriptor/hybrid.py
+++ b/deepmd/pt/model/descriptor/hybrid.py
@@ -223,6 +223,38 @@ class DescrptHybrid(BaseDescriptor, torch.nn.Module):
             mean_list.append(mean_item)
             stddev_list.append(stddev_item)
         return mean_list, stddev_list
+    
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        """Receive the statisitcs (distance, max_nbor_size and env_mat_range) of the training data.
+
+        Parameters
+        ----------
+        min_nbor_dist
+            The nearest distance between atoms
+        table_extrapolate
+            The scale of model extrapolation
+        table_stride_1
+            The uniform stride of the first table
+        table_stride_2
+            The uniform stride of the second table
+        check_frequency
+            The overflow check frequency
+        """
+        for descrpt in self.descrpt_list:
+            descrpt.enable_compression(
+                min_nbor_dist,
+                table_extrapolate,
+                table_stride_1,
+                table_stride_2,
+                check_frequency,
+            )
 
     def forward(
         self,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method `enable_compression` in the `DescrptHybrid` class, allowing users to configure compression settings related to neighbor distance and table parameters.
- **Documentation**
	- Enhanced documentation for the `call` method, providing clearer descriptions of parameters and return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->