### PR TITLE
fix: lower `num_workers` to 4

### DIFF
--- a/deepmd/pt/utils/env.py
+++ b/deepmd/pt/utils/env.py
@@ -21,7 +21,7 @@ try:
     ncpus = len(os.sched_getaffinity(0))
 except AttributeError:
     ncpus = os.cpu_count()
-NUM_WORKERS = int(os.environ.get("NUM_WORKERS", min(8, ncpus)))
+NUM_WORKERS = int(os.environ.get("NUM_WORKERS", min(4, ncpus)))
 # Make sure DDP uses correct device if applicable
 LOCAL_RANK = os.environ.get("LOCAL_RANK")
 LOCAL_RANK = int(0 if LOCAL_RANK is None else LOCAL_RANK)

--- a/doc/env.md
+++ b/doc/env.md
@@ -72,7 +72,7 @@ Default backend.
 
 :::{envvar} NUM_WORKERS
 
-**Default**: 8 or the number of cores (whichever is smaller)
+**Default**: 4 or the number of cores (whichever is smaller)
 
 {{ pytorch_icon }} Number of subprocesses to use for data loading in the PyTorch backend.
 See [PyTorch documentation](https://pytorch.org/docs/stable/data.html) for details.


### PR DESCRIPTION
For multi-task training in pytorch, each data source will have their own dataloader. If the number of workers of dataloaders is large, there will be many (number of tasks * num_workers) worker processes stressing CPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Optimization**
  - Adjusted default maximum worker configuration from 8 to 4 CPUs
  - Reduced potential parallel processing resources for the environment
- **Documentation**
  - Updated documentation to reflect the change in default value for `NUM_WORKERS` from 8 to 4
<!-- end of auto-generated comment: release notes by coderabbit.ai -->