### PR TITLE
perf: use einsum to calculate virial

### DIFF
--- a/deepmd/pd/model/model/transform_output.py
+++ b/deepmd/pd/model/model/transform_output.py
@@ -82,7 +82,9 @@ def task_deriv_one(
     assert extended_force is not None
     extended_force = -extended_force
     if do_virial:
-        extended_virial = extended_force.unsqueeze(-1) @ extended_coord.unsqueeze(-2)
+        extended_virial = paddle.einsum(
+            "...ik,...ij->...ikj", extended_force, extended_coord
+        )
         # the correction sums to zero, which does not contribute to global virial
         if do_atomic_virial:
             extended_virial_corr = atomic_virial_corr(extended_coord, atom_energy)

--- a/deepmd/pt/model/model/transform_output.py
+++ b/deepmd/pt/model/model/transform_output.py
@@ -85,7 +85,7 @@ def task_deriv_one(
     assert extended_force is not None
     extended_force = -extended_force
     if do_virial:
-        extended_virial = extended_force.unsqueeze(-1) @ extended_coord.unsqueeze(-2)
+        extended_virial = torch.einsum("...ik,...ij->...ikj", extended_force, extended_coord)
         # the correction sums to zero, which does not contribute to global virial
         if do_atomic_virial:
             extended_virial_corr = atomic_virial_corr(extended_coord, atom_energy)


### PR DESCRIPTION
By profiling results, using `@ matmul` creates 7 matmul to complete this operation, which are time-consuming. `einsum` only requires one matmul.
This optimization benefits smaller batch size and model.

<details><summary>Profiling results on PyTorch</summary>
<p>

<img width="788" alt="image" src="https://github.com/user-attachments/assets/ed7c05f5-aa47-4e20-acd4-32c5a5fd63ee" />
<img width="348" alt="image" src="https://github.com/user-attachments/assets/d348196a-65b0-48ec-af18-0fd4399268c2" />

---

<img width="407" alt="image" src="https://github.com/user-attachments/assets/17502003-e497-464e-bf04-d4509de691de" />


</p>
</details> 
