### PR TITLE
fix(cmake): improve CUDA C++ standard for compatibility with gcc-14

### DIFF
--- a/source/lib/src/gpu/CMakeLists.txt
+++ b/source/lib/src/gpu/CMakeLists.txt
@@ -43,9 +43,15 @@ if(USE_CUDA_TOOLKIT)
     message(FATAL_ERROR "CUDA version must be >= 9.0")
   endif()
 
+  # NVCC compilation errors with gcc-14 and c++11 Cases in other repos:
+  # https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/issues/12
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14")
+    set_if_higher(CMAKE_CUDA_STANDARD 14)
+  endif()
+
   # CUDA 13.0+ requires C++17
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")
-    set(CMAKE_CUDA_STANDARD 17)
+    set_if_higher(CMAKE_CUDA_STANDARD 17)
     message(
       STATUS
         "CUDA ${CMAKE_CUDA_COMPILER_VERSION} detected, setting C++ standard to 17"


### PR DESCRIPTION
NVCC compilation errors with gcc-14 and C++11.

Cases in other repos: https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/issues/12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GPU build configuration to better support newer compiler versions (GCC/Clang 14+) and preserve user-specified C++ standards during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->