### PR TITLE
feat: add PyTorch profiler support to LAMMPS MD

### DIFF
--- a/doc/env.md
+++ b/doc/env.md
@@ -119,4 +119,4 @@ Tips:
 
 - Large runs can generate sizable JSON files; consider limiting numbers of MD steps, like 20.
 - Currently this feature only supports single process, or multi-process runs where each process uses a distinct GPU on the same node.
-:::
+  :::

--- a/doc/env.md
+++ b/doc/env.md
@@ -89,4 +89,33 @@ These environment variables also apply to third-party programs using the C++ int
 
 List of customized OP plugin libraries to load, such as `/path/to/plugin1.so:/path/to/plugin2.so` on Linux and `/path/to/plugin1.dll;/path/to/plugin2.dll` on Windows.
 
+:::{envvar} DP_PROFILER
+
+Enable the built-in PyTorch Kineto profiler for the PyTorch C++ (inference) backend.
+
+**Type**: string (output file stem)
+**Default**: unset (disabled)
+
+When set to a non-empty value, profiling is enabled for the lifetime of the loaded PyTorch model (e.g. during LAMMPS runs). A JSON trace file is written on finish. The final file name is constructed as:
+
+- `<ENV_VALUE>_gpu<ID>.json` if running on GPU (multi-GPU safe: the CUDA device id is appended)
+- `<ENV_VALUE>.json` if running on CPU
+
+The trace is compatible with [Chrome trace viewer](https://ui.perfetto.dev/) (alternatively chrome://tracing) and PyTorch profiler tooling. It includes:
+
+- CPU operator activities (always)
+- CUDA activities (if GPU available)
+
+Example:
+
+```bash
+export DP_PROFILER=result
+mpirun -np 4 lmp -in in.lammps
+# Produces result_gpuX.json, where X is the GPU id used by each MPI rank.
+```
+
+Tips:
+
+- Large runs can generate sizable JSON files; consider limiting numbers of MD steps, like 20.
+- Currently this feature only supports single process, or multi-process runs where each process uses a distinct GPU on the same node.
 :::

--- a/doc/env.md
+++ b/doc/env.md
@@ -118,4 +118,4 @@ Tips:
 
 - Large runs can generate sizable JSON files; consider limiting numbers of MD steps, like 20.
 - Currently this feature only supports single process, or multi-process runs where each process uses a distinct GPU on the same node.
-:::
+  :::

--- a/doc/env.md
+++ b/doc/env.md
@@ -95,17 +95,18 @@ List of customized OP plugin libraries to load, such as `/path/to/plugin1.so:/pa
 {{ pytorch_icon }} Enable the built-in PyTorch Kineto profiler for the PyTorch C++ (inference) backend.
 
 **Type**: string (output file stem)
+
 **Default**: unset (disabled)
 
-When set to a non-empty value, profiling is enabled for the lifetime of the loaded PyTorch model (e.g. during LAMMPS runs). A JSON trace file is written on finish. The final file name is constructed as:
+When set to a non-empty value, profiling is enabled for the lifetime of the loaded PyTorch model (e.g. during LAMMPS runs). A JSON trace file is created on finish. The final file name is constructed as:
 
-- `<ENV_VALUE>_gpu<ID>.json` if running on GPU (multi-GPU safe: the CUDA device id is appended)
+- `<ENV_VALUE>_gpu<ID>.json` if running on GPU
 - `<ENV_VALUE>.json` if running on CPU
 
-The trace is compatible with [Chrome trace viewer](https://ui.perfetto.dev/) (alternatively chrome://tracing) and PyTorch profiler tooling. It includes:
+The trace can be examined with [Chrome trace viewer](https://ui.perfetto.dev/) (alternatively chrome://tracing). It includes:
 
-- CPU operator activities (always)
-- CUDA activities (if GPU available)
+- CPU operator activities
+- CUDA activities (if available)
 
 Example:
 
@@ -119,4 +120,5 @@ Tips:
 
 - Large runs can generate sizable JSON files; consider limiting numbers of MD steps, like 20.
 - Currently this feature only supports single process, or multi-process runs where each process uses a distinct GPU on the same node.
-  :::
+
+:::

--- a/doc/env.md
+++ b/doc/env.md
@@ -88,6 +88,7 @@ These environment variables also apply to third-party programs using the C++ int
 **Type**: List of paths, split by `:` on Unix and `;` on Windows
 
 List of customized OP plugin libraries to load, such as `/path/to/plugin1.so:/path/to/plugin2.so` on Linux and `/path/to/plugin1.dll;/path/to/plugin2.dll` on Windows.
+:::
 
 :::{envvar} DP_PROFILER
 
@@ -118,4 +119,4 @@ Tips:
 
 - Large runs can generate sizable JSON files; consider limiting numbers of MD steps, like 20.
 - Currently this feature only supports single process, or multi-process runs where each process uses a distinct GPU on the same node.
-  :::
+:::

--- a/doc/env.md
+++ b/doc/env.md
@@ -91,7 +91,7 @@ List of customized OP plugin libraries to load, such as `/path/to/plugin1.so:/pa
 
 :::{envvar} DP_PROFILER
 
-Enable the built-in PyTorch Kineto profiler for the PyTorch C++ (inference) backend.
+{{ pytorch_icon }} Enable the built-in PyTorch Kineto profiler for the PyTorch C++ (inference) backend.
 
 **Type**: string (output file stem)
 **Default**: unset (disabled)

--- a/source/api_cc/include/DeepPotPT.h
+++ b/source/api_cc/include/DeepPotPT.h
@@ -340,6 +340,8 @@ class DeepPotPT : public DeepPotBackend {
   at::Tensor firstneigh_tensor;
   c10::optional<torch::Tensor> mapping_tensor;
   torch::Dict<std::string, torch::Tensor> comm_dict;
+  bool profiler_enabled{false};
+  std::string profiler_file;
   /**
    * @brief Translate PyTorch exceptions to the DeePMD-kit exception.
    * @param[in] f The function to run.

--- a/source/api_cc/src/DeepPotPT.cc
+++ b/source/api_cc/src/DeepPotPT.cc
@@ -107,8 +107,7 @@ void DeepPotPT::init(const std::string& model,
                        true,   // with_stack
                        false,  // with_flops
                        true,   // with_modules
-                       exp_cfg
-    );
+                       exp_cfg);
     torch::autograd::profiler::prepareProfiler(cfg, activities);
     torch::autograd::profiler::enableProfiler(cfg, activities);
     std::cout << "PyTorch profiler enabled, output file: " << profiler_file

--- a/source/api_cc/src/DeepPotPT.cc
+++ b/source/api_cc/src/DeepPotPT.cc
@@ -102,13 +102,12 @@ void DeepPotPT::init(const std::string& model,
     profiler_file += ".json";
     ExperimentalConfig exp_cfg;
     ProfilerConfig cfg(ProfilerState::KINETO,
-                       false,  // report_input_shapes,
-                       false,  // profile_memory,
-                       true,   // with_stack,
-                       false,  // with_flops,
-                       true,   // with_modules,
-                       exp_cfg,
-                       std::string()  // trace_id
+                       false,  // report_input_shapes
+                       false,  // profile_memory
+                       true,   // with_stack
+                       false,  // with_flops
+                       true,   // with_modules
+                       exp_cfg
     );
     torch::autograd::profiler::prepareProfiler(cfg, activities);
     torch::autograd::profiler::enableProfiler(cfg, activities);


### PR DESCRIPTION
This pull request adds support for enabling the PyTorch profiler in the `DeepPotPT` backend via an environment variable, making it easier to profile and debug performance issues. 
The profiler can be activated by setting the `DP_PROFILER` environment variable, and will save profiling results to a JSON file when the object is destroyed.

Fixes #4431 


**Profiler integration:**

* Added a `profiler_enabled` flag and `profiler_file` string to the `DeepPotPT` class to track profiler state and output location (`DeepPotPT.h`).
* In the `init` method, added logic to check for the `DP_PROFILER` environment variable. If set, the PyTorch profiler is configured and enabled, with output written to a file named according to the environment variable and GPU ID (`DeepPotPT.cc`).
* On destruction of `DeepPotPT`, if profiling was enabled, the profiler is properly disabled and results are saved to the specified file (`DeepPotPT.cc`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional runtime profiling via DP_PROFILER environment variable. Produces per-process JSON traces (CPU-only or CPU+GPU) and saves them automatically on shutdown; console messages report profiler status and output filename.

* **Refactor**
  * Improved device selection: auto-detects CUDA, selects a GPU per process when available and falls back to CPU; clearer startup diagnostics with no public API changes.

* **Documentation**
  * Added DP_PROFILER usage, filename rules, examples, and operational tips to the C++ interface docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->