### PR TITLE
fix: Avoid setting pin_memory in tests

### DIFF
--- a/source/tests/pt/model/test_saveload_dpa1.py
+++ b/source/tests/pt/model/test_saveload_dpa1.py
@@ -69,7 +69,6 @@ class TestSaveLoadDPA1(unittest.TestCase):
             batch_size=None,
             num_workers=0,  # setting to 0 diverges the behavior of its iterator; should be >=1
             drop_last=False,
-            pin_memory=True,
         )
 
         def cycle_iterator(iterable):

--- a/source/tests/pt/model/test_saveload_se_e2_a.py
+++ b/source/tests/pt/model/test_saveload_se_e2_a.py
@@ -69,7 +69,6 @@ class TestSaveLoadSeA(unittest.TestCase):
             batch_size=None,
             num_workers=0,  # setting to 0 diverges the behavior of its iterator; should be >=1
             drop_last=False,
-            pin_memory=True,
         )
 
         def cycle_iterator(iterable):

--- a/source/tests/pt/test_sampler.py
+++ b/source/tests/pt/test_sampler.py
@@ -62,7 +62,6 @@ class TestSampler(unittest.TestCase):
             batch_size=None,
             num_workers=0,  # setting to 0 diverges the behavior of its iterator; should be >=1
             drop_last=False,
-            pin_memory=True,
         )
         with torch.device("cpu"):
             batch_data = next(iter(dataloader))


### PR DESCRIPTION
Avoid specifying pin_memory for test DataLoaders to eliminate warnings when no accelerator is available.
