### PR TITLE
fix(finetune): calculate fitting stat when using random fitting in finetuning process

### DIFF
--- a/deepmd/pt/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/base_atomic_model.py
@@ -487,6 +487,26 @@ class BaseAtomicModel(torch.nn.Module, BaseAtomicModel_):
         else:
             raise RuntimeError("Unknown bias_adjust_mode mode: " + bias_adjust_mode)
 
+    def compute_fitting_stat(
+        self,
+        sample_merged
+    ) -> None:
+        """Compute the input statistics (e.g. mean and stddev) for the fittings from packed data..
+
+        Parameters
+        ----------
+        sample_merged : Union[Callable[[], list[dict]], list[dict]]
+            - list[dict]: A list of data samples from various data systems.
+                Each element, `merged[i]`, is a data dictionary containing `keys`: `torch.Tensor`
+                originating from the `i`-th data system.
+            - Callable[[], list[dict]]: A lazy function that returns data samples in the above format
+                only when needed. Since the sampling process can be slow and memory-intensive,
+                the lazy function helps by only sampling once.
+        """
+        self.fitting_net.compute_input_stats(
+            sample_merged, protection=self.data_stat_protect
+        )
+
     def _get_forward_wrapper_func(self) -> Callable[..., torch.Tensor]:
         """Get a forward wrapper of the atomic model for output bias calculation."""
 

--- a/deepmd/pt/model/atomic_model/dp_atomic_model.py
+++ b/deepmd/pt/model/atomic_model/dp_atomic_model.py
@@ -324,9 +324,7 @@ class DPAtomicModel(BaseAtomicModel):
             return sampled
 
         self.descriptor.compute_input_stats(wrapped_sampler, stat_file_path)
-        self.fitting_net.compute_input_stats(
-            wrapped_sampler, protection=self.data_stat_protect
-        )
+        self.compute_fitting_stat(wrapped_sampler)
         if compute_or_load_out_stat:
             self.compute_or_load_out_stat(wrapped_sampler, stat_file_path)
 

--- a/deepmd/pt/model/model/make_model.py
+++ b/deepmd/pt/model/model/make_model.py
@@ -230,6 +230,8 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]):
                 merged,
                 bias_adjust_mode=bias_adjust_mode,
             )
+            if bias_adjust_mode == "set-by-statistic":
+                self.atomic_model.compute_fitting_stat(merged)
 
         def forward_common_lower(
             self,


### PR DESCRIPTION
In finetuing process, the computation of fitting stat is skipped in previous code. There are two situations:
1. Finetuning from pretrained model's branch: it means pretrained model also has `fparam` or `aparam` which has the same meaning of finetuning task. The key `fparam_avg`/`fparam_inv_std`/ `aparam_avg`/`aparam_inv_std` load from the pretrained model. It is correct.
2. Finetuning using RANDOM fitting. The fitting stat should be calculated in this situation. But the computation of fitting stat is skipped now. There is some error.