### PR TITLE
perf: calculate grad on-the-fly for SiLUT

### DIFF
--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -54,7 +54,7 @@ def silut_double_backward(
     sig = torch.sigmoid(x)
 
     sig_prime = sig * (1 - sig)
-    grad_silu = sig * (1 + x * (1 - sig))
+    grad_silu = sig + x * sig_prime
     grad_grad_silu = sig_prime * (2 + x * (1 - 2 * sig))
 
     # Tanh branch


### PR DESCRIPTION
Current implementation of SiLUT involves one extra storage for saving the 1st-order gradient. This PR reduces the memory footprint by calculating the 1st-order gradient on-the-fly in `silut_double_backward`. It introduces an overhead of ~0.5% of  calculation time.

I've tested this PR on OMat with 9 DPA-3 layers and batch size=auto:512.
| Metric                 | Before   | After    | Improvement |
|------------------------|----------|----------|-------------|
| Peak Memory  | 25.0G    | 21.7G    | -13%         |
| Speed (per 100 steps)  | 30.29s   | 30.46s    | -0.56%       |

The correctness of this modification is covered by `source/tests/pt/test_custom_activation.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal computation logic by refining variable naming for clarity.
  - Updated public method signatures to return outputs in a structured tuple, ensuring more intuitive and consistent integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->