### PR TITLE
pd: fix typo in deepmd-kit-tmp/deepmd/pd/utils/dataloader.py

### DIFF
--- a/deepmd/pd/utils/dataloader.py
+++ b/deepmd/pd/utils/dataloader.py
@@ -36,7 +36,7 @@ from deepmd.pd.utils import (
 from deepmd.pd.utils.dataset import (
     DeepmdDataSetForLoader,
 )
-from deepmd.pt.utils.utils import (
+from deepmd.pd.utils.utils import (
     mix_entropy,
 )
 from deepmd.utils import random as dp_random


### PR DESCRIPTION
Fix a typo introduced in #4479, which will cause an error if torch is not installed.
![image](https://github.com/user-attachments/assets/3f9b0955-ec2b-46ac-9efa-1ed4b4e023eb)

cc @njzjz 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the import path for the `mix_entropy` function to reflect a reorganization of utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->