### PR TITLE
fix: set multiprocessing start method to 'fork' in pt env (since python3.14 defaults to forkserver)

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -984,19 +984,6 @@ def main(args: Optional[list[str]] = None) -> None:
     RuntimeError
         if no command was input
     """
-    try:
-        import multiprocessing
-        import sys
-
-        # Force fork multiprocessing start method (not available on Windows)
-        if sys.platform != "win32":
-            multiprocessing.set_start_method("fork", force=True)
-            logging.debug("Successfully set multiprocessing start method to 'fork'.")
-        else:
-            logging.debug("Skipping fork start method on Windows (not supported).")
-    except (RuntimeError, ValueError) as e:
-        logging.warning(f"Could not set multiprocessing start method: {e}")
-
     args = parse_args(args=args)
 
     if args.backend not in BACKEND_TABLE:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced platform-specific multiprocessing initialization with improved logging for better diagnostics.
  * Streamlined module logging setup to reduce code redundancy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->