### PR TITLE
Chore(pt): add `--model-branch` as alias

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -330,9 +330,10 @@ def main_parser() -> argparse.ArgumentParser:
     )
     parser_frz.add_argument(
         "--head",
+        "--model-branch",
         default=None,
         type=str,
-        help="(Supported backend: PyTorch) Task head to freeze if in multi-task mode.",
+        help="(Supported backend: PyTorch) Task head (alias: model branch) to freeze if in multi-task mode.",
     )
 
     # * test script ********************************************************************
@@ -409,9 +410,10 @@ def main_parser() -> argparse.ArgumentParser:
     )
     parser_tst.add_argument(
         "--head",
+        "--model-branch",
         default=None,
         type=str,
-        help="(Supported backend: PyTorch) Task head to test if in multi-task mode.",
+        help="(Supported backend: PyTorch) Task head (alias: model branch) to test if in multi-task mode.",
     )
 
     # * compress model *****************************************************************

--- a/source/tests/pd/test_dp_show.py
+++ b/source/tests/pd/test_dp_show.py
@@ -148,7 +148,7 @@ class TestMultiTaskModel(unittest.TestCase):
         )
         trainer = get_trainer(deepcopy(self.config), shared_links=self.shared_links)
         trainer.run()
-        run_dp("dp --pd freeze --head model_1")
+        run_dp("dp --pd freeze --model-branch model_1")
 
     def test_checkpoint(self):
         INPUT = "model.ckpt.pd"

--- a/source/tests/pt/test_dp_show.py
+++ b/source/tests/pt/test_dp_show.py
@@ -140,7 +140,7 @@ class TestMultiTaskModel(unittest.TestCase):
         )
         trainer = get_trainer(deepcopy(self.config), shared_links=self.shared_links)
         trainer.run()
-        run_dp("dp --pt freeze --head model_1")
+        run_dp("dp --pt freeze --model-branch model_1")
 
     def test_checkpoint(self) -> None:
         INPUT = "model.ckpt.pt"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command-line option alias, `--model-branch`, for the `--head` argument in the "freeze" and "test" subcommands. Both options can now be used interchangeably.

- **Tests**
  - Updated tests to use the new `--model-branch` argument in command-line examples, ensuring compatibility with the updated interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->