### PR TITLE
docs: add bfloat16 option to the model precision choice

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -44,7 +44,7 @@ __all__ = [
     "select_idx_map",
 ]
 
-_PRECISION = Literal["default", "float16", "float32", "float64"]
+_PRECISION = Literal["default", "float16", "bfloat16", "float32", "float64"]
 _ACTIVATION = Literal[
     "relu",
     "relu6",


### PR DESCRIPTION
The parameter "precision" supports bfloat16 with most backends, but it is not documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "bfloat16" as a selectable precision option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->