### PR TITLE
chore: test consistency of rotation matrix

### DIFF
--- a/source/tests/consistent/descriptor/common.py
+++ b/source/tests/consistent/descriptor/common.py
@@ -74,7 +74,7 @@ class DescriptorTest:
         )
         # ensure get_dim_out gives the correct shape
         t_des = tf.reshape(t_des, [1, natoms[0], obj.get_dim_out()])
-        return [t_des], {
+        return [t_des, obj.get_rot_mat()], {
             t_coord: coords,
             t_type: atype,
             t_natoms: natoms,

--- a/source/tests/consistent/descriptor/test_dpa1.py
+++ b/source/tests/consistent/descriptor/test_dpa1.py
@@ -442,7 +442,7 @@ class TestDPA1(CommonTest, DescriptorTest, unittest.TestCase):
         )
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
-        return (ret[0],)
+        return (ret[0], ret[1])
 
     @property
     def rtol(self) -> float:

--- a/source/tests/consistent/descriptor/test_hybrid.py
+++ b/source/tests/consistent/descriptor/test_hybrid.py
@@ -168,4 +168,4 @@ class TestHybrid(CommonTest, DescriptorTest, unittest.TestCase):
         )
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
-        return (ret[0],)
+        return (ret[0], ret[1])

--- a/source/tests/consistent/descriptor/test_se_atten_v2.py
+++ b/source/tests/consistent/descriptor/test_se_atten_v2.py
@@ -340,7 +340,7 @@ class TestSeAttenV2(CommonTest, DescriptorTest, unittest.TestCase):
         )
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
-        return (ret[0],)
+        return (ret[0], ret[1])
 
     @property
     def rtol(self) -> float:

--- a/source/tests/consistent/descriptor/test_se_e2_a.py
+++ b/source/tests/consistent/descriptor/test_se_e2_a.py
@@ -259,7 +259,7 @@ class TestSeA(CommonTest, DescriptorTest, unittest.TestCase):
         )
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
-        return (ret[0],)
+        return (ret[0], ret[1])
 
     @property
     def rtol(self) -> float:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test methods in multiple descriptor test files to return two-element tuples instead of single-element tuples
	- Modified `build_tf_descriptor` method to include rotation matrix in the return value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->