### PR TITLE
fix(jax): fix typo c_differentiable -> r_differentiable

### DIFF
--- a/deepmd/jax/model/base_model.py
+++ b/deepmd/jax/model/base_model.py
@@ -47,7 +47,7 @@ def forward_common_atomic(
             kk_redu = get_reduce_name(kk)
             model_predict[kk_redu] = jnp.sum(vv, axis=atom_axis)
             kk_derv_r, kk_derv_c = get_deriv_name(kk)
-            if vdef.c_differentiable:
+            if vdef.r_differentiable:
 
                 def eval_output(
                     cc_ext,


### PR DESCRIPTION
We haven't met a situation where  c_differentiable != r_differentiable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Refined internal processing to streamline evaluation logic. These improvements optimize back-end calculations while ensuring consistent performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->