### PR TITLE
Fix: always output weighted average error

### DIFF
--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -28,14 +28,14 @@ from deepmd.infer.deep_polar import (
     DeepGlobalPolar,
     DeepPolar,
 )
-from deepmd.infer.deep_wfc import (
-    DeepWFC,
-)
 from deepmd.infer.deep_pot import (
     DeepPot,
 )
 from deepmd.infer.deep_property import (
     DeepProperty,
+)
+from deepmd.infer.deep_wfc import (
+    DeepWFC,
 )
 from deepmd.utils import random as dp_random
 from deepmd.utils.data import (

--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -28,6 +28,9 @@ from deepmd.infer.deep_polar import (
     DeepGlobalPolar,
     DeepPolar,
 )
+from deepmd.infer.deep_wfc import (
+    DeepWFC,
+)
 from deepmd.infer.deep_pot import (
     DeepPot,
 )
@@ -45,9 +48,6 @@ from deepmd.utils.weight_avg import (
 if TYPE_CHECKING:
     from deepmd.infer.deep_tensor import (
         DeepTensor,
-    )
-    from deepmd.infer.deep_wfc import (
-        DeepWFC,
     )
 
 __all__ = ["test"]

--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -196,7 +196,7 @@ def test(
         print_polar_sys_avg(avg_err)
     elif isinstance(dp, DeepGlobalPolar):
         print_polar_sys_avg(avg_err)
-    elif isinstance(dp, DeepGlobalPolar):
+    elif isinstance(dp, DeepWFC):
         print_wfc_sys_avg(avg_err)
     log.info("# ----------------------------------------------- ")
 

--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -182,24 +182,23 @@ def test(
     if len(all_sys) != len(err_coll):
         log.warning("Not all systems are tested! Check if the systems are valid")
 
-    if len(all_sys) > 1:
-        log.info("# ----------weighted average of errors----------- ")
-        log.info(f"# number of systems : {len(all_sys)}")
-        if isinstance(dp, DeepPot):
-            print_ener_sys_avg(avg_err)
-        elif isinstance(dp, DeepDOS):
-            print_dos_sys_avg(avg_err)
-        elif isinstance(dp, DeepProperty):
-            print_property_sys_avg(avg_err)
-        elif isinstance(dp, DeepDipole):
-            print_dipole_sys_avg(avg_err)
-        elif isinstance(dp, DeepPolar):
-            print_polar_sys_avg(avg_err)
-        elif isinstance(dp, DeepGlobalPolar):
-            print_polar_sys_avg(avg_err)
-        elif isinstance(dp, DeepGlobalPolar):
-            print_wfc_sys_avg(avg_err)
-        log.info("# ----------------------------------------------- ")
+    log.info("# ----------weighted average of errors----------- ")
+    log.info(f"# number of systems : {len(all_sys)}")
+    if isinstance(dp, DeepPot):
+        print_ener_sys_avg(avg_err)
+    elif isinstance(dp, DeepDOS):
+        print_dos_sys_avg(avg_err)
+    elif isinstance(dp, DeepProperty):
+        print_property_sys_avg(avg_err)
+    elif isinstance(dp, DeepDipole):
+        print_dipole_sys_avg(avg_err)
+    elif isinstance(dp, DeepPolar):
+        print_polar_sys_avg(avg_err)
+    elif isinstance(dp, DeepGlobalPolar):
+        print_polar_sys_avg(avg_err)
+    elif isinstance(dp, DeepGlobalPolar):
+        print_wfc_sys_avg(avg_err)
+    log.info("# ----------------------------------------------- ")
 
 
 def mae(diff: np.ndarray) -> float:


### PR DESCRIPTION
This PR makes all dp test result output the "weighted average of errors" part. It would be better for post-processing tools to handle the output data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for the `DeepWFC` model, enhancing the functionality of the testing framework.

- **Bug Fixes**
	- Improved error reporting by streamlining the handling of the `DeepGlobalPolar` model, ensuring consistent logging of average errors for all models.

- **Refactor**
	- Simplified control flow by removing redundant conditional checks related to the `DeepGlobalPolar` model.
	- Enhanced clarity of output by repositioning logging statements for average errors to execute unconditionally.
	- Updated import statements for better organization and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->