### PR TITLE
perf: avoid graph break for SiLUT when inferring

### DIFF
--- a/deepmd/pt/utils/utils.py
+++ b/deepmd/pt/utils/utils.py
@@ -149,13 +149,10 @@ class SiLUT(torch.nn.Module):
         self.const = float(silu(threshold))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        silu_part = F.silu(x)
-        mask = x >= self.threshold
-        if torch.any(mask):
-            tanh_part = torch.tanh(self.slope * (x - self.threshold)) + self.const
-            return torch.where(x < self.threshold, silu_part, tanh_part)
-        else:
-            return silu_part
+        sig = torch.sigmoid(x)
+        silu = x * sig
+        tanh = torch.tanh(self.slope * (x - self.threshold)) + self.const
+        return torch.where(x >= self.threshold, tanh, silu)
 
 
 class ActivationFn(torch.nn.Module):


### PR DESCRIPTION
This pull request simplifies and optimizes the implementation of the `forward` method in the `ActivationFn` class within `deepmd/pt/utils/utils.py`. The changes streamline the logic by removing unnecessary condition checks and directly using `torch.where` for computation.

I've evaluated this change using inference efficiency tasks from LAMBench with DPA 3.1 3M model.

| System            | Before: Avg Time ± Std (s) | After: Avg Time ± Std (s) | Speedup | Success Rate |
|-------------------|---------------------------|--------------------------|---------|--------------|
| `catalysts_500.traj` | 211.82 ± 19.31           | **196.14 ± 18.11**       | +7.1%   | 100.0%       |
| `inorganic_500.traj` | 204.62 ± 40.22           | **191.20 ± 36.44**       | +6.4%   | 100.0%       |