### PR TITLE
fix: print dlerror if dlopen fails

### DIFF
--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -390,7 +390,11 @@ static inline void _load_library_path(std::string dso_path) {
   if (!dso_handle) {
     throw deepmd::deepmd_exception(
         dso_path +
-        " is not found! You can add the library directory to LD_LIBRARY_PATH");
+        " is not found or fails to load! You can add the library directory to LD_LIBRARY_PATH."
+#ifndef _WIN32
+        " Error message: " + std::string(dlerror())
+#endif
+    );
   }
 }
 

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -390,9 +390,11 @@ static inline void _load_library_path(std::string dso_path) {
   if (!dso_handle) {
     throw deepmd::deepmd_exception(
         dso_path +
-        " is not found or fails to load! You can add the library directory to LD_LIBRARY_PATH."
+        " is not found or fails to load! You can add the library directory to "
+        "LD_LIBRARY_PATH."
 #ifndef _WIN32
-        " Error message: " + std::string(dlerror())
+        " Error message: " +
+        std::string(dlerror())
 #endif
     );
   }

--- a/source/lib/src/gpu/cudart/cudart_stub.cc
+++ b/source/lib/src/gpu/cudart/cudart_stub.cc
@@ -25,6 +25,9 @@ void *DP_cudart_dlopen(char *libname) {
 #endif
     if (!dso_handle) {
       std::cerr << "DeePMD-kit: Cannot find " << libname << std::endl;
+#ifndef _WIN32
+      std::cerr << "DeePMD-kit: Error message: " << std::string(dlerror()) << std::endl;
+#endif
       return nullptr;
     }
     std::cerr << "DeePMD-kit: Successfully load " << libname << std::endl;

--- a/source/lib/src/gpu/cudart/cudart_stub.cc
+++ b/source/lib/src/gpu/cudart/cudart_stub.cc
@@ -26,7 +26,8 @@ void *DP_cudart_dlopen(char *libname) {
     if (!dso_handle) {
       std::cerr << "DeePMD-kit: Cannot find " << libname << std::endl;
 #ifndef _WIN32
-      std::cerr << "DeePMD-kit: Error message: " << std::string(dlerror()) << std::endl;
+      std::cerr << "DeePMD-kit: Error message: " << std::string(dlerror())
+                << std::endl;
 #endif
       return nullptr;
     }


### PR DESCRIPTION
xref: https://github.com/njzjz/deepmd-gnn/issues/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages for library loading failures on non-Windows platforms.
	- Updated thread management environment variable checks for improved compatibility.
	- Added support for mixed types in tensor input handling, allowing for more flexible configurations.

- **Bug Fixes**
	- Improved error reporting for dynamic library loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->