### PR TITLE
Fix: support "max:N" and "filter:N" batch_size rules in DeepmdDataSystem

### DIFF
--- a/deepmd/utils/data_system.py
+++ b/deepmd/utils/data_system.py
@@ -152,6 +152,45 @@ class DeepmdDataSystem:
                 else:
                     raise RuntimeError("batch size must be specified for mixed systems")
                 self.batch_size = rule * np.ones(self.nsystems, dtype=int)
+            elif "max" == words[0]:
+                # Determine batch size so that batch_size * natoms <= rule, at least 1
+                if len(words) != 2:
+                    raise RuntimeError("batch size must be specified for max systems")
+                rule = int(words[1])
+                bs = []
+                for ii in self.data_systems:
+                    ni = ii.get_natoms()
+                    bsi = rule // ni
+                    if bsi == 0:
+                        bsi = 1
+                    bs.append(bsi)
+                self.batch_size = bs
+            elif "filter" == words[0]:
+                # Remove systems with natoms > rule, then set batch size like "max:rule"
+                if len(words) != 2:
+                    raise RuntimeError("batch size must be specified for filter systems")
+                rule = int(words[1])
+                filtered_data_systems = []
+                filtered_system_dirs = []
+                for sys_dir, data_sys in zip(self.system_dirs, self.data_systems):
+                    if data_sys.get_natoms() <= rule:
+                        filtered_data_systems.append(data_sys)
+                        filtered_system_dirs.append(sys_dir)
+                if len(filtered_data_systems) == 0:
+                    raise RuntimeError(f"No system left after removing systems with more than {rule} atoms")
+                if len(filtered_data_systems) != len(self.data_systems):
+                    warnings.warn(f"Remove {len(self.data_systems) - len(filtered_data_systems)} systems with more than {rule} atoms")
+                self.data_systems = filtered_data_systems
+                self.system_dirs = filtered_system_dirs
+                self.nsystems = len(self.data_systems)
+                bs = []
+                for ii in self.data_systems:
+                    ni = ii.get_natoms()
+                    bsi = rule // ni
+                    if bsi == 0:
+                        bsi = 1
+                    bs.append(bsi)
+                self.batch_size = bs
             else:
                 raise RuntimeError("unknown batch_size rule " + words[0])
         elif isinstance(self.batch_size, list):


### PR DESCRIPTION
# Fix: support "max:N" and "filter:N" batch_size rules in DeepmdDataSystem

## Problem

- Using `batch_size: "max:..."` or `"filter:..."` in configs caused:
  - `RuntimeError: unknown batch_size rule max` during the PyTorch path (neighbor statistics).
- Docs mention these rules and PyTorch `DpLoaderSet` already supports them, so behavior was inconsistent across layers.

## Cause

- The common data layer `DeepmdDataSystem` only implemented `"auto"` and `"mixed"` for string `batch_size`, missing `"max"` and `"filter"`.
- PT training performs neighbor statistics via `DeepmdDataSystem` before real training, so it failed early when those rules were used.

## Fix

- Implement `"max:N"` and `"filter:N"` in `DeepmdDataSystem.__init__` to mirror `DpLoaderSet` semantics:
  - `max:N`: per-system `batch_size = max(1, N // natoms)` so `batch_size * natoms <= N`.
  - `filter:N`: drop systems with `natoms > N` (warn if any removed; error if none left), then set per-system `batch_size` as in `max:N`.
- After filtering, update `self.data_systems`, `self.system_dirs`, and `self.nsystems` before computing other metadata.

## Impact

- Aligns the common layer behavior with PyTorch `DpLoaderSet` and with the documentation.
- Prevents PT neighbor-stat crashes with configs using `"max"`/`"filter"`.

## Compatibility

- No change to numeric `batch_size` or existing `"auto"/"auto:N"/"mixed:N"` rules.
- TF/PT/PD paths now accept the same `batch_size` rules consistently in the common layer.

## Files Changed

- `deepmd/utils/data_system.py`: add parsing branches for `"max:N"` and `"filter:N"` in `DeepmdDataSystem.__init__`.

elif "max" == words[0]:
                # Determine batch size so that batch_size * natoms <= rule, at least 1
                if len(words) != 2:
                    raise RuntimeError("batch size must be specified for max systems")
                rule = int(words[1])
                bs = []
                for ii in self.data_systems:
                    ni = ii.get_natoms()
                    bsi = rule // ni
                    if bsi == 0:
                        bsi = 1
                    bs.append(bsi)
                self.batch_size = bs
            elif "filter" == words[0]:
                # Remove systems with natoms > rule, then set batch size like "max:rule"
                if len(words) != 2:
                    raise RuntimeError("batch size must be specified for filter systems")
                rule = int(words[1])
                filtered_data_systems = []
                filtered_system_dirs = []
                for sys_dir, data_sys in zip(self.system_dirs, self.data_systems):
                    if data_sys.get_natoms() <= rule:
                        filtered_data_systems.append(data_sys)
                        filtered_system_dirs.append(sys_dir)
                if len(filtered_data_systems) == 0:
                    raise RuntimeError(f"No system left after removing systems with more than {rule} atoms")
                if len(filtered_data_systems) != len(self.data_systems):
                    warnings.warn(f"Remove {len(self.data_systems) - len(filtered_data_systems)} systems with more than {rule} atoms")
                self.data_systems = filtered_data_systems
                self.system_dirs = filtered_system_dirs
                self.nsystems = len(self.data_systems)
                bs = []
                for ii in self.data_systems:
                    ni = ii.get_natoms()
                    bsi = rule // ni
                    if bsi == 0:
                        bsi = 1
                    bs.append(bsi)
                self.batch_size = bs