### PR TITLE
fix(tf): fix argcheck when compressing a model converted from other backends

### DIFF
--- a/deepmd/tf/entrypoints/compress.py
+++ b/deepmd/tf/entrypoints/compress.py
@@ -147,6 +147,8 @@ def compress(
         10 * step,
         int(frequency),
     ]
+    jdata.setdefault("training", {"numb_steps": 0})
+    jdata.setdefault("learning_rate", {})
     jdata["training"]["save_ckpt"] = os.path.join("model-compression", "model.ckpt")
     jdata = update_deepmd_input(jdata)
     jdata = normalize(jdata)


### PR DESCRIPTION
When the model is converted from other backends, the input script only contains the `model` section. This PR sets the default for any necessary argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the data structure for model compression by adding default keys for training steps and learning rate.
  
- **Bug Fixes**
	- Improved error handling with more informative runtime exceptions for missing training scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->