### PR TITLE
use variable to store the bias of atomic polarizability

### DIFF
--- a/deepmd/dpmodel/fitting/polarizability_fitting.py
+++ b/deepmd/dpmodel/fitting/polarizability_fitting.py
@@ -195,7 +195,6 @@ class PolarFitting(GeneralFitting):
         data["shift_diag"] = self.shift_diag
         data["@variables"]["scale"] = to_numpy_array(self.scale)
         data["@variables"]["constant_matrix"] = to_numpy_array(self.constant_matrix)
-        data["@variables"].pop("bias_atom_e")
         return data
 
     @classmethod

--- a/deepmd/dpmodel/fitting/polarizability_fitting.py
+++ b/deepmd/dpmodel/fitting/polarizability_fitting.py
@@ -195,6 +195,7 @@ class PolarFitting(GeneralFitting):
         data["shift_diag"] = self.shift_diag
         data["@variables"]["scale"] = to_numpy_array(self.scale)
         data["@variables"]["constant_matrix"] = to_numpy_array(self.constant_matrix)
+        data["@variables"].pop("bias_atom_e")
         return data
 
     @classmethod

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -575,7 +575,9 @@ class PolarFittingSeA(Fitting):
                     graph, f"fitting_attr{suffix}/t_bias_atom_polar"
                 )
             except GraphWithoutTensorError:
-                warnings.warn("You are trying to read a model trained with shift_diag=True, but the mean of the diagonal terms of the polarizability is not stored in the graph. This will lead to wrong inference results. You may train your model with the latest DeePMD-kit to avoid this issue.")
+                warnings.warn(
+                    "You are trying to read a model trained with shift_diag=True, but the mean of the diagonal terms of the polarizability is not stored in the graph. This will lead to wrong inference results. You may train your model with the latest DeePMD-kit to avoid this issue."
+                )
                 pass
 
     def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -576,7 +576,8 @@ class PolarFittingSeA(Fitting):
                 )
             except GraphWithoutTensorError:
                 warnings.warn(
-                    "You are trying to read a model trained with shift_diag=True, but the mean of the diagonal terms of the polarizability is not stored in the graph. This will lead to wrong inference results. You may train your model with the latest DeePMD-kit to avoid this issue."
+                    "You are trying to read a model trained with shift_diag=True, but the mean of the diagonal terms of the polarizability is not stored in the graph. This will lead to wrong inference results. You may train your model with the latest DeePMD-kit to avoid this issue.",
+                    stacklevel=2
                 )
 
     def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -640,6 +640,9 @@ class PolarFittingSeA(Fitting):
                 variables=self.fitting_net_variables,
                 suffix=suffix,
             ),
+            "@variables": {
+                "bias_atom_polar": self.bias_atom_polar.reshape(-1),
+            },
             "type_map": self.type_map,
         }
         return data
@@ -667,6 +670,7 @@ class PolarFittingSeA(Fitting):
             data["nets"],
             suffix=suffix,
         )
+        fitting.bias_atom_polar = data["@variables"]["bias_atom_polar"].ravel()
         return fitting
 
 

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -667,7 +667,6 @@ class PolarFittingSeA(Fitting):
         Model
             The deserialized model
         """
-        print("executing deserialize")
         data = data.copy()
         check_version_compatibility(
             data.pop("@version", 1), 4, 1

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -437,7 +437,6 @@ class PolarFittingSeA(Fitting):
         start_index = 0
 
         with tf.variable_scope("fitting_attr" + suffix, reuse=reuse):
-            # self.t_bias_atom_polar = tf.constant(self.constant_matrix, name="t_bias_atom_polar", dtype=GLOBAL_TF_FLOAT_PRECISION)
             self.t_bias_atom_polar = tf.get_variable(
                 "t_bias_atom_polar",
                 self.constant_matrix.shape,
@@ -522,7 +521,6 @@ class PolarFittingSeA(Fitting):
                 sel_type_idx = self.sel_type.index(type_i)
                 final_layer = final_layer * self.scale[sel_type_idx]
                 final_layer = final_layer + tf.slice(self.t_bias_atom_polar, [sel_type_idx], [1]) * tf.eye(
-                # final_layer = final_layer + self.constant_matrix[sel_type_idx] * tf.eye(
                     3,
                     batch_shape=[tf.shape(inputs)[0], natoms[2 + type_i]],
                     dtype=GLOBAL_TF_FLOAT_PRECISION,

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -571,7 +571,8 @@ class PolarFittingSeA(Fitting):
                     graph, f"fitting_attr{suffix}/t_bias_atom_polar"
                 )
             except GraphWithoutTensorError:
-                raise RuntimeError("No bias_atom_polar in the graph.")
+                warnings.warn("You are trying to read a model trained with shift_diag=True, but the mean of the diagonal terms of the polarizability is not stored in the graph. This will lead to wrong inference results. You may train your model with the latest DeePMD-kit to avoid this issue.")
+                pass
 
     def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:
         """Receive the mixed precision setting.

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -578,7 +578,6 @@ class PolarFittingSeA(Fitting):
                 warnings.warn(
                     "You are trying to read a model trained with shift_diag=True, but the mean of the diagonal terms of the polarizability is not stored in the graph. This will lead to wrong inference results. You may train your model with the latest DeePMD-kit to avoid this issue."
                 )
-                pass
 
     def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:
         """Receive the mixed precision setting.

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -466,7 +466,7 @@ class PolarFittingSeA(Fitting):
                 # nframes x nloc_masked
                 constant_matrix = tf.reshape(
                     tf.reshape(
-                        tf.tile(tf.repeat(self.constant_matrix, natoms[2:]), [nframes]),
+                        tf.tile(tf.repeat(self.t_bias_atom_polar, natoms[2:]), [nframes]),
                         [nframes, -1],
                     )[nloc_mask],
                     [nframes, -1],

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -521,8 +521,8 @@ class PolarFittingSeA(Fitting):
                 # shift and scale
                 sel_type_idx = self.sel_type.index(type_i)
                 final_layer = final_layer * self.scale[sel_type_idx]
-                # final_layer = final_layer + tf.slice(self.t_bias_atom_polar, [sel_type_idx], [1]) * tf.eye(
-                final_layer = final_layer + self.constant_matrix[sel_type_idx] * tf.eye(
+                final_layer = final_layer + tf.slice(self.t_bias_atom_polar, [sel_type_idx], [1]) * tf.eye(
+                # final_layer = final_layer + self.constant_matrix[sel_type_idx] * tf.eye(
                     3,
                     batch_shape=[tf.shape(inputs)[0], natoms[2 + type_i]],
                     dtype=GLOBAL_TF_FLOAT_PRECISION,
@@ -569,15 +569,13 @@ class PolarFittingSeA(Fitting):
         self.fitting_net_variables = get_fitting_net_variables_from_graph_def(
             graph_def, suffix=suffix
         )
-        try:
-            self.bias_atom_polar = get_tensor_by_name_from_graph(
-                graph, f"fitting_attr{suffix}/t_bias_atom_polar"
-            )
-        except GraphWithoutTensorError:
-            raise RuntimeError("No bias_atom_polar in the graph.")
-            # print("No bias_atom_polar in the graph.")
-            # for compatibility, old models has no t_bias_atom_e
-            # pass
+        if self.shift_diag
+            try:
+                self.bias_atom_polar = get_tensor_by_name_from_graph(
+                    graph, f"fitting_attr{suffix}/t_bias_atom_polar"
+                )
+            except GraphWithoutTensorError:
+                raise RuntimeError("No bias_atom_polar in the graph.")
 
     def enable_mixed_precision(self, mixed_prec: Optional[dict] = None) -> None:
         """Receive the mixed precision setting.

--- a/source/tests/consistent/common.py
+++ b/source/tests/consistent/common.py
@@ -354,6 +354,9 @@ class CommonTest(ABC):
         data1.pop("@version")
         data2.pop("@version")
 
+        if tf_obj.__class__.__name__.startswith("Polar"):
+            data1["@variables"].pop("bias_atom_e")
+
         np.testing.assert_equal(data1, data2)
         for rr1, rr2 in zip(ret1, ret2):
             np.testing.assert_allclose(


### PR DESCRIPTION
This PR fixes #4559.
It uses variable to store the bias of atomic polarizability, which is the mean of the diagonal terms of the polarizability tensor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
	- Enhanced core processing reliability with improved error management and resource consistency, leading to more stable model performance during inference.
- Tests
	- Refined internal validation checks to better support advanced configurations and ensure consistent outcomes.

These improvements contribute to a more robust and reliable experience for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->