### PR TITLE
Update input_torch.json of DPA3 to fit DPA-3.1-3M.pt

### DIFF
--- a/examples/water/dpa3/input_torch.json
+++ b/examples/water/dpa3/input_torch.json
@@ -14,7 +14,7 @@
         "nlayers": 6,
         "e_rcut": 6.0,
         "e_rcut_smth": 5.3,
-        "e_sel": 120,
+        "e_sel": 1200,
         "a_rcut": 4.0,
         "a_rcut_smth": 3.5,
         "a_sel": 30,


### PR DESCRIPTION
the e_sel is different from the size of 'DPA-3.1-3M.pt', while training, it causes error： 

`size mismatch for model.Default.atomic_model.descriptor.repflows.mean: copying a param with shape torch.Size([118, 1200, 4]) from checkpoint, the shape in current model is torch.Size([118, 120, 4]).`

now the e_sel in sample is change to 1200 to fit DPA-3.1-3M.pt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to increase the value of the "e_sel" parameter in the "repflow" section for improved performance or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->