### PR TITLE
feat(pt): add `trainable` to property fitting

### DIFF
--- a/deepmd/pt/model/task/property.py
+++ b/deepmd/pt/model/task/property.py
@@ -2,6 +2,7 @@
 import logging
 from typing import (
     Optional,
+    Union,
 )
 
 import torch
@@ -88,6 +89,7 @@ class PropertyFittingNet(InvarFitting):
         activation_function: str = "tanh",
         precision: str = DEFAULT_PRECISION,
         mixed_types: bool = True,
+        trainable: Union[bool, list[bool]] = True,
         seed: Optional[int] = None,
         **kwargs,
     ) -> None:
@@ -107,6 +109,7 @@ class PropertyFittingNet(InvarFitting):
             activation_function=activation_function,
             precision=precision,
             mixed_types=mixed_types,
+            trainable=trainable,
             seed=seed,
             **kwargs,
         )

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -1580,6 +1580,9 @@ def fitting_property():
     doc_task_dim = "The dimension of outputs of fitting net"
     doc_intensive = "Whether the fitting property is intensive"
     doc_property_name = "The names of fitting property, which should be consistent with the property name in the dataset."
+    doc_trainable = "Whether the parameters in the fitting net are trainable. This option can be\n\n\
+- bool: True if all parameters of the fitting net are trainable, False otherwise.\n\n\
+- list of bool: Specifies if each layer is trainable. Since the fitting net is composed by hidden layers followed by a output layer, the length of this list should be equal to len(`neuron`)+1."
     return [
         Argument("numb_fparam", int, optional=True, default=0, doc=doc_numb_fparam),
         Argument("numb_aparam", int, optional=True, default=0, doc=doc_numb_aparam),
@@ -1615,6 +1618,13 @@ def fitting_property():
             str,
             optional=False,
             doc=doc_property_name,
+        ),
+        Argument(
+            "trainable",
+            [list[bool], bool],
+            optional=True,
+            default=True,
+            doc=doc_trainable,
         ),
     ]
 


### PR DESCRIPTION
Add keyword `trainable` to property fitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable "trainable" option that allows users to control whether network parameters are updated individually or collectively.

- **Documentation**
  - Enhanced descriptions to clearly explain how the new trainability setting works.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->