### PR TITLE
perf: use torch.topk to construct nlist

### DIFF
--- a/deepmd/pt/utils/nlist.py
+++ b/deepmd/pt/utils/nlist.py
@@ -119,7 +119,9 @@ def build_neighbor_list(
     rr = torch.linalg.norm(diff, dim=-1)
     # if central atom has two zero distances, sorting sometimes can not exclude itself
     rr -= torch.eye(nloc, nall, dtype=rr.dtype, device=rr.device).unsqueeze(0)
-    rr, nlist = torch.sort(rr, dim=-1)
+    nsel = sum(sel)
+    nnei = rr.shape[-1]
+    rr, nlist = torch.topk(rr, min(nsel, nnei), largest=False)
     # nloc x (nall-1)
     rr = rr[:, :, 1:]
     nlist = nlist[:, :, 1:]


### PR DESCRIPTION
This pull request updates the `build_neighbor_list` function in `deepmd/pt/utils/nlist.py` to improve its performance and correctness when selecting neighbors. The key change involves replacing `torch.sort` with `torch.topk` to optimize the selection of the nearest neighbors.

<details><summary>Details</summary>
<p>
Before: 16.4ms
<img width="495" alt="image" src="https://github.com/user-attachments/assets/e6b0c091-b11b-491a-b2fd-e0aadc6c35ba" />

After: 3.4ms
<img width="303" alt="image" src="https://github.com/user-attachments/assets/81931c76-60eb-46a5-9934-0d837b954df9" />

Step time goes from 212.5ms to 200.5ms, ~5% speed-up.

</p>
</details> 