### PR TITLE
fix: no pinning memory on CPU

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -194,7 +194,7 @@ class Trainer:
                     else 0,  # setting to 0 diverges the behavior of its iterator; should be >=1
                     drop_last=False,
                     collate_fn=lambda batch: batch,  # prevent extra conversion
-                    pin_memory=(DEVICE != "cpu"), # pin memory only if not on CPU
+                    pin_memory=(DEVICE != "cpu"),  # pin memory only if not on CPU
                 )
                 _data_iter = cycle_iterator(_dataloader)
                 return _dataloader, _data_iter

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -194,7 +194,7 @@ class Trainer:
                     else 0,  # setting to 0 diverges the behavior of its iterator; should be >=1
                     drop_last=False,
                     collate_fn=lambda batch: batch,  # prevent extra conversion
-                    pin_memory=True,
+                    pin_memory=(DEVICE != "cpu"), # pin memory only if not on CPU
                 )
                 _data_iter = cycle_iterator(_dataloader)
                 return _dataloader, _data_iter


### PR DESCRIPTION
This PR fixes the warning message when running on CPU:
```
torch/utils/data/dataloader.py:665: UserWarning: 'pin_memory' argument is set as true but no accelerator is found, then device pinned memory won't be used.
  warnings.warn(warn_msg)
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory handling by enabling memory pinning only when using non-CPU devices, which may enhance performance and stability when training on GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->