### PR TITLE
feat(pt): add eta message for pt backend

### DIFF
--- a/deepmd/loggers/training.py
+++ b/deepmd/loggers/training.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import datetime
 from typing import (
     Optional,
 )
@@ -7,9 +8,13 @@ from typing import (
 def format_training_message(
     batch: int,
     wall_time: float,
+    eta: Optional[int] = None,
 ) -> str:
     """Format a training message."""
-    return f"batch {batch:7d}: total wall time = {wall_time:.2f} s"
+    msg = f"batch {batch:7d}: total wall time = {wall_time:.2f} s"
+    if isinstance(eta, int):
+        msg += f", eta = {datetime.timedelta(seconds=int(eta))!s}"
+    return msg
 
 
 def format_training_message_per_task(

--- a/deepmd/pd/train/training.py
+++ b/deepmd/pd/train/training.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import datetime
 import functools
 import logging
 import time
@@ -30,6 +29,7 @@ from deepmd.common import (
     symlink_prefix_files,
 )
 from deepmd.loggers.training import (
+    format_training_message,
     format_training_message_per_task,
 )
 from deepmd.pd.loss import (
@@ -77,22 +77,6 @@ from deepmd.utils.path import (
 )
 
 log = logging.getLogger(__name__)
-
-from typing import (
-    Optional,
-)
-
-
-def format_training_message(
-    batch: int,
-    wall_time: float,
-    eta: Optional[int] = None,
-):
-    """Format a training message."""
-    msg = f"batch {batch:7d}: total wall time = {wall_time:.2f} s"
-    if isinstance(eta, int):
-        msg += f", eta = {datetime.timedelta(seconds=int(eta))!s}"
-    return msg
 
 
 class Trainer:
@@ -863,7 +847,7 @@ class Trainer:
                 self.t0 = current_time
                 if self.rank == 0 and self.timing_in_training:
                     eta = int(
-                        (self.num_steps - _step_id - 1) / self.disp_freq * train_time
+                        (self.num_steps - display_step_id) / self.disp_freq * train_time
                     )
                     log.info(
                         format_training_message(

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -899,10 +899,14 @@ class Trainer:
                 train_time = current_time - self.t0
                 self.t0 = current_time
                 if self.rank == 0 and self.timing_in_training:
+                    eta = int(
+                        (self.num_steps - display_step_id) / self.disp_freq * train_time
+                    )
                     log.info(
                         format_training_message(
                             batch=display_step_id,
                             wall_time=train_time,
+                            eta=eta,
                         )
                     )
                 # the first training time is not accurate


### PR DESCRIPTION
add Estimated Time of Arrival for pytorch backend which is convenient when training model(to avoid affecting performance, synchronization was not used for timing, so it will not be very precise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Training progress messages now optionally display an estimated time of arrival (ETA) for completion, providing users with clearer expectations during training.
- **Improvements**
  - Enhanced accuracy of ETA calculations in training logs for better progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->