### PR TITLE
fix: throw exception in consumer thread

### DIFF
--- a/deepmd/pd/utils/dataloader.py
+++ b/deepmd/pd/utils/dataloader.py
@@ -258,11 +258,13 @@ class BackgroundConsumer(Thread):
         self._max_len = max_len  #
 
     def run(self) -> None:
-        for item in self._source:
-            self._queue.put(item)  # Blocking if the queue is full
-
-        # Signal the consumer we are done.
-        self._queue.put(_sentinel)
+        try:
+            for item in self._source:
+                self._queue.put(item)  # Blocking if the queue is full
+        except Exception as e:
+            self._queue.put(e)
+        else:
+            self._queue.put(StopIteration())
 
 
 class BufferedIterator:

--- a/deepmd/pt/utils/dataloader.py
+++ b/deepmd/pt/utils/dataloader.py
@@ -218,11 +218,13 @@ class BackgroundConsumer(Thread):
         self._source = source  # Main DL iterator
 
     def run(self) -> None:
-        for item in self._source:
-            self._queue.put(item)  # Blocking if the queue is full
-
-        # Signal the consumer we are done; this should not happen for DataLoader
-        self._queue.put(StopIteration())
+        try:
+            for item in self._source:
+                self._queue.put(item)  # Blocking if the queue is full
+        except Exception as e:
+            self._queue.put(e)
+        else:
+            self._queue.put(StopIteration())
 
 
 QUEUESIZE = 32


### PR DESCRIPTION
This pull request includes changes to improve error handling in the `dataloader.py` files for both `deepmd/pd/utils` and `deepmd/pt/utils`. The most important changes are the addition of a try-except block to handle exceptions during the data loading process and signaling the end of iteration properly.

Error handling improvements:

* [`deepmd/pd/utils/dataloader.py`](diffhunk://#diff-9739b359f76568c738a7f8df9a0235879c2b9dd166975323e328747bb065022eR261-R267): Added a try-except block to catch exceptions during the iteration over the data source, and modified the signaling of the end of iteration to use `StopIteration()`.
* [`deepmd/pt/utils/dataloader.py`](diffhunk://#diff-0f565156af2bed1d158fe99e5b06ec50ec97ed7de45fb8e0f1144dc40f74f17dR221-R226): Added a try-except block to catch exceptions during the iteration over the data source, and ensured the end of iteration is signaled with `StopIteration()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Improved robustness in background data processing. Errors encountered during data loading are now explicitly reported, and process completion is clearly signaled, ensuring more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->