### PR TITLE
docs: set the background color of platform icons to transparent

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -18,5 +18,7 @@ html[data-theme="dark"] {
   }
   img.platform-icon {
     filter: invert(1);
+    /* otherwise the backgorund is black */
+    background-color: transparent !important;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where platform icons displayed with a black background in dark theme by ensuring the background remains transparent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->