### PR TITLE
fix(cc): use insert_or_assign instead of insert

### DIFF
--- a/source/api_cc/src/DeepPotPT.cc
+++ b/source/api_cc/src/DeepPotPT.cc
@@ -197,12 +197,12 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
           std::accumulate(lmp_list.sendnum, lmp_list.sendnum + nswap, 0);
       torch::Tensor sendlist_tensor =
           torch::from_blob(lmp_list.sendlist, {total_send}, int32_option);
-      comm_dict.insert("send_list", sendlist_tensor);
-      comm_dict.insert("send_proc", sendproc_tensor);
-      comm_dict.insert("recv_proc", recvproc_tensor);
-      comm_dict.insert("send_num", sendnum_tensor);
-      comm_dict.insert("recv_num", recvnum_tensor);
-      comm_dict.insert("communicator", communicator_tensor);
+      comm_dict.insert_or_assign("send_list", sendlist_tensor);
+      comm_dict.insert_or_assign("send_proc", sendproc_tensor);
+      comm_dict.insert_or_assign("recv_proc", recvproc_tensor);
+      comm_dict.insert_or_assign("send_num", sendnum_tensor);
+      comm_dict.insert_or_assign("recv_num", recvnum_tensor);
+      comm_dict.insert_or_assign("communicator", communicator_tensor);
     }
     if (lmp_list.mapping) {
       std::vector<std::int64_t> mapping(nall_real);

--- a/source/api_cc/src/DeepSpinPT.cc
+++ b/source/api_cc/src/DeepSpinPT.cc
@@ -205,13 +205,13 @@ void DeepSpinPT::compute(ENERGYVTYPE& ener,
       torch::Tensor sendlist_tensor =
           torch::from_blob(lmp_list.sendlist, {total_send}, int32_option);
       torch::Tensor has_spin = torch::tensor({1}, int32_option);
-      comm_dict.insert("send_list", sendlist_tensor);
-      comm_dict.insert("send_proc", sendproc_tensor);
-      comm_dict.insert("recv_proc", recvproc_tensor);
-      comm_dict.insert("send_num", sendnum_tensor);
-      comm_dict.insert("recv_num", recvnum_tensor);
-      comm_dict.insert("communicator", communicator_tensor);
-      comm_dict.insert("has_spin", has_spin);
+      comm_dict.insert_or_assign("send_list", sendlist_tensor);
+      comm_dict.insert_or_assign("send_proc", sendproc_tensor);
+      comm_dict.insert_or_assign("recv_proc", recvproc_tensor);
+      comm_dict.insert_or_assign("send_num", sendnum_tensor);
+      comm_dict.insert_or_assign("recv_num", recvnum_tensor);
+      comm_dict.insert_or_assign("communicator", communicator_tensor);
+      comm_dict.insert_or_assign("has_spin", has_spin);
     }
   }
   at::Tensor firstneigh = createNlistTensor2(nlist_data.jlist);


### PR DESCRIPTION
dict.insert will not replace old value of the key value while lammps reallocate will keep old value in old address. This may cause dict always use the initial value of some keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of communication settings to ensure that updates to existing entries are correctly applied, preventing potential issues with outdated or duplicate information during tensor communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->