### PR TITLE
feat: add input data caching for pytorch dataset

### DIFF
--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -2,8 +2,10 @@
 
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import bisect
-from functools import lru_cache
 import logging
+from functools import (
+    lru_cache,
+)
 from typing import (
     Optional,
 )

--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import bisect
+from functools import lru_cache
 import logging
 from typing import (
     Optional,
@@ -501,6 +502,7 @@ class DeepmdData:
             data["box"] = None
         return data
 
+    @lru_cache(1)
     def _load_set(self, set_name: DPPath):
         # get nframes
         if not isinstance(set_name, DPPath):


### PR DESCRIPTION
The current implementation reads data from set determined by a random index  generated with torch RandomSampler.

However, for a batch size > 1 and system containing few sets, each get data operation will load `coord.npy` file batch_size times. This leads to read amplification.

This PR adds `lru_cache(1)` for `_load_set` method. We set the max cache size to 1 to minimize memory overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optimized data retrieval by caching results for repeated requests, leading to a smoother and faster user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->