### PR TITLE
docs: clean up deprecated deepmodeling conda channel docs

### DIFF
--- a/doc/install/build-conda.md
+++ b/doc/install/build-conda.md
@@ -6,23 +6,3 @@ The official channel has been deprecated since 3.0.0.
 Refer to [conda-forge documentation](https://conda-forge.org/docs/maintainer/adding_pkgs/) for how to contribute and build packages locally.
 :::
 ::::
-
-One may want to keep both convenience and personalization of the DeePMD-kit. To achieve this goal, one can consider building conda packages. We provide building scripts in [deepmd-kit-recipes organization](https://github.com/deepmd-kit-recipes/). These building tools are driven by [conda-build](https://github.com/conda/conda-build) and [conda-smithy](https://github.com/conda-forge/conda-smithy).
-
-For example, if one wants to turn on `MPIIO` package in LAMMPS, go to [`lammps-feedstock`](https://github.com/deepmd-kit-recipes/lammps-feedstock/) repository and modify `recipe/build.sh`. `-D PKG_MPIIO=OFF` should be changed to `-D PKG_MPIIO=ON`. Then go to the main directory and execute
-
-```sh
-./build-locally.py
-```
-
-This requires that Docker has been installed. After the building, the packages will be generated in `build_artifacts/linux-64` and `build_artifacts/noarch`, and then one can install then executing
-
-```sh
-conda create -n deepmd lammps -c file:///path/to/build_artifacts -c https://conda.deepmodeling.com -c nvidia
-```
-
-One may also upload packages to one's Anaconda channel, so they can be installed on other machines:
-
-```sh
-anaconda upload /path/to/build_artifacts/linux-64/*.tar.bz2 /path/to/build_artifacts/noarch/*.tar.bz2
-```

--- a/doc/install/easy-install.md
+++ b/doc/install/easy-install.md
@@ -60,32 +60,6 @@ Maintainers will build packages in the conda-forge organization together with ot
 :::
 ::::
 
-One may create an environment that contains the CPU version of DeePMD-kit and LAMMPS:
-
-```bash
-conda create -n deepmd deepmd-kit=*=*cpu libdeepmd=*=*cpu lammps -c https://conda.deepmodeling.com -c defaults
-```
-
-Or one may want to create a GPU environment containing [CUDA Toolkit](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver):
-
-```bash
-conda create -n deepmd deepmd-kit=*=*gpu libdeepmd=*=*gpu lammps cudatoolkit=11.6 horovod -c https://conda.deepmodeling.com -c defaults
-```
-
-One could change the CUDA Toolkit version from `10.2` or `11.6`.
-
-One may specify the DeePMD-kit version such as `2.2.9` using
-
-```bash
-conda create -n deepmd deepmd-kit=2.2.9=*cpu libdeepmd=2.2.9=*cpu lammps horovod -c https://conda.deepmodeling.com -c defaults
-```
-
-One may enable the environment using
-
-```bash
-conda activate deepmd
-```
-
 ## Install with docker
 
 A docker for installing the DeePMD-kit is available [here](https://github.com/deepmodeling/deepmd-kit/pkgs/container/deepmd-kit).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated conda package building instructions for clarity and streamlined content.
	- Enhanced easy installation guide for DeePMD-kit, emphasizing command availability and system requirements.
	- Removed outdated installation steps and clarified requirements for offline and conda packages.
	- Reorganized pip installation instructions into tabbed sections for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->