### PR TITLE
fix bug: cannot set property `default_mesh` of `DeepmdDataSystem`

### DIFF
--- a/deepmd_utils/utils/data_system.py
+++ b/deepmd_utils/utils/data_system.py
@@ -95,6 +95,7 @@ class DeepmdDataSystem:
         self.system_dirs = systems
         self.nsystems = len(self.system_dirs)
         self.data_systems = []
+        self._default_mesh = None
         for ii in self.system_dirs:
             self.data_systems.append(
                 DeepmdData(
@@ -233,12 +234,18 @@ class DeepmdDataSystem:
     @lru_cache(maxsize=None)
     def default_mesh(self) -> List[np.ndarray]:
         """Mesh for each system."""
-        return [
-            make_default_mesh(
-                self.data_systems[ii].pbc, self.data_systems[ii].mixed_type
-            )
-            for ii in range(self.nsystems)
-        ]
+        if self._default_mesh is None:
+            self._default_mesh = [
+                make_default_mesh(
+                    self.data_systems[ii].pbc, self.data_systems[ii].mixed_type
+                )
+                for ii in range(self.nsystems)
+            ]
+        return self._default_mesh
+
+    @default_mesh.setter
+    def default_mesh(self, value: List[np.ndarray]):
+        self._default_mesh = value
 
     def compute_energy_shift(self, rcond=None, key="energy"):
         sys_ener = []


### PR DESCRIPTION
Currently, the multi-task cannot work correctly, and an error is thrown. (See #4358 for more details)
To fix this bug, a minor change in `DeepmdDataSystem` is made to make the property `default_mesh` editable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new attribute for caching default mesh values, improving efficiency.
	- Added functionality to set test size as a percentage of total structures.
	- New method for automated test size calculation based on specified percentages.

- **Deprecations**
	- Marked the `get_test` method as deprecated, shifting to a new approach for accessing test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->