### PR TITLE
pd: update paddlepaddle version to release/3.0

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -51,7 +51,7 @@ jobs:
     - run: |
         export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
         export TENSORFLOW_ROOT=$(python -c 'import importlib,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
-        source/install/uv_with_retry.sh pip install --system "paddlepaddle-gpu==3.0.0" -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
+        pip install "paddlepaddle-gpu==3.0.0" -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
         source/install/uv_with_retry.sh pip install --system -v -e .[gpu,test,lmp,cu12,torch,jax] mpi4py --reinstall-package deepmd-kit
       env:
         DP_VARIANT: cuda

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -51,7 +51,7 @@ jobs:
     - run: |
         export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
         export TENSORFLOW_ROOT=$(python -c 'import importlib,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
-        source/install/uv_with_retry.sh pip install --system --pre https://paddle-whl.bj.bcebos.com/nightly/cu123/paddlepaddle-gpu/paddlepaddle_gpu-3.0.0.dev20241126-cp311-cp311-linux_x86_64.whl
+        source/install/uv_with_retry.sh pip install --system "paddlepaddle-gpu==3.0.0" -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
         source/install/uv_with_retry.sh pip install --system -v -e .[gpu,test,lmp,cu12,torch,jax] mpi4py --reinstall-package deepmd-kit
       env:
         DP_VARIANT: cuda

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -31,7 +31,7 @@ jobs:
         export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
         source/install/uv_with_retry.sh pip install --system -e .[test,jax] mpi4py "jax==0.5.0;python_version>='3.10'"
         source/install/uv_with_retry.sh pip install --system horovod --no-build-isolation
-        source/install/uv_with_retry.sh pip install --system --pre "paddlepaddle==3.0.0rc1" -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
+        source/install/uv_with_retry.sh pip install --system --pre "paddlepaddle==3.0.0" -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
       env:
         # Please note that uv has some issues with finding
         # existing TensorFlow package. Currently, it uses

--- a/backend/find_paddle.py
+++ b/backend/find_paddle.py
@@ -105,7 +105,7 @@ def get_pd_requirement(pd_version: str = "") -> dict:
 
     return {
         "paddle": [
-            "paddlepaddle>=3.0.0b1",
+            "paddlepaddle>=3.0.0",
         ],
     }
 

--- a/doc/install/easy-install.md
+++ b/doc/install/easy-install.md
@@ -190,10 +190,10 @@ Switch to the TensorFlow {{ tensorflow_icon }} tab for more information.
 
 :::::{tab-set}
 
-::::{tab-item} CUDA 12.3
+::::{tab-item} CUDA 12.6
 
 ```bash
-pip install paddlepaddle-gpu==3.0.0rc0 -i https://www.paddlepaddle.org.cn/packages/stable/cu123/
+pip install paddlepaddle-gpu==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
 pip install deepmd-kit
 ```
 
@@ -202,7 +202,7 @@ pip install deepmd-kit
 ::::{tab-item} CUDA 11.8
 
 ```bash
-pip install paddlepaddle-gpu==3.0.0rc0 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
+pip install paddlepaddle-gpu==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
 pip install deepmd-kit
 ```
 
@@ -211,7 +211,7 @@ pip install deepmd-kit
 ::::{tab-item} CPU
 
 ```bash
-pip install paddlepaddle==3.0.0rc0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
+pip install paddlepaddle==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
 pip install deepmd-kit
 ```
 

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -99,11 +99,11 @@ To install Paddle, run
 
 ```sh
 # cu123
-pip install paddlepaddle-gpu==3.0.0rc0 -i https://www.paddlepaddle.org.cn/packages/stable/cu123/
+pip install paddlepaddle-gpu==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
 # cu118
-pip install paddlepaddle-gpu==3.0.0rc0 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
+pip install paddlepaddle-gpu==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
 # cpu
-pip install paddlepaddle==3.0.0rc0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
+pip install paddlepaddle==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
 ```
 
 :::

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -98,7 +98,7 @@ One can also [use conda](https://docs.deepmodeling.org/faq/conda.html) to instal
 To install Paddle, run
 
 ```sh
-# cu123
+# cu126
 pip install paddlepaddle-gpu==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
 # cu118
 pip install paddlepaddle-gpu==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -37,21 +37,23 @@ if(ENABLE_PADDLE)
       find_package(CUDAToolkit REQUIRED)
       string(REGEX MATCH "^[0-9]+" CUDA_MAJOR_VERSION "${CUDAToolkit_VERSION}")
       message(STATUS "Find CUDAToolkit_VERSION: ${CUDAToolkit_VERSION}")
+      # "6ed5dd3" is the commit id of paddle release/3.0, see:
+      # https://github.com/PaddlePaddle/Paddle/tree/v3.0.0
       if(CUDA_MAJOR_VERSION VERSION_EQUAL "11")
         message(
           STATUS
-            "PADDLE_INFERENCE_DIR is not defined, downloading CUDA11.8 infernece lib to: ${CMAKE_BINARY_DIR}/"
+            "PADDLE_INFERENCE_DIR is not defined, downloading CUDA11.8 inference lib to: ${CMAKE_BINARY_DIR}/"
         )
         set(DOWNLOAD_URL
-            "https://paddle-qa.bj.bcebos.com/paddle-pipeline/GITHUB_Docker_Compile_Test_Cuda118_cudnn860_Trt8531_D1/latest/paddle_inference.tgz"
+            "https://paddle-qa.bj.bcebos.com/paddle-pipeline/GITHUB_Docker_Compile_Test_Cuda118_cudnn897_Trt8616_D1/6ed5dd3833c32c3b21e14b1fb1a71f5a535a0fcc/paddle_inference.tgz"
         )
       elseif(CUDA_MAJOR_VERSION VERSION_EQUAL "12")
         message(
           STATUS
-            "PADDLE_INFERENCE_DIR is not defined, downloading CUDA12.3 infernece lib to: ${CMAKE_BINARY_DIR}/"
+            "PADDLE_INFERENCE_DIR is not defined, downloading CUDA12.6 inference lib to: ${CMAKE_BINARY_DIR}/"
         )
         set(DOWNLOAD_URL
-            "https://paddle-qa.bj.bcebos.com/paddle-pipeline/GITHUB_Docker_Compile_Test_Cuda123_cudnn900_Trt8616_D1/latest/paddle_inference.tgz"
+            "https://paddle-qa.bj.bcebos.com/paddle-pipeline/GITHUB_Docker_Compile_Test_Cuda126_cudnn951_Trt105018_D1/6ed5dd3833c32c3b21e14b1fb1a71f5a535a0fcc/paddle_inference.tgz"
         )
       else()
         message(
@@ -62,10 +64,10 @@ if(ENABLE_PADDLE)
     else()
       message(
         STATUS
-          "PADDLE_INFERENCE_DIR is not defined, downloading CPU infernece lib to: ${CMAKE_BINARY_DIR}/"
+          "PADDLE_INFERENCE_DIR is not defined, downloading CPU inference lib to: ${CMAKE_BINARY_DIR}/"
       )
       set(DOWNLOAD_URL
-          "https://paddle-qa.bj.bcebos.com/paddle-pipeline/GITHUB_Docker_Compile_Test_Cpu_Mkl_Avx_D1/latest/paddle_inference.tgz"
+          "https://paddle-qa.bj.bcebos.com/paddle-pipeline/GITHUB_Docker_Compile_Test_Cpu_Mkl_Avx_D1/6ed5dd3833c32c3b21e14b1fb1a71f5a535a0fcc/paddle_inference.tgz"
       )
     endif()
     set(TGZ_FILE "${CMAKE_BINARY_DIR}/paddle_inference.tgz")


### PR DESCRIPTION
Update related document as paddle 3.0 has been released <https://github.com/PaddlePaddle/Paddle/releases/tag/v3.0.0>

TODO: update `paddle_inference_dir` auto download url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised installation instructions to reference the stable PaddlePaddle release (v3.0.0) with updated CUDA version references for GPU and CPU setups.

- **Chores**
  - Updated dependency specifications in continuous integration processes and internal management scripts to use the stable release, ensuring improved consistency and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->