### PR TITLE
Add pt compression doc

### DIFF
--- a/doc/freeze/compress.md
+++ b/doc/freeze/compress.md
@@ -1,7 +1,7 @@
-# Compress a model {{ tensorflow_icon }}
+# Compress a model {{ tensorflow_icon }} {{ pytorch_icon }}
 
 :::{note}
-**Supported backends**: TensorFlow {{ tensorflow_icon }}
+**Supported backends**: TensorFlow {{ tensorflow_icon }}, PyTorch {{ pytorch_icon }}
 :::
 
 ## Theory
@@ -64,9 +64,24 @@ In the compressed DP model, the number of neighbors is precisely indexed at the 
 
 Once the frozen model is obtained from DeePMD-kit, we can get the neural network structure and its parameters (weights, biases, etc.) from the trained model, and compress it in the following way:
 
+::::{tab-set}
+
+:::{tab-item} TensorFlow {{ tensorflow_icon }}
+
 ```bash
 dp compress -i graph.pb -o graph-compress.pb
 ```
+
+:::
+
+:::{tab-item} PyTorch {{ pytorch_icon }}
+
+```bash
+dp compress -i model.pt -o model-compress.pt
+```
+
+:::
+::::
 
 where `-i` gives the original frozen model, `-o` gives the compressed model. Several other command line options can be passed to `dp compress`, which can be checked with
 

--- a/doc/freeze/compress.md
+++ b/doc/freeze/compress.md
@@ -77,7 +77,7 @@ dp compress -i graph.pb -o graph-compress.pb
 :::{tab-item} PyTorch {{ pytorch_icon }}
 
 ```bash
-dp compress -i model.pt -o model-compress.pt
+dp compress -i model.pth -o model-compress.pth
 ```
 
 :::


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the PyTorch backend alongside TensorFlow in the documentation.
	- Introduced a new command for compressing models using PyTorch: `dp compress -i model.pth -o model-compress.pth`.

- **Documentation**
	- Updated the header to reflect both TensorFlow and PyTorch support.
	- Enhanced instructions section with clear guidance for users of both frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->