### PR TITLE
fix(pt): ensure proper cleanup of distributed process group 

### DIFF
--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -363,6 +363,7 @@ def train(
     if dist.is_available() and dist.is_initialized():
         dist.destroy_process_group()
 
+
 def freeze(
     model: str,
     output: str = "frozen_model.pth",

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -333,9 +333,7 @@ def train(
         json.dump(config, fp, indent=4)
 
     # Initialize DDP
-    local_rank = os.environ.get("LOCAL_RANK")
-    if local_rank is not None:
-        local_rank = int(local_rank)
+    if os.environ.get("LOCAL_RANK") is not None:
         dist.init_process_group(backend="cuda:nccl,cpu:gloo")
 
     trainer = get_trainer(

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -1031,8 +1031,6 @@ class Trainer:
                 log.info(
                     f"The profiling trace have been saved to: {self.profiling_file}"
                 )
-        if dist.is_available() and dist.is_initialized():
-            dist.destroy_process_group()
 
     def save_model(self, save_path, lr=0.0, step=0) -> None:
         module = (

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -1031,6 +1031,8 @@ class Trainer:
                 log.info(
                     f"The profiling trace have been saved to: {self.profiling_file}"
                 )
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
 
     def save_model(self, save_path, lr=0.0, step=0) -> None:
         module = (


### PR DESCRIPTION
There is a warning when DDP training exits normally:

```
[rank0]:[W228 05:53:44.357651908 ProcessGroupNCCL.cpp:1487] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

It is required by PyTorch to cleanup resources after training to ensure a graceful exit.
This PR adds the missing destructor to eliminate the warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the distributed training process by ensuring that resource setup and cleanup occur exclusively during training, leading to more efficient and stable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->