### PR TITLE
fix: set fused option for Adam optimizer based on device type

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -594,7 +594,9 @@ class Trainer:
         # author: iProzd
         if self.opt_type == "Adam":
             self.optimizer = torch.optim.Adam(
-                self.wrapper.parameters(), lr=self.lr_exp.start_lr, fused=True
+                self.wrapper.parameters(),
+                lr=self.lr_exp.start_lr,
+                fused=False if DEVICE.type == "cpu" else True,
             )
             if optimizer_state_dict is not None and self.restart_training:
                 self.optimizer.load_state_dict(optimizer_state_dict)


### PR DESCRIPTION
Parsing pytorch version and determining if CPU fused optimizer is supported would be verbose, and the time for optimizer update time is usually much more smaller than forward/backward time when training on CPU. So, this PR disables using fused optimizer for CPU backend.
The issue only affects PyTorch backed.
Fix #4667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted training optimizer behavior to conditionally apply optimal settings based on your device type, helping improve performance on both CPU and non-CPU hardware.
  
- **Refactor**
  - Enhanced code organization for the optimizer setup to boost clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->