### PR TITLE
breaking(pt/dp):change env_protection for spin

### DIFF
--- a/deepmd/pt/model/model/__init__.py
+++ b/deepmd/pt/model/model/__init__.py
@@ -130,7 +130,7 @@ def get_spin_model(model_params):
         "env_protection" not in model_params["descriptor"]
         or model_params["descriptor"]["env_protection"] == 0.0
     ):
-        model_params["descriptor"]["env_protection"] = 1e-6
+        model_params["descriptor"]["env_protection"] = 0.01
     if model_params["descriptor"]["type"] in ["se_e2_a"]:
         # only expand sel for se_e2_a
         model_params["descriptor"]["sel"] += model_params["descriptor"]["sel"]

--- a/doc/model/train-energy-spin.md
+++ b/doc/model/train-energy-spin.md
@@ -71,6 +71,14 @@ See `se_e2_a` examples in `$deepmd_source_dir/examples/spin/se_e2_a/input_torch.
   List of float values with shape of `ntypes` or `ntypes_spin` or one single float value for all types,
   only used when {ref}`use_spin <model/spin[ener_spin]/use_spin>` is True for each atom type.
 
+:::{note}
+It should be noted that the spin models in PyTorch/DP are capable of addressing scenarios where the spin approaches zero
+(indicating the virtual atom is in close proximity to the real atom) by adjusting the non-zero
+{ref}`env_protection <model[standard]/descriptor[se_e2_a]/env_protection>` parameter within the descriptor.
+This parameter is set to 0.01 by default in the spin model. It appears that a value of 0.01 is generally sufficient for maintaining model stability.
+For systems with nearly zero spin, users can also consider tuning this parameter to potentially enhance stability.
+:::
+
 ## Spin Loss
 
 The spin loss function $L$ for training energy is given by


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation for incorporating spin information into energy models for TensorFlow and PyTorch, enhancing clarity and usability.
	- Added detailed instructions on spin settings, loss functions, and data formats for both backends.

- **Bug Fixes**
	- Adjusted the default value of the `env_protection` parameter to improve model handling of environmental protection during computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->