### PR TITLE
[pd] Use rc whl instead of dev whl for python cpu test

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -31,7 +31,7 @@ jobs:
         export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
         source/install/uv_with_retry.sh pip install --system -e .[test,jax] mpi4py "jax==0.5.0;python_version>='3.10'"
         source/install/uv_with_retry.sh pip install --system horovod --no-build-isolation
-        source/install/uv_with_retry.sh pip install --system --pre "paddlepaddle" -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
+        source/install/uv_with_retry.sh pip install --system --pre "paddlepaddle==3.0.0rc1" -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
       env:
         # Please note that uv has some issues with finding
         # existing TensorFlow package. Currently, it uses


### PR DESCRIPTION
Use 3.0rc-1 for paddle python ci test as error occurs for dev.2025.3.13 whl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
  - Updated the testing environment’s dependency management to lock a key package to a stable release, ensuring a more consistent and predictable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->