### PR TITLE
docs: set precision explicitly in the DPA-2 example

### DIFF
--- a/examples/water/dpa2/input_torch_compressible.json
+++ b/examples/water/dpa2/input_torch_compressible.json
@@ -52,6 +52,7 @@
         "g1_out_conv": true,
         "g1_out_mlp": true
       },
+      "precision": "float64",
       "add_tebd_to_repinit_out": false
     },
     "fitting_net": {
@@ -61,6 +62,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/dpa2/input_torch_large.json
+++ b/examples/water/dpa2/input_torch_large.json
@@ -51,6 +51,7 @@
         "g1_out_conv": true,
         "g1_out_mlp": true
       },
+      "precision": "float64",
       "add_tebd_to_repinit_out": false
     },
     "fitting_net": {
@@ -60,6 +61,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/dpa2/input_torch_medium.json
+++ b/examples/water/dpa2/input_torch_medium.json
@@ -51,6 +51,7 @@
         "g1_out_conv": true,
         "g1_out_mlp": true
       },
+      "precision": "float64",
       "add_tebd_to_repinit_out": false
     },
     "fitting_net": {
@@ -60,6 +61,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },

--- a/examples/water/dpa2/input_torch_small.json
+++ b/examples/water/dpa2/input_torch_small.json
@@ -51,6 +51,7 @@
         "g1_out_conv": true,
         "g1_out_mlp": true
       },
+      "precision": "float64",
       "add_tebd_to_repinit_out": false
     },
     "fitting_net": {
@@ -60,6 +61,7 @@
         240
       ],
       "resnet_dt": true,
+      "precision": "float64",
       "seed": 1,
       "_comment": " that's all"
     },


### PR DESCRIPTION
This reminds users that precision can be changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `"precision": "float64"`, in the `descriptor` and `fitting_net` sections of multiple JSON configuration files to enhance numerical precision specifications for computations.

- **Documentation**
	- Updated JSON configuration files to clarify the data types used for calculations without altering existing structures or values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->