### PR TITLE
fix(jax): fix several serialization and jit issues for DPA-2

### DIFF
--- a/deepmd/dpmodel/descriptor/dpa1.py
+++ b/deepmd/dpmodel/descriptor/dpa1.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import math
 from typing import (
     Any,
     Callable,
@@ -852,7 +853,7 @@ class DescrptBlockSeAtten(NativeOP, DescriptorBlock):
     ):
         xp = array_api_compat.array_namespace(ss)
         nfnl, nnei = ss.shape[0:2]
-        shape2 = xp.prod(xp.asarray(ss.shape[2:]))
+        shape2 = math.prod(ss.shape[2:])
         ss = xp.reshape(ss, (nfnl, nnei, shape2))
         # nfnl x nnei x ng
         gg = self.embeddings[embedding_idx].call(ss)
@@ -866,7 +867,7 @@ class DescrptBlockSeAtten(NativeOP, DescriptorBlock):
         assert self.embeddings_strip is not None
         xp = array_api_compat.array_namespace(ss)
         nfnl, nnei = ss.shape[0:2]
-        shape2 = xp.prod(xp.asarray(ss.shape[2:]))
+        shape2 = math.prod(ss.shape[2:])
         ss = xp.reshape(ss, (nfnl, nnei, shape2))
         # nfnl x nnei x ng
         gg = self.embeddings_strip[embedding_idx].call(ss)

--- a/deepmd/jax/descriptor/__init__.py
+++ b/deepmd/jax/descriptor/__init__.py
@@ -2,6 +2,9 @@
 from deepmd.jax.descriptor.dpa1 import (
     DescrptDPA1,
 )
+from deepmd.jax.descriptor.dpa2 import (
+    DescrptDPA2,
+)
 from deepmd.jax.descriptor.hybrid import (
     DescrptHybrid,
 )
@@ -14,11 +17,16 @@ from deepmd.jax.descriptor.se_e2_r import (
 from deepmd.jax.descriptor.se_t import (
     DescrptSeT,
 )
+from deepmd.jax.descriptor.se_t_tebd import (
+    DescrptSeTTebd,
+)
 
 __all__ = [
     "DescrptSeA",
     "DescrptSeR",
     "DescrptSeT",
+    "DescrptSeTTebd",
     "DescrptDPA1",
+    "DescrptDPA2",
     "DescrptHybrid",
 ]

--- a/deepmd/jax/model/dp_zbl_model.py
+++ b/deepmd/jax/model/dp_zbl_model.py
@@ -12,6 +12,7 @@ from deepmd.jax.common import (
     flax_module,
 )
 from deepmd.jax.env import (
+    jax,
     jnp,
 )
 from deepmd.jax.model.base_model import (
@@ -47,4 +48,19 @@ class DPZBLModel(DPZBLModelDP):
             fparam=fparam,
             aparam=aparam,
             do_atomic_virial=do_atomic_virial,
+        )
+
+    def format_nlist(
+        self,
+        extended_coord: jnp.ndarray,
+        extended_atype: jnp.ndarray,
+        nlist: jnp.ndarray,
+        extra_nlist_sort: bool = False,
+    ):
+        return DPZBLModelDP.format_nlist(
+            self,
+            jax.lax.stop_gradient(extended_coord),
+            extended_atype,
+            nlist,
+            extra_nlist_sort=extra_nlist_sort,
         )

--- a/deepmd/jax/model/ener_model.py
+++ b/deepmd/jax/model/ener_model.py
@@ -12,6 +12,7 @@ from deepmd.jax.common import (
     flax_module,
 )
 from deepmd.jax.env import (
+    jax,
     jnp,
 )
 from deepmd.jax.model.base_model import (
@@ -47,4 +48,19 @@ class EnergyModel(EnergyModelDP):
             fparam=fparam,
             aparam=aparam,
             do_atomic_virial=do_atomic_virial,
+        )
+
+    def format_nlist(
+        self,
+        extended_coord: jnp.ndarray,
+        extended_atype: jnp.ndarray,
+        nlist: jnp.ndarray,
+        extra_nlist_sort: bool = False,
+    ):
+        return EnergyModelDP.format_nlist(
+            self,
+            jax.lax.stop_gradient(extended_coord),
+            extended_atype,
+            nlist,
+            extra_nlist_sort=extra_nlist_sort,
         )


### PR DESCRIPTION
- `deepmd/jax/descriptor/__init__.py` imports SeT and DPA-2 to let them found by the plugin;
- `deepmd/dpmodel/descriptor/dpa1.py` fixes the jit issue regarding to the shape generated by `jnp.prod`. The shape should be static by using `math.prod`.
- `deepmd/jax/model/ener_model.py` and `deepmd/jax/model/dp_zbl_model.py` stop the graident of coordinates when rebuilding the neighbor list. The graient of sort causes an error due to https://github.com/jax-ml/jax/issues/24730.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new methods `format_nlist` in `DPZBLModel` and `EnergyModel` classes for improved neighbor list formatting.
	- Added new descriptors `DescrptDPA2` and `DescrptSeTTebd` to the public API.

- **Bug Fixes**
	- Enhanced attribute handling in `DPZBLModel` and `EnergyModel` to ensure proper serialization and deserialization of `atomic_model`.

- **Documentation**
	- Updated the public API to reflect new additions and maintain existing documentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->