### PR TITLE
fix(jax): fix the usage of `jaxlib.xla_extension`

### DIFF
--- a/deepmd/jax/utils/auto_batch_size.py
+++ b/deepmd/jax/utils/auto_batch_size.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-import jaxlib
 
 from deepmd.jax.env import (
     jax,

--- a/deepmd/jax/utils/auto_batch_size.py
+++ b/deepmd/jax/utils/auto_batch_size.py
@@ -52,7 +52,7 @@ class AutoBatchSize(AutoBatchSizeBase):
         # several sources think CUSOLVER_STATUS_INTERNAL_ERROR is another out-of-memory error,
         # such as https://github.com/JuliaGPU/CUDA.jl/issues/1924
         # (the meaningless error message should be considered as a bug in cusolver)
-        if isinstance(e, (jaxlib.xla_extension.XlaRuntimeError, ValueError)) and (
+        if isinstance(e, (RuntimeError, ValueError)) and (
             "RESOURCE_EXHAUSTED:" in e.args[0]
         ):
             return True


### PR DESCRIPTION
`jaxlib.xla_extension` has been removed in recent versions of JAX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved exception handling by updating error type checks and removing an unnecessary dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->