### PR TITLE
Perf: allow tf32 datatype for matmul

### DIFF
--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -103,7 +103,8 @@ def get_trainer(
     finetune_links=None,
 ):
     multi_task = "model_dict" in config.get("model", {})
-
+    # https://pytorch.org/docs/stable/notes/cuda.html#tf32-on-ampere
+    torch.backends.cuda.matmul.allow_tf32 = True
     # Initialize DDP
     local_rank = os.environ.get("LOCAL_RANK")
     if local_rank is not None:


### PR DESCRIPTION
Pytorch by default disables using TF32 data type starting from A100 GPU. Enabling TF32 utilizes tensor core on A100 GPUs, expecting better performance.

I will later attach some test results on the speed-up and accuracy of this PR.

Ref:
https://pytorch.org/docs/stable/notes/cuda.html#tf32-on-ampere
https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for TensorFloat-32 (TF32) in PyTorch to enhance matrix multiplication performance on compatible hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->