### PR TITLE
docs: fix PyTorch compression command

### DIFF
--- a/doc/freeze/compress.md
+++ b/doc/freeze/compress.md
@@ -77,7 +77,7 @@ dp compress -i graph.pb -o graph-compress.pb
 :::{tab-item} PyTorch {{ pytorch_icon }}
 
 ```bash
-dp compress -i model.pth -o model-compress.pth
+dp --pt compress -i model.pth -o model-compress.pth
 ```
 
 :::


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the command example for compressing a PyTorch model to explicitly include the `--pt` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->