### PR TITLE
fix(CI): clean up mpi4py index

### DIFF
--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -21,17 +21,13 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
-    - name: Setup MPI
-      uses: mpi4py/setup-mpi@v1
-      with:
-        mpi: mpich
     - uses: lukka/get-cmake@latest
     - run: python -m pip install uv
     - name: Install Python dependencies
       run: |
         source/install/uv_with_retry.sh pip install --system tensorflow-cpu~=2.18.0 jax==0.5.0
         export TENSORFLOW_ROOT=$(python -c 'import importlib,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
-        source/install/uv_with_retry.sh pip install --system -e .[cpu,test,lmp,jax] mpi4py
+        source/install/uv_with_retry.sh pip install --system -e .[cpu,test,lmp,jax] mpi4py mpich
         source/install/uv_with_retry.sh pip install --system 'torch==2.7' --index-url https://download.pytorch.org/whl/cpu
     - name: Convert models
       run: source/tests/infer/convert-models.sh

--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -50,13 +50,13 @@ jobs:
         cp ${{ github.workspace }}/source/build_tests/paddle_inference_install_dir/paddle/lib/*.so ${{ github.workspace }}/dp_test/lib/
         cp ${{ github.workspace }}/source/build_tests/paddle_inference_install_dir/third_party/install/onednn/lib/* ${{ github.workspace }}/dp_test/lib/
         cp ${{ github.workspace }}/source/build_tests/paddle_inference_install_dir/third_party/install/mklml/lib/* ${{ github.workspace }}/dp_test/lib/
+        export LD_LIBRARY_PATH=${{ github.workspace }}/dp_test/lib:$LD_LIBRARY_PATH
         pytest --cov=deepmd source/lmp/tests
       env:
         OMP_NUM_THREADS: 1
         TF_INTRA_OP_PARALLELISM_THREADS: 1
         TF_INTER_OP_PARALLELISM_THREADS: 1
         LAMMPS_PLUGIN_PATH: ${{ github.workspace }}/dp_test/lib/deepmd_lmp
-        LD_LIBRARY_PATH: ${{ github.workspace }}/dp_test/lib
       if: ${{ !matrix.check_memleak }}
     # test ipi
     - run: |

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -40,7 +40,6 @@ jobs:
         # changes, setting `TENSORFLOW_ROOT`.
         DP_ENABLE_PYTORCH: 1
         DP_BUILD_TESTING: 1
-        UV_EXTRA_INDEX_URL: "https://pypi.anaconda.org/mpi4py/simple"
         HOROVOD_WITH_TENSORFLOW: 1
         HOROVOD_WITHOUT_PYTORCH: 1
         HOROVOD_WITH_MPI: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,7 @@ manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 before-all = [
-    '''pip install -i https://pypi.anaconda.org/mpi4py/simple mpich''',
+    '''pip install mpich''',
 ]
 repair-wheel-command = """delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"""
 
@@ -272,7 +272,7 @@ before-all = [
     # https://almalinux.org/blog/2023-12-20-almalinux-8-key-update/
     """rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux""",
     """{ if [ "$(uname -m)" = "x86_64" ] ; then yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && yum install -y cuda-nvcc-${CUDA_VERSION/./-} cuda-cudart-devel-${CUDA_VERSION/./-}; fi }""",
-    '''/opt/python/cp311-cp311/bin/python -m pip install -i https://pypi.anaconda.org/mpi4py/simple mpich''',
+    '''/opt/python/cp311-cp311/bin/python -m pip install mpich''',
     # uv is not available in the old manylinux image
     """{ if [ "$(uname -m)" = "x86_64" ] ; then pipx install uv; fi }""",
 ]
@@ -458,15 +458,6 @@ select = [
     "TOR1",
     "TOR2",
 ]
-
-[tool.uv.sources]
-mpich = { index = "mpi4py" }
-openmpi = { index = "mpi4py" }
-
-[[tool.uv.index]]
-name = "mpi4py"
-url = "https://pypi.anaconda.org/mpi4py/simple"
-explicit = true
 
 [[tool.uv.dependency-metadata]]
 # Fix https://github.com/deepmodeling/deepmd-kit/issues/4679


### PR DESCRIPTION
It has been moved to PyPI. See https://github.com/mpi4py/mpi4py/releases/tag/4.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed use of a custom package index for installing certain dependencies in the build and test configurations.
  * Updated workflow and build settings to use the default package index for installations.
  * Improved environment variable handling to preserve existing paths during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->