### PR TITLE
pd: add missing `dp.eval()` in pd backend

### DIFF
--- a/deepmd/pd/infer/deep_eval.py
+++ b/deepmd/pd/infer/deep_eval.py
@@ -354,6 +354,12 @@ class DeepEval(DeepEvalBackend):
         request_defs: list[OutputVariableDef],
     ):
         model = self.dp.to(DEVICE)
+
+        # switch to eval mode
+        is_training = model.training
+        if is_training:
+            model.eval()
+
         prec = NP_PRECISION_DICT[RESERVED_PRECISON_DICT[GLOBAL_PD_FLOAT_PRECISION]]
 
         nframes = coords.shape[0]
@@ -419,6 +425,11 @@ class DeepEval(DeepEvalBackend):
                 results.append(
                     np.full(np.abs(shape), np.nan, dtype=prec)
                 )  # this is kinda hacky
+
+        # switch back to training mode if previously enabled
+        if is_training:
+            model.train()
+
         return tuple(results)
 
     def _eval_model_spin(

--- a/deepmd/pd/infer/deep_eval.py
+++ b/deepmd/pd/infer/deep_eval.py
@@ -113,6 +113,7 @@ class DeepEval(DeepEvalBackend):
         else:
             # self.dp = paddle.jit.load(self.model_path.split(".json")[0])
             raise ValueError(f"Unknown model file format: {self.model_path}!")
+        self.dp.eval()
         self.rcut = self.dp.model["Default"].get_rcut()
         self.type_map = self.dp.model["Default"].get_type_map()
         if isinstance(auto_batch_size, bool):
@@ -237,11 +238,6 @@ class DeepEval(DeepEvalBackend):
             The output of the evaluation. The keys are the names of the output
             variables, and the values are the corresponding output arrays.
         """
-        # switch to eval mode
-        is_training = self.dp.training
-        if is_training:
-            self.dp.eval()
-
         # convert all of the input to numpy array
         atom_types = np.array(atom_types, dtype=np.int32)
         coords = np.array(coords)
@@ -265,11 +261,6 @@ class DeepEval(DeepEvalBackend):
                 aparam,
                 request_defs,
             )
-
-        # switch back to training mode if previously enabled
-        if is_training:
-            self.dp.train()
-
         return dict(
             zip(
                 [x.name for x in request_defs],

--- a/deepmd/pd/utils/region.py
+++ b/deepmd/pd/utils/region.py
@@ -108,5 +108,5 @@ def normalize_coord(
 
     """
     icoord = phys2inter(coord, cell)
-    icoord = paddle.remainder(icoord, paddle.full([], 1.0))
+    icoord = paddle.remainder(icoord, paddle.full([], 1.0, dtype=icoord.dtype))
     return inter2phys(icoord, cell)


### PR DESCRIPTION
Switch to eval mode when evaluating model, otherwise `self.training` will be `True`, backward graph will be created and cause OOM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced model evaluation state management to ensure correct behavior during evaluation.

- **Bug Fixes**
	- Improved type consistency in the `normalize_coord` function for better computational accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->