### PR TITLE
fix: unmark `eval_pd` as `abstractmethod`

### DIFF
--- a/source/tests/consistent/common.py
+++ b/source/tests/consistent/common.py
@@ -185,7 +185,6 @@ class CommonTest(ABC):
         """
         raise NotImplementedError("Not implemented")
 
-    @abstractmethod
     def eval_pd(self, pd_obj: Any) -> Any:
         """Evaluate the return value of PD.
 
@@ -194,6 +193,7 @@ class CommonTest(ABC):
         pd_obj : Any
             The object of PD
         """
+        raise NotImplementedError("Not implemented")
 
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
         """Evaluate the return value of array_api_strict.

--- a/source/tests/consistent/common.py
+++ b/source/tests/consistent/common.py
@@ -101,7 +101,7 @@ class CommonTest(ABC):
     # we may usually skip jax before jax is fully supported
     skip_jax: ClassVar[bool] = True
     """Whether to skip the JAX model."""
-    skip_pd: ClassVar[bool] = not INSTALLED_PD
+    skip_pd: ClassVar[bool] = True
     """Whether to skip the Paddle model."""
     skip_array_api_strict: ClassVar[bool] = True
     """Whether to skip the array_api_strict model."""

--- a/source/tests/consistent/descriptor/test_se_e2_a.py
+++ b/source/tests/consistent/descriptor/test_se_e2_a.py
@@ -136,7 +136,7 @@ class TestSeA(CommonTest, DescriptorTest, unittest.TestCase):
             precision,
             env_protection,
         ) = self.param
-        return CommonTest.skip_pd
+        return not INSTALLED_PD
 
     @property
     def skip_array_api_strict(self) -> bool:

--- a/source/tests/consistent/fitting/test_ener.py
+++ b/source/tests/consistent/fitting/test_ener.py
@@ -135,7 +135,7 @@ class TestEner(CommonTest, FittingTest, unittest.TestCase):
         ) = self.param
         # Paddle do not support "bfloat16" in some kernels,
         # so skip this in CI test
-        return CommonTest.skip_pd or precision == "bfloat16"
+        return not INSTALLED_PD or precision == "bfloat16"
 
     tf_class = EnerFittingTF
     dp_class = EnerFittingDP


### PR DESCRIPTION
Many classes don't have this method and become abstract classes. It looks to me like these tests are skipped silently and don't throw errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `eval_pd` method to provide a clearer indication of its implementation status by raising a `NotImplementedError`.
	- Changed the `skip_pd` class variable to always skip Paddle-related tests.

- **Tests**
	- Adjusted the `skip_pd` property in the `TestSeA` and `TestEner` classes to directly reflect the installation status of Paddle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->