### PR TITLE
fix: fix for `__array__` removal from array-api-strict

### DIFF
--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -105,6 +105,10 @@ def to_numpy_array(x: Any) -> Optional[np.ndarray]:
     """
     if x is None:
         return None
+    if x.device == "cpu":
+        # dlpack needs the device to be the same
+        return np.from_dlpack(x)
+    # asarray is not within Array API standard, so may fail
     return np.asarray(x)
 
 

--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -105,7 +105,8 @@ def to_numpy_array(x: Any) -> Optional[np.ndarray]:
     """
     if x is None:
         return None
-    if x.device == "cpu":
+    if x.__dlpack_device__[0] == 1:
+        # CPU = 1, see https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack_device__.html#api-specification-generated-array-api-array-dlpack-device--page-root
         # dlpack needs the device to be the same
         return np.from_dlpack(x)
     # asarray is not within Array API standard, so may fail

--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -105,12 +105,11 @@ def to_numpy_array(x: Any) -> Optional[np.ndarray]:
     """
     if x is None:
         return None
-    if hasattr(x, "__dlpack_device__") and x.__dlpack_device__()[0] == 1:
-        # CPU = 1, see https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack_device__.html#api-specification-generated-array-api-array-dlpack-device--page-root
-        # dlpack needs the device to be the same
-        return np.from_dlpack(x)
-    # asarray is not within Array API standard, so may fail
-    return np.asarray(x)
+    try:
+        # asarray is not within Array API standard, so may fail
+        return np.asarray(x)
+    except (ValueError, AttributeError):
+        return np.from_dlpack(x, copy=True)
 
 
 __all__ = [

--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -105,7 +105,7 @@ def to_numpy_array(x: Any) -> Optional[np.ndarray]:
     """
     if x is None:
         return None
-    if x.__dlpack_device__[0] == 1:
+    if hasattr(x, "__dlpack_device__") and x.__dlpack_device__()[0] == 1:
         # CPU = 1, see https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack_device__.html#api-specification-generated-array-api-array-dlpack-device--page-root
         # dlpack needs the device to be the same
         return np.from_dlpack(x)

--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
 )
 
+import array_api_compat
 import ml_dtypes
 import numpy as np
 
@@ -109,7 +110,10 @@ def to_numpy_array(x: Any) -> Optional[np.ndarray]:
         # asarray is not within Array API standard, so may fail
         return np.asarray(x)
     except (ValueError, AttributeError):
-        return np.from_dlpack(x, copy=True)
+        xp = array_api_compat.array_namespace(x)
+        # to fix BufferError: Cannot export readonly array since signalling readonly is unsupported by DLPack.
+        x = xp.asarray(x, copy=True)
+        return np.from_dlpack(x)
 
 
 __all__ = [

--- a/deepmd/dpmodel/descriptor/dpa1.py
+++ b/deepmd/dpmodel/descriptor/dpa1.py
@@ -18,6 +18,9 @@ from deepmd.dpmodel import (
 from deepmd.dpmodel.array_api import (
     xp_take_along_axis,
 )
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.utils import (
     EmbeddingNet,
     EnvMat,
@@ -548,8 +551,8 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
             "exclude_types": obj.exclude_types,
             "env_protection": obj.env_protection,
             "@variables": {
-                "davg": np.array(obj["davg"]),
-                "dstd": np.array(obj["dstd"]),
+                "davg": to_numpy_array(obj["davg"]),
+                "dstd": to_numpy_array(obj["dstd"]),
             },
             ## to be updated when the options are supported.
             "trainable": self.trainable,
@@ -1022,8 +1025,8 @@ class DescrptBlockSeAtten(NativeOP, DescriptorBlock):
             "exclude_types": obj.exclude_types,
             "env_protection": obj.env_protection,
             "@variables": {
-                "davg": np.array(obj["davg"]),
-                "dstd": np.array(obj["dstd"]),
+                "davg": to_numpy_array(obj["davg"]),
+                "dstd": to_numpy_array(obj["dstd"]),
             },
         }
         if obj.tebd_input_mode in ["strip"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ test = [
     "pytest-sugar",
     "pytest-split",
     "dpgui",
-    'array-api-strict>=2;python_version>="3.9"',
+    'array-api-strict>=2,!=2.1.1;python_version>="3.9"',
 ]
 docs = [
     "sphinx>=3.1.1",

--- a/source/tests/common/dpmodel/array_api/test_env_mat.py
+++ b/source/tests/common/dpmodel/array_api/test_env_mat.py
@@ -14,7 +14,6 @@ from .utils import (
 
 class TestEnvMat(unittest.TestCase, ArrayAPITest):
     def test_compute_smooth_weight(self):
-        self.set_array_api_version(compute_smooth_weight)
         d = xp.arange(10, dtype=xp.float64)
         w = compute_smooth_weight(
             d,

--- a/source/tests/consistent/descriptor/common.py
+++ b/source/tests/consistent/descriptor/common.py
@@ -8,6 +8,9 @@ import numpy as np
 from deepmd.common import (
     make_default_mesh,
 )
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.utils.nlist import (
     build_neighbor_list,
     extend_coord_with_ghosts,
@@ -157,7 +160,7 @@ class DescriptorTest:
             distinguish_types=(not mixed_types),
         )
         return [
-            np.asarray(x) if hasattr(x, "__array_namespace__") else x
+            to_numpy_array(x) if hasattr(x, "__array_namespace__") else x
             for x in array_api_strict_obj(
                 ext_coords, ext_atype, nlist=nlist, mapping=mapping
             )

--- a/source/tests/consistent/descriptor/common.py
+++ b/source/tests/consistent/descriptor/common.py
@@ -144,7 +144,6 @@ class DescriptorTest:
         box,
         mixed_types: bool = False,
     ) -> Any:
-        array_api_strict.set_array_api_strict_flags(api_version="2023.12")
         ext_coords, ext_atype, mapping = extend_coord_with_ghosts(
             array_api_strict.asarray(coords.reshape(1, -1, 3)),
             array_api_strict.asarray(atype.reshape(1, -1)),

--- a/source/tests/consistent/fitting/test_dipole.py
+++ b/source/tests/consistent/fitting/test_dipole.py
@@ -6,6 +6,9 @@ from typing import (
 
 import numpy as np
 
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.fitting.dipole_fitting import DipoleFitting as DipoleFittingDP
 from deepmd.env import (
     GLOBAL_NP_FLOAT_PRECISION,
@@ -175,7 +178,7 @@ class TestDipole(CommonTest, DipoleFittingTest, unittest.TestCase):
         )
 
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
-        return np.asarray(
+        return to_numpy_array(
             array_api_strict_obj(
                 array_api_strict.asarray(self.inputs),
                 array_api_strict.asarray(self.atype.reshape(1, -1)),

--- a/source/tests/consistent/fitting/test_dos.py
+++ b/source/tests/consistent/fitting/test_dos.py
@@ -221,7 +221,6 @@ class TestDOS(CommonTest, FittingTest, unittest.TestCase):
         )
 
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
-        array_api_strict.set_array_api_strict_flags(api_version="2023.12")
         (
             resnet_dt,
             precision,

--- a/source/tests/consistent/fitting/test_dos.py
+++ b/source/tests/consistent/fitting/test_dos.py
@@ -6,6 +6,9 @@ from typing import (
 
 import numpy as np
 
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.fitting.dos_fitting import DOSFittingNet as DOSFittingDP
 from deepmd.env import (
     GLOBAL_NP_FLOAT_PRECISION,
@@ -227,7 +230,7 @@ class TestDOS(CommonTest, FittingTest, unittest.TestCase):
             numb_aparam,
             numb_dos,
         ) = self.param
-        return np.asarray(
+        return to_numpy_array(
             array_api_strict_obj(
                 array_api_strict.asarray(self.inputs),
                 array_api_strict.asarray(self.atype.reshape(1, -1)),

--- a/source/tests/consistent/fitting/test_ener.py
+++ b/source/tests/consistent/fitting/test_ener.py
@@ -235,7 +235,6 @@ class TestEner(CommonTest, FittingTest, unittest.TestCase):
         )
 
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
-        array_api_strict.set_array_api_strict_flags(api_version="2023.12")
         (
             resnet_dt,
             precision,

--- a/source/tests/consistent/fitting/test_ener.py
+++ b/source/tests/consistent/fitting/test_ener.py
@@ -6,6 +6,9 @@ from typing import (
 
 import numpy as np
 
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.fitting.ener_fitting import EnergyFittingNet as EnerFittingDP
 from deepmd.env import (
     GLOBAL_NP_FLOAT_PRECISION,
@@ -241,7 +244,7 @@ class TestEner(CommonTest, FittingTest, unittest.TestCase):
             (numb_aparam, use_aparam_as_mask),
             atom_ener,
         ) = self.param
-        return np.asarray(
+        return to_numpy_array(
             array_api_strict_obj(
                 array_api_strict.asarray(self.inputs),
                 array_api_strict.asarray(self.atype.reshape(1, -1)),

--- a/source/tests/consistent/fitting/test_polar.py
+++ b/source/tests/consistent/fitting/test_polar.py
@@ -6,6 +6,9 @@ from typing import (
 
 import numpy as np
 
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.fitting.polarizability_fitting import PolarFitting as PolarFittingDP
 from deepmd.env import (
     GLOBAL_NP_FLOAT_PRECISION,
@@ -175,7 +178,7 @@ class TestPolar(CommonTest, DipoleFittingTest, unittest.TestCase):
         )
 
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
-        return np.asarray(
+        return to_numpy_array(
             array_api_strict_obj(
                 array_api_strict.asarray(self.inputs),
                 array_api_strict.asarray(self.atype.reshape(1, -1)),

--- a/source/tests/consistent/fitting/test_property.py
+++ b/source/tests/consistent/fitting/test_property.py
@@ -6,6 +6,9 @@ from typing import (
 
 import numpy as np
 
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.fitting.property_fitting import (
     PropertyFittingNet as PropertyFittingDP,
 )
@@ -236,7 +239,7 @@ class TestProperty(CommonTest, FittingTest, unittest.TestCase):
             task_dim,
             intensive,
         ) = self.param
-        return np.asarray(
+        return to_numpy_array(
             array_api_strict_obj(
                 array_api_strict.asarray(self.inputs),
                 array_api_strict.asarray(self.atype.reshape(1, -1)),

--- a/source/tests/consistent/fitting/test_property.py
+++ b/source/tests/consistent/fitting/test_property.py
@@ -229,7 +229,6 @@ class TestProperty(CommonTest, FittingTest, unittest.TestCase):
         )
 
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
-        array_api_strict.set_array_api_strict_flags(api_version="2023.12")
         (
             resnet_dt,
             precision,

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -70,9 +70,6 @@ class TestActivationFunctionConsistent(unittest.TestCase):
     def test_arary_api_strict(self):
         import array_api_strict as xp
 
-        xp.set_array_api_strict_flags(
-            api_version=get_activation_fn_dp.array_api_version
-        )
         input = xp.asarray(self.random_input)
         test = get_activation_fn_dp(self.activation)(input)
         np.testing.assert_allclose(self.ref, np.array(test), atol=1e-10)

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -72,7 +72,7 @@ class TestActivationFunctionConsistent(unittest.TestCase):
 
         input = xp.asarray(self.random_input)
         test = get_activation_fn_dp(self.activation)(input)
-        np.testing.assert_allclose(self.ref, np.array(test), atol=1e-10)
+        np.testing.assert_allclose(self.ref, to_numpy_array(test), atol=1e-10)
 
     @unittest.skipUnless(INSTALLED_JAX, "JAX is not installed")
     def test_jax_consistent_with_ref(self):

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -7,6 +7,9 @@ import numpy as np
 from deepmd.common import (
     VALID_ACTIVATION,
 )
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.utils.network import get_activation_fn as get_activation_fn_dp
 
 from ..seed import (
@@ -21,8 +24,8 @@ from .common import (
 
 if INSTALLED_PT:
     from deepmd.pt.utils.utils import ActivationFn as ActivationFn_pt
+    from deepmd.pt.utils.utils import to_numpy_array as torch_to_numpy
     from deepmd.pt.utils.utils import (
-        to_numpy_array,
         to_torch_tensor,
     )
 if INSTALLED_TF:
@@ -59,7 +62,7 @@ class TestActivationFunctionConsistent(unittest.TestCase):
     @unittest.skipUnless(INSTALLED_PT, "PyTorch is not installed")
     def test_pt_consistent_with_ref(self):
         if INSTALLED_PT:
-            test = to_numpy_array(
+            test = torch_to_numpy(
                 ActivationFn_pt(self.activation)(to_torch_tensor(self.random_input))
             )
             np.testing.assert_allclose(self.ref, test, atol=1e-10)

--- a/source/tests/consistent/test_type_embedding.py
+++ b/source/tests/consistent/test_type_embedding.py
@@ -6,6 +6,9 @@ from typing import (
 
 import numpy as np
 
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.utils.type_embed import TypeEmbedNet as TypeEmbedNetDP
 from deepmd.utils.argcheck import (
     type_embedding_args,
@@ -130,7 +133,8 @@ class TestTypeEmbedding(CommonTest, unittest.TestCase):
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
         out = array_api_strict_obj()
         return [
-            np.asarray(x) if hasattr(x, "__array_namespace__") else x for x in (out,)
+            to_numpy_array(x) if hasattr(x, "__array_namespace__") else x
+            for x in (out,)
         ]
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:


### PR DESCRIPTION
See: https://github.com/data-apis/array-api-strict/blob/main/docs/changelog.md#major-changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced array conversion capability to handle device-specific data for improved performance.
	- Introduced a robust error handling mechanism for array conversions.
	- Updated serialization methods to consistently format data as NumPy arrays.
	- Standardized the conversion process across various evaluation methods in tests.
- **Bug Fixes**
	- Improved handling of input arrays from the CPU to ensure seamless conversion to NumPy arrays.
- **Chores**
	- Refined dependency specifications in `pyproject.toml` for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->