### PR TITLE
perf: gather node embedding before matmul

### DIFF
--- a/deepmd/pt/model/descriptor/repflow_layer.py
+++ b/deepmd/pt/model/descriptor/repflow_layer.py
@@ -455,10 +455,10 @@ class RepFlowLayer(torch.nn.Module):
 
         # nf * nloc * node/edge_dim
         sub_node_update = torch.matmul(node_ebd, node)
-        # nf * nall * node/edge_dim
-        sub_node_ext_update = torch.matmul(node_ebd_ext, node_ext)
         # nf * nloc * nnei * node/edge_dim
-        sub_node_ext_update = _make_nei_g1(sub_node_ext_update, nlist)
+        gathered_node_ebd_ext = _make_nei_g1(node_ebd_ext, nlist)
+        # nf * nloc * nnei * node/edge_dim
+        sub_node_ext_update = torch.matmul(gathered_node_ebd_ext, node_ext)
         # nf * nloc * nnei * node/edge_dim
         sub_edge_update = torch.matmul(edge_ebd, edge)
 


### PR DESCRIPTION
`node_ebd_ext` contains embedding on expanded atoms, which might be large for a large cut-off. Current implementation do matmul first, then gather tensor by the neighbors. This introduces saving `sub_node_ext_update` of size `nf * nall * ndim` in each repflow layer, where `nall` might be multiple times larger than `nloc`.
This PR do gathering first, then compute matmul. After this PR, the peak memory size is of `O(nlayer * nf * nloc + 1* nf*nall)`. I've tested that the `sub_node_ext_update` calculated by those two methods are numerically equal.