### PR TITLE
chore: fix spelling PRECISON -> PRECISION

### DIFF
--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -43,7 +43,7 @@ PRECISION_DICT = {
 }
 assert VALID_PRECISION.issubset(PRECISION_DICT.keys())
 
-RESERVED_PRECISON_DICT = {
+RESERVED_PRECISION_DICT = {
     np.float16: "float16",
     np.float32: "float32",
     np.float64: "float64",
@@ -52,7 +52,7 @@ RESERVED_PRECISON_DICT = {
     ml_dtypes.bfloat16: "bfloat16",
     np.bool_: "bool",
 }
-assert set(RESERVED_PRECISON_DICT.keys()) == set(PRECISION_DICT.values())
+assert set(RESERVED_PRECISION_DICT.keys()) == set(PRECISION_DICT.values())
 DEFAULT_PRECISION = "float64"
 
 
@@ -74,9 +74,9 @@ def get_xp_precision(
     elif precision == "bool":
         return bool
     elif precision == "default":
-        return get_xp_precision(xp, RESERVED_PRECISON_DICT[PRECISION_DICT[precision]])
+        return get_xp_precision(xp, RESERVED_PRECISION_DICT[PRECISION_DICT[precision]])
     elif precision == "global":
-        return get_xp_precision(xp, RESERVED_PRECISON_DICT[GLOBAL_NP_FLOAT_PRECISION])
+        return get_xp_precision(xp, RESERVED_PRECISION_DICT[GLOBAL_NP_FLOAT_PRECISION])
     elif precision == "bfloat16":
         return ml_dtypes.bfloat16
     else:
@@ -225,6 +225,6 @@ __all__ = [
     "GLOBAL_ENER_FLOAT_PRECISION",
     "GLOBAL_NP_FLOAT_PRECISION",
     "PRECISION_DICT",
-    "RESERVED_PRECISON_DICT",
+    "RESERVED_PRECISION_DICT",
     "NativeOP",
 ]

--- a/deepmd/dpmodel/model/make_model.py
+++ b/deepmd/dpmodel/model/make_model.py
@@ -14,7 +14,7 @@ from deepmd.dpmodel.common import (
     GLOBAL_ENER_FLOAT_PRECISION,
     GLOBAL_NP_FLOAT_PRECISION,
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
     NativeOP,
 )
 from deepmd.dpmodel.model.base_model import (
@@ -169,7 +169,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
                 self.atomic_model: T_AtomicModel = T_AtomicModel(*args, **kwargs)
             self.precision_dict = PRECISION_DICT
             # not supported by flax
-            # self.reverse_precision_dict = RESERVED_PRECISON_DICT
+            # self.reverse_precision_dict = RESERVED_PRECISION_DICT
             self.global_np_float_precision = GLOBAL_NP_FLOAT_PRECISION
             self.global_ener_float_precision = GLOBAL_ENER_FLOAT_PRECISION
 
@@ -373,7 +373,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
             str,
         ]:
             """Cast the input data to global float type."""
-            input_prec = RESERVED_PRECISON_DICT[self.precision_dict[coord.dtype.name]]
+            input_prec = RESERVED_PRECISION_DICT[self.precision_dict[coord.dtype.name]]
             ###
             ### type checking would not pass jit, convert to coord prec anyway
             ###
@@ -382,7 +382,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
                 for vv in [box, fparam, aparam]
             ]
             box, fparam, aparam = _lst
-            if input_prec == RESERVED_PRECISON_DICT[self.global_np_float_precision]:
+            if input_prec == RESERVED_PRECISION_DICT[self.global_np_float_precision]:
                 return coord, box, fparam, aparam, input_prec
             else:
                 pp = self.global_np_float_precision
@@ -401,7 +401,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
         ) -> dict[str, np.ndarray]:
             """Convert the model output to the input prec."""
             do_cast = (
-                input_prec != RESERVED_PRECISON_DICT[self.global_np_float_precision]
+                input_prec != RESERVED_PRECISION_DICT[self.global_np_float_precision]
             )
             pp = self.precision_dict[input_prec]
             odef = self.model_output_def()

--- a/deepmd/pd/infer/deep_eval.py
+++ b/deepmd/pd/infer/deep_eval.py
@@ -35,7 +35,7 @@ from deepmd.pd.utils.auto_batch_size import (
 from deepmd.pd.utils.env import (
     DEVICE,
     GLOBAL_PD_FLOAT_PRECISION,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
     enable_prim,
 )
 from deepmd.pd.utils.utils import (
@@ -355,7 +355,7 @@ class DeepEval(DeepEvalBackend):
         request_defs: list[OutputVariableDef],
     ):
         model = self.dp.to(DEVICE)
-        prec = NP_PRECISION_DICT[RESERVED_PRECISON_DICT[GLOBAL_PD_FLOAT_PRECISION]]
+        prec = NP_PRECISION_DICT[RESERVED_PRECISION_DICT[GLOBAL_PD_FLOAT_PRECISION]]
 
         nframes = coords.shape[0]
         if len(atom_types.shape) == 1:
@@ -370,7 +370,7 @@ class DeepEval(DeepEvalBackend):
             place=DEVICE,
         )
         type_input = paddle.to_tensor(
-            atom_types.astype(NP_PRECISION_DICT[RESERVED_PRECISON_DICT[paddle.int64]]),
+            atom_types.astype(NP_PRECISION_DICT[RESERVED_PRECISION_DICT[paddle.int64]]),
             dtype=paddle.int64,
             place=DEVICE,
         )

--- a/deepmd/pd/model/descriptor/dpa1.py
+++ b/deepmd/pd/model/descriptor/dpa1.py
@@ -23,7 +23,7 @@ from deepmd.pd.utils import (
 )
 from deepmd.pd.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pd.utils.update_sel import (
     UpdateSel,
@@ -503,7 +503,7 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
             "use_tebd_bias": self.use_tebd_bias,
             "type_map": self.type_map,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "attention_layers": obj.dpa1_attention.serialize(),
             "env_mat": DPEnvMat(obj.rcut, obj.rcut_smth).serialize(),

--- a/deepmd/pd/model/descriptor/se_a.py
+++ b/deepmd/pd/model/descriptor/se_a.py
@@ -23,7 +23,7 @@ from deepmd.pd.utils import (
 )
 from deepmd.pd.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pd.utils.env_mat_stat import (
     EnvMatStatSe,
@@ -334,7 +334,7 @@ class DescrptSeA(BaseDescriptor, paddle.nn.Layer):
             "set_davg_zero": obj.set_davg_zero,
             "activation_function": obj.activation_function,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "env_mat": DPEnvMat(obj.rcut, obj.rcut_smth).serialize(),
             "exclude_types": obj.exclude_types,

--- a/deepmd/pd/model/descriptor/se_t_tebd.py
+++ b/deepmd/pd/model/descriptor/se_t_tebd.py
@@ -30,7 +30,7 @@ from deepmd.pd.utils import (
 )
 from deepmd.pd.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pd.utils.env_mat_stat import (
     EnvMatStatSe,
@@ -358,7 +358,7 @@ class DescrptSeTTebd(BaseDescriptor, paddle.nn.Layer):
             "use_econf_tebd": self.use_econf_tebd,
             "type_map": self.type_map,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "env_mat": DPEnvMat(obj.rcut, obj.rcut_smth).serialize(),
             "type_embedding": self.type_embedding.embedding.serialize(),

--- a/deepmd/pd/model/model/make_model.py
+++ b/deepmd/pd/model/model/make_model.py
@@ -28,7 +28,7 @@ from deepmd.pd.utils.env import (
     GLOBAL_PD_ENER_FLOAT_PRECISION,
     GLOBAL_PD_FLOAT_PRECISION,
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pd.utils.nlist import (
     extend_input_and_build_neighbor_list,
@@ -76,7 +76,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
             else:
                 self.atomic_model: T_AtomicModel = T_AtomicModel(*args, **kwargs)
             self.precision_dict = PRECISION_DICT
-            self.reverse_precision_dict = RESERVED_PRECISON_DICT
+            self.reverse_precision_dict = RESERVED_PRECISION_DICT
             self.global_pd_float_precision = GLOBAL_PD_FLOAT_PRECISION
             self.global_pd_ener_float_precision = GLOBAL_PD_ENER_FLOAT_PRECISION
 

--- a/deepmd/pd/utils/env.py
+++ b/deepmd/pd/utils/env.py
@@ -55,7 +55,7 @@ GLOBAL_PD_ENER_FLOAT_PRECISION = PRECISION_DICT[
 PRECISION_DICT["default"] = GLOBAL_PD_FLOAT_PRECISION
 assert VALID_PRECISION.issubset(PRECISION_DICT.keys())
 # cannot automatically generated
-RESERVED_PRECISON_DICT = {
+RESERVED_PRECISION_DICT = {
     paddle.float16: "float16",
     paddle.float32: "float32",
     paddle.float64: "float64",
@@ -64,7 +64,7 @@ RESERVED_PRECISON_DICT = {
     paddle.bfloat16: "bfloat16",
     paddle.bool: "bool",
 }
-assert set(PRECISION_DICT.values()) == set(RESERVED_PRECISON_DICT.keys())
+assert set(PRECISION_DICT.values()) == set(RESERVED_PRECISION_DICT.keys())
 DEFAULT_PRECISION = "float64"
 
 # throw warnings if threads not set
@@ -163,7 +163,7 @@ __all__ = [
     "LOCAL_RANK",
     "NUM_WORKERS",
     "PRECISION_DICT",
-    "RESERVED_PRECISON_DICT",
+    "RESERVED_PRECISION_DICT",
     "SAMPLER_RECORD",
     "enable_prim",
 ]

--- a/deepmd/pt/infer/deep_eval.py
+++ b/deepmd/pt/infer/deep_eval.py
@@ -58,7 +58,7 @@ from deepmd.pt.utils.auto_batch_size import (
 from deepmd.pt.utils.env import (
     DEVICE,
     GLOBAL_PT_FLOAT_PRECISION,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pt.utils.utils import (
     to_numpy_array,
@@ -406,7 +406,7 @@ class DeepEval(DeepEvalBackend):
         request_defs: list[OutputVariableDef],
     ):
         model = self.dp.to(DEVICE)
-        prec = NP_PRECISION_DICT[RESERVED_PRECISON_DICT[GLOBAL_PT_FLOAT_PRECISION]]
+        prec = NP_PRECISION_DICT[RESERVED_PRECISION_DICT[GLOBAL_PT_FLOAT_PRECISION]]
 
         nframes = coords.shape[0]
         if len(atom_types.shape) == 1:
@@ -421,7 +421,7 @@ class DeepEval(DeepEvalBackend):
             device=DEVICE,
         )
         type_input = torch.tensor(
-            atom_types.astype(NP_PRECISION_DICT[RESERVED_PRECISON_DICT[torch.long]]),
+            atom_types.astype(NP_PRECISION_DICT[RESERVED_PRECISION_DICT[torch.long]]),
             dtype=torch.long,
             device=DEVICE,
         )
@@ -553,7 +553,7 @@ class DeepEval(DeepEvalBackend):
                         np.abs(shape),
                         np.nan,
                         dtype=NP_PRECISION_DICT[
-                            RESERVED_PRECISON_DICT[GLOBAL_PT_FLOAT_PRECISION]
+                            RESERVED_PRECISION_DICT[GLOBAL_PT_FLOAT_PRECISION]
                         ],
                     )
                 )  # this is kinda hacky

--- a/deepmd/pt/model/descriptor/dpa1.py
+++ b/deepmd/pt/model/descriptor/dpa1.py
@@ -23,7 +23,7 @@ from deepmd.pt.utils import (
 )
 from deepmd.pt.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pt.utils.tabulate import (
     DPTabulate,
@@ -505,7 +505,7 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
             "use_tebd_bias": self.use_tebd_bias,
             "type_map": self.type_map,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "attention_layers": obj.dpa1_attention.serialize(),
             "env_mat": DPEnvMat(obj.rcut, obj.rcut_smth).serialize(),

--- a/deepmd/pt/model/descriptor/se_a.py
+++ b/deepmd/pt/model/descriptor/se_a.py
@@ -23,7 +23,7 @@ from deepmd.pt.utils import (
 )
 from deepmd.pt.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pt.utils.env_mat_stat import (
     EnvMatStatSe,
@@ -379,7 +379,7 @@ class DescrptSeA(BaseDescriptor, torch.nn.Module):
             "set_davg_zero": obj.set_davg_zero,
             "activation_function": obj.activation_function,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "env_mat": DPEnvMat(obj.rcut, obj.rcut_smth).serialize(),
             "exclude_types": obj.exclude_types,

--- a/deepmd/pt/model/descriptor/se_atten_v2.py
+++ b/deepmd/pt/model/descriptor/se_atten_v2.py
@@ -20,7 +20,7 @@ from deepmd.pt.utils import (
     env,
 )
 from deepmd.pt.utils.env import (
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.utils.version import (
     check_version_compatibility,
@@ -223,7 +223,7 @@ class DescrptSeAttenV2(DescrptDPA1):
             "use_tebd_bias": self.use_tebd_bias,
             "type_map": self.type_map,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "embeddings_strip": obj.filter_layers_strip.serialize(),
             "attention_layers": obj.dpa1_attention.serialize(),

--- a/deepmd/pt/model/descriptor/se_r.py
+++ b/deepmd/pt/model/descriptor/se_r.py
@@ -25,7 +25,7 @@ from deepmd.pt.utils import (
 )
 from deepmd.pt.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pt.utils.env_mat_stat import (
     EnvMatStatSe,
@@ -549,7 +549,7 @@ class DescrptSeR(BaseDescriptor, torch.nn.Module):
             "set_davg_zero": self.set_davg_zero,
             "activation_function": self.activation_function,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[self.prec],
+            "precision": RESERVED_PRECISION_DICT[self.prec],
             "embeddings": self.filter_layers.serialize(),
             "env_mat": DPEnvMat(self.rcut, self.rcut_smth).serialize(),
             "exclude_types": self.exclude_types,

--- a/deepmd/pt/model/descriptor/se_t.py
+++ b/deepmd/pt/model/descriptor/se_t.py
@@ -23,7 +23,7 @@ from deepmd.pt.utils import (
 )
 from deepmd.pt.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pt.utils.env_mat_stat import (
     EnvMatStatSe,
@@ -413,7 +413,7 @@ class DescrptSeT(BaseDescriptor, torch.nn.Module):
             "resnet_dt": obj.resnet_dt,
             "set_davg_zero": obj.set_davg_zero,
             "activation_function": obj.activation_function,
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "env_mat": DPEnvMat(obj.rcut, obj.rcut_smth).serialize(),
             "exclude_types": obj.exclude_types,

--- a/deepmd/pt/model/descriptor/se_t_tebd.py
+++ b/deepmd/pt/model/descriptor/se_t_tebd.py
@@ -30,7 +30,7 @@ from deepmd.pt.utils import (
 )
 from deepmd.pt.utils.env import (
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pt.utils.env_mat_stat import (
     EnvMatStatSe,
@@ -354,7 +354,7 @@ class DescrptSeTTebd(BaseDescriptor, torch.nn.Module):
             "use_econf_tebd": self.use_econf_tebd,
             "type_map": self.type_map,
             # make deterministic
-            "precision": RESERVED_PRECISON_DICT[obj.prec],
+            "precision": RESERVED_PRECISION_DICT[obj.prec],
             "embeddings": obj.filter_layers.serialize(),
             "env_mat": DPEnvMat(obj.rcut, obj.rcut_smth).serialize(),
             "type_embedding": self.type_embedding.embedding.serialize(),

--- a/deepmd/pt/model/model/make_model.py
+++ b/deepmd/pt/model/model/make_model.py
@@ -28,7 +28,7 @@ from deepmd.pt.utils.env import (
     GLOBAL_PT_ENER_FLOAT_PRECISION,
     GLOBAL_PT_FLOAT_PRECISION,
     PRECISION_DICT,
-    RESERVED_PRECISON_DICT,
+    RESERVED_PRECISION_DICT,
 )
 from deepmd.pt.utils.nlist import (
     extend_input_and_build_neighbor_list,
@@ -76,7 +76,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
             else:
                 self.atomic_model: T_AtomicModel = T_AtomicModel(*args, **kwargs)
             self.precision_dict = PRECISION_DICT
-            self.reverse_precision_dict = RESERVED_PRECISON_DICT
+            self.reverse_precision_dict = RESERVED_PRECISION_DICT
             self.global_pt_float_precision = GLOBAL_PT_FLOAT_PRECISION
             self.global_pt_ener_float_precision = GLOBAL_PT_ENER_FLOAT_PRECISION
 

--- a/deepmd/pt/utils/env.py
+++ b/deepmd/pt/utils/env.py
@@ -54,7 +54,7 @@ GLOBAL_PT_ENER_FLOAT_PRECISION = PRECISION_DICT[
 PRECISION_DICT["default"] = GLOBAL_PT_FLOAT_PRECISION
 assert VALID_PRECISION.issubset(PRECISION_DICT.keys())
 # cannot automatically generated
-RESERVED_PRECISON_DICT = {
+RESERVED_PRECISION_DICT = {
     torch.float16: "float16",
     torch.float32: "float32",
     torch.float64: "float64",
@@ -63,7 +63,7 @@ RESERVED_PRECISON_DICT = {
     torch.bfloat16: "bfloat16",
     torch.bool: "bool",
 }
-assert set(PRECISION_DICT.values()) == set(RESERVED_PRECISON_DICT.keys())
+assert set(PRECISION_DICT.values()) == set(RESERVED_PRECISION_DICT.keys())
 DEFAULT_PRECISION = "float64"
 
 # throw warnings if threads not set
@@ -87,6 +87,6 @@ __all__ = [
     "LOCAL_RANK",
     "NUM_WORKERS",
     "PRECISION_DICT",
-    "RESERVED_PRECISON_DICT",
+    "RESERVED_PRECISION_DICT",
     "SAMPLER_RECORD",
 ]


### PR DESCRIPTION
Luckily, this variable has never been used otherwhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of `RESERVED_PRECISON_DICT` to `RESERVED_PRECISION_DICT` across multiple files to ensure consistency and prevent potential runtime errors.
  
- **Documentation**
	- Updated comments and documentation to reflect the corrected variable name, enhancing clarity without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->