### PR TITLE
fix: fix compatibility with CMake 4.0

### DIFF
--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -52,7 +52,7 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
     - run: |
-         echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/5.3/ jammy main' | sudo tee /etc/apt/sources.list.d/rocm.list \
+         echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/6.3/ jammy main' | sudo tee /etc/apt/sources.list.d/rocm.list \
          && printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600 \
          && curl -s https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add - \
          && sudo apt-get update \

--- a/source/cmake/googletest.cmake.in
+++ b/source/cmake/googletest.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the ROCm dependency configuration to version 6.3 for improved package installation during builds.
	- Raised the minimum build tool version to enable enhanced functionality and better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->