### PR TITLE
breaking(pt): drop PyTorch 2.0 support

### DIFF
--- a/backend/find_pytorch.py
+++ b/backend/find_pytorch.py
@@ -132,7 +132,7 @@ def get_pt_requirement(pt_version: str = "") -> dict:
             # luckily, .* (prefix matching) defined in PEP 440 can match any local version
             # https://peps.python.org/pep-0440/#version-matching
             f"torch=={Version(pt_version).base_version}.*",
-            # https://github.com/kulinseth/pytorch/commit/241f586919b9f370e3cc6aea657f96a23adac554
+            # https://github.com/pytorch/pytorch/commit/241f586919b9f370e3cc6aea657f96a23adac554
             "torch>=2.1.0",
         ],
     }

--- a/backend/find_pytorch.py
+++ b/backend/find_pytorch.py
@@ -131,9 +131,10 @@ def get_pt_requirement(pt_version: str = "") -> dict:
             # https://github.com/astral-sh/uv/blob/main/PIP_COMPATIBILITY.md#local-version-identifiers
             # luckily, .* (prefix matching) defined in PEP 440 can match any local version
             # https://peps.python.org/pep-0440/#version-matching
-            f"torch=={Version(pt_version).base_version}.*",
+            f"torch=={Version(pt_version).base_version}.*"
+            if pt_version != ""
             # https://github.com/pytorch/pytorch/commit/7e0c26d4d80d6602aed95cb680dfc09c9ce533bc
-            "torch>=2.1.0",
+            else "torch>=2.1.0"
         ],
     }
 

--- a/backend/find_pytorch.py
+++ b/backend/find_pytorch.py
@@ -131,9 +131,9 @@ def get_pt_requirement(pt_version: str = "") -> dict:
             # https://github.com/astral-sh/uv/blob/main/PIP_COMPATIBILITY.md#local-version-identifiers
             # luckily, .* (prefix matching) defined in PEP 440 can match any local version
             # https://peps.python.org/pep-0440/#version-matching
-            f"torch=={Version(pt_version).base_version}.*"
-            if pt_version != ""
-            else "torch>=2a",
+            f"torch=={Version(pt_version).base_version}.*",
+            # https://github.com/kulinseth/pytorch/commit/241f586919b9f370e3cc6aea657f96a23adac554
+            "torch>=2.1.0",
         ],
     }
 

--- a/backend/find_pytorch.py
+++ b/backend/find_pytorch.py
@@ -132,7 +132,7 @@ def get_pt_requirement(pt_version: str = "") -> dict:
             # luckily, .* (prefix matching) defined in PEP 440 can match any local version
             # https://peps.python.org/pep-0440/#version-matching
             f"torch=={Version(pt_version).base_version}.*",
-            # https://github.com/pytorch/pytorch/commit/241f586919b9f370e3cc6aea657f96a23adac554
+            # https://github.com/pytorch/pytorch/commit/7e0c26d4d80d6602aed95cb680dfc09c9ce533bc
             "torch>=2.1.0",
         ],
     }

--- a/doc/backend.md
+++ b/doc/backend.md
@@ -20,7 +20,7 @@ DeePMD-kit does not use the TensorFlow v2 API but uses the TensorFlow v1 API (`t
 - Model filename extension: `.pth`
 - Checkpoint filename extension: `.pt`
 
-[PyTorch](https://pytorch.org/) 2.0 or above is required.
+[PyTorch](https://pytorch.org/) 2.1 or above is required.
 While `.pth` and `.pt` are the same in the PyTorch package, they have different meanings in the DeePMD-kit to distinguish the model and the checkpoint.
 
 ### JAX {{ jax_icon }}


### PR DESCRIPTION
Fix https://github.com/deepmodeling/deepmd-kit/discussions/4382. See https://github.com/pytorch/pytorch/commit/7e0c26d4d80d6602aed95cb680dfc09c9ce533bc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated minimum version requirement for PyTorch to "torch>=2.1.0" to ensure compatibility.
  
- **Documentation**
	- Revised backend documentation to reflect the updated PyTorch version requirement from "2.0 or above" to "2.1 or above."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->