### PR TITLE
refactor(training): Average training loss for smoother and more representative logging

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -844,6 +844,7 @@ class Trainer:
                 self.wrapper.eval()  # Will set to train mode before fininshing validation
 
                 if self.disp_avg:
+
                     def log_loss_train(_loss, _more_loss, _task_key="Default"):
                         results = {}
                         if not self.multi_task:
@@ -866,9 +867,14 @@ class Trainer:
                                     )
                         return results
                 else:
+
                     def log_loss_train(_loss, _more_loss, _task_key="Default"):
                         results = {}
-                        rmse_val = {item: _more_loss[item] for item in _more_loss if "l2_" not in item}
+                        rmse_val = {
+                            item: _more_loss[item]
+                            for item in _more_loss
+                            if "l2_" not in item
+                        }
                         for item in sorted(rmse_val.keys()):
                             results[item] = rmse_val[item]
                         return results
@@ -936,18 +942,24 @@ class Trainer:
                                 loss, more_loss, _task_key=_key
                             )
                     else:
-                        train_results[task_key] = log_loss_train(loss, more_loss, _task_key=task_key)
+                        train_results[task_key] = log_loss_train(
+                            loss, more_loss, _task_key=task_key
+                        )
                         for _key in self.model_keys:
                             if _key != task_key:
                                 self.optimizer.zero_grad()
-                                input_dict, label_dict, _ = self.get_data(is_train=True, task_key=_key)
+                                input_dict, label_dict, _ = self.get_data(
+                                    is_train=True, task_key=_key
+                                )
                                 _, loss, more_loss = self.wrapper(
                                     **input_dict,
                                     cur_lr=pref_lr,
                                     label=label_dict,
                                     task_key=_key,
                                 )
-                                train_results[_key] = log_loss_train(loss, more_loss, _task_key=_key)
+                                train_results[_key] = log_loss_train(
+                                    loss, more_loss, _task_key=_key
+                                )
                         valid_results[_key] = log_loss_valid(_task_key=_key)
                         if self.rank == 0:
                             log.info(

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -150,6 +150,12 @@ class Trainer:
         )
         self.lcurve_should_print_header = True
 
+        # Loss accumulation for averaging over display interval
+        self.loss_accumulator = {}
+        self.step_count_in_interval = 0
+        self.last_display_step = 0
+        self.step_count_per_task = {}
+
         def get_opt_param(params):
             opt_type = params.get("opt_type", "Adam")
             opt_param = {
@@ -808,22 +814,48 @@ class Trainer:
             else:
                 raise ValueError(f"Not supported optimizer type '{self.opt_type}'")
 
+            # Accumulate loss for averaging over display interval
+            self.step_count_in_interval += 1
+            if not self.multi_task:
+                # Accumulate loss for single task
+                if not self.loss_accumulator:
+                    # Initialize accumulator with current loss structure
+                    for item in more_loss:
+                        if "l2_" not in item:
+                            self.loss_accumulator[item] = 0.0
+                for item in more_loss:
+                    if "l2_" not in item:
+                        self.loss_accumulator[item] += more_loss[item]
+            else:
+                # Accumulate loss for multi-task
+                if task_key not in self.loss_accumulator:
+                    self.loss_accumulator[task_key] = {}
+                if task_key not in self.step_count_per_task:
+                    self.step_count_per_task[task_key] = 0
+                self.step_count_per_task[task_key] += 1
+
+                for item in more_loss:
+                    if "l2_" not in item:
+                        if item not in self.loss_accumulator[task_key]:
+                            self.loss_accumulator[task_key][item] = 0.0
+                        self.loss_accumulator[task_key][item] += more_loss[item]
+
             # Log and persist
             display_step_id = _step_id + 1
-            if self.display_in_training and (
-                display_step_id % self.disp_freq == 0 or display_step_id == 1
-            ):
+            if self.display_in_training and (display_step_id % self.disp_freq == 0 or display_step_id == 1):
                 self.wrapper.eval()  # Will set to train mode before fininshing validation
 
                 def log_loss_train(_loss, _more_loss, _task_key="Default"):
                     results = {}
-                    rmse_val = {
-                        item: _more_loss[item]
-                        for item in _more_loss
-                        if "l2_" not in item
-                    }
-                    for item in sorted(rmse_val.keys()):
-                        results[item] = rmse_val[item]
+                    if not self.multi_task:
+                        # Use accumulated average loss for single task
+                        for item in self.loss_accumulator:
+                            results[item] = self.loss_accumulator[item] / self.step_count_in_interval
+                    else:
+                        # Use accumulated average loss for multi-task
+                        if _task_key in self.loss_accumulator and _task_key in self.step_count_per_task:
+                            for item in self.loss_accumulator[_task_key]:
+                                results[item] = self.loss_accumulator[_task_key][item] / self.step_count_per_task[_task_key]
                     return results
 
                 def log_loss_valid(_task_key="Default"):
@@ -882,24 +914,10 @@ class Trainer:
                 else:
                     train_results = {_key: {} for _key in self.model_keys}
                     valid_results = {_key: {} for _key in self.model_keys}
-                    train_results[task_key] = log_loss_train(
-                        loss, more_loss, _task_key=task_key
-                    )
+
+                    # For multi-task, use accumulated average loss for all tasks
                     for _key in self.model_keys:
-                        if _key != task_key:
-                            self.optimizer.zero_grad()
-                            input_dict, label_dict, _ = self.get_data(
-                                is_train=True, task_key=_key
-                            )
-                            _, loss, more_loss = self.wrapper(
-                                **input_dict,
-                                cur_lr=pref_lr,
-                                label=label_dict,
-                                task_key=_key,
-                            )
-                            train_results[_key] = log_loss_train(
-                                loss, more_loss, _task_key=_key
-                            )
+                        train_results[_key] = log_loss_train(loss, more_loss, _task_key=_key)
                         valid_results[_key] = log_loss_valid(_task_key=_key)
                         if self.rank == 0:
                             log.info(
@@ -920,6 +938,20 @@ class Trainer:
                                     )
                                 )
                 self.wrapper.train()
+
+                # Reset loss accumulators after display
+                if not self.multi_task:
+                    for item in self.loss_accumulator:
+                        self.loss_accumulator[item] = 0.0
+                else:
+                    for task_key in self.model_keys:
+                        if task_key in self.loss_accumulator:
+                            for item in self.loss_accumulator[task_key]:
+                                self.loss_accumulator[task_key][item] = 0.0
+                        if task_key in self.step_count_per_task:
+                            self.step_count_per_task[task_key] = 0
+                self.step_count_in_interval = 0
+                self.last_display_step = display_step_id
 
                 current_time = time.time()
                 train_time = current_time - self.t0
@@ -993,6 +1025,16 @@ class Trainer:
         self.t0 = time.time()
         self.total_train_time = 0.0
         self.timed_steps = 0
+
+        # Initialize loss accumulators
+        if not self.multi_task:
+            self.loss_accumulator = {}
+        else:
+            self.loss_accumulator = {key: {} for key in self.model_keys}
+            self.step_count_per_task = dict.fromkeys(self.model_keys, 0)
+        self.step_count_in_interval = 0
+        self.last_display_step = 0
+
         for step_id in range(self.start_step, self.num_steps):
             step(step_id)
             if JIT:

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -842,7 +842,9 @@ class Trainer:
 
             # Log and persist
             display_step_id = _step_id + 1
-            if self.display_in_training and (display_step_id % self.disp_freq == 0 or display_step_id == 1):
+            if self.display_in_training and (
+                display_step_id % self.disp_freq == 0 or display_step_id == 1
+            ):
                 self.wrapper.eval()  # Will set to train mode before fininshing validation
 
                 def log_loss_train(_loss, _more_loss, _task_key="Default"):
@@ -850,12 +852,21 @@ class Trainer:
                     if not self.multi_task:
                         # Use accumulated average loss for single task
                         for item in self.loss_accumulator:
-                            results[item] = self.loss_accumulator[item] / self.step_count_in_interval
+                            results[item] = (
+                                self.loss_accumulator[item]
+                                / self.step_count_in_interval
+                            )
                     else:
                         # Use accumulated average loss for multi-task
-                        if _task_key in self.loss_accumulator and _task_key in self.step_count_per_task:
+                        if (
+                            _task_key in self.loss_accumulator
+                            and _task_key in self.step_count_per_task
+                        ):
                             for item in self.loss_accumulator[_task_key]:
-                                results[item] = self.loss_accumulator[_task_key][item] / self.step_count_per_task[_task_key]
+                                results[item] = (
+                                    self.loss_accumulator[_task_key][item]
+                                    / self.step_count_per_task[_task_key]
+                                )
                     return results
 
                 def log_loss_valid(_task_key="Default"):
@@ -917,7 +928,9 @@ class Trainer:
 
                     # For multi-task, use accumulated average loss for all tasks
                     for _key in self.model_keys:
-                        train_results[_key] = log_loss_train(loss, more_loss, _task_key=_key)
+                        train_results[_key] = log_loss_train(
+                            loss, more_loss, _task_key=_key
+                        )
                         valid_results[_key] = log_loss_valid(_task_key=_key)
                         if self.rank == 0:
                             log.info(

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3137,7 +3137,9 @@ def training_args(
     )
     doc_disp_training = "Displaying verbose information during training."
     doc_time_training = "Timing during training."
-    doc_disp_avg = "Display the average loss over the display interval for training sets."
+    doc_disp_avg = (
+        "Display the average loss over the display interval for training sets."
+    )
     doc_profiling = "Export the profiling results to the Chrome JSON file for performance analysis, driven by the legacy TensorFlow profiling API or PyTorch Profiler. The output file will be saved to `profiling_file`."
     doc_profiling_file = "Output file for profiling."
     doc_enable_profiler = "Export the profiling results to the TensorBoard log for performance analysis, driven by TensorFlow Profiler (available in TensorFlow 2.3) or PyTorch Profiler. The log will be saved to `tensorboard_log_dir`."
@@ -3214,9 +3216,7 @@ def training_args(
         Argument(
             "time_training", bool, optional=True, default=True, doc=doc_time_training
         ),
-        Argument(
-            "disp_avg", bool, optional=True, default=False, doc=doc_disp_avg
-        ),
+        Argument("disp_avg", bool, optional=True, default=False, doc=doc_disp_avg),
         Argument(
             "profiling",
             bool,

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3216,7 +3216,13 @@ def training_args(
         Argument(
             "time_training", bool, optional=True, default=True, doc=doc_time_training
         ),
-        Argument("disp_avg", bool, optional=True, default=False, doc=doc_only_pt_supported + doc_disp_avg),
+        Argument(
+            "disp_avg",
+            bool,
+            optional=True,
+            default=False,
+            doc=doc_only_pt_supported + doc_disp_avg,
+        ),
         Argument(
             "profiling",
             bool,

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3137,6 +3137,7 @@ def training_args(
     )
     doc_disp_training = "Displaying verbose information during training."
     doc_time_training = "Timing during training."
+    doc_disp_avg = "Display the average loss over the display interval for training sets."
     doc_profiling = "Export the profiling results to the Chrome JSON file for performance analysis, driven by the legacy TensorFlow profiling API or PyTorch Profiler. The output file will be saved to `profiling_file`."
     doc_profiling_file = "Output file for profiling."
     doc_enable_profiler = "Export the profiling results to the TensorBoard log for performance analysis, driven by TensorFlow Profiler (available in TensorFlow 2.3) or PyTorch Profiler. The log will be saved to `tensorboard_log_dir`."
@@ -3212,6 +3213,9 @@ def training_args(
         ),
         Argument(
             "time_training", bool, optional=True, default=True, doc=doc_time_training
+        ),
+        Argument(
+            "disp_avg", bool, optional=True, default=False, doc=doc_disp_avg
         ),
         Argument(
             "profiling",

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3216,7 +3216,7 @@ def training_args(
         Argument(
             "time_training", bool, optional=True, default=True, doc=doc_time_training
         ),
-        Argument("disp_avg", bool, optional=True, default=False, doc=doc_disp_avg),
+        Argument("disp_avg", bool, optional=True, default=False, doc=doc_only_pt_supported + doc_disp_avg),
         Argument(
             "profiling",
             bool,


### PR DESCRIPTION
This pull request modifies the training loop to improve the quality and readability of the reported training loss.

## Summary of Changes

Previously, the training loss and associated metrics (e.g., rmse_e_trn) reported in lcurve.out and the console log at each disp_freq step represented the instantaneous value from that single training batch. This could be quite noisy and subject to high variance depending on the specific batch sampled.

This PR introduces an accumulator for the training loss. The key changes are:

During each training step, the loss values are accumulated.

When a display step is reached, the accumulated values are averaged over the number of steps in that interval.

This averaged loss is then reported in the log and lcurve.out.

The accumulators are reset for the next interval.

The validation logic remains unchanged, continuing to provide a periodic snapshot of model performance, which is the standard and efficient approach.

## Significance and Benefits

Reporting the averaged training loss provides a much smoother and more representative training curve. The benefits include:

Reduced Noise: Eliminates high-frequency fluctuations, making it easier to see the true learning trend.

Improved Readability: Plotted learning curves from lcurve.out are cleaner and more interpretable.

Better Comparability: Simplifies the comparison of model performance across different training runs, as the impact of single-batch anomalies is minimized.

## A Note on Formatting

Please note that due to automatic code formatters (e.g., black, isort), some minor, purely stylistic changes may appear in the diff that are not directly related to the core logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Training loss values displayed during training are now averaged over the display interval, providing more stable and representative loss metrics for both single-task and multi-task modes.
  * Added an option to enable or disable averaging of training loss display via a new configuration setting.

* **Improvements**
  * Enhanced training loss reporting for improved monitoring and analysis during model training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->