### PR TITLE
fix: print summary on local_rank=0

### DIFF
--- a/deepmd/pd/entrypoints/main.py
+++ b/deepmd/pd/entrypoints/main.py
@@ -46,6 +46,7 @@ from deepmd.pd.utils.dataloader import (
 )
 from deepmd.pd.utils.env import (
     DEVICE,
+    LOCAL_RANK,
 )
 from deepmd.pd.utils.finetune import (
     get_finetune_rules,
@@ -232,7 +233,8 @@ def train(
     output: str = "out.json",
 ) -> None:
     log.info("Configuration path: %s", input_file)
-    SummaryPrinter()()
+    if LOCAL_RANK == 0:
+        SummaryPrinter()()
     with open(input_file) as fin:
         config = json.load(fin)
     # ensure suffix, as in the command line help, we say "path prefix of checkpoint files"

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -61,6 +61,7 @@ from deepmd.pt.utils.dataloader import (
 )
 from deepmd.pt.utils.env import (
     DEVICE,
+    LOCAL_RANK,
 )
 from deepmd.pt.utils.finetune import (
     get_finetune_rules,
@@ -254,7 +255,8 @@ def train(
     output: str = "out.json",
 ) -> None:
     log.info("Configuration path: %s", input_file)
-    SummaryPrinter()()
+    if LOCAL_RANK == 0:
+        SummaryPrinter()()
     with open(input_file) as fin:
         config = json.load(fin)
     # ensure suffix, as in the command line help, we say "path prefix of checkpoint files"


### PR DESCRIPTION
fix #4595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved training summary display in distributed environments. Now, only the main process outputs the training summary, ensuring clearer and more concise logging without duplicate information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->