### PR TITLE
Chore: prevent from printing additional header in `lcurve.out` on resuming

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -145,7 +145,7 @@ class Trainer:
         self.change_bias_after_training = training_params.get(
             "change_bias_after_training", False
         )
-        self.lcurve_should_print_header = True
+        self.lcurve_should_print_header = not self.restart_training # prevent from printing header when resuming
 
         def get_opt_param(params):
             opt_type = params.get("opt_type", "Adam")

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -145,7 +145,9 @@ class Trainer:
         self.change_bias_after_training = training_params.get(
             "change_bias_after_training", False
         )
-        self.lcurve_should_print_header = not self.restart_training # prevent from printing header when resuming
+        self.lcurve_should_print_header = (
+            not self.restart_training
+        )  # prevent from printing header when resuming
 
         def get_opt_param(params):
             opt_type = params.get("opt_type", "Adam")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging control during training by adjusting header printing when resuming training.
	- Enhanced data handling to ensure seamless continuation of training and validation processes when data is exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->