### PR TITLE
fix(pt): fix precision

### DIFF
--- a/deepmd/pt/model/descriptor/dpa1.py
+++ b/deepmd/pt/model/descriptor/dpa1.py
@@ -22,6 +22,7 @@ from deepmd.pt.utils import (
     env,
 )
 from deepmd.pt.utils.env import (
+    PRECISION_DICT,
     RESERVED_PRECISON_DICT,
 )
 from deepmd.pt.utils.tabulate import (
@@ -311,6 +312,7 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
         )
+        self.prec = PRECISION_DICT[precision]
         self.tebd_dim = tebd_dim
         self.concat_output_tebd = concat_output_tebd
         self.trainable = trainable

--- a/deepmd/pt/model/descriptor/dpa1.py
+++ b/deepmd/pt/model/descriptor/dpa1.py
@@ -678,6 +678,8 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
             The smooth switch function. shape: nf x nloc x nnei
 
         """
+        # cast the input to internal precsion
+        extended_coord = extended_coord.to(dtype=self.prec)
         del mapping
         nframes, nloc, nnei = nlist.shape
         nall = extended_coord.view(nframes, -1).shape[1] // 3
@@ -693,7 +695,13 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
         if self.concat_output_tebd:
             g1 = torch.cat([g1, g1_inp], dim=-1)
 
-        return g1, rot_mat, g2, h2, sw
+        return (
+            g1.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+            rot_mat.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+            g2.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION) if g2 is not None else None,
+            h2.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+            sw.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+        )
 
     @classmethod
     def update_sel(

--- a/deepmd/pt/model/descriptor/dpa2.py
+++ b/deepmd/pt/model/descriptor/dpa2.py
@@ -27,6 +27,9 @@ from deepmd.pt.model.network.network import (
 from deepmd.pt.utils import (
     env,
 )
+from deepmd.pt.utils.env import (
+    PRECISION_DICT,
+)
 from deepmd.pt.utils.nlist import (
     build_multiple_neighbor_list,
     get_multiple_nlist_key,
@@ -268,6 +271,7 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
         )
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision
+        self.prec = PRECISION_DICT[self.precision]
         self.smooth = smooth
         self.exclude_types = exclude_types
         self.env_protection = env_protection
@@ -745,6 +749,9 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
             The smooth switch function. shape: nf x nloc x nnei
 
         """
+        # cast the input to internal precsion
+        extended_coord = extended_coord.to(dtype=self.prec)
+
         use_three_body = self.use_three_body
         nframes, nloc, nnei = nlist.shape
         nall = extended_coord.view(nframes, -1).shape[1] // 3
@@ -810,7 +817,13 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
         )
         if self.concat_output_tebd:
             g1 = torch.cat([g1, g1_inp], dim=-1)
-        return g1, rot_mat, g2, h2, sw
+        return (
+            g1.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+            rot_mat.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+            g2.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+            h2.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+            sw.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
+        )
 
     @classmethod
     def update_sel(

--- a/deepmd/pt/model/descriptor/repformers.py
+++ b/deepmd/pt/model/descriptor/repformers.py
@@ -22,6 +22,9 @@ from deepmd.pt.model.network.mlp import (
 from deepmd.pt.utils import (
     env,
 )
+from deepmd.pt.utils.env import (
+    PRECISION_DICT,
+)
 from deepmd.pt.utils.env_mat_stat import (
     EnvMatStatSe,
 )
@@ -237,6 +240,7 @@ class DescrptBlockRepformers(DescriptorBlock):
         self.reinit_exclude(exclude_types)
         self.env_protection = env_protection
         self.precision = precision
+        self.prec = PRECISION_DICT[precision]
         self.trainable_ln = trainable_ln
         self.ln_eps = ln_eps
         self.epsilon = 1e-4
@@ -286,12 +290,8 @@ class DescrptBlockRepformers(DescriptorBlock):
         self.layers = torch.nn.ModuleList(layers)
 
         wanted_shape = (self.ntypes, self.nnei, 4)
-        mean = torch.zeros(
-            wanted_shape, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE
-        )
-        stddev = torch.ones(
-            wanted_shape, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE
-        )
+        mean = torch.zeros(wanted_shape, dtype=self.prec, device=env.DEVICE)
+        stddev = torch.ones(wanted_shape, dtype=self.prec, device=env.DEVICE)
         self.register_buffer("mean", mean)
         self.register_buffer("stddev", stddev)
         self.stats = None

--- a/deepmd/pt/model/descriptor/se_a.py
+++ b/deepmd/pt/model/descriptor/se_a.py
@@ -118,6 +118,7 @@ class DescrptSeA(BaseDescriptor, torch.nn.Module):
         super().__init__()
         self.type_map = type_map
         self.compress = False
+        self.prec = PRECISION_DICT[precision]
         self.sea = DescrptBlockSeA(
             rcut,
             rcut_smth,

--- a/deepmd/pt/model/descriptor/se_atten.py
+++ b/deepmd/pt/model/descriptor/se_atten.py
@@ -227,12 +227,8 @@ class DescrptBlockSeAtten(DescriptorBlock):
         )
 
         wanted_shape = (self.ntypes, self.nnei, 4)
-        mean = torch.zeros(
-            wanted_shape, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE
-        )
-        stddev = torch.ones(
-            wanted_shape, dtype=env.GLOBAL_PT_FLOAT_PRECISION, device=env.DEVICE
-        )
+        mean = torch.zeros(wanted_shape, dtype=self.prec, device=env.DEVICE)
+        stddev = torch.ones(wanted_shape, dtype=self.prec, device=env.DEVICE)
         self.register_buffer("mean", mean)
         self.register_buffer("stddev", stddev)
         self.tebd_dim_input = self.tebd_dim if self.type_one_side else self.tebd_dim * 2
@@ -568,8 +564,6 @@ class DescrptBlockSeAtten(DescriptorBlock):
                 # nfnl x nnei x ng
                 # gg = gg_s * gg_t + gg_s
                 gg_t = gg_t.reshape(-1, gg_t.size(-1))
-                # Convert all tensors to the required precision at once
-                ss, rr, gg_t = (t.to(self.prec) for t in (ss, rr, gg_t))
                 xyz_scatter = torch.ops.deepmd.tabulate_fusion_se_atten(
                     self.compress_data[0].contiguous(),
                     self.compress_info[0].cpu().contiguous(),

--- a/deepmd/pt/model/descriptor/se_r.py
+++ b/deepmd/pt/model/descriptor/se_r.py
@@ -456,6 +456,8 @@ class DescrptSeR(BaseDescriptor, torch.nn.Module):
             The smooth switch function.
 
         """
+        # cast the input to internal precsion
+        coord_ext = coord_ext.to(dtype=self.prec)
         del mapping, comm_dict
         nf = nlist.shape[0]
         nloc = nlist.shape[1]
@@ -474,7 +476,6 @@ class DescrptSeR(BaseDescriptor, torch.nn.Module):
 
         assert self.filter_layers is not None
         dmatrix = dmatrix.view(-1, self.nnei, 1)
-        dmatrix = dmatrix.to(dtype=self.prec)
         nfnl = dmatrix.shape[0]
         # pre-allocate a shape to pass jit
         xyz_scatter = torch.zeros(
@@ -519,7 +520,7 @@ class DescrptSeR(BaseDescriptor, torch.nn.Module):
             None,
             None,
             None,
-            sw,
+            sw.to(dtype=env.GLOBAL_PT_FLOAT_PRECISION),
         )
 
     def set_stat_mean_and_stddev(

--- a/deepmd/pt/model/descriptor/se_t.py
+++ b/deepmd/pt/model/descriptor/se_t.py
@@ -154,6 +154,7 @@ class DescrptSeT(BaseDescriptor, torch.nn.Module):
         super().__init__()
         self.type_map = type_map
         self.compress = False
+        self.prec = PRECISION_DICT[precision]
         self.seat = DescrptBlockSeT(
             rcut,
             rcut_smth,

--- a/deepmd/pt/model/descriptor/se_t_tebd.py
+++ b/deepmd/pt/model/descriptor/se_t_tebd.py
@@ -161,6 +161,7 @@ class DescrptSeTTebd(BaseDescriptor, torch.nn.Module):
             smooth=smooth,
             seed=child_seed(seed, 1),
         )
+        self.prec = PRECISION_DICT[precision]
         self.use_econf_tebd = use_econf_tebd
         self.type_map = type_map
         self.smooth = smooth

--- a/deepmd/pt/model/network/mlp.py
+++ b/deepmd/pt/model/network/mlp.py
@@ -200,7 +200,6 @@ class MLPLayer(nn.Module):
             The output.
         """
         ori_prec = xx.dtype
-        xx = xx.to(self.prec)
         yy = (
             torch.matmul(xx, self.matrix) + self.bias
             if self.bias is not None
@@ -215,7 +214,6 @@ class MLPLayer(nn.Module):
                 yy += torch.concat([xx, xx], dim=-1)
             else:
                 yy = yy
-        yy = yy.to(ori_prec)
         return yy
 
     def serialize(self) -> dict:

--- a/deepmd/pt/model/network/mlp.py
+++ b/deepmd/pt/model/network/mlp.py
@@ -32,6 +32,7 @@ from deepmd.pt.model.network.init import (
 )
 from deepmd.pt.utils.env import (
     DEFAULT_PRECISION,
+    DP_DTYPE_PROMOTION_STRICT,
     PRECISION_DICT,
 )
 from deepmd.pt.utils.utils import (
@@ -200,6 +201,8 @@ class MLPLayer(nn.Module):
             The output.
         """
         ori_prec = xx.dtype
+        if not DP_DTYPE_PROMOTION_STRICT:
+            xx = xx.to(self.prec)
         yy = (
             torch.matmul(xx, self.matrix) + self.bias
             if self.bias is not None
@@ -214,6 +217,8 @@ class MLPLayer(nn.Module):
                 yy += torch.concat([xx, xx], dim=-1)
             else:
                 yy = yy
+        if not DP_DTYPE_PROMOTION_STRICT:
+            yy = yy.to(ori_prec)
         return yy
 
     def serialize(self) -> dict:

--- a/deepmd/pt/model/network/mlp.py
+++ b/deepmd/pt/model/network/mlp.py
@@ -32,7 +32,6 @@ from deepmd.pt.model.network.init import (
 )
 from deepmd.pt.utils.env import (
     DEFAULT_PRECISION,
-    DP_DTYPE_PROMOTION_STRICT,
     PRECISION_DICT,
 )
 from deepmd.pt.utils.utils import (
@@ -201,7 +200,7 @@ class MLPLayer(nn.Module):
             The output.
         """
         ori_prec = xx.dtype
-        if not DP_DTYPE_PROMOTION_STRICT:
+        if not env.DP_DTYPE_PROMOTION_STRICT:
             xx = xx.to(self.prec)
         yy = (
             torch.matmul(xx, self.matrix) + self.bias
@@ -217,7 +216,7 @@ class MLPLayer(nn.Module):
                 yy += torch.concat([xx, xx], dim=-1)
             else:
                 yy = yy
-        if not DP_DTYPE_PROMOTION_STRICT:
+        if not env.DP_DTYPE_PROMOTION_STRICT:
             yy = yy.to(ori_prec)
         return yy
 

--- a/deepmd/pt/model/task/dipole.py
+++ b/deepmd/pt/model/task/dipole.py
@@ -180,6 +180,8 @@ class DipoleFittingNet(GeneralFitting):
     ):
         nframes, nloc, _ = descriptor.shape
         assert gr is not None, "Must provide the rotation matrix for dipole fitting."
+        # cast the input to internal precsion
+        gr = gr.to(self.prec)
         # (nframes, nloc, m1)
         out = self._forward_common(descriptor, atype, gr, g2, h2, fparam, aparam)[
             self.var_name

--- a/deepmd/pt/model/task/dipole.py
+++ b/deepmd/pt/model/task/dipole.py
@@ -186,8 +186,6 @@ class DipoleFittingNet(GeneralFitting):
         ]
         # (nframes * nloc, 1, m1)
         out = out.view(-1, 1, self.embedding_width)
-        # cast from global to gr precision again
-        out = out.to(dtype=gr.dtype)
         # (nframes * nloc, m1, 3)
         gr = gr.view(nframes * nloc, self.embedding_width, 3)
         # (nframes, nloc, 3)

--- a/deepmd/pt/model/task/dipole.py
+++ b/deepmd/pt/model/task/dipole.py
@@ -186,6 +186,8 @@ class DipoleFittingNet(GeneralFitting):
         ]
         # (nframes * nloc, 1, m1)
         out = out.view(-1, 1, self.embedding_width)
+        # cast from global to gr precision again
+        out = out.to(dtype=gr.dtype)
         # (nframes * nloc, m1, 3)
         gr = gr.view(nframes * nloc, self.embedding_width, 3)
         # (nframes, nloc, 3)

--- a/deepmd/pt/model/task/fitting.py
+++ b/deepmd/pt/model/task/fitting.py
@@ -506,7 +506,7 @@ class GeneralFitting(Fitting):
                     outs + atom_property
                 )  # Shape is [nframes, natoms[0], net_dim_out]
         # nf x nloc
-        mask = self.emask(atype).bool()
+        mask = self.emask(atype).to(torch.bool)
         # nf x nloc x nod
         outs = torch.where(mask[:, :, None], outs, 0.0)
         return {self.var_name: outs.to(env.GLOBAL_PT_FLOAT_PRECISION)}

--- a/deepmd/pt/model/task/invar_fitting.py
+++ b/deepmd/pt/model/task/invar_fitting.py
@@ -177,7 +177,10 @@ class InvarFitting(GeneralFitting):
         -------
         - `torch.Tensor`: Total energy with shape [nframes, natoms[0]].
         """
-        return self._forward_common(descriptor, atype, gr, g2, h2, fparam, aparam)
+        out = self._forward_common(descriptor, atype, gr, g2, h2, fparam, aparam)[
+            self.var_name
+        ]
+        return {self.var_name: out.to(env.GLOBAL_PT_FLOAT_PRECISION)}
 
     # make jit happy with torch 2.0.0
     exclude_types: list[int]

--- a/deepmd/pt/model/task/polarizability.py
+++ b/deepmd/pt/model/task/polarizability.py
@@ -233,6 +233,8 @@ class PolarFittingNet(GeneralFitting):
         assert (
             gr is not None
         ), "Must provide the rotation matrix for polarizability fitting."
+        # cast the input to internal precsion
+        gr = gr.to(self.prec)
         # (nframes, nloc, _net_out_dim)
         out = self._forward_common(descriptor, atype, gr, g2, h2, fparam, aparam)[
             self.var_name

--- a/deepmd/pt/model/task/polarizability.py
+++ b/deepmd/pt/model/task/polarizability.py
@@ -237,9 +237,7 @@ class PolarFittingNet(GeneralFitting):
         out = self._forward_common(descriptor, atype, gr, g2, h2, fparam, aparam)[
             self.var_name
         ]
-        out = out * (self.scale.to(atype.device))[atype]
-        # cast from global to gr precision again
-        out = out.to(dtype=gr.dtype)
+        out = out * (self.scale.to(atype.device).to(self.prec))[atype]
 
         gr = gr.view(nframes * nloc, self.embedding_width, 3)  # (nframes * nloc, m1, 3)
 

--- a/deepmd/pt/model/task/polarizability.py
+++ b/deepmd/pt/model/task/polarizability.py
@@ -238,6 +238,9 @@ class PolarFittingNet(GeneralFitting):
             self.var_name
         ]
         out = out * (self.scale.to(atype.device))[atype]
+        # cast from global to gr precision again
+        out = out.to(dtype=gr.dtype)
+
         gr = gr.view(nframes * nloc, self.embedding_width, 3)  # (nframes * nloc, m1, 3)
 
         if self.fit_diag:

--- a/deepmd/pt/utils/env.py
+++ b/deepmd/pt/utils/env.py
@@ -15,6 +15,7 @@ from deepmd.env import (
 )
 
 SAMPLER_RECORD = os.environ.get("SAMPLER_RECORD", False)
+DP_DTYPE_PROMOTION_STRICT = os.environ.get("DP_DTYPE_PROMOTION_STRICT", "0") == "1"
 try:
     # only linux
     ncpus = len(os.sched_getaffinity(0))

--- a/source/tests/pt/model/test_compressed_descriptor_dpa2.py
+++ b/source/tests/pt/model/test_compressed_descriptor_dpa2.py
@@ -54,11 +54,6 @@ class TestDescriptorDPA2(unittest.TestCase):
     def setUp(self):
         (self.dtype, self.type_one_side) = self.param
         if self.dtype == "float32":
-            self.skipTest("FP32 has bugs:")
-            # ../../../../deepmd/pt/model/descriptor/repformer_layer.py:521: in forward
-            # torch.matmul(attnw.unsqueeze(-2), gg1v).squeeze(-2).view(nb, nloc, nh * ni)
-            # E       RuntimeError: expected scalar type Float but found Double
-        if self.dtype == "float32":
             self.atol = 1e-5
         elif self.dtype == "float64":
             self.atol = 1e-10

--- a/source/tests/pt/model/test_compressed_descriptor_se_atten.py
+++ b/source/tests/pt/model/test_compressed_descriptor_se_atten.py
@@ -115,11 +115,6 @@ class TestDescriptorSeAtten(unittest.TestCase):
             self.box,
         )
 
-        if self.dtype == "float32":
-            result_pt = result_pt.to(torch.float32)
-        elif self.dtype == "float64":
-            result_pt = result_pt.to(torch.float64)
-
         self.se_atten.enable_compression(0.5)
         result_pt_compressed = eval_pt_descriptor(
             self.se_atten,

--- a/source/tests/pt/model/test_dipole_fitting.py
+++ b/source/tests/pt/model/test_dipole_fitting.py
@@ -262,7 +262,7 @@ class TestEquivalence(unittest.TestCase):
                 nlist,
             )
 
-            ret0 = ft0(rd0, atype, gr0, fparam=0, aparam=0)
+            ret0 = ft0(rd0, atype, gr0, fparam=None, aparam=None)
             res.append(ret0["dipole"])
 
         np.testing.assert_allclose(
@@ -303,7 +303,7 @@ class TestEquivalence(unittest.TestCase):
                 nlist,
             )
 
-            ret0 = ft0(rd0, atype, gr0, fparam=0, aparam=0)
+            ret0 = ft0(rd0, atype, gr0, fparam=None, aparam=None)
             res.append(ret0["dipole"])
 
         np.testing.assert_allclose(to_numpy_array(res[0]), to_numpy_array(res[1]))

--- a/source/tests/pt/model/test_polarizability_fitting.py
+++ b/source/tests/pt/model/test_polarizability_fitting.py
@@ -326,7 +326,7 @@ class TestEquivalence(unittest.TestCase):
                     nlist,
                 )
 
-                ret0 = ft0(rd0, atype, gr0, fparam=0, aparam=0)
+                ret0 = ft0(rd0, atype, gr0, fparam=None, aparam=None)
                 res.append(ret0["polarizability"])
 
             np.testing.assert_allclose(to_numpy_array(res[0]), to_numpy_array(res[1]))

--- a/source/tests/pt/model/test_property_fitting.py
+++ b/source/tests/pt/model/test_property_fitting.py
@@ -228,7 +228,7 @@ class TestInvarianceOutCell(unittest.TestCase):
                 nlist,
             )
 
-            ret0 = ft0(rd0, atype, gr0, fparam=0, aparam=0)
+            ret0 = ft0(rd0, atype, gr0, fparam=None, aparam=None)
             res.append(ret0["property"])
 
         np.testing.assert_allclose(to_numpy_array(res[0]), to_numpy_array(res[1]))
@@ -399,7 +399,7 @@ class TestInvarianceRandomShift(unittest.TestCase):
                 nlist,
             )
 
-            ret0 = ft0(rd0, atype, gr0, fparam=0, aparam=0)
+            ret0 = ft0(rd0, atype, gr0, fparam=None, aparam=None)
             res.append(ret0["property"])
 
         np.testing.assert_allclose(to_numpy_array(res[0]), to_numpy_array(res[1]))


### PR DESCRIPTION
Tried to implement the decorator as in #4343, but encountered JIT errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced precision handling across various descriptor classes and methods, ensuring consistent tensor operations.
	- Updated output formats in several classes to improve clarity and usability.
	- Introduced a new environment variable for stricter control over tensor precision handling.
	- Added a new parameter to the `DipoleFittingNet` class for excluding specific types.

- **Bug Fixes**
	- Removed conditions that skipped tests for "float32" data type, allowing all tests to run consistently.

- **Documentation**
	- Improved error messages for dimension mismatches and unsupported parameters, enhancing user understanding.

- **Tests**
	- Adjusted test parameters for consistency in handling `fparam` and `aparam` across multiple test cases.
	- Simplified tensor handling in tests by removing unnecessary type conversions before compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->