### PR TITLE
fix(dpmodel): fix energy loss

### DIFF
--- a/deepmd/dpmodel/loss/ener.py
+++ b/deepmd/dpmodel/loss/ener.py
@@ -189,9 +189,7 @@ class EnergyLoss(Loss):
                     delta=self.huber_delta,
                 )
                 loss += pref_f * l_huber_loss
-            more_loss["rmse_f"] = self.display_if_exist(
-                l2_force_loss, find_force
-            )
+            more_loss["rmse_f"] = self.display_if_exist(l2_force_loss, find_force)
         if self.has_v:
             virial_reshape = xp.reshape(virial, [-1])
             virial_hat_reshape = xp.reshape(virial_hat, [-1])
@@ -207,9 +205,7 @@ class EnergyLoss(Loss):
                     delta=self.huber_delta,
                 )
                 loss += pref_v * l_huber_loss
-            more_loss["rmse_v"] = self.display_if_exist(
-                l2_virial_loss, find_virial
-            )
+            more_loss["rmse_v"] = self.display_if_exist(l2_virial_loss, find_virial)
         if self.has_ae:
             atom_ener_reshape = xp.reshape(atom_ener, [-1])
             atom_ener_hat_reshape = xp.reshape(atom_ener_hat, [-1])
@@ -256,9 +252,7 @@ class EnergyLoss(Loss):
                 + (self.start_pref_gf - self.limit_pref_gf) * lr_ratio
             )
             loss += pref_gf * l2_gen_force_loss
-            more_loss["rmse_gf"] = self.display_if_exist(
-                l2_gen_force_loss, find_drdq
-            )
+            more_loss["rmse_gf"] = self.display_if_exist(l2_gen_force_loss, find_drdq)
 
         self.l2_l = loss
         more_loss["rmse"] = xp.sqrt(loss)

--- a/deepmd/dpmodel/loss/ener.py
+++ b/deepmd/dpmodel/loss/ener.py
@@ -177,7 +177,7 @@ class EnergyLoss(Loss):
                     delta=self.huber_delta,
                 )
                 loss += pref_e * l_huber_loss
-            more_loss["l2_ener_loss"] = self.display_if_exist(l2_ener_loss, find_energy)
+            more_loss["rmse_e"] = self.display_if_exist(l2_ener_loss, find_energy)
         if self.has_f:
             l2_force_loss = xp.mean(xp.square(diff_f))
             if not self.use_huber:
@@ -189,7 +189,7 @@ class EnergyLoss(Loss):
                     delta=self.huber_delta,
                 )
                 loss += pref_f * l_huber_loss
-            more_loss["l2_force_loss"] = self.display_if_exist(
+            more_loss["rmse_f"] = self.display_if_exist(
                 l2_force_loss, find_force
             )
         if self.has_v:
@@ -207,7 +207,7 @@ class EnergyLoss(Loss):
                     delta=self.huber_delta,
                 )
                 loss += pref_v * l_huber_loss
-            more_loss["l2_virial_loss"] = self.display_if_exist(
+            more_loss["rmse_v"] = self.display_if_exist(
                 l2_virial_loss, find_virial
             )
         if self.has_ae:
@@ -225,7 +225,7 @@ class EnergyLoss(Loss):
                     delta=self.huber_delta,
                 )
                 loss += pref_ae * l_huber_loss
-            more_loss["l2_atom_ener_loss"] = self.display_if_exist(
+            more_loss["rmse_ae"] = self.display_if_exist(
                 l2_atom_ener_loss, find_atom_ener
             )
         if self.has_pf:
@@ -234,7 +234,7 @@ class EnergyLoss(Loss):
                 xp.multiply(xp.square(diff_f), atom_pref_reshape),
             )
             loss += pref_pf * l2_pref_force_loss
-            more_loss["l2_pref_force_loss"] = self.display_if_exist(
+            more_loss["rmse_pf"] = self.display_if_exist(
                 l2_pref_force_loss, find_atom_pref
             )
         if self.has_gf:
@@ -256,11 +256,12 @@ class EnergyLoss(Loss):
                 + (self.start_pref_gf - self.limit_pref_gf) * lr_ratio
             )
             loss += pref_gf * l2_gen_force_loss
-            more_loss["l2_gen_force_loss"] = self.display_if_exist(
+            more_loss["rmse_gf"] = self.display_if_exist(
                 l2_gen_force_loss, find_drdq
             )
 
         self.l2_l = loss
+        more_loss["rmse"] = xp.sqrt(loss)
         self.l2_more = more_loss
         return loss, more_loss
 

--- a/deepmd/dpmodel/loss/ener.py
+++ b/deepmd/dpmodel/loss/ener.py
@@ -93,10 +93,10 @@ class EnergyLoss(Loss):
         label_dict: dict[str, np.ndarray],
     ) -> dict[str, np.ndarray]:
         """Calculate loss from model results and labeled results."""
-        energy = model_dict["energy"]
-        force = model_dict["force"]
-        virial = model_dict["virial"]
-        atom_ener = model_dict["atom_ener"]
+        energy = model_dict["energy_redu"]
+        force = model_dict["energy_derv_r"]
+        virial = model_dict["energy_derv_c_redu"]
+        atom_ener = model_dict["energy"]
         energy_hat = label_dict["energy"]
         force_hat = label_dict["force"]
         virial_hat = label_dict["virial"]
@@ -268,57 +268,52 @@ class EnergyLoss(Loss):
     def label_requirement(self) -> list[DataRequirementItem]:
         """Return data label requirements needed for this loss calculation."""
         label_requirement = []
-        if self.has_e:
-            label_requirement.append(
-                DataRequirementItem(
-                    "energy",
-                    ndof=1,
-                    atomic=False,
-                    must=False,
-                    high_prec=True,
-                )
+        label_requirement.append(
+            DataRequirementItem(
+                "energy",
+                ndof=1,
+                atomic=False,
+                must=False,
+                high_prec=True,
             )
-        if self.has_f:
-            label_requirement.append(
-                DataRequirementItem(
-                    "force",
-                    ndof=3,
-                    atomic=True,
-                    must=False,
-                    high_prec=False,
-                )
+        )
+        label_requirement.append(
+            DataRequirementItem(
+                "force",
+                ndof=3,
+                atomic=True,
+                must=False,
+                high_prec=False,
             )
-        if self.has_v:
-            label_requirement.append(
-                DataRequirementItem(
-                    "virial",
-                    ndof=9,
-                    atomic=False,
-                    must=False,
-                    high_prec=False,
-                )
+        )
+        label_requirement.append(
+            DataRequirementItem(
+                "virial",
+                ndof=9,
+                atomic=False,
+                must=False,
+                high_prec=False,
             )
-        if self.has_ae:
-            label_requirement.append(
-                DataRequirementItem(
-                    "atom_ener",
-                    ndof=1,
-                    atomic=True,
-                    must=False,
-                    high_prec=False,
-                )
+        )
+        label_requirement.append(
+            DataRequirementItem(
+                "atom_ener",
+                ndof=1,
+                atomic=True,
+                must=False,
+                high_prec=False,
             )
-        if self.has_pf:
-            label_requirement.append(
-                DataRequirementItem(
-                    "atom_pref",
-                    ndof=1,
-                    atomic=True,
-                    must=False,
-                    high_prec=False,
-                    repeat=3,
-                )
+        )
+        label_requirement.append(
+            DataRequirementItem(
+                "atom_pref",
+                ndof=1,
+                atomic=True,
+                must=False,
+                high_prec=False,
+                repeat=3,
             )
+        )
         if self.has_gf > 0:
             label_requirement.append(
                 DataRequirementItem(

--- a/source/tests/consistent/loss/test_ener.py
+++ b/source/tests/consistent/loss/test_ener.py
@@ -108,6 +108,12 @@ class TestEner(CommonTest, LossTest, unittest.TestCase):
                 )
             ),
         }
+        self.predict_dpmodel_style = {
+            "energy_derv_c_redu": self.predict["virial"],
+            "energy_derv_r": self.predict["force"],
+            "energy_redu": self.predict["energy"],
+            "energy": self.predict["atom_ener"],
+        }
         self.label = {
             "energy": rng.random((self.nframes,)),
             "force": rng.random((self.nframes, self.natoms, 3)),
@@ -187,12 +193,12 @@ class TestEner(CommonTest, LossTest, unittest.TestCase):
         return dp_obj(
             self.learning_rate,
             self.natoms,
-            self.predict,
+            self.predict_dpmodel_style,
             self.label,
         )
 
     def eval_jax(self, jax_obj: Any) -> Any:
-        predict = {kk: jnp.asarray(vv) for kk, vv in self.predict.items()}
+        predict = {kk: jnp.asarray(vv) for kk, vv in self.predict_dpmodel_style.items()}
         label = {kk: jnp.asarray(vv) for kk, vv in self.label.items()}
 
         loss, more_loss = jax_obj(
@@ -206,7 +212,10 @@ class TestEner(CommonTest, LossTest, unittest.TestCase):
         return loss, more_loss
 
     def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
-        predict = {kk: array_api_strict.asarray(vv) for kk, vv in self.predict.items()}
+        predict = {
+            kk: array_api_strict.asarray(vv)
+            for kk, vv in self.predict_dpmodel_style.items()
+        }
         label = {kk: array_api_strict.asarray(vv) for kk, vv in self.label.items()}
 
         loss, more_loss = array_api_strict_obj(


### PR DESCRIPTION
1. dpmodel has different model output keys;
2. in the current code, energy, force, virial, etc are necessary keys.
3. update more_loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted internal handling and reporting of energy, force, virial, and atomic energy loss metrics for improved clarity and consistency.
- **Tests**
  - Updated test cases to align with the new prediction key structure, ensuring continued accuracy and reliability of energy loss evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->