### PR TITLE
fix(pt): fix clearing the list in set_eval_descriptor_hook

### DIFF
--- a/deepmd/pt/model/atomic_model/dp_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/dp_atomic_model.py
@@ -69,7 +69,8 @@ class DPAtomicModel(BaseAtomicModel):
     def set_eval_descriptor_hook(self, enable: bool) -> None:
         """Set the hook for evaluating descriptor and clear the cache for descriptor list."""
         self.enable_eval_descriptor_hook = enable
-        self.eval_descriptor_list = []
+        # = [] does not work; See #4533
+        self.eval_descriptor_list.clear()
 
     def eval_descriptor(self) -> torch.Tensor:
         """Evaluate the descriptor."""

--- a/source/tests/infer/test_models.py
+++ b/source/tests/infer/test_models.py
@@ -159,6 +159,10 @@ class TestDeepPot(unittest.TestCase):
             descpt = self.dp.eval_descriptor(result.coord, result.box, result.atype)
             expected_descpt = result.descriptor
             np.testing.assert_almost_equal(descpt.ravel(), expected_descpt.ravel())
+            # See #4533
+            descpt = self.dp.eval_descriptor(result.coord, result.box, result.atype)
+            expected_descpt = result.descriptor
+            np.testing.assert_almost_equal(descpt.ravel(), expected_descpt.ravel())
 
     def test_2frame_atm(self) -> None:
         for ii, result in enumerate(self.case.results):


### PR DESCRIPTION
Fix #4533.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved list clearing mechanism in `DPAtomicModel` class
  - Enhanced test coverage for descriptor evaluation in `TestDeepPot`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->