### PR TITLE
fix(lmp): add `pair_deepmd_index` key to `is_key` function in dplr

### DIFF
--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
 #include "fix_dplr.h"
 
 #include <iomanip>
@@ -30,6 +29,7 @@ static bool is_key(const string &input) {
   keys.push_back("type_associate");
   keys.push_back("bond_type");
   keys.push_back("efield");
+  keys.push_back("pair_deepmd_index");
   for (int ii = 0; ii < keys.size(); ++ii) {
     if (input == keys[ii]) {
       return true;

--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 #include "fix_dplr.h"
 
 #include <iomanip>

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -486,9 +486,7 @@ def test_min_dplr(lammps):
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.kspace_style("pppm/dplr 1e-5")
     lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1"
-    )
+    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1")
     lammps.fix_modify("0 virial yes")
     lammps.min_style("cg")
     lammps.minimize("0 1.0e-6 2 2")

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -414,7 +414,7 @@ def test_pair_deepmd_lr_efield_constant(lammps):
     lammps.bond_coeff("*")
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 1 pair_deepmd_index 0"
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 1"
     )
     lammps.fix_modify("0 energy yes virial yes")
     lammps.run(0)
@@ -450,7 +450,7 @@ def test_pair_deepmd_lr_efield_variable(lammps):
     lammps.bond_coeff("*")
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 v_EFIELD_Z pair_deepmd_index 0"
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 v_EFIELD_Z"
     )
     lammps.fix_modify("0 energy yes virial yes")
     lammps.run(0)
@@ -487,7 +487,7 @@ def test_min_dplr(lammps):
     lammps.kspace_style("pppm/dplr 1e-5")
     lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
     lammps.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0"
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1"
     )
     lammps.fix_modify("0 virial yes")
     lammps.min_style("cg")
@@ -515,7 +515,7 @@ def test_pair_deepmd_lr_type_map(lammps_type_map):
         f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}"
     )
     lammps_type_map.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 1 pair_deepmd_index 0"
+        f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 1"
     )
     lammps_type_map.fix_modify("0 virial yes")
     lammps_type_map.run(0)
@@ -545,7 +545,7 @@ def test_pair_deepmd_lr_si(lammps_si):
         f"gewald {beta / constants.dist_metal2si:.6e} diff ik mesh {mesh:d} {mesh:d} {mesh:d}"
     )
     lammps_si.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0"
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1"
     )
     lammps_si.fix_modify("0 virial yes")
     lammps_si.run(0)

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -387,7 +387,9 @@ def test_pair_deepmd_lr(lammps):
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.kspace_style("pppm/dplr 1e-5")
     lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0")
+    lammps.fix(
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0"
+    )
     lammps.fix_modify("0 virial yes")
     lammps.run(0)
     for ii in range(8):
@@ -484,7 +486,9 @@ def test_min_dplr(lammps):
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.kspace_style("pppm/dplr 1e-5")
     lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0")
+    lammps.fix(
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0"
+    )
     lammps.fix_modify("0 virial yes")
     lammps.min_style("cg")
     lammps.minimize("0 1.0e-6 2 2")

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -387,7 +387,7 @@ def test_pair_deepmd_lr(lammps):
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.kspace_style("pppm/dplr 1e-5")
     lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1")
+    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0")
     lammps.fix_modify("0 virial yes")
     lammps.run(0)
     for ii in range(8):
@@ -412,7 +412,7 @@ def test_pair_deepmd_lr_efield_constant(lammps):
     lammps.bond_coeff("*")
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 1"
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 1 pair_deepmd_index 0"
     )
     lammps.fix_modify("0 energy yes virial yes")
     lammps.run(0)
@@ -448,7 +448,7 @@ def test_pair_deepmd_lr_efield_variable(lammps):
     lammps.bond_coeff("*")
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 v_EFIELD_Z"
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 v_EFIELD_Z pair_deepmd_index 0"
     )
     lammps.fix_modify("0 energy yes virial yes")
     lammps.run(0)
@@ -484,7 +484,7 @@ def test_min_dplr(lammps):
     lammps.special_bonds("lj/coul 1 1 1 angle no")
     lammps.kspace_style("pppm/dplr 1e-5")
     lammps.kspace_modify(f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}")
-    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1")
+    lammps.fix(f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0")
     lammps.fix_modify("0 virial yes")
     lammps.min_style("cg")
     lammps.minimize("0 1.0e-6 2 2")
@@ -511,7 +511,7 @@ def test_pair_deepmd_lr_type_map(lammps_type_map):
         f"gewald {beta:.2f} diff ik mesh {mesh:d} {mesh:d} {mesh:d}"
     )
     lammps_type_map.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 1"
+        f"0 all dplr model {pb_file.resolve()} type_associate 2 3 bond_type 1 pair_deepmd_index 0"
     )
     lammps_type_map.fix_modify("0 virial yes")
     lammps_type_map.run(0)
@@ -541,7 +541,7 @@ def test_pair_deepmd_lr_si(lammps_si):
         f"gewald {beta / constants.dist_metal2si:.6e} diff ik mesh {mesh:d} {mesh:d} {mesh:d}"
     )
     lammps_si.fix(
-        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1"
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 pair_deepmd_index 0"
     )
     lammps_si.fix_modify("0 virial yes")
     lammps_si.run(0)


### PR DESCRIPTION
Fix #4273. Tests are added in this PR.

* Modify `is_key` function to include `keys.push_back("pair_deepmd_index")`

Update tests in `test_dplr.py` to include `pair_deepmd_index` command

* Add `pair_deepmd_index 0` to various `lammps.fix` commands in the test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new key, `pair_deepmd_index`, enhancing the `FixDPLR` class for improved pair validation in simulations.
  
- **Bug Fixes**
	- Updated error handling to ensure robustness when the new `pair_deepmd_index` is not provided.

- **Tests**
	- Modified test parameters to include `pair_deepmd_index 0`, ensuring compatibility with the new functionality while maintaining existing validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->