### PR TITLE
CI: remove duration flag from pytest commands in workflows

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -58,7 +58,7 @@ jobs:
         DP_ENABLE_NATIVE_OPTIMIZATION: 1
         DP_ENABLE_PYTORCH: 1
     - run: dp --version
-    - run: python -m pytest source/tests --durations=0
+    - run: python -m pytest source/tests
       env:
         NUM_WORKERS: 0
         CUDA_VISIBLE_DEVICES: 0

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -55,11 +55,11 @@ jobs:
         restore-keys: |
           test2-durations-combined-${{ matrix.python }}-${{ github.sha }}
           test2-durations-combined-${{ matrix.python }}
-    - run: pytest --cov=deepmd source/tests --durations=0 --splits 6 --group ${{ matrix.group }} --store-durations --clean-durations --durations-path=.test_durations --splitting-algorithm least_duration
+    - run: pytest --cov=deepmd source/tests  --splits 6 --group ${{ matrix.group }} --store-durations --clean-durations --durations-path=.test_durations --splitting-algorithm least_duration
       env:
         NUM_WORKERS: 0
     - name: Test TF2 eager mode
-      run: pytest --cov=deepmd --cov-append source/tests/consistent/io/test_io.py source/jax2tf_tests --durations=0
+      run: pytest --cov=deepmd --cov-append source/tests/consistent/io/test_io.py source/jax2tf_tests
       env:
         NUM_WORKERS: 0
         DP_TEST_TF2_ONLY: 1


### PR DESCRIPTION
Current CI command line arguments contains `--durations=0` flag to output execution time of every test case. This will make it difficult to locate the real warning message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal test commands to modify how test durations are reported, simplifying the test output configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->