### PR TITLE
Perf: load data systems on rank 0

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -579,7 +579,7 @@ class Trainer:
         # author: iProzd
         if self.opt_type == "Adam":
             self.optimizer = torch.optim.Adam(
-                self.wrapper.parameters(), lr=self.lr_exp.start_lr
+                self.wrapper.parameters(), lr=self.lr_exp.start_lr, fused=True
             )
             if optimizer_state_dict is not None and self.restart_training:
                 self.optimizer.load_state_dict(optimizer_state_dict)

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -97,7 +97,7 @@ class DpLoaderSet(Dataset):
         global_rank = dist.get_rank() if dist.is_initialized() else 0
         if global_rank == 0:
             log.info(f"Constructing DataLoaders from {len(systems)} systems")
-            with Pool(os.cpu_count()) as pool:
+            with Pool(env.NUM_WORKERS) as pool:
                 self.systems = pool.map(construct_dataset, systems)
         else:
             self.systems = [None] * len(systems)  # type: ignore

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import time
-from multiprocessing.dummy import (
+from multiprocessing import (
     Pool,
 )
 from queue import (
@@ -88,25 +88,25 @@ class DpLoaderSet(Dataset):
                 systems = [os.path.join(systems, item) for item in file.keys()]
 
         self.systems: list[DeepmdDataSetForLoader] = []
-        if len(systems) >= 100:
-            log.info(f"Constructing DataLoaders from {len(systems)} systems")
 
         def construct_dataset(system):
+            if len(systems) >= 100:
+                log.info(f"Constructing DataLoaders from {len(systems)} systems")
             return DeepmdDataSetForLoader(
                 system=system,
                 type_map=type_map,
             )
 
-        with Pool(
-            os.cpu_count()
-            // (
-                int(os.environ["LOCAL_WORLD_SIZE"])
-                if dist.is_available() and dist.is_initialized()
-                else 1
-            )
-        ) as pool:
-            self.systems = pool.map(construct_dataset, systems)
-
+        global_rank = dist.get_rank() if dist.is_initialized() else 0
+        if global_rank == 0:
+            with Pool(os.cpu_count()) as pool:
+                self.systems = pool.map(construct_dataset, systems)
+            if dist.is_initialized():
+                dist.broadcast_object_list(self.systems)
+        else:
+            self.systems = [None] * len(systems) # type: ignore
+            dist.broadcast_object_list(self.systems)
+            assert self.systems[-1] is not None
         self.sampler_list: list[DistributedSampler] = []
         self.index = []
         self.total_batch = 0

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -97,7 +97,7 @@ class DpLoaderSet(Dataset):
         global_rank = dist.get_rank() if dist.is_initialized() else 0
         if global_rank == 0:
             log.info(f"Constructing DataLoaders from {len(systems)} systems")
-            with Pool(env.NUM_WORKERS) as pool:
+            with Pool(max(1, env.NUM_WORKERS)) as pool:
                 self.systems = pool.map(construct_dataset, systems)
         else:
             self.systems = [None] * len(systems)  # type: ignore

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -87,18 +87,16 @@ class DpLoaderSet(Dataset):
             with h5py.File(systems) as file:
                 systems = [os.path.join(systems, item) for item in file.keys()]
 
-        self.systems: list[DeepmdDataSetForLoader] = []
-
         def construct_dataset(system):
-            if len(systems) >= 100:
-                log.info(f"Constructing DataLoaders from {len(systems)} systems")
             return DeepmdDataSetForLoader(
                 system=system,
                 type_map=type_map,
             )
-
+        self.systems: list[DeepmdDataSetForLoader] = []
         global_rank = dist.get_rank() if dist.is_initialized() else 0
         if global_rank == 0:
+            if len(systems) >= 100:
+                log.info(f"Constructing DataLoaders from {len(systems)} systems")
             with Pool(os.cpu_count()) as pool:
                 self.systems = pool.map(construct_dataset, systems)
         else:

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import time
-from multiprocessing import (
+from multiprocessing.dummy import (
     Pool,
 )
 from queue import (

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -92,6 +92,7 @@ class DpLoaderSet(Dataset):
                 system=system,
                 type_map=type_map,
             )
+
         self.systems: list[DeepmdDataSetForLoader] = []
         global_rank = dist.get_rank() if dist.is_initialized() else 0
         if global_rank == 0:

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -101,10 +101,9 @@ class DpLoaderSet(Dataset):
         if global_rank == 0:
             with Pool(os.cpu_count()) as pool:
                 self.systems = pool.map(construct_dataset, systems)
-            if dist.is_initialized():
-                dist.broadcast_object_list(self.systems)
         else:
             self.systems = [None] * len(systems) # type: ignore
+        if dist.is_initialized():
             dist.broadcast_object_list(self.systems)
             assert self.systems[-1] is not None
         self.sampler_list: list[DistributedSampler] = []

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -96,8 +96,7 @@ class DpLoaderSet(Dataset):
         self.systems: list[DeepmdDataSetForLoader] = []
         global_rank = dist.get_rank() if dist.is_initialized() else 0
         if global_rank == 0:
-            if len(systems) >= 100:
-                log.info(f"Constructing DataLoaders from {len(systems)} systems")
+            log.info(f"Constructing DataLoaders from {len(systems)} systems")
             with Pool(os.cpu_count()) as pool:
                 self.systems = pool.map(construct_dataset, systems)
         else:


### PR DESCRIPTION
The current implementation loads data on each rank. This will stress the file system.
In this PR, only rank 0 will load data systems, and it will be broadcasted to each rank.
The data sampler initialized later will still use the exclusive seed of each rank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of distributed data loading for improved synchronization across processes.
	- Added broadcasting of the constructed dataset to ensure consistency in all processes.

- **Bug Fixes**
	- Implemented safeguards to prevent incomplete data distribution by asserting the integrity of the dataset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->