### PR TITLE
CI: set `--clean-durations` for pytest-split

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -54,7 +54,7 @@ jobs:
         restore-keys: |
           test2-durations-combined-${{ matrix.python }}-${{ github.sha }}
           test2-durations-combined-${{ matrix.python }}
-    - run: pytest --cov=deepmd source/tests --durations=0 --splits 6 --group ${{ matrix.group }} --store-durations --durations-path=.test_durations --splitting-algorithm least_duration
+    - run: pytest --cov=deepmd source/tests --durations=0 --splits 6 --group ${{ matrix.group }} --store-durations --clean-durations --durations-path=.test_durations --splitting-algorithm least_duration
       env:
         NUM_WORKERS: 0
     - name: Test TF2 eager mode


### PR DESCRIPTION
I noticed that the CI is broken in several PRs. The duration files are not generated correctly and become larger and larger, causing out-of-memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow configuration for Python testing to enhance test duration management and artifact handling. 
	- Improved caching mechanisms for test durations to ensure uniqueness and avoid conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->