### PR TITLE
perf: optionally use `torch_scatter.segment_coo` for feature aggregation

### DIFF
--- a/deepmd/pt/model/network/utils.py
+++ b/deepmd/pt/model/network/utils.py
@@ -13,7 +13,6 @@ except ImportError:
     has_torch_scatter = False
 
 
-@torch.jit.script
 def aggregate(
     data: torch.Tensor,
     owners: torch.Tensor,
@@ -37,6 +36,7 @@ def aggregate(
     -------
     output: [num_owner, feature_dim]
     """
+    # faster and recommended
     if has_torch_scatter:
         output = torch_scatter.segment_coo(
             src=data,
@@ -46,7 +46,7 @@ def aggregate(
         )
         return output
 
-    # if torch_scatter is not available, use index_add_
+    # if torch_scatter is not available, use native index_add
     if num_owner is None or average:
         # requires bincount
         bin_count = torch.bincount(owners)


### PR DESCRIPTION
[`torch_scatter.segment_coo`](https://pytorch-scatter.readthedocs.io/en/latest/functions/segment_coo.html) performs the same operation as `index_add` of native pytorch. Here, we can leverage the sorted trait of the index. My test shows an ~25% speed-up on DPA3 dynamic sel models (0.56s vs 0.76s per step, 24 thin).

> In contrast to [scatter()](https://pytorch-scatter.readthedocs.io/en/latest/functions/scatter.html#torch_scatter.scatter), this method expects values in index to be sorted along dimension index.dim() - 1. Due to the use of sorted indices, [segment_coo()](https://pytorch-scatter.readthedocs.io/en/latest/functions/segment_coo.html#torch_scatter.segment_coo) is usually faster than the more general [scatter()](https://pytorch-scatter.readthedocs.io/en/latest/functions/scatter.html#torch_scatter.scatter) operation.

---
It is also possible to use [`scatter_reduce`](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.scatter_reduce_.html#torch.Tensor.scatter_reduce_) for this operation, and this is slightly faster than the original implementation (0.70s/step). However, this requires `src.shape == index.shape` for computing backward pass, so an additional expanding step is required: `owners = owners.unsqueeze(-1).expand(-1,data.shape[1])`.