### PR TITLE
chore(deps): bump scikit-build-core to 0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     # TODO: unpin the upper bound when scikit-build dynamic metadata API is stable
     # dynamic metadata API is still unstable
-    "scikit-build-core>=0.5,<0.10,!=0.6.0",
+    "scikit-build-core>=0.5,<0.11,!=0.6.0",
     "packaging",
     'tomli >= 1.1.0 ; python_version < "3.11"',
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `scikit-build-core` dependency to allow for newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->