### PR TITLE
fix(dpmodel/pt/pd/jax): pass trainable to layer & support JAX trainable & support TF tensor fitting trainable

### DIFF
--- a/deepmd/dpmodel/descriptor/dpa1.py
+++ b/deepmd/dpmodel/descriptor/dpa1.py
@@ -319,6 +319,7 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
             trainable_ln=trainable_ln,
             ln_eps=ln_eps,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.use_econf_tebd = use_econf_tebd
         self.use_tebd_bias = use_tebd_bias
@@ -333,6 +334,7 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.tebd_dim = tebd_dim
         self.concat_output_tebd = concat_output_tebd
@@ -691,6 +693,7 @@ class DescrptBlockSeAtten(NativeOP, DescriptorBlock):
         ln_eps: Optional[float] = 1e-5,
         smooth: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         self.rcut = rcut
         self.rcut_smth = rcut_smth
@@ -741,6 +744,7 @@ class DescrptBlockSeAtten(NativeOP, DescriptorBlock):
             self.resnet_dt,
             self.precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.embeddings = embeddings
         if self.tebd_input_mode in ["strip"]:
@@ -756,6 +760,7 @@ class DescrptBlockSeAtten(NativeOP, DescriptorBlock):
                 self.resnet_dt,
                 self.precision,
                 seed=child_seed(seed, 1),
+                trainable=trainable,
             )
             self.embeddings_strip = embeddings_strip
         else:
@@ -774,6 +779,7 @@ class DescrptBlockSeAtten(NativeOP, DescriptorBlock):
             smooth=self.smooth,
             precision=self.precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
 
         wanted_shape = (self.ntypes, self.nnei, 4)
@@ -1186,6 +1192,7 @@ class NeighborGatedAttention(NativeOP):
         smooth: bool = True,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a neighbor-wise attention net."""
         super().__init__()
@@ -1219,6 +1226,7 @@ class NeighborGatedAttention(NativeOP):
                 smooth=smooth,
                 precision=precision,
                 seed=child_seed(seed, ii),
+                trainable=trainable,
             )
             for ii in range(layer_num)
         ]
@@ -1314,6 +1322,7 @@ class NeighborGatedAttentionLayer(NativeOP):
         smooth: bool = True,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a neighbor-wise attention layer."""
         super().__init__()
@@ -1340,6 +1349,7 @@ class NeighborGatedAttentionLayer(NativeOP):
             smooth=smooth,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.attn_layer_norm = LayerNorm(
             self.embed_dim,
@@ -1420,6 +1430,7 @@ class GatedAttentionLayer(NativeOP):
         smooth: bool = True,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a multi-head neighbor-wise attention net."""
         super().__init__()
@@ -1449,6 +1460,7 @@ class GatedAttentionLayer(NativeOP):
             use_timestep=False,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.out_proj = NativeLayer(
             hidden_dim,
@@ -1457,6 +1469,7 @@ class GatedAttentionLayer(NativeOP):
             use_timestep=False,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
 
     def call(self, query, nei_mask, input_r=None, sw=None, attnw_shift=20.0):

--- a/deepmd/dpmodel/descriptor/dpa2.py
+++ b/deepmd/dpmodel/descriptor/dpa2.py
@@ -474,6 +474,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
             smooth=smooth,
             type_one_side=self.repinit_args.type_one_side,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.use_three_body = self.repinit_args.use_three_body
         if self.use_three_body:
@@ -493,6 +494,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
                 resnet_dt=self.repinit_args.resnet_dt,
                 smooth=smooth,
                 seed=child_seed(seed, 5),
+                trainable=trainable,
             )
         else:
             self.repinit_three_body = None
@@ -533,6 +535,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
             g1_out_mlp=self.repformer_args.g1_out_mlp,
             ln_eps=self.repformer_args.ln_eps,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.rcsl_list = [
             (self.repformers.get_rcut(), self.repformers.get_nsel()),
@@ -562,6 +565,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision
@@ -585,6 +589,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
                 bias=False,
                 precision=precision,
                 seed=child_seed(seed, 3),
+                trainable=trainable,
             )
         self.tebd_transform = None
         if self.add_tebd_to_repinit_out:
@@ -594,6 +599,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
                 bias=False,
                 precision=precision,
                 seed=child_seed(seed, 4),
+                trainable=trainable,
             )
         assert self.repinit.rcut > self.repformers.rcut
         assert self.repinit.sel[0] > self.repformers.sel[0]

--- a/deepmd/dpmodel/descriptor/dpa3.py
+++ b/deepmd/dpmodel/descriptor/dpa3.py
@@ -357,6 +357,7 @@ class DescrptDPA3(NativeOP, BaseDescriptor):
             env_protection=env_protection,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
 
         self.use_econf_tebd = use_econf_tebd
@@ -374,6 +375,7 @@ class DescrptDPA3(NativeOP, BaseDescriptor):
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision

--- a/deepmd/dpmodel/descriptor/repflows.py
+++ b/deepmd/dpmodel/descriptor/repflows.py
@@ -167,6 +167,8 @@ class DescrptBlockRepflows(NativeOP, DescriptorBlock):
         For example, when using paddings, there may be zero distances of neighbors, which may make division by zero error during environment matrix calculations without protection.
     seed : int, optional
         Random seed for parameter initialization.
+    trainable : bool, default: True
+        Whether the block is trainable
     """
 
     def __init__(
@@ -205,6 +207,7 @@ class DescrptBlockRepflows(NativeOP, DescriptorBlock):
         sel_reduce_factor: float = 10.0,
         use_loc_mapping: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.e_rcut = float(e_rcut)
@@ -269,10 +272,19 @@ class DescrptBlockRepflows(NativeOP, DescriptorBlock):
         self.seed = seed
 
         self.edge_embd = NativeLayer(
-            1, self.e_dim, precision=precision, seed=child_seed(seed, 0)
+            1,
+            self.e_dim,
+            precision=precision,
+            seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.angle_embd = NativeLayer(
-            1, self.a_dim, precision=precision, bias=False, seed=child_seed(seed, 1)
+            1,
+            self.a_dim,
+            precision=precision,
+            bias=False,
+            seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         layers = []
         for ii in range(nlayers):
@@ -304,6 +316,7 @@ class DescrptBlockRepflows(NativeOP, DescriptorBlock):
                     sel_reduce_factor=self.sel_reduce_factor,
                     smooth_edge_update=self.smooth_edge_update,
                     seed=child_seed(child_seed(seed, 1), ii),
+                    trainable=trainable,
                 )
             )
         self.layers = layers
@@ -860,6 +873,7 @@ class RepFlowLayer(NativeOP):
         update_residual_init: str = "const",
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.epsilon = 1e-4  # protection of 1./nnei
@@ -922,6 +936,7 @@ class RepFlowLayer(NativeOP):
             n_dim,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.n_residual.append(
@@ -931,6 +946,7 @@ class RepFlowLayer(NativeOP):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 1),
+                    trainable=trainable,
                 )
             )
 
@@ -941,6 +957,7 @@ class RepFlowLayer(NativeOP):
             n_dim,
             precision=precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.n_residual.append(
@@ -950,6 +967,7 @@ class RepFlowLayer(NativeOP):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 3),
+                    trainable=trainable,
                 )
             )
 
@@ -959,6 +977,7 @@ class RepFlowLayer(NativeOP):
             self.n_multi_edge_message * n_dim,
             precision=precision,
             seed=child_seed(seed, 4),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             for head_index in range(self.n_multi_edge_message):
@@ -969,6 +988,7 @@ class RepFlowLayer(NativeOP):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(child_seed(seed, 5), head_index),
+                        trainable=trainable,
                     )
                 )
 
@@ -978,6 +998,7 @@ class RepFlowLayer(NativeOP):
             e_dim,
             precision=precision,
             seed=child_seed(seed, 6),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.e_residual.append(
@@ -987,6 +1008,7 @@ class RepFlowLayer(NativeOP):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 7),
+                    trainable=trainable,
                 )
             )
 
@@ -1015,6 +1037,7 @@ class RepFlowLayer(NativeOP):
                         precision=precision,
                         bias=False,
                         seed=child_seed(seed, 8),
+                        trainable=trainable,
                     )
                     self.a_compress_e_linear = NativeLayer(
                         self.e_dim,
@@ -1022,6 +1045,7 @@ class RepFlowLayer(NativeOP):
                         precision=precision,
                         bias=False,
                         seed=child_seed(seed, 9),
+                        trainable=trainable,
                     )
                 else:
                     self.a_compress_n_linear = None
@@ -1033,12 +1057,14 @@ class RepFlowLayer(NativeOP):
                 self.e_dim,
                 precision=precision,
                 seed=child_seed(seed, 10),
+                trainable=trainable,
             )
             self.edge_angle_linear2 = NativeLayer(
                 self.e_dim,
                 self.e_dim,
                 precision=precision,
                 seed=child_seed(seed, 11),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.e_residual.append(
@@ -1048,6 +1074,7 @@ class RepFlowLayer(NativeOP):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 12),
+                        trainable=trainable,
                     )
                 )
 
@@ -1057,6 +1084,7 @@ class RepFlowLayer(NativeOP):
                 self.a_dim,
                 precision=precision,
                 seed=child_seed(seed, 13),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.a_residual.append(
@@ -1066,6 +1094,7 @@ class RepFlowLayer(NativeOP):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 14),
+                        trainable=trainable,
                     )
                 )
         else:

--- a/deepmd/dpmodel/descriptor/se_e2_a.py
+++ b/deepmd/dpmodel/descriptor/se_e2_a.py
@@ -207,6 +207,7 @@ class DescrptSeA(NativeOP, BaseDescriptor):
                 self.resnet_dt,
                 self.precision,
                 seed=child_seed(seed, ii),
+                trainable=trainable,
             )
         self.embeddings = embeddings
         self.env_mat = EnvMat(self.rcut, self.rcut_smth, protection=self.env_protection)

--- a/deepmd/dpmodel/descriptor/se_r.py
+++ b/deepmd/dpmodel/descriptor/se_r.py
@@ -166,6 +166,7 @@ class DescrptSeR(NativeOP, BaseDescriptor):
                 self.resnet_dt,
                 self.precision,
                 seed=child_seed(seed, ii),
+                trainable=trainable,
             )
         self.embeddings = embeddings
         self.env_mat = EnvMat(self.rcut, self.rcut_smth, protection=self.env_protection)

--- a/deepmd/dpmodel/descriptor/se_t.py
+++ b/deepmd/dpmodel/descriptor/se_t.py
@@ -147,6 +147,7 @@ class DescrptSeT(NativeOP, BaseDescriptor):
                 self.resnet_dt,
                 self.precision,
                 seed=child_seed(self.seed, ii),
+                trainable=trainable,
             )
         self.embeddings = embeddings
         self.env_mat = EnvMat(self.rcut, self.rcut_smth, protection=self.env_protection)

--- a/deepmd/dpmodel/descriptor/se_t_tebd.py
+++ b/deepmd/dpmodel/descriptor/se_t_tebd.py
@@ -157,6 +157,7 @@ class DescrptSeTTebd(NativeOP, BaseDescriptor):
             env_protection=env_protection,
             smooth=smooth,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.use_econf_tebd = use_econf_tebd
         self.type_map = type_map
@@ -171,6 +172,7 @@ class DescrptSeTTebd(NativeOP, BaseDescriptor):
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.tebd_dim = tebd_dim
         self.concat_output_tebd = concat_output_tebd
@@ -497,6 +499,7 @@ class DescrptBlockSeTTebd(NativeOP, DescriptorBlock):
         env_protection: float = 0.0,
         smooth: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         self.rcut = rcut
         self.rcut_smth = rcut_smth
@@ -542,6 +545,7 @@ class DescrptBlockSeTTebd(NativeOP, DescriptorBlock):
             self.resnet_dt,
             self.precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.embeddings = embeddings
         if self.tebd_input_mode in ["strip"]:
@@ -557,6 +561,7 @@ class DescrptBlockSeTTebd(NativeOP, DescriptorBlock):
                 self.resnet_dt,
                 self.precision,
                 seed=child_seed(seed, 1),
+                trainable=trainable,
             )
             self.embeddings_strip = embeddings_strip
         else:

--- a/deepmd/dpmodel/fitting/general_fitting.py
+++ b/deepmd/dpmodel/fitting/general_fitting.py
@@ -198,6 +198,7 @@ class GeneralFitting(NativeOP, BaseFitting):
                     self.precision,
                     bias_out=True,
                     seed=child_seed(seed, ii),
+                    trainable=trainable,
                 )
                 for ii in range(self.ntypes if not self.mixed_types else 1)
             ],

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -690,10 +690,12 @@ def make_embedding_network(T_Network, T_NetworkLayer):
             precision: str = DEFAULT_PRECISION,
             seed: Optional[Union[int, list[int]]] = None,
             bias: bool = True,
-            trainable: bool = True,
+            trainable: Union[bool, list[bool]] = True,
         ) -> None:
             layers = []
             i_in = in_dim
+            if isinstance(trainable, bool):
+                trainable = [trainable] * len(neuron)
             for idx, ii in enumerate(neuron):
                 i_ot = ii
                 layers.append(
@@ -706,7 +708,7 @@ def make_embedding_network(T_Network, T_NetworkLayer):
                         resnet=True,
                         precision=precision,
                         seed=child_seed(seed, idx),
-                        trainable=trainable,
+                        trainable=trainable[idx],
                     ).serialize()
                 )
                 i_in = i_ot
@@ -797,8 +799,10 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
             precision: str = DEFAULT_PRECISION,
             bias_out: bool = True,
             seed: Optional[Union[int, list[int]]] = None,
-            trainable: bool = True,
+            trainable: Optional[list[bool]] = None,
         ) -> None:
+            if trainable is None:
+                trainable = [True] * (len(neuron) + 1)
             super().__init__(
                 in_dim,
                 neuron=neuron,
@@ -806,7 +810,7 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
                 resnet_dt=resnet_dt,
                 precision=precision,
                 seed=seed,
-                trainable=trainable,
+                trainable=trainable[:-1],
             )
             i_in = neuron[-1] if len(neuron) > 0 else in_dim
             i_ot = out_dim
@@ -820,7 +824,7 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
                     resnet=False,
                     precision=precision,
                     seed=child_seed(seed, len(neuron)),
-                    trainable=trainable,
+                    trainable=trainable[-1],
                 )
             )
             self.out_dim = out_dim

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -806,7 +806,7 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
             elif isinstance(trainable, bool):
                 trainable = [trainable] * (len(neuron) + 1)
             else:
-                trainable = trainable
+                pass
             super().__init__(
                 in_dim,
                 neuron=neuron,

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -799,10 +799,10 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
             precision: str = DEFAULT_PRECISION,
             bias_out: bool = True,
             seed: Optional[Union[int, list[int]]] = None,
-            trainable: Optional[list[bool]] = None,
+            trainable: Union[bool, list[bool]] = True,
         ) -> None:
-            if trainable is None:
-                trainable = [True] * (len(neuron) + 1)
+            if isinstance(trainable, bool):
+                trainable = [trainable] * (len(neuron) + 1)
             super().__init__(
                 in_dim,
                 neuron=neuron,

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -144,7 +144,7 @@ class NativeLayer(NativeOP):
         }
         return {
             "@class": "Layer",
-            "@version": 1,
+            "@version": 2,
             "bias": self.b is not None,
             "use_timestep": self.idt is not None,
             "activation_function": self.activation_function,
@@ -165,7 +165,7 @@ class NativeLayer(NativeOP):
             The dict to deserialize from.
         """
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 1, 1)
+        check_version_compatibility(data.pop("@version", 1), 2, 1)
         data.pop("@class", None)
         variables = data.pop("@variables")
         assert variables["w"] is not None and len(variables["w"].shape) == 2

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -801,7 +801,9 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
             seed: Optional[Union[int, list[int]]] = None,
             trainable: Union[bool, list[bool]] = True,
         ) -> None:
-            if isinstance(trainable, bool):
+            if trainable is None:
+                trainable = [True] * (len(neuron) + 1)
+            elif isinstance(trainable, bool):
                 trainable = [trainable] * (len(neuron) + 1)
             super().__init__(
                 in_dim,

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -805,6 +805,8 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
                 trainable = [True] * (len(neuron) + 1)
             elif isinstance(trainable, bool):
                 trainable = [trainable] * (len(neuron) + 1)
+            else:
+                trainable = trainable
             super().__init__(
                 in_dim,
                 neuron=neuron,

--- a/deepmd/dpmodel/utils/network.py
+++ b/deepmd/dpmodel/utils/network.py
@@ -87,6 +87,8 @@ class NativeLayer(NativeOP):
         The precision of the layer.
     seed : int, optional
         Random seed.
+    trainable : bool, default=True
+        Whether the layer is trainable.
     """
 
     def __init__(
@@ -99,7 +101,10 @@ class NativeLayer(NativeOP):
         resnet: bool = False,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
+        # trainable must be set before any array attribute is set
+        self.trainable = trainable
         prec = PRECISION_DICT[precision.lower()]
         self.precision = precision
         # only use_timestep when skip connection is established.
@@ -146,6 +151,7 @@ class NativeLayer(NativeOP):
             "resnet": self.resnet,
             # make deterministic
             "precision": np.dtype(PRECISION_DICT[self.precision]).name,
+            "trainable": self.trainable,
             "@variables": data,
         }
 
@@ -240,6 +246,8 @@ class NativeLayer(NativeOP):
             return self.resnet
         elif key == "precision":
             return self.precision
+        elif key == "trainable":
+            return self.trainable
         else:
             raise KeyError(key)
 
@@ -429,6 +437,7 @@ class LayerNorm(NativeLayer):
             resnet=False,
             precision=precision,
             seed=seed,
+            trainable=trainable,
         )
         xp = array_api_compat.array_namespace(self.w, self.b)
         self.w = xp.squeeze(self.w, 0)  # keep the weight shape to be [num_in]
@@ -681,6 +690,7 @@ def make_embedding_network(T_Network, T_NetworkLayer):
             precision: str = DEFAULT_PRECISION,
             seed: Optional[Union[int, list[int]]] = None,
             bias: bool = True,
+            trainable: bool = True,
         ) -> None:
             layers = []
             i_in = in_dim
@@ -696,6 +706,7 @@ def make_embedding_network(T_Network, T_NetworkLayer):
                         resnet=True,
                         precision=precision,
                         seed=child_seed(seed, idx),
+                        trainable=trainable,
                     ).serialize()
                 )
                 i_in = i_ot
@@ -786,6 +797,7 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
             precision: str = DEFAULT_PRECISION,
             bias_out: bool = True,
             seed: Optional[Union[int, list[int]]] = None,
+            trainable: bool = True,
         ) -> None:
             super().__init__(
                 in_dim,
@@ -794,6 +806,7 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
                 resnet_dt=resnet_dt,
                 precision=precision,
                 seed=seed,
+                trainable=trainable,
             )
             i_in = neuron[-1] if len(neuron) > 0 else in_dim
             i_ot = out_dim
@@ -807,6 +820,7 @@ def make_fitting_network(T_EmbeddingNet, T_Network, T_NetworkLayer):
                     resnet=False,
                     precision=precision,
                     seed=child_seed(seed, len(neuron)),
+                    trainable=trainable,
                 )
             )
             self.out_dim = out_dim

--- a/deepmd/dpmodel/utils/type_embed.py
+++ b/deepmd/dpmodel/utils/type_embed.py
@@ -93,6 +93,7 @@ class TypeEmbedNet(NativeOP):
             self.precision,
             seed=self.seed,
             bias=self.use_tebd_bias,
+            trainable=trainable,
         )
 
     @support_array_api(version="2022.12")

--- a/deepmd/jax/utils/network.py
+++ b/deepmd/jax/utils/network.py
@@ -16,6 +16,7 @@ from deepmd.dpmodel.utils.network import (
     make_multilayer_network,
 )
 from deepmd.jax.common import (
+    ArrayAPIVariable,
     flax_module,
     to_jax_array,
 )
@@ -44,7 +45,10 @@ class NativeLayer(NativeLayerDP):
         if name in {"w", "b", "idt"}:
             value = to_jax_array(value)
             if value is not None:
-                value = ArrayAPIParam(value)
+                if self.trainable:
+                    value = ArrayAPIParam(value)
+                else:
+                    value = ArrayAPIVariable(value)
         return super().__setattr__(name, value)
 
 

--- a/deepmd/pd/model/descriptor/dpa1.py
+++ b/deepmd/pd/model/descriptor/dpa1.py
@@ -292,6 +292,7 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
             trainable_ln=trainable_ln,
             ln_eps=ln_eps,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.use_econf_tebd = use_econf_tebd
         self.use_tebd_bias = use_tebd_bias
@@ -305,6 +306,7 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
             use_econf_tebd=use_econf_tebd,
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
+            trainable=trainable,
         )
         self.prec = PRECISION_DICT[precision]
         self.tebd_dim = tebd_dim

--- a/deepmd/pd/model/descriptor/dpa2.py
+++ b/deepmd/pd/model/descriptor/dpa2.py
@@ -184,6 +184,7 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
             smooth=smooth,
             type_one_side=self.repinit_args.type_one_side,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.use_three_body = self.repinit_args.use_three_body
         if self.use_three_body:
@@ -203,6 +204,7 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
                 resnet_dt=self.repinit_args.resnet_dt,
                 smooth=smooth,
                 seed=child_seed(seed, 5),
+                trainable=trainable,
             )
         else:
             self.repinit_three_body = None
@@ -243,6 +245,7 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
             g1_out_conv=self.repformer_args.g1_out_conv,
             g1_out_mlp=self.repformer_args.g1_out_mlp,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.rcsl_list = [
             (self.repformers.get_rcut(), self.repformers.get_nsel()),
@@ -270,6 +273,7 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
             use_econf_tebd=self.use_econf_tebd,
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
+            trainable=trainable,
         )
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision
@@ -295,6 +299,7 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
                 precision=precision,
                 init="glorot",
                 seed=child_seed(seed, 3),
+                trainable=trainable,
             )
         self.tebd_transform = None
         if self.add_tebd_to_repinit_out:
@@ -304,6 +309,7 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
                 bias=False,
                 precision=precision,
                 seed=child_seed(seed, 4),
+                trainable=trainable,
             )
         assert self.repinit.rcut > self.repformers.rcut
         assert self.repinit.sel[0] > self.repformers.sel[0]

--- a/deepmd/pd/model/descriptor/dpa3.py
+++ b/deepmd/pd/model/descriptor/dpa3.py
@@ -167,6 +167,7 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
             env_protection=env_protection,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
 
         self.use_econf_tebd = use_econf_tebd
@@ -182,6 +183,7 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
             use_econf_tebd=self.use_econf_tebd,
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
+            trainable=trainable,
         )
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision

--- a/deepmd/pd/model/descriptor/repflow_layer.py
+++ b/deepmd/pd/model/descriptor/repflow_layer.py
@@ -61,6 +61,7 @@ class RepFlowLayer(paddle.nn.Layer):
         update_residual_init: str = "const",
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.epsilon = 1e-4  # protection of 1./nnei
@@ -123,6 +124,7 @@ class RepFlowLayer(paddle.nn.Layer):
             n_dim,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.n_residual.append(
@@ -132,6 +134,7 @@ class RepFlowLayer(paddle.nn.Layer):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 1),
+                    trainable=trainable,
                 )
             )
 
@@ -142,6 +145,7 @@ class RepFlowLayer(paddle.nn.Layer):
             n_dim,
             precision=precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.n_residual.append(
@@ -151,6 +155,7 @@ class RepFlowLayer(paddle.nn.Layer):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 3),
+                    trainable=trainable,
                 )
             )
 
@@ -160,6 +165,7 @@ class RepFlowLayer(paddle.nn.Layer):
             self.n_multi_edge_message * n_dim,
             precision=precision,
             seed=child_seed(seed, 4),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             for head_index in range(self.n_multi_edge_message):
@@ -170,6 +176,7 @@ class RepFlowLayer(paddle.nn.Layer):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(child_seed(seed, 5), head_index),
+                        trainable=trainable,
                     )
                 )
 
@@ -179,6 +186,7 @@ class RepFlowLayer(paddle.nn.Layer):
             e_dim,
             precision=precision,
             seed=child_seed(seed, 6),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.e_residual.append(
@@ -188,6 +196,7 @@ class RepFlowLayer(paddle.nn.Layer):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 7),
+                    trainable=trainable,
                 )
             )
 
@@ -216,6 +225,7 @@ class RepFlowLayer(paddle.nn.Layer):
                         precision=precision,
                         bias=False,
                         seed=child_seed(seed, 8),
+                        trainable=trainable,
                     )
                     self.a_compress_e_linear = MLPLayer(
                         self.e_dim,
@@ -223,6 +233,7 @@ class RepFlowLayer(paddle.nn.Layer):
                         precision=precision,
                         bias=False,
                         seed=child_seed(seed, 9),
+                        trainable=trainable,
                     )
                 else:
                     self.a_compress_n_linear = None
@@ -234,12 +245,14 @@ class RepFlowLayer(paddle.nn.Layer):
                 self.e_dim,
                 precision=precision,
                 seed=child_seed(seed, 10),
+                trainable=trainable,
             )
             self.edge_angle_linear2 = MLPLayer(
                 self.e_dim,
                 self.e_dim,
                 precision=precision,
                 seed=child_seed(seed, 11),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.e_residual.append(
@@ -249,6 +262,7 @@ class RepFlowLayer(paddle.nn.Layer):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 12),
+                        trainable=trainable,
                     )
                 )
 
@@ -258,6 +272,7 @@ class RepFlowLayer(paddle.nn.Layer):
                 self.a_dim,
                 precision=precision,
                 seed=child_seed(seed, 13),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.a_residual.append(
@@ -267,6 +282,7 @@ class RepFlowLayer(paddle.nn.Layer):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 14),
+                        trainable=trainable,
                     )
                 )
         else:

--- a/deepmd/pd/model/descriptor/repflows.py
+++ b/deepmd/pd/model/descriptor/repflows.py
@@ -131,6 +131,8 @@ class DescrptBlockRepflows(DescriptorBlock):
         For example, when using paddings, there may be zero distances of neighbors, which may make division by zero error during environment matrix calculations without protection.
     seed : int, optional
         Random seed for parameter initialization.
+    trainable : bool, default: True
+        Whether this block is trainable
     """
 
     def __init__(

--- a/deepmd/pd/model/descriptor/repflows.py
+++ b/deepmd/pd/model/descriptor/repflows.py
@@ -167,6 +167,7 @@ class DescrptBlockRepflows(DescriptorBlock):
         use_loc_mapping: bool = False,
         optim_update: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.e_rcut = float(e_rcut)
@@ -223,10 +224,19 @@ class DescrptBlockRepflows(DescriptorBlock):
         self.seed = seed
 
         self.edge_embd = MLPLayer(
-            1, self.e_dim, precision=precision, seed=child_seed(seed, 0)
+            1,
+            self.e_dim,
+            precision=precision,
+            seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.angle_embd = MLPLayer(
-            1, self.a_dim, precision=precision, bias=False, seed=child_seed(seed, 1)
+            1,
+            self.a_dim,
+            precision=precision,
+            bias=False,
+            seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         layers = []
         for ii in range(nlayers):
@@ -258,6 +268,7 @@ class DescrptBlockRepflows(DescriptorBlock):
                     sel_reduce_factor=self.sel_reduce_factor,
                     smooth_edge_update=self.smooth_edge_update,
                     seed=child_seed(child_seed(seed, 1), ii),
+                    trainable=trainable,
                 )
             )
         self.layers = paddle.nn.LayerList(layers)

--- a/deepmd/pd/model/descriptor/repformer_layer.py
+++ b/deepmd/pd/model/descriptor/repformer_layer.py
@@ -163,6 +163,7 @@ class Atten2Map(paddle.nn.Layer):
         attnw_shift: float = 20.0,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Return neighbor-wise multi-head self-attention maps, with gate mechanism."""
         super().__init__()
@@ -175,6 +176,7 @@ class Atten2Map(paddle.nn.Layer):
             bias=False,
             precision=precision,
             seed=seed,
+            trainable=trainable,
         )
         self.has_gate = has_gate
         self.smooth = smooth
@@ -288,6 +290,7 @@ class Atten2MultiHeadApply(paddle.nn.Layer):
         head_num: int,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.input_dim = input_dim
@@ -298,12 +301,14 @@ class Atten2MultiHeadApply(paddle.nn.Layer):
             bias=False,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.head_map = MLPLayer(
             input_dim * head_num,
             input_dim,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.precision = precision
 
@@ -375,12 +380,18 @@ class Atten2EquiVarApply(paddle.nn.Layer):
         head_num: int,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.input_dim = input_dim
         self.head_num = head_num
         self.head_map = MLPLayer(
-            head_num, 1, bias=False, precision=precision, seed=seed
+            head_num,
+            1,
+            bias=False,
+            precision=precision,
+            seed=seed,
+            trainable=trainable,
         )
         self.precision = precision
 
@@ -448,6 +459,7 @@ class LocalAtten(paddle.nn.Layer):
         attnw_shift: float = 20.0,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.input_dim = input_dim
@@ -459,6 +471,7 @@ class LocalAtten(paddle.nn.Layer):
             bias=False,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.mapkv = MLPLayer(
             input_dim,
@@ -466,12 +479,14 @@ class LocalAtten(paddle.nn.Layer):
             bias=False,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.head_map = MLPLayer(
             input_dim * head_num,
             input_dim,
             precision=precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
         self.smooth = smooth
         self.attnw_shift = attnw_shift
@@ -612,6 +627,7 @@ class RepformerLayer(paddle.nn.Layer):
         g1_out_conv: bool = True,
         g1_out_mlp: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.epsilon = 1e-4  # protection of 1./nnei
@@ -672,6 +688,7 @@ class RepformerLayer(paddle.nn.Layer):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 0),
+                    trainable=trainable,
                 )
             )
 
@@ -681,6 +698,7 @@ class RepformerLayer(paddle.nn.Layer):
             g1_dim,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.linear2 = None
         self.proj_g1g2 = None
@@ -697,6 +715,7 @@ class RepformerLayer(paddle.nn.Layer):
                 g2_dim,
                 precision=precision,
                 seed=child_seed(seed, 2),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g2_residual.append(
@@ -706,6 +725,7 @@ class RepformerLayer(paddle.nn.Layer):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 3),
+                        trainable=trainable,
                     )
                 )
         if self.g1_out_mlp:
@@ -714,6 +734,7 @@ class RepformerLayer(paddle.nn.Layer):
                 g1_dim,
                 precision=precision,
                 seed=child_seed(seed, 15),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g1_residual.append(
@@ -723,6 +744,7 @@ class RepformerLayer(paddle.nn.Layer):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 16),
+                        trainable=trainable,
                     )
                 )
         else:
@@ -735,6 +757,7 @@ class RepformerLayer(paddle.nn.Layer):
                     bias=False,
                     precision=precision,
                     seed=child_seed(seed, 4),
+                    trainable=trainable,
                 )
             else:
                 self.proj_g1g2 = MLPLayer(
@@ -743,6 +766,7 @@ class RepformerLayer(paddle.nn.Layer):
                     bias=False,
                     precision=precision,
                     seed=child_seed(seed, 4),
+                    trainable=trainable,
                 )
                 if self.update_style == "res_residual":
                     self.g1_residual.append(
@@ -752,6 +776,7 @@ class RepformerLayer(paddle.nn.Layer):
                             self.update_residual_init,
                             precision=precision,
                             seed=child_seed(seed, 17),
+                            trainable=trainable,
                         )
                     )
         if self.update_g2_has_g1g1:
@@ -761,6 +786,7 @@ class RepformerLayer(paddle.nn.Layer):
                 bias=False,
                 precision=precision,
                 seed=child_seed(seed, 5),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g2_residual.append(
@@ -770,6 +796,7 @@ class RepformerLayer(paddle.nn.Layer):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 6),
+                        trainable=trainable,
                     )
                 )
         if self.update_g2_has_attn or self.update_h2:
@@ -781,10 +808,15 @@ class RepformerLayer(paddle.nn.Layer):
                 self.smooth,
                 precision=precision,
                 seed=child_seed(seed, 7),
+                trainable=trainable,
             )
             if self.update_g2_has_attn:
                 self.attn2_mh_apply = Atten2MultiHeadApply(
-                    g2_dim, attn2_nhead, precision=precision, seed=child_seed(seed, 8)
+                    g2_dim,
+                    attn2_nhead,
+                    precision=precision,
+                    seed=child_seed(seed, 8),
+                    trainable=trainable,
                 )
                 self.attn2_lm = LayerNorm(
                     g2_dim,
@@ -801,12 +833,17 @@ class RepformerLayer(paddle.nn.Layer):
                             self.update_residual_init,
                             precision=precision,
                             seed=child_seed(seed, 10),
+                            trainable=trainable,
                         )
                     )
 
             if self.update_h2:
                 self.attn2_ev_apply = Atten2EquiVarApply(
-                    g2_dim, attn2_nhead, precision=precision, seed=child_seed(seed, 11)
+                    g2_dim,
+                    attn2_nhead,
+                    precision=precision,
+                    seed=child_seed(seed, 11),
+                    trainable=trainable,
                 )
                 if self.update_style == "res_residual":
                     self.h2_residual.append(
@@ -816,6 +853,7 @@ class RepformerLayer(paddle.nn.Layer):
                             self.update_residual_init,
                             precision=precision,
                             seed=child_seed(seed, 12),
+                            trainable=trainable,
                         )
                     )
         if self.update_g1_has_attn:
@@ -826,6 +864,7 @@ class RepformerLayer(paddle.nn.Layer):
                 self.smooth,
                 precision=precision,
                 seed=child_seed(seed, 13),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g1_residual.append(
@@ -835,6 +874,7 @@ class RepformerLayer(paddle.nn.Layer):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 14),
+                        trainable=trainable,
                     )
                 )
 

--- a/deepmd/pd/model/descriptor/repformers.py
+++ b/deepmd/pd/model/descriptor/repformers.py
@@ -174,6 +174,8 @@ class DescrptBlockRepformers(DescriptorBlock):
             The epsilon value for layer normalization.
         seed : int, optional
             Random seed for parameter initialization.
+        trainable : bool, default: True
+            Whether this block is trainable
         """
         super().__init__()
         self.rcut = float(rcut)

--- a/deepmd/pd/model/descriptor/repformers.py
+++ b/deepmd/pd/model/descriptor/repformers.py
@@ -87,6 +87,7 @@ class DescrptBlockRepformers(DescriptorBlock):
         use_sqrt_nnei: bool = True,
         g1_out_conv: bool = True,
         g1_out_mlp: bool = True,
+        trainable: bool = True,
     ) -> None:
         r"""
         The repformer descriptor block.
@@ -223,7 +224,11 @@ class DescrptBlockRepformers(DescriptorBlock):
         self.seed = seed
 
         self.g2_embd = MLPLayer(
-            1, self.g2_dim, precision=precision, seed=child_seed(seed, 0)
+            1,
+            self.g2_dim,
+            precision=precision,
+            seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         layers = []
         for ii in range(nlayers):
@@ -261,6 +266,7 @@ class DescrptBlockRepformers(DescriptorBlock):
                     g1_out_conv=self.g1_out_conv,
                     g1_out_mlp=self.g1_out_mlp,
                     seed=child_seed(child_seed(seed, 1), ii),
+                    trainable=trainable,
                 )
             )
         self.layers = paddle.nn.LayerList(layers)

--- a/deepmd/pd/model/descriptor/se_a.py
+++ b/deepmd/pd/model/descriptor/se_a.py
@@ -481,6 +481,7 @@ class DescrptBlockSeA(DescriptorBlock):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, ii),
+                trainable=trainable,
             )
         self.filter_layers = filter_layers
         self.stats = None

--- a/deepmd/pd/model/descriptor/se_atten.py
+++ b/deepmd/pd/model/descriptor/se_atten.py
@@ -147,6 +147,8 @@ class DescrptBlockSeAtten(DescriptorBlock):
             If not None, the scaling of attention weights is `temperature` itself.
         seed : int, Optional
             Random seed for parameter initialization.
+        trainable : bool, default: True
+            Whether this block is trainable
         """
         super().__init__()
         del type

--- a/deepmd/pd/model/descriptor/se_atten.py
+++ b/deepmd/pd/model/descriptor/se_atten.py
@@ -81,6 +81,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
         ln_eps: Optional[float] = 1e-5,
         seed: Optional[Union[int, list[int]]] = None,
         type: Optional[str] = None,
+        trainable: bool = True,
     ) -> None:
         r"""Construct an embedding net of type `se_atten`.
 
@@ -205,6 +206,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
             smooth=self.smooth,
             precision=self.precision,
             seed=child_seed(self.seed, 0),
+            trainable=trainable,
         )
 
         wanted_shape = (self.ntypes, self.nnei, 4)
@@ -229,6 +231,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
             precision=self.precision,
             resnet_dt=self.resnet_dt,
             seed=child_seed(self.seed, 1),
+            trainable=trainable,
         )
         self.filter_layers = filter_layers
         if self.tebd_input_mode in ["strip"]:
@@ -242,6 +245,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, 2),
+                trainable=trainable,
             )
             self.filter_layers_strip = filter_layers_strip
         self.stats = None
@@ -655,6 +659,7 @@ class NeighborGatedAttention(nn.Layer):
         smooth: bool = True,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a neighbor-wise attention net."""
         super().__init__()
@@ -690,6 +695,7 @@ class NeighborGatedAttention(nn.Layer):
                     smooth=smooth,
                     precision=precision,
                     seed=child_seed(seed, i),
+                    trainable=trainable,
                 )
             )
         self.attention_layers = nn.LayerList(attention_layers)
@@ -797,6 +803,7 @@ class NeighborGatedAttentionLayer(nn.Layer):
         ln_eps: float = 1e-5,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a neighbor-wise attention layer."""
         super().__init__()
@@ -824,6 +831,7 @@ class NeighborGatedAttentionLayer(nn.Layer):
             smooth=smooth,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.attn_layer_norm = LayerNorm(
             self.embed_dim,
@@ -904,6 +912,7 @@ class GatedAttentionLayer(nn.Layer):
         smooth: bool = True,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a multi-head neighbor-wise attention net."""
         super().__init__()
@@ -936,6 +945,7 @@ class GatedAttentionLayer(nn.Layer):
             stddev=1.0,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.out_proj = MLPLayer(
             hidden_dim,
@@ -946,6 +956,7 @@ class GatedAttentionLayer(nn.Layer):
             stddev=1.0,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
 
     def forward(

--- a/deepmd/pd/model/descriptor/se_t_tebd.py
+++ b/deepmd/pd/model/descriptor/se_t_tebd.py
@@ -160,6 +160,7 @@ class DescrptSeTTebd(BaseDescriptor, paddle.nn.Layer):
             env_protection=env_protection,
             smooth=smooth,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.prec = PRECISION_DICT[precision]
         self.use_econf_tebd = use_econf_tebd
@@ -173,6 +174,7 @@ class DescrptSeTTebd(BaseDescriptor, paddle.nn.Layer):
             use_econf_tebd=use_econf_tebd,
             type_map=type_map,
             use_tebd_bias=use_tebd_bias,
+            trainable=trainable,
         )
         self.tebd_dim = tebd_dim
         self.tebd_input_mode = tebd_input_mode
@@ -529,6 +531,7 @@ class DescrptBlockSeTTebd(DescriptorBlock):
         env_protection: float = 0.0,
         smooth: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.rcut = float(rcut)
@@ -585,6 +588,7 @@ class DescrptBlockSeTTebd(DescriptorBlock):
             precision=self.precision,
             resnet_dt=self.resnet_dt,
             seed=child_seed(self.seed, 1),
+            trainable=trainable,
         )
         self.filter_layers = filter_layers
         if self.tebd_input_mode in ["strip"]:
@@ -598,6 +602,7 @@ class DescrptBlockSeTTebd(DescriptorBlock):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, 2),
+                trainable=trainable,
             )
             self.filter_layers_strip = filter_layers_strip
         self.stats = None

--- a/deepmd/pd/model/network/mlp.py
+++ b/deepmd/pd/model/network/mlp.py
@@ -88,6 +88,7 @@ class MLPLayer(nn.Layer):
         trainable: bool = True,
     ):
         super().__init__()
+        self.trainable = trainable
         # only use_timestep when skip connection is established.
         self.use_timestep = use_timestep and (
             num_out == num_in or num_out == num_in * 2
@@ -252,6 +253,7 @@ class MLPLayer(nn.Layer):
             activation_function=self.activate_name,
             resnet=self.resnet,
             precision=self.precision,
+            trainable=self.trainable,
         )
         nl.w, nl.b, nl.idt = (
             to_numpy_array(self.matrix),

--- a/deepmd/pd/model/network/mlp.py
+++ b/deepmd/pd/model/network/mlp.py
@@ -85,6 +85,7 @@ class MLPLayer(nn.Layer):
         precision: str = DEFAULT_PRECISION,
         init: str = "default",
         seed: int | list[int] | None = None,
+        trainable: bool = True,
     ):
         super().__init__()
         # only use_timestep when skip connection is established.
@@ -277,6 +278,7 @@ class MLPLayer(nn.Layer):
             activation_function=nl["activation_function"],
             resnet=nl["resnet"],
             precision=nl["precision"],
+            trainable=nl["trainable"],
         )
         prec = PRECISION_DICT[obj.precision]
 

--- a/deepmd/pd/model/network/network.py
+++ b/deepmd/pd/model/network/network.py
@@ -197,6 +197,7 @@ class TypeEmbedNetConsistent(nn.Layer):
             self.precision,
             self.seed,
             bias=self.use_tebd_bias,
+            trainable=trainable,
         )
         for param in self.parameters():
             param.stop_gradient = not trainable

--- a/deepmd/pd/model/network/network.py
+++ b/deepmd/pd/model/network/network.py
@@ -45,6 +45,7 @@ class TypeEmbedNet(nn.Layer):
         use_econf_tebd=False,
         use_tebd_bias: bool = False,
         type_map=None,
+        trainable: bool = True,
     ) -> None:
         """Construct a type embedding net."""
         super().__init__()
@@ -65,6 +66,7 @@ class TypeEmbedNet(nn.Layer):
             type_map=type_map,
             precision=precision,
             seed=seed,
+            trainable=trainable,
         )
         # init.normal_(self.embedding.weight[:-1], mean=bavg, std=stddev)
 

--- a/deepmd/pt/model/descriptor/dpa1.py
+++ b/deepmd/pt/model/descriptor/dpa1.py
@@ -298,6 +298,7 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
             trainable_ln=trainable_ln,
             ln_eps=ln_eps,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.use_econf_tebd = use_econf_tebd
         self.use_tebd_bias = use_tebd_bias
@@ -311,6 +312,7 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
             use_econf_tebd=use_econf_tebd,
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
+            trainable=trainable,
         )
         self.prec = PRECISION_DICT[precision]
         self.tebd_dim = tebd_dim

--- a/deepmd/pt/model/descriptor/dpa2.py
+++ b/deepmd/pt/model/descriptor/dpa2.py
@@ -188,6 +188,7 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
             smooth=smooth,
             type_one_side=self.repinit_args.type_one_side,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.use_three_body = self.repinit_args.use_three_body
         if self.use_three_body:
@@ -207,6 +208,7 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
                 resnet_dt=self.repinit_args.resnet_dt,
                 smooth=smooth,
                 seed=child_seed(seed, 5),
+                trainable=trainable,
             )
         else:
             self.repinit_three_body = None
@@ -247,6 +249,7 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
             g1_out_conv=self.repformer_args.g1_out_conv,
             g1_out_mlp=self.repformer_args.g1_out_mlp,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.rcsl_list = [
             (self.repformers.get_rcut(), self.repformers.get_nsel()),
@@ -274,6 +277,7 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
             use_econf_tebd=self.use_econf_tebd,
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
+            trainable=trainable,
         )
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision
@@ -299,6 +303,7 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
                 precision=precision,
                 init="glorot",
                 seed=child_seed(seed, 3),
+                trainable=trainable,
             )
         self.tebd_transform = None
         if self.add_tebd_to_repinit_out:
@@ -308,6 +313,7 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
                 bias=False,
                 precision=precision,
                 seed=child_seed(seed, 4),
+                trainable=trainable,
             )
         assert self.repinit.rcut > self.repformers.rcut
         assert self.repinit.sel[0] > self.repformers.sel[0]

--- a/deepmd/pt/model/descriptor/dpa3.py
+++ b/deepmd/pt/model/descriptor/dpa3.py
@@ -169,6 +169,7 @@ class DescrptDPA3(BaseDescriptor, torch.nn.Module):
             env_protection=env_protection,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
 
         self.use_econf_tebd = use_econf_tebd
@@ -184,6 +185,7 @@ class DescrptDPA3(BaseDescriptor, torch.nn.Module):
             use_econf_tebd=self.use_econf_tebd,
             use_tebd_bias=use_tebd_bias,
             type_map=type_map,
+            trainable=trainable,
         )
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision

--- a/deepmd/pt/model/descriptor/repflow_layer.py
+++ b/deepmd/pt/model/descriptor/repflow_layer.py
@@ -64,6 +64,7 @@ class RepFlowLayer(torch.nn.Module):
         update_residual_init: str = "const",
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.epsilon = 1e-4  # protection of 1./nnei
@@ -126,6 +127,7 @@ class RepFlowLayer(torch.nn.Module):
             n_dim,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.n_residual.append(
@@ -135,6 +137,7 @@ class RepFlowLayer(torch.nn.Module):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 1),
+                    trainable=trainable,
                 )
             )
 
@@ -145,6 +148,7 @@ class RepFlowLayer(torch.nn.Module):
             n_dim,
             precision=precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.n_residual.append(
@@ -154,6 +158,7 @@ class RepFlowLayer(torch.nn.Module):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 3),
+                    trainable=trainable,
                 )
             )
 
@@ -163,6 +168,7 @@ class RepFlowLayer(torch.nn.Module):
             self.n_multi_edge_message * n_dim,
             precision=precision,
             seed=child_seed(seed, 4),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             for head_index in range(self.n_multi_edge_message):
@@ -173,6 +179,7 @@ class RepFlowLayer(torch.nn.Module):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(child_seed(seed, 5), head_index),
+                        trainable=trainable,
                     )
                 )
 
@@ -182,6 +189,7 @@ class RepFlowLayer(torch.nn.Module):
             e_dim,
             precision=precision,
             seed=child_seed(seed, 6),
+            trainable=trainable,
         )
         if self.update_style == "res_residual":
             self.e_residual.append(
@@ -191,6 +199,7 @@ class RepFlowLayer(torch.nn.Module):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 7),
+                    trainable=trainable,
                 )
             )
 
@@ -219,6 +228,7 @@ class RepFlowLayer(torch.nn.Module):
                         precision=precision,
                         bias=False,
                         seed=child_seed(seed, 8),
+                        trainable=trainable,
                     )
                     self.a_compress_e_linear = MLPLayer(
                         self.e_dim,
@@ -226,6 +236,7 @@ class RepFlowLayer(torch.nn.Module):
                         precision=precision,
                         bias=False,
                         seed=child_seed(seed, 9),
+                        trainable=trainable,
                     )
                 else:
                     self.a_compress_n_linear = None
@@ -237,12 +248,14 @@ class RepFlowLayer(torch.nn.Module):
                 self.e_dim,
                 precision=precision,
                 seed=child_seed(seed, 10),
+                trainable=trainable,
             )
             self.edge_angle_linear2 = MLPLayer(
                 self.e_dim,
                 self.e_dim,
                 precision=precision,
                 seed=child_seed(seed, 11),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.e_residual.append(
@@ -252,6 +265,7 @@ class RepFlowLayer(torch.nn.Module):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 12),
+                        trainable=trainable,
                     )
                 )
 
@@ -261,6 +275,7 @@ class RepFlowLayer(torch.nn.Module):
                 self.a_dim,
                 precision=precision,
                 seed=child_seed(seed, 13),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.a_residual.append(
@@ -270,6 +285,7 @@ class RepFlowLayer(torch.nn.Module):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 14),
+                        trainable=trainable,
                     )
                 )
         else:

--- a/deepmd/pt/model/descriptor/repflows.py
+++ b/deepmd/pt/model/descriptor/repflows.py
@@ -219,6 +219,7 @@ class DescrptBlockRepflows(DescriptorBlock):
         use_loc_mapping: bool = True,
         optim_update: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.e_rcut = float(e_rcut)
@@ -283,10 +284,19 @@ class DescrptBlockRepflows(DescriptorBlock):
         self.seed = seed
 
         self.edge_embd = MLPLayer(
-            1, self.e_dim, precision=precision, seed=child_seed(seed, 0)
+            1,
+            self.e_dim,
+            precision=precision,
+            seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.angle_embd = MLPLayer(
-            1, self.a_dim, precision=precision, bias=False, seed=child_seed(seed, 1)
+            1,
+            self.a_dim,
+            precision=precision,
+            bias=False,
+            seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         layers = []
         for ii in range(nlayers):
@@ -318,6 +328,7 @@ class DescrptBlockRepflows(DescriptorBlock):
                     sel_reduce_factor=self.sel_reduce_factor,
                     smooth_edge_update=self.smooth_edge_update,
                     seed=child_seed(child_seed(seed, 1), ii),
+                    trainable=trainable,
                 )
             )
         self.layers = torch.nn.ModuleList(layers)

--- a/deepmd/pt/model/descriptor/repflows.py
+++ b/deepmd/pt/model/descriptor/repflows.py
@@ -181,6 +181,8 @@ class DescrptBlockRepflows(DescriptorBlock):
         For example, when using paddings, there may be zero distances of neighbors, which may make division by zero error during environment matrix calculations without protection.
     seed : int, optional
         Random seed for parameter initialization.
+    trainable : bool, default: True
+        Whether this block is trainable
     """
 
     def __init__(

--- a/deepmd/pt/model/descriptor/repformer_layer.py
+++ b/deepmd/pt/model/descriptor/repformer_layer.py
@@ -160,6 +160,7 @@ class Atten2Map(torch.nn.Module):
         attnw_shift: float = 20.0,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Return neighbor-wise multi-head self-attention maps, with gate mechanism."""
         super().__init__()
@@ -172,6 +173,7 @@ class Atten2Map(torch.nn.Module):
             bias=False,
             precision=precision,
             seed=seed,
+            trainable=trainable,
         )
         self.has_gate = has_gate
         self.smooth = smooth
@@ -285,6 +287,7 @@ class Atten2MultiHeadApply(torch.nn.Module):
         head_num: int,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.input_dim = input_dim
@@ -295,12 +298,14 @@ class Atten2MultiHeadApply(torch.nn.Module):
             bias=False,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.head_map = MLPLayer(
             input_dim * head_num,
             input_dim,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.precision = precision
 
@@ -370,12 +375,18 @@ class Atten2EquiVarApply(torch.nn.Module):
         head_num: int,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.input_dim = input_dim
         self.head_num = head_num
         self.head_map = MLPLayer(
-            head_num, 1, bias=False, precision=precision, seed=seed
+            head_num,
+            1,
+            bias=False,
+            precision=precision,
+            seed=seed,
+            trainable=trainable,
         )
         self.precision = precision
 
@@ -443,6 +454,7 @@ class LocalAtten(torch.nn.Module):
         attnw_shift: float = 20.0,
         precision: str = "float64",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.input_dim = input_dim
@@ -454,6 +466,7 @@ class LocalAtten(torch.nn.Module):
             bias=False,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.mapkv = MLPLayer(
             input_dim,
@@ -461,12 +474,14 @@ class LocalAtten(torch.nn.Module):
             bias=False,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.head_map = MLPLayer(
             input_dim * head_num,
             input_dim,
             precision=precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
         )
         self.smooth = smooth
         self.attnw_shift = attnw_shift
@@ -602,6 +617,7 @@ class RepformerLayer(torch.nn.Module):
         g1_out_conv: bool = True,
         g1_out_mlp: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.epsilon = 1e-4  # protection of 1./nnei
@@ -662,6 +678,7 @@ class RepformerLayer(torch.nn.Module):
                     self.update_residual_init,
                     precision=precision,
                     seed=child_seed(seed, 0),
+                    trainable=trainable,
                 )
             )
 
@@ -671,6 +688,7 @@ class RepformerLayer(torch.nn.Module):
             g1_dim,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.linear2 = None
         self.proj_g1g2 = None
@@ -687,6 +705,7 @@ class RepformerLayer(torch.nn.Module):
                 g2_dim,
                 precision=precision,
                 seed=child_seed(seed, 2),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g2_residual.append(
@@ -696,6 +715,7 @@ class RepformerLayer(torch.nn.Module):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 3),
+                        trainable=trainable,
                     )
                 )
         if self.g1_out_mlp:
@@ -704,6 +724,7 @@ class RepformerLayer(torch.nn.Module):
                 g1_dim,
                 precision=precision,
                 seed=child_seed(seed, 15),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g1_residual.append(
@@ -713,6 +734,7 @@ class RepformerLayer(torch.nn.Module):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 16),
+                        trainable=trainable,
                     )
                 )
         else:
@@ -725,6 +747,7 @@ class RepformerLayer(torch.nn.Module):
                     bias=False,
                     precision=precision,
                     seed=child_seed(seed, 4),
+                    trainable=trainable,
                 )
             else:
                 self.proj_g1g2 = MLPLayer(
@@ -733,6 +756,7 @@ class RepformerLayer(torch.nn.Module):
                     bias=False,
                     precision=precision,
                     seed=child_seed(seed, 4),
+                    trainable=trainable,
                 )
                 if self.update_style == "res_residual":
                     self.g1_residual.append(
@@ -742,6 +766,7 @@ class RepformerLayer(torch.nn.Module):
                             self.update_residual_init,
                             precision=precision,
                             seed=child_seed(seed, 17),
+                            trainable=trainable,
                         )
                     )
         if self.update_g2_has_g1g1:
@@ -751,6 +776,7 @@ class RepformerLayer(torch.nn.Module):
                 bias=False,
                 precision=precision,
                 seed=child_seed(seed, 5),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g2_residual.append(
@@ -760,6 +786,7 @@ class RepformerLayer(torch.nn.Module):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 6),
+                        trainable=trainable,
                     )
                 )
         if self.update_g2_has_attn or self.update_h2:
@@ -771,10 +798,15 @@ class RepformerLayer(torch.nn.Module):
                 self.smooth,
                 precision=precision,
                 seed=child_seed(seed, 7),
+                trainable=trainable,
             )
             if self.update_g2_has_attn:
                 self.attn2_mh_apply = Atten2MultiHeadApply(
-                    g2_dim, attn2_nhead, precision=precision, seed=child_seed(seed, 8)
+                    g2_dim,
+                    attn2_nhead,
+                    precision=precision,
+                    seed=child_seed(seed, 8),
+                    trainable=trainable,
                 )
                 self.attn2_lm = LayerNorm(
                     g2_dim,
@@ -791,12 +823,17 @@ class RepformerLayer(torch.nn.Module):
                             self.update_residual_init,
                             precision=precision,
                             seed=child_seed(seed, 10),
+                            trainable=trainable,
                         )
                     )
 
             if self.update_h2:
                 self.attn2_ev_apply = Atten2EquiVarApply(
-                    g2_dim, attn2_nhead, precision=precision, seed=child_seed(seed, 11)
+                    g2_dim,
+                    attn2_nhead,
+                    precision=precision,
+                    seed=child_seed(seed, 11),
+                    trainable=trainable,
                 )
                 if self.update_style == "res_residual":
                     self.h2_residual.append(
@@ -806,6 +843,7 @@ class RepformerLayer(torch.nn.Module):
                             self.update_residual_init,
                             precision=precision,
                             seed=child_seed(seed, 12),
+                            trainable=trainable,
                         )
                     )
         if self.update_g1_has_attn:
@@ -816,6 +854,7 @@ class RepformerLayer(torch.nn.Module):
                 self.smooth,
                 precision=precision,
                 seed=child_seed(seed, 13),
+                trainable=trainable,
             )
             if self.update_style == "res_residual":
                 self.g1_residual.append(
@@ -825,6 +864,7 @@ class RepformerLayer(torch.nn.Module):
                         self.update_residual_init,
                         precision=precision,
                         seed=child_seed(seed, 14),
+                        trainable=trainable,
                     )
                 )
 

--- a/deepmd/pt/model/descriptor/repformers.py
+++ b/deepmd/pt/model/descriptor/repformers.py
@@ -111,6 +111,7 @@ class DescrptBlockRepformers(DescriptorBlock):
         use_sqrt_nnei: bool = True,
         g1_out_conv: bool = True,
         g1_out_mlp: bool = True,
+        trainable: bool = True,
     ) -> None:
         r"""
         The repformer descriptor block.
@@ -197,6 +198,8 @@ class DescrptBlockRepformers(DescriptorBlock):
             The epsilon value for layer normalization.
         seed : int, optional
             Random seed for parameter initialization.
+        trainable : bool
+            Whether the block is trainable
         """
         super().__init__()
         self.rcut = float(rcut)
@@ -247,7 +250,11 @@ class DescrptBlockRepformers(DescriptorBlock):
         self.seed = seed
 
         self.g2_embd = MLPLayer(
-            1, self.g2_dim, precision=precision, seed=child_seed(seed, 0)
+            1,
+            self.g2_dim,
+            precision=precision,
+            seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         layers = []
         for ii in range(nlayers):
@@ -285,6 +292,7 @@ class DescrptBlockRepformers(DescriptorBlock):
                     g1_out_conv=self.g1_out_conv,
                     g1_out_mlp=self.g1_out_mlp,
                     seed=child_seed(child_seed(seed, 1), ii),
+                    trainable=trainable,
                 )
             )
         self.layers = torch.nn.ModuleList(layers)

--- a/deepmd/pt/model/descriptor/se_a.py
+++ b/deepmd/pt/model/descriptor/se_a.py
@@ -525,6 +525,7 @@ class DescrptBlockSeA(DescriptorBlock):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, ii),
+                trainable=trainable,
             )
         self.filter_layers = filter_layers
         self.stats = None

--- a/deepmd/pt/model/descriptor/se_atten.py
+++ b/deepmd/pt/model/descriptor/se_atten.py
@@ -100,6 +100,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
         ln_eps: Optional[float] = 1e-5,
         seed: Optional[Union[int, list[int]]] = None,
         type: Optional[str] = None,
+        trainable: bool = True,
     ) -> None:
         r"""Construct an embedding net of type `se_atten`.
 
@@ -224,6 +225,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
             smooth=self.smooth,
             precision=self.precision,
             seed=child_seed(self.seed, 0),
+            trainable=trainable,
         )
 
         wanted_shape = (self.ntypes, self.nnei, 4)
@@ -248,6 +250,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
             precision=self.precision,
             resnet_dt=self.resnet_dt,
             seed=child_seed(self.seed, 1),
+            trainable=trainable,
         )
         self.filter_layers = filter_layers
         if self.tebd_input_mode in ["strip"]:
@@ -261,6 +264,7 @@ class DescrptBlockSeAtten(DescriptorBlock):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, 2),
+                trainable=trainable,
             )
             self.filter_layers_strip = filter_layers_strip
         self.stats = None
@@ -680,6 +684,7 @@ class NeighborGatedAttention(nn.Module):
         smooth: bool = True,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a neighbor-wise attention net."""
         super().__init__()
@@ -715,6 +720,7 @@ class NeighborGatedAttention(nn.Module):
                     smooth=smooth,
                     precision=precision,
                     seed=child_seed(seed, i),
+                    trainable=trainable,
                 )
             )
         self.attention_layers = nn.ModuleList(attention_layers)
@@ -823,6 +829,7 @@ class NeighborGatedAttentionLayer(nn.Module):
         ln_eps: float = 1e-5,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a neighbor-wise attention layer."""
         super().__init__()
@@ -850,6 +857,7 @@ class NeighborGatedAttentionLayer(nn.Module):
             smooth=smooth,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.attn_layer_norm = LayerNorm(
             self.embed_dim,
@@ -930,6 +938,7 @@ class GatedAttentionLayer(nn.Module):
         smooth: bool = True,
         precision: str = DEFAULT_PRECISION,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         """Construct a multi-head neighbor-wise attention net."""
         super().__init__()
@@ -962,6 +971,7 @@ class GatedAttentionLayer(nn.Module):
             stddev=1.0,
             precision=precision,
             seed=child_seed(seed, 0),
+            trainable=trainable,
         )
         self.out_proj = MLPLayer(
             hidden_dim,
@@ -972,6 +982,7 @@ class GatedAttentionLayer(nn.Module):
             stddev=1.0,
             precision=precision,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
 
     def forward(

--- a/deepmd/pt/model/descriptor/se_atten.py
+++ b/deepmd/pt/model/descriptor/se_atten.py
@@ -166,6 +166,8 @@ class DescrptBlockSeAtten(DescriptorBlock):
             If not None, the scaling of attention weights is `temperature` itself.
         seed : int, Optional
             Random seed for parameter initialization.
+        trainable : bool, default: True
+            Whether this block is trainable
         """
         super().__init__()
         del type

--- a/deepmd/pt/model/descriptor/se_r.py
+++ b/deepmd/pt/model/descriptor/se_r.py
@@ -142,6 +142,7 @@ class DescrptSeR(BaseDescriptor, torch.nn.Module):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, ii),
+                trainable=trainable,
             )
         self.filter_layers = filter_layers
         self.stats = None

--- a/deepmd/pt/model/descriptor/se_t.py
+++ b/deepmd/pt/model/descriptor/se_t.py
@@ -575,6 +575,7 @@ class DescrptBlockSeT(DescriptorBlock):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, ii),
+                trainable=trainable,
             )
         self.filter_layers = filter_layers
         self.stats = None

--- a/deepmd/pt/model/descriptor/se_t_tebd.py
+++ b/deepmd/pt/model/descriptor/se_t_tebd.py
@@ -160,6 +160,7 @@ class DescrptSeTTebd(BaseDescriptor, torch.nn.Module):
             env_protection=env_protection,
             smooth=smooth,
             seed=child_seed(seed, 1),
+            trainable=trainable,
         )
         self.prec = PRECISION_DICT[precision]
         self.use_econf_tebd = use_econf_tebd
@@ -170,6 +171,7 @@ class DescrptSeTTebd(BaseDescriptor, torch.nn.Module):
             tebd_dim,
             precision=precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
             use_econf_tebd=use_econf_tebd,
             type_map=type_map,
             use_tebd_bias=use_tebd_bias,
@@ -525,6 +527,7 @@ class DescrptBlockSeTTebd(DescriptorBlock):
         env_protection: float = 0.0,
         smooth: bool = True,
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
         self.rcut = float(rcut)
@@ -577,6 +580,7 @@ class DescrptBlockSeTTebd(DescriptorBlock):
             precision=self.precision,
             resnet_dt=self.resnet_dt,
             seed=child_seed(self.seed, 1),
+            trainable=trainable,
         )
         self.filter_layers = filter_layers
         if self.tebd_input_mode in ["strip"]:
@@ -590,6 +594,7 @@ class DescrptBlockSeTTebd(DescriptorBlock):
                 precision=self.precision,
                 resnet_dt=self.resnet_dt,
                 seed=child_seed(self.seed, 2),
+                trainable=trainable,
             )
             self.filter_layers_strip = filter_layers_strip
         self.stats = None

--- a/deepmd/pt/model/network/mlp.py
+++ b/deepmd/pt/model/network/mlp.py
@@ -83,8 +83,10 @@ class MLPLayer(nn.Module):
         precision: str = DEFAULT_PRECISION,
         init: str = "default",
         seed: Optional[Union[int, list[int]]] = None,
+        trainable: bool = True,
     ) -> None:
         super().__init__()
+        self.trainable = trainable
         # only use_timestep when skip connection is established.
         self.use_timestep = use_timestep and (
             num_out == num_in or num_out == num_in * 2
@@ -233,6 +235,7 @@ class MLPLayer(nn.Module):
             activation_function=self.activate_name,
             resnet=self.resnet,
             precision=self.precision,
+            trainable=self.trainable,
         )
         nl.w, nl.b, nl.idt = (
             to_numpy_array(self.matrix),
@@ -259,6 +262,7 @@ class MLPLayer(nn.Module):
             activation_function=nl["activation_function"],
             resnet=nl["resnet"],
             precision=nl["precision"],
+            trainable=nl["trainable"],
         )
         prec = PRECISION_DICT[obj.precision]
 

--- a/deepmd/pt/model/network/network.py
+++ b/deepmd/pt/model/network/network.py
@@ -253,6 +253,7 @@ class TypeEmbedNet(nn.Module):
         use_econf_tebd=False,
         use_tebd_bias: bool = False,
         type_map=None,
+        trainable: bool = True,
     ) -> None:
         """Construct a type embedding net."""
         super().__init__()
@@ -273,6 +274,7 @@ class TypeEmbedNet(nn.Module):
             type_map=type_map,
             precision=precision,
             seed=seed,
+            trainable=trainable,
         )
         # nn.init.normal_(self.embedding.weight[:-1], mean=bavg, std=stddev)
 

--- a/deepmd/pt/model/task/fitting.py
+++ b/deepmd/pt/model/task/fitting.py
@@ -320,6 +320,7 @@ class GeneralFitting(Fitting):
                     self.precision,
                     bias_out=True,
                     seed=child_seed(self.seed, ii),
+                    trainable=trainable,
                 )
                 for ii in range(self.ntypes if not self.mixed_types else 1)
             ],

--- a/deepmd/tf/descriptor/se.py
+++ b/deepmd/tf/descriptor/se.py
@@ -192,6 +192,7 @@ class DescrptSe(Descriptor):
         resnet_dt: bool,
         variables: dict,
         excluded_types: set[tuple[int, int]] = set(),
+        trainable: bool = True,
         suffix: str = "",
     ) -> dict:
         """Serialize network.
@@ -214,6 +215,8 @@ class DescrptSe(Descriptor):
             The input variables
         excluded_types : set[tuple[int, int]], optional
             The excluded types
+        trainable : bool
+            Whether the network is trainable
         suffix : str, optional
             The suffix of the scope
 
@@ -236,6 +239,7 @@ class DescrptSe(Descriptor):
                     activation_function=activation_function,
                     resnet_dt=resnet_dt,
                     precision=self.precision.name,
+                    trainable=trainable,
                 )
                 embeddings[(type_j, type_i)] = EmbeddingNet(
                     in_dim=in_dim,
@@ -243,6 +247,7 @@ class DescrptSe(Descriptor):
                     activation_function=activation_function,
                     resnet_dt=resnet_dt,
                     precision=self.precision.name,
+                    trainable=trainable,
                 )
                 embeddings[(type_i, type_j)].clear()
                 embeddings[(type_j, type_i)].clear()
@@ -278,6 +283,7 @@ class DescrptSe(Descriptor):
                     activation_function=activation_function,
                     resnet_dt=resnet_dt,
                     precision=self.precision.name,
+                    trainable=trainable,
                 )
             assert embeddings[network_idx] is not None
             if weight_name == "idt":

--- a/deepmd/tf/descriptor/se_a.py
+++ b/deepmd/tf/descriptor/se_a.py
@@ -1462,6 +1462,7 @@ class DescrptSeA(DescrptSe):
                 resnet_dt=self.filter_resnet_dt,
                 variables=self.embedding_net_variables,
                 excluded_types=self.exclude_types,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "env_mat": EnvMat(self.rcut_r, self.rcut_r_smth).serialize(),

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -1593,6 +1593,7 @@ class DescrptSeAtten(DescrptSeA):
                 bias=bias,
                 use_timestep=False,
                 precision=self.precision.name,
+                trainable=self.trainable,
             )
             matrix_list = [
                 attention_layer_params[layer_idx][key]["matrix"]
@@ -1611,6 +1612,7 @@ class DescrptSeAtten(DescrptSeA):
                 bias=bias,
                 use_timestep=False,
                 precision=self.precision.name,
+                trainable=self.trainable,
             )
             out_proj["matrix"] = attention_layer_params[layer_idx]["c_out"]["matrix"]
             if bias:
@@ -1654,6 +1656,7 @@ class DescrptSeAtten(DescrptSeA):
         variables: dict,
         suffix: str = "",
         type_one_side: bool = False,
+        trainable: bool = True,
     ) -> dict:
         """Serialize network.
 
@@ -1679,6 +1682,8 @@ class DescrptSeAtten(DescrptSeA):
             If 'False', type embeddings of both neighbor and central atoms are considered.
             If 'True', only type embeddings of neighbor atoms are considered.
             Default is 'False'.
+        trainable : bool
+            Whether the network is trainable
 
         Returns
         -------
@@ -1719,6 +1724,7 @@ class DescrptSeAtten(DescrptSeA):
                     activation_function=activation_function,
                     resnet_dt=resnet_dt,
                     precision=self.precision.name,
+                    trainable=trainable,
                 )
             assert embeddings[network_idx] is not None
             if weight_name == "idt":

--- a/deepmd/tf/descriptor/se_atten.py
+++ b/deepmd/tf/descriptor/se_atten.py
@@ -1989,6 +1989,7 @@ class DescrptSeAtten(DescrptSeA):
                 resnet_dt=self.filter_resnet_dt,
                 variables=self.embedding_net_variables,
                 excluded_types=self.exclude_types,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "attention_layers": self.serialize_attention_layers(
@@ -2038,6 +2039,7 @@ class DescrptSeAtten(DescrptSeA):
                         variables=self.two_side_embeeding_net_variables,
                         suffix=suffix,
                         type_one_side=self.type_one_side,
+                        trainable=self.trainable,
                     )
                 }
             )

--- a/deepmd/tf/descriptor/se_r.py
+++ b/deepmd/tf/descriptor/se_r.py
@@ -795,6 +795,7 @@ class DescrptSeR(DescrptSe):
                 resnet_dt=self.filter_resnet_dt,
                 variables=self.embedding_net_variables,
                 excluded_types=self.exclude_types,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "env_mat": EnvMat(self.rcut, self.rcut_smth).serialize(),

--- a/deepmd/tf/descriptor/se_t.py
+++ b/deepmd/tf/descriptor/se_t.py
@@ -946,6 +946,7 @@ class DescrptSeT(DescrptSe):
                 resnet_dt=self.filter_resnet_dt,
                 variables=self.embedding_net_variables,
                 excluded_types=self.exclude_types,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "env_mat": EnvMat(self.rcut_r, self.rcut_r_smth).serialize(),

--- a/deepmd/tf/descriptor/se_t.py
+++ b/deepmd/tf/descriptor/se_t.py
@@ -726,6 +726,7 @@ class DescrptSeT(DescrptSe):
         resnet_dt: bool,
         variables: dict,
         excluded_types: set[tuple[int, int]] = set(),
+        trainable: bool = True,
         suffix: str = "",
     ) -> dict:
         """Serialize network.
@@ -748,6 +749,8 @@ class DescrptSeT(DescrptSe):
             The input variables
         excluded_types : set[tuple[int, int]], optional
             The excluded types
+        trainable : bool, optional
+            Whether the network is trainable
         suffix : str, optional
             The suffix of the scope
 
@@ -771,6 +774,7 @@ class DescrptSeT(DescrptSe):
                 activation_function=activation_function,
                 resnet_dt=resnet_dt,
                 precision=self.precision.name,
+                trainable=trainable,
             )
             embeddings[(type_i, type_j)].clear()
 
@@ -805,6 +809,7 @@ class DescrptSeT(DescrptSe):
                     activation_function=activation_function,
                     resnet_dt=resnet_dt,
                     precision=self.precision.name,
+                    trainable=trainable,
                 )
             assert embeddings[network_idx] is not None
             if weight_name == "idt":

--- a/deepmd/tf/fit/dipole.py
+++ b/deepmd/tf/fit/dipole.py
@@ -75,6 +75,10 @@ class DipoleFittingSeA(Fitting):
         different fitting nets for different atom types.
     type_map: list[str], Optional
             A list of strings. Give the name to each type of atoms.
+    trainable : list[bool], Optional
+        If the weights of fitting net are trainable.
+        Suppose that we have :math:`N_l` hidden layers in the fitting net,
+        this list is of length :math:`N_l + 1`, specifying if the hidden layers and the output layer are trainable.
     """
 
     def __init__(
@@ -94,6 +98,7 @@ class DipoleFittingSeA(Fitting):
         uniform_seed: bool = False,
         mixed_types: bool = False,
         type_map: Optional[list[str]] = None,  # to be compat with input
+        trainable: Optional[list[bool]] = None,
         **kwargs,
     ) -> None:
         """Constructor."""
@@ -135,6 +140,15 @@ class DipoleFittingSeA(Fitting):
         self.aparam_avg = None
         self.aparam_std = None
         self.aparam_inv_std = None
+        if trainable is None:
+            self.trainable = [True for _ in range(len(self.n_neuron) + 1)]
+        elif isinstance(trainable, bool):
+            self.trainable = [trainable] * (len(self.n_neuron) + 1)
+        else:
+            self.trainable = trainable
+        assert len(self.trainable) == len(self.n_neuron) + 1, (
+            "length of trainable should be that of n_neuron + 1"
+        )
 
     def get_sel_type(self) -> int:
         """Get selected type."""
@@ -166,6 +180,7 @@ class DipoleFittingSeA(Fitting):
                     uniform_seed=self.uniform_seed,
                     initial_variables=self.fitting_net_variables,
                     mixed_prec=self.mixed_prec,
+                    trainable=self.trainable[ii],
                 )
             else:
                 layer = one_layer(
@@ -179,6 +194,7 @@ class DipoleFittingSeA(Fitting):
                     uniform_seed=self.uniform_seed,
                     initial_variables=self.fitting_net_variables,
                     mixed_prec=self.mixed_prec,
+                    trainable=self.trainable[ii],
                 )
             if (not self.uniform_seed) and (self.seed is not None):
                 self.seed += self.seed_shift
@@ -195,6 +211,7 @@ class DipoleFittingSeA(Fitting):
             initial_variables=self.fitting_net_variables,
             mixed_prec=self.mixed_prec,
             final_layer=True,
+            trainable=self.trainable[-1],
         )
         if (not self.uniform_seed) and (self.seed is not None):
             self.seed += self.seed_shift

--- a/deepmd/tf/fit/dipole.py
+++ b/deepmd/tf/fit/dipole.py
@@ -414,6 +414,7 @@ class DipoleFittingSeA(Fitting):
                 activation_function=self.activation_function_name,
                 resnet_dt=self.resnet_dt,
                 variables=self.fitting_net_variables,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "type_map": self.type_map,

--- a/deepmd/tf/fit/dos.py
+++ b/deepmd/tf/fit/dos.py
@@ -730,6 +730,7 @@ class DOSFitting(Fitting):
                 activation_function=self.activation_function,
                 resnet_dt=self.resnet_dt,
                 variables=self.fitting_net_variables,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "@variables": {

--- a/deepmd/tf/fit/ener.py
+++ b/deepmd/tf/fit/ener.py
@@ -944,6 +944,7 @@ class EnerFitting(Fitting):
                 activation_function=self.activation_function_name,
                 resnet_dt=self.resnet_dt,
                 variables=self.fitting_net_variables,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "@variables": {

--- a/deepmd/tf/fit/fitting.py
+++ b/deepmd/tf/fit/fitting.py
@@ -135,6 +135,7 @@ class Fitting(PluginVariant, make_plugin_registry("fitting")):
         resnet_dt: bool,
         variables: dict,
         out_dim: Optional[int] = 1,
+        trainable: bool = True,
         suffix: str = "",
     ) -> dict:
         """Serialize network.
@@ -199,6 +200,7 @@ class Fitting(PluginVariant, make_plugin_registry("fitting")):
                     resnet_dt=resnet_dt,
                     precision=self.precision.name,
                     bias_out=True,
+                    trainable=trainable,
                 )
             assert fittings[network_idx] is not None
             if weight_name == "idt":

--- a/deepmd/tf/fit/fitting.py
+++ b/deepmd/tf/fit/fitting.py
@@ -135,7 +135,7 @@ class Fitting(PluginVariant, make_plugin_registry("fitting")):
         resnet_dt: bool,
         variables: dict,
         out_dim: Optional[int] = 1,
-        trainable: bool = True,
+        trainable: Optional[list[bool]] = None,
         suffix: str = "",
     ) -> dict:
         """Serialize network.
@@ -156,6 +156,8 @@ class Fitting(PluginVariant, make_plugin_registry("fitting")):
             Whether to use resnet
         variables : dict
             The input variables
+        trainable : list[bool]
+            Whether the network is trainable
         suffix : str, optional
             The suffix of the scope
         out_dim : int, optional
@@ -192,6 +194,8 @@ class Fitting(PluginVariant, make_plugin_registry("fitting")):
                 raise ValueError(f"Invalid ndim: {ndim}")
             if fittings[network_idx] is None:
                 # initialize the network if it is not initialized
+                if trainable is None:
+                    trainable = [True for _ in range(len(neuron) + 1)]
                 fittings[network_idx] = FittingNet(
                     in_dim=in_dim,
                     out_dim=out_dim,

--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -638,6 +638,7 @@ class PolarFittingSeA(Fitting):
                 activation_function=self.activation_function_name,
                 resnet_dt=self.resnet_dt,
                 variables=self.fitting_net_variables,
+                trainable=self.trainable,
                 suffix=suffix,
             ),
             "@variables": {

--- a/source/tests/consistent/descriptor/test_dpa1.py
+++ b/source/tests/consistent/descriptor/test_dpa1.py
@@ -127,6 +127,7 @@ class TestDPA1(CommonTest, DescriptorTest, unittest.TestCase):
             "use_tebd_bias": use_tebd_bias,
             "type_map": ["O", "H"] if use_econf_tebd else None,
             "seed": 1145141919810,
+            "trainable": False,
         }
 
     def is_meaningless_zero_attention_layer_tests(

--- a/source/tests/consistent/descriptor/test_dpa2.py
+++ b/source/tests/consistent/descriptor/test_dpa2.py
@@ -181,7 +181,7 @@ class TestDPA2(CommonTest, DescriptorTest, unittest.TestCase):
             "smooth": smooth,
             "exclude_types": exclude_types,
             "env_protection": 0.0,
-            "trainable": True,
+            "trainable": False,
             "use_econf_tebd": use_econf_tebd,
             "use_tebd_bias": use_tebd_bias,
             "type_map": ["O", "H"] if use_econf_tebd else None,

--- a/source/tests/consistent/descriptor/test_dpa3.py
+++ b/source/tests/consistent/descriptor/test_dpa3.py
@@ -130,7 +130,7 @@ class TestDPA3(CommonTest, DescriptorTest, unittest.TestCase):
             "exclude_types": exclude_types,
             "env_protection": 0.0,
             "use_loc_mapping": use_loc_mapping,
-            "trainable": True,
+            "trainable": False,
         }
 
     @property


### PR DESCRIPTION
1. For dpmodel, pt, and pd, pass the trainable parameter to the layer (not actually used in this PR).
2. For JAX, support the `trainable` parameter in the layer.
3. "trainable" is now serialized in dpmodel, tf, pt, pd, etc.
4. Support trainable in TF dipole & polar fitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a `trainable` parameter to numerous model components, descriptors, embedding and fitting networks, and attention layers, allowing users to enable or disable parameter trainability.
  - Ensured consistent propagation of the `trainable` flag across submodules and layers in PyTorch, TensorFlow, and JAX backends.
  - Enhanced serialization and deserialization processes to include the `trainable` attribute, maintaining trainability settings during model save and load.
  - Implemented conditional parameter wrapping in the JAX backend to differentiate trainable parameters from fixed variables.

- **Tests**
  - Updated test configurations to include the `trainable` flag, validating behavior with non-trainable components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->