### PR TITLE
fix: merge `get_np_precision` to `get_xp_precision`

### DIFF
--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -27,9 +27,6 @@ except ImportError:
 import numpy as np
 import yaml
 
-from deepmd.env import (
-    GLOBAL_NP_FLOAT_PRECISION,
-)
 from deepmd.utils.path import (
     DPPath,
 )
@@ -249,16 +246,11 @@ def get_np_precision(precision: "_PRECISION") -> np.dtype:
     RuntimeError
         if string is invalid
     """
-    if precision == "default":
-        return GLOBAL_NP_FLOAT_PRECISION
-    elif precision == "float16":
-        return np.float16
-    elif precision == "float32":
-        return np.float32
-    elif precision == "float64":
-        return np.float64
-    else:
-        raise RuntimeError(f"{precision} is not a valid precision")
+    from deepmd.dpmodel.common import (
+        get_xp_precision,
+    )
+
+    return get_xp_precision(np, precision)
 
 
 def symlink_prefix_files(old_prefix: str, new_prefix: str) -> None:

--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -35,6 +35,7 @@ from deepmd.utils.path import (
 )
 
 __all__ = [
+    "GLOBAL_NP_FLOAT_PRECISION",
     "VALID_ACTIVATION",
     "VALID_PRECISION",
     "expand_sys_str",
@@ -42,7 +43,6 @@ __all__ = [
     "j_loader",
     "make_default_mesh",
     "select_idx_map",
-    "GLOBAL_NP_FLOAT_PRECISION",
 ]
 
 _PRECISION = Literal["default", "float16", "bfloat16", "float32", "float64"]

--- a/deepmd/common.py
+++ b/deepmd/common.py
@@ -27,6 +27,9 @@ except ImportError:
 import numpy as np
 import yaml
 
+from deepmd.env import (
+    GLOBAL_NP_FLOAT_PRECISION,
+)
 from deepmd.utils.path import (
     DPPath,
 )
@@ -39,6 +42,7 @@ __all__ = [
     "j_loader",
     "make_default_mesh",
     "select_idx_map",
+    "GLOBAL_NP_FLOAT_PRECISION",
 ]
 
 _PRECISION = Literal["default", "float16", "bfloat16", "float32", "float64"]


### PR DESCRIPTION
`get_xp_precision` is more general and has more precisions (including bfloat16).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of precision settings for numerical operations, streamlining how precision is determined. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->