### PR TITLE
doc: fix inconsistency between the docstring and the implementation of argument `auto_batch_size` of `DeepEval` with paddle and pytorch backend

### DIFF
--- a/deepmd/dpmodel/infer/deep_eval.py
+++ b/deepmd/dpmodel/infer/deep_eval.py
@@ -62,7 +62,7 @@ class DeepEval(DeepEvalBackend):
         The output definition of the model.
     *args : list
         Positional arguments.
-    auto_batch_size : bool or int or AutomaticBatchSize, default: False
+    auto_batch_size : bool or int or AutomaticBatchSize, default: True
         If True, automatic batch size will be used. If int, it will be used
         as the initial batch size.
     neighbor_list : ase.neighborlist.NewPrimitiveNeighborList, optional

--- a/deepmd/pd/infer/deep_eval.py
+++ b/deepmd/pd/infer/deep_eval.py
@@ -58,7 +58,7 @@ class DeepEval(DeepEvalBackend):
         The output definition of the model.
     *args : list
         Positional arguments.
-    auto_batch_size : bool or int or AutomaticBatchSize, default: False
+    auto_batch_size : bool or int or AutomaticBatchSize, default: True
         If True, automatic batch size will be used. If int, it will be used
         as the initial batch size.
     neighbor_list : ase.neighborlist.NewPrimitiveNeighborList, optional

--- a/deepmd/pt/infer/deep_eval.py
+++ b/deepmd/pt/infer/deep_eval.py
@@ -80,7 +80,7 @@ class DeepEval(DeepEvalBackend):
         The output definition of the model.
     *args : list
         Positional arguments.
-    auto_batch_size : bool or int or AutomaticBatchSize, default: False
+    auto_batch_size : bool or int or AutomaticBatchSize, default: True
         If True, automatic batch size will be used. If int, it will be used
         as the initial batch size.
     neighbor_list : ase.neighborlist.NewPrimitiveNeighborList, optional

--- a/doc/model/show-model-info.md
+++ b/doc/model/show-model-info.md
@@ -11,7 +11,6 @@ dp --pt show <INPUT> <ATTRIBUTES...>
 
 - `<INPUT>`: Path to the model checkpoint file or frozen model file.
 - `<ATTRIBUTES>`: One or more information categories to display. Supported values are:
-
   - `model-branch`: Shows available branches for multi-task models.
   - `type-map`: Shows the type mapping used by the model.
   - `descriptor`: Displays the model descriptor parameters.
@@ -33,31 +32,25 @@ dp show frozen_model.pth type-map descriptor fitting-net size
 Depending on the provided attributes and the model type, the output includes:
 
 - **Model Type**
-
   - Logs whether the loaded model is a _singletask_ or _multitask_ model.
 
 - **model-branch**
-
   - _Only available for multitask models._
   - Lists all available model branches and the special `"RANDOM"` branch, which refers to a randomly initialized fitting net.
 
 - **type-map**
-
   - For multitask models: Shows the type map for each branch.
   - For singletask models: Shows the model's type map.
 
 - **descriptor**
-
   - For multitask models: Displays the descriptor parameter for each branch.
   - For singletask models: Displays the descriptor parameter.
 
 - **fitting-net**
-
   - For multitask models: Shows the fitting network parameters for each branch.
   - For singletask models: Shows the fitting network parameters.
 
 - **size**
-
   - Prints the number of parameters for each component (`descriptor`, `fitting-net`, etc.), as well as the total parameter count.
 
 ## Example Output

--- a/doc/train/multi-task-training.md
+++ b/doc/train/multi-task-training.md
@@ -48,7 +48,6 @@ Specifically, there are several parts that need to be modified:
 - {ref}`model/model_dict <model/model_dict>`: The core definition of the model part and the explanation of sharing rules,
   starting with user-defined model name keys `model_key`, such as `my_model_1`.
   Each model part needs to align with the components of the single-task training {ref}`model <model>`, but with the following sharing rules:
-
   - If you want to share the current model component with other tasks, which should be part of the {ref}`model/shared_dict <model/shared_dict>`,
     you can directly fill in the corresponding `part_key`, such as
     `"descriptor": "my_descriptor", `


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic batch size handling is now enabled by default when creating a new DeepEval instance.

* **Documentation**
  * Improved formatting consistency in model information and multi-task training guides by removing unnecessary blank lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->