### PR TITLE
feat: add method to access fele in pppm/dplr

### DIFF
--- a/source/lmp/pppm_dplr.h
+++ b/source/lmp/pppm_dplr.h
@@ -28,7 +28,7 @@ class PPPMDPLR : public PPPM {
   ~PPPMDPLR() override {};
   void init() override;
   const std::vector<double> &get_fele() const { return fele; };
-  void set_fele(const std::vector<double> &new_fele) { fele = new_fele; }
+  std::vector<double>* get_fele_pointer() {return &fele;}
 
  protected:
   void compute(int, int) override;

--- a/source/lmp/pppm_dplr.h
+++ b/source/lmp/pppm_dplr.h
@@ -28,7 +28,7 @@ class PPPMDPLR : public PPPM {
   ~PPPMDPLR() override {};
   void init() override;
   const std::vector<double> &get_fele() const { return fele; };
-  std::vector<double>* get_fele_pointer() {return &fele;}
+  std::vector<double> *get_fele_pointer() { return &fele; }
 
  protected:
   void compute(int, int) override;

--- a/source/lmp/pppm_dplr.h
+++ b/source/lmp/pppm_dplr.h
@@ -28,7 +28,7 @@ class PPPMDPLR : public PPPM {
   ~PPPMDPLR() override {};
   void init() override;
   const std::vector<double> &get_fele() const { return fele; };
-  std::vector<double> *get_fele_pointer() { return &fele; }
+  std::vector<double> &get_fele() { return fele; }
 
  protected:
   void compute(int, int) override;


### PR DESCRIPTION
- I would like to modify the fele vector in pppm/dplr (e.g., by a fix plugin), which would be used to calculate the long-range interaction in fix dplr. 
- Therefore, I would like to add a new method to access the editable fele. This method would not change the current workflows of the lammps-dplr interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to access a vector of doubles, enhancing the class interface for better usability. This allows for external modification of the vector.

- **Bug Fixes**
	- No bug fixes included in this release.

- **Documentation**
	- Updated documentation to reflect the addition of the new method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->