### PR TITLE
fix: fix unit display in dp test

### DIFF
--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -1070,7 +1070,7 @@ def test_wfc(
     rmse_f = rmse(wfc - test_data["wfc"][:numb_test])
 
     log.info("# number of test data : {numb_test:d} ")
-    log.info("WFC  RMSE : {rmse_f:e} eV/Å")
+    log.info("WFC  RMSE : {rmse_f:e}")
 
     if detail_file is not None:
         detail_path = Path(detail_file)
@@ -1097,7 +1097,7 @@ def print_wfc_sys_avg(avg: dict) -> None:
     avg : np.ndarray
         array with summaries
     """
-    log.info(f"WFC  RMSE : {avg['rmse']:e} eV/Å")
+    log.info(f"WFC  RMSE : {avg['rmse']:e}")
 
 
 def test_polar(
@@ -1239,7 +1239,7 @@ def print_polar_sys_avg(avg: dict) -> None:
     avg : np.ndarray
         array with summaries
     """
-    log.info(f"Polarizability  RMSE : {avg['rmse']:e} eV/Å")
+    log.info(f"Polarizability  RMSE : {avg['rmse']:e}")
 
 
 def test_dipole(
@@ -1353,4 +1353,4 @@ def print_dipole_sys_avg(avg: dict) -> None:
     avg : np.ndarray
         array with summaries
     """
-    log.info(f"Dipole  RMSE         : {avg['rmse']:e} eV/Å")
+    log.info(f"Dipole  RMSE         : {avg['rmse']:e}")

--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -1069,8 +1069,8 @@ def test_wfc(
     wfc, numb_test, _ = run_test(dp, test_data, numb_test, data)
     rmse_f = rmse(wfc - test_data["wfc"][:numb_test])
 
-    log.info("# number of test data : {numb_test:d} ")
-    log.info("WFC  RMSE : {rmse_f:e}")
+    log.info(f"# number of test data : {numb_test:d} ")
+    log.info(f"WFC  RMSE : {rmse_f:e}")
 
     if detail_file is not None:
         detail_path = Path(detail_file)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified RMSE log messages by removing the " eV/Å" unit suffix for WFC, Polarizability, and Dipole metrics in both per-system and aggregated outputs.
  * Minor wording and formatting tweaks in test/log output messages; no changes to calculations, reported values, or program behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->