### PR TITLE
CI: Replace the macos-13 images with the macos-15-intel images

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -37,7 +37,7 @@ jobs:
             cuda_version: 11.8
             dp_pkg_name: deepmd-kit-cu11
           # macos-x86-64
-          - os: macos-13
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
             dp_variant: cpu


### PR DESCRIPTION
per https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build matrix in CI to use macOS 15 Intel runners for x86_64 wheel builds, keeping Python versions and other matrix settings unchanged.
  * No user-facing changes; application behavior remains the same. This update only affects build infrastructure, improving reliability and maintaining platform coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->