### PR TITLE
fix: fix pytorch in the cuda11 image

### DIFF
--- a/source/install/docker/Dockerfile
+++ b/source/install/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH="/opt/deepmd-kit/bin:$PATH"
 ENV VIRTUAL_ENV="/opt/deepmd-kit"
 # Install package
 COPY dist /dist
-RUN if [ "${CUDA_VERSION}" = 11 ]; then uv pip install torch --index-url https://download.pytorch.org/whl/cu118; fi \
+RUN if [ "${CUDA_VERSION}" = 11 ]; then uv pip install 'torch==2.3.1.*' --index-url https://download.pytorch.org/whl/cu118; fi \
     && uv pip install "$(ls /dist/deepmd_kit${VARIANT}-*manylinux*_x86_64.whl)[gpu,cu${CUDA_VERSION},lmp,ipi,torch]" \
     && dp -h \
     && lmp -h \


### PR DESCRIPTION
As reported by https://github.com/deepmodeling/deepmd-kit/issues/4837#issuecomment-3068217334, the pytorch in the cuda 11 image is currently cuda12.