### PR TITLE
fix(CI): prefer stable versions

### DIFF
--- a/.github/workflows/package_c.yml
+++ b/.github/workflows/package_c.yml
@@ -22,7 +22,7 @@ jobs:
             tensorflow_version: ""
             filename: libdeepmd_c.tar.gz
           - tensorflow_build_version: "2.14"
-            tensorflow_version: ">=2.5.0rc0,<2.15"
+            tensorflow_version: ">=2.5.0,<2.15"
             filename: libdeepmd_c_cu11.tar.gz
     steps:
       - uses: actions/checkout@v4

--- a/backend/find_tensorflow.py
+++ b/backend/find_tensorflow.py
@@ -88,14 +88,14 @@ def find_tensorflow() -> tuple[Optional[str], list[str]]:
                 # CUDA 12.2, cudnn 9
                 requires.extend(
                     [
-                        "tensorflow-cpu>=2.18.0rc0; platform_machine=='x86_64' and platform_system == 'Linux'",
+                        "tensorflow-cpu>=2.18.0; platform_machine=='x86_64' and platform_system == 'Linux'",
                     ]
                 )
             elif cuda_version in SpecifierSet(">=11,<12"):
                 # CUDA 11.8, cudnn 8
                 requires.extend(
                     [
-                        "tensorflow-cpu>=2.5.0rc0,<2.15; platform_machine=='x86_64' and platform_system == 'Linux'",
+                        "tensorflow-cpu>=2.5.0,<2.15; platform_machine=='x86_64' and platform_system == 'Linux'",
                     ]
                 )
                 tf_version = "2.14.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ test = [
 docs = [
     "sphinx>=3.1.1",
     "sphinx-book-theme",
-    "myst-nb>=1.0.0rc0",
+    "myst-nb>=1.0.0",
     "myst-parser>=0.19.2",
     "sphinx-design",
     "breathe",


### PR DESCRIPTION
Remove version `>=a.b.crc0` from dependencies. The stable version should be preferred.
This prevents the installation of TensorFlow 2.20.0rc0, which breaks the CI. However, the incompatibility should still be fixed in the future. TensorFlow 2.20.0rc0 removes the version information from the header files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version requirements for TensorFlow and myst-nb packages to use stable releases instead of release candidate versions in build and documentation workflows.
  * Adjusted dependency handling for TensorFlow CPU to ensure stable versions are used during build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->