### PR TITLE
fix: don't distinguish nlist types in high model interfaces

### DIFF
--- a/deepmd/dpmodel/model/make_model.py
+++ b/deepmd/dpmodel/model/make_model.py
@@ -108,7 +108,9 @@ def model_call_from_call_lower(
         nloc,
         rcut,
         sel,
-        distinguish_types=not mixed_types,
+        # types will be distinguished in the lower interface,
+        # so it doesn't need to be distinguished here
+        distinguish_types=False,
     )
     extended_coord = extended_coord.reshape(nframes, -1, 3)
     model_predict_lower = call_lower(

--- a/deepmd/jax/jax2tf/make_model.py
+++ b/deepmd/jax/jax2tf/make_model.py
@@ -90,7 +90,9 @@ def model_call_from_call_lower(
         nloc,
         rcut,
         sel,
-        distinguish_types=not mixed_types,
+        # types will be distinguished in the lower interface,
+        # so it doesn't need to be distinguished here
+        distinguish_types=False,
     )
     extended_coord = extended_coord.reshape(nframes, -1, 3)
     model_predict_lower = call_lower(

--- a/deepmd/pt/model/model/make_model.py
+++ b/deepmd/pt/model/model/make_model.py
@@ -175,7 +175,9 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
                 atype,
                 self.get_rcut(),
                 self.get_sel(),
-                mixed_types=self.mixed_types(),
+                # types will be distinguished in the lower interface,
+                # so it doesn't need to be distinguished here
+                mixed_types=False,
                 box=bb,
             )
             model_predict_lower = self.forward_common_lower(

--- a/deepmd/pt/model/model/make_model.py
+++ b/deepmd/pt/model/model/make_model.py
@@ -177,7 +177,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
                 self.get_sel(),
                 # types will be distinguished in the lower interface,
                 # so it doesn't need to be distinguished here
-                mixed_types=False,
+                mixed_types=True,
                 box=bb,
             )
             model_predict_lower = self.forward_common_lower(


### PR DESCRIPTION
It will be distinguished in the low interfaces anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of atomic types in model predictions, simplifying neighbor list processing.
	- Updated logic for neighbor list construction, improving clarity and consistency.

- **Bug Fixes**
	- Adjusted logic for distinguishing atomic types, potentially improving model performance.

- **Documentation**
	- Improved docstrings for methods to clarify expected input shapes and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->