### PR TITLE
fix: relax `atol` and `rtol` value of padding atoms UT

### DIFF
--- a/source/tests/pt/test_padding_atoms.py
+++ b/source/tests/pt/test_padding_atoms.py
@@ -49,7 +49,7 @@ class TestCaseSingleFrameWithoutNlist:
         self.sel = [16, 8]
         self.rcut = 2.2
         self.rcut_smth = 0.4
-        self.atol = 1e-8
+        self.atol = 1e-5
 
 
 class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):

--- a/source/tests/pt/test_padding_atoms.py
+++ b/source/tests/pt/test_padding_atoms.py
@@ -49,7 +49,8 @@ class TestCaseSingleFrameWithoutNlist:
         self.sel = [16, 8]
         self.rcut = 2.2
         self.rcut_smth = 0.4
-        self.atol = 1e-5
+        self.atol = 1e-6
+        self.rtol = 1e-5
 
 
 class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
@@ -79,6 +80,7 @@ class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
             to_numpy_array(result[var_name].cpu().detach()),
             np.mean(to_numpy_array(result[f"atom_{var_name}"].cpu().detach()), axis=1),
             atol=self.atol,
+            rtol=self.rtol,
         )
         # test padding atoms
         padding_atoms_list = [1, 5, 10]
@@ -105,6 +107,7 @@ class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
                 to_numpy_array(result[var_name].cpu().detach()),
                 to_numpy_array(result_padding[var_name].cpu().detach()),
                 atol=self.atol,
+                rtol=self.rtol,
             )
 
 


### PR DESCRIPTION
The UT of padding atoms(pytorch backend) sometimes fails like:
```
Mismatched elements: 1 / 2 (50%)
Max absolute difference among violations: 1.97471693e-08
Max relative difference among violations: 6.45619919e-07
 ACTUAL: array([[-0.236542],
       [ 0.030586]])
 DESIRED: array([[-0.236542],
       [ 0.030586]])
= 1 failed, 15442 passed, 4135 skipped, 97877 deselected, 224 warnings in 2825.25s (0:47:05) =
```