### PR TITLE
feat: use bfloat16 with `torch.autocast` on training

### DIFF
--- a/deepmd/pt/model/descriptor/repflow_layer.py
+++ b/deepmd/pt/model/descriptor/repflow_layer.py
@@ -682,7 +682,6 @@ class RepFlowLayer(torch.nn.Module):
                     )
                 )
 
-            a_sw.to(edge_angle_update.dtype)
             # nb x nloc x a_nnei x a_nnei x e_dim
             weighted_edge_angle_update = (
                 a_sw[..., None, None] * a_sw[..., None, :, None] * edge_angle_update

--- a/deepmd/pt/model/descriptor/repflow_layer.py
+++ b/deepmd/pt/model/descriptor/repflow_layer.py
@@ -424,7 +424,7 @@ class RepFlowLayer(torch.nn.Module):
         sub_edge_update_ik = torch.matmul(edge_ebd, sub_edge_ik)
 
         result_update = (
-            bias
+            bias.to(sub_angle_update.dtype)
             + sub_node_update.unsqueeze(2).unsqueeze(3)
             + sub_edge_update_ij.unsqueeze(2)
             + sub_edge_update_ik.unsqueeze(3)
@@ -463,7 +463,10 @@ class RepFlowLayer(torch.nn.Module):
         sub_edge_update = torch.matmul(edge_ebd, edge)
 
         result_update = (
-            bias + sub_node_update.unsqueeze(2) + sub_edge_update + sub_node_ext_update
+            bias.to(sub_node_update.dtype)
+            + sub_node_update.unsqueeze(2)
+            + sub_edge_update
+            + sub_node_ext_update
         )
         return result_update
 
@@ -679,6 +682,7 @@ class RepFlowLayer(torch.nn.Module):
                     )
                 )
 
+            a_sw.to(edge_angle_update.dtype)
             # nb x nloc x a_nnei x a_nnei x e_dim
             weighted_edge_angle_update = (
                 a_sw[..., None, None] * a_sw[..., None, :, None] * edge_angle_update

--- a/deepmd/pt/train/wrapper.py
+++ b/deepmd/pt/train/wrapper.py
@@ -5,6 +5,7 @@ from typing import (
     Union,
 )
 
+from deepmd.pt.utils.env import BF16_AUTOCAST
 import torch
 
 if torch.__version__.startswith("2"):
@@ -136,7 +137,7 @@ class ModelWrapper(torch.nn.Module):
                             f"Shared params of {model_key_base}.{class_type_base} and {model_key_link}.{class_type_link}!"
                         )
 
-    @torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True)
+    @torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=BF16_AUTOCAST)
     def forward(
         self,
         coord,

--- a/deepmd/pt/train/wrapper.py
+++ b/deepmd/pt/train/wrapper.py
@@ -5,8 +5,11 @@ from typing import (
     Union,
 )
 
-from deepmd.pt.utils.env import BF16_AUTOCAST
 import torch
+
+from deepmd.pt.utils.env import (
+    BF16_AUTOCAST,
+)
 
 if torch.__version__.startswith("2"):
     import torch._dynamo

--- a/deepmd/pt/train/wrapper.py
+++ b/deepmd/pt/train/wrapper.py
@@ -136,6 +136,7 @@ class ModelWrapper(torch.nn.Module):
                             f"Shared params of {model_key_base}.{class_type_base} and {model_key_link}.{class_type_link}!"
                         )
 
+    @torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True)
     def forward(
         self,
         coord,

--- a/deepmd/pt/utils/env.py
+++ b/deepmd/pt/utils/env.py
@@ -35,6 +35,7 @@ JIT = False
 CACHE_PER_SYS = 5  # keep at most so many sets per sys in memory
 ENERGY_BIAS_TRAINABLE = True
 CUSTOM_OP_USE_JIT = False
+BF16_AUTOCAST = False
 
 PRECISION_DICT = {
     "float16": torch.float16,
@@ -76,6 +77,7 @@ if intra_nthreads > 0:
     torch.set_num_threads(intra_nthreads)
 
 __all__ = [
+    "BF16_AUTOCAST",
     "CACHE_PER_SYS",
     "CUSTOM_OP_USE_JIT",
     "DEFAULT_PRECISION",

--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -93,7 +93,7 @@ class SiLUTScript(torch.nn.Module):
                 ctx.threshold = threshold
                 ctx.slope = slope
                 ctx.const_val = const_val
-                return silut_forward_script(x, threshold, slope, const_val)
+                return silut_forward_script(x, threshold, slope, const_val).to(x.dtype)
 
             @staticmethod
             def backward(ctx, grad_output):


### PR DESCRIPTION
This PR adds feature using `torch.autocast` with the accuracy of `torch.bfloat16` when training on nvidia GPUs.
By adding the decorator to `ModelWrapper.forward`, torch downcasts the data type for tensor computing and storage. This change expects a **37% peak memory reduction** compared with training under float32.

Todo:
- [x] Evaluate the impact on accuracy.
- [x] Make it configurable.

Note: 
- The element-wise operations of pytorch automatically upcast to the highest accuracy of the operands. Changes in `repflow_layer.py` makes the function output matches with the input if the input tensor is downcasted, even if tensors of higher accuracy like the parameters are involved.
- For unknown reasons, the `silut_forward_script` function fails to keep the data type of the output tensor as `bfloat16` when input tensor is of that type. Using raw silut function or using `torch.compile` can avoid the problem, so I believe the problem is related to `torch.jit.script`. So I have to manually cast the output data type to match with the input tensor.

Test results:
I trained 1 million steps on mptrj dataset, and the result shows that training under BF16 somehow affects the accuracy. This observation is consistent with other MLIP models: when training under BF16 accuracy, it might requires more training steps, and followed by fine-tuning in FP32 to keep the accuracy.

| Metric                        | BF16                     | FP32                     |
|-------------------------------|--------------------------|--------------------------|
| Energy MAE (eV)               | 8.649451 × 10^-1         | 8.084421 × 10^-1         |
| Energy RMSE (eV)              | 1.931963 × 10^0          | 1.765754 × 10^0          |
| Energy MAE/Natoms (eV)        | 3.495069 × 10^-2         | 3.300770 × 10^-2         |
| Energy RMSE/Natoms (eV)       | 8.879076 × 10^-2         | 8.778768 × 10^-2         |
| Force MAE (eV/Å)              | 1.158567 × 10^-1         | 1.103375 × 10^-1         |
| Force RMSE (eV/Å)             | 3.550471 × 10^-1         | 3.164068 × 10^-1         |
| Virial MAE (eV)               | 1.111046 × 10^0          | 1.051787 × 10^0          |
| Virial RMSE (eV)              | 3.856514 × 10^0          | 3.535781 × 10^0          |
| Virial MAE/Natoms (eV)        | 4.698042 × 10^-2         | 4.510412 × 10^-2         |
| Virial RMSE/Natoms (eV)       | 1.490477 × 10^-1         | 1.467897 × 10^-1         |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved consistency of tensor data types during computations to prevent potential errors and ensure reliable results.
	- Ensured output tensors maintain the same data type as inputs for consistent processing.

- **New Features**
	- Enabled automatic mixed precision with bfloat16 precision on CUDA devices for enhanced performance during model execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->