### PR TITLE
refactor(pd): replace `build_strategy` with `backend` option in `to_static` API

### DIFF
--- a/deepmd/pd/train/training.py
+++ b/deepmd/pd/train/training.py
@@ -636,13 +636,12 @@ class Trainer:
         if CINN:
             from paddle import (
                 jit,
-                static,
             )
 
             backend = "CINN" if CINN else None
-            self.wrapper.forward = jit.to_static(
-                full_graph=True, backend=backend
-            )(self.wrapper.forward)
+            self.wrapper.forward = jit.to_static(full_graph=True, backend=backend)(
+                self.wrapper.forward
+            )
             log.info(
                 "Enable CINN during training, there may be some additional "
                 "compilation time in the first traning step."

--- a/deepmd/pd/train/training.py
+++ b/deepmd/pd/train/training.py
@@ -639,10 +639,9 @@ class Trainer:
                 static,
             )
 
-            build_strategy = static.BuildStrategy()
-            build_strategy.build_cinn_pass: bool = CINN
+            backend = "CINN" if CINN else None
             self.wrapper.forward = jit.to_static(
-                full_graph=True, build_strategy=build_strategy
+                full_graph=True, backend=backend
             )(self.wrapper.forward)
             log.info(
                 "Enable CINN during training, there may be some additional "


### PR DESCRIPTION
In PaddlePaddle 3.0, we recommend to use `backend` option to instead of `build_strategy.build_cinn_pass` to enable our compiler `CINN`.

cc @HydrogenSulfate 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the internal process for selecting the backend during training, reducing complexity while retaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->