### PR TITLE
pd: revert einsum to matmul for paddle backend

### DIFF
--- a/deepmd/pd/model/model/transform_output.py
+++ b/deepmd/pd/model/model/transform_output.py
@@ -82,9 +82,7 @@ def task_deriv_one(
     assert extended_force is not None
     extended_force = -extended_force
     if do_virial:
-        extended_virial = paddle.einsum(
-            "...ik,...ij->...ikj", extended_force, extended_coord
-        )
+        extended_virial = extended_force.unsqueeze(-1) @ extended_coord.unsqueeze(-2)
         # the correction sums to zero, which does not contribute to global virial
         if do_atomic_virial:
             extended_virial_corr = atomic_virial_corr(extended_coord, atom_energy)


### PR DESCRIPTION
revert einsum to matmul for paddle backend as einsum may not trigger infermeta error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal computation method for certain tensor operations to enhance performance and maintainability. No changes to user-facing features or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->