### PR TITLE
fix: remove hessian outdef if not necessary

### DIFF
--- a/deepmd/pt/infer/deep_eval.py
+++ b/deepmd/pt/infer/deep_eval.py
@@ -397,9 +397,9 @@ class DeepEval(DeepEvalBackend):
             The requested output definitions.
         """
         if atomic:
-            return list(self.output_def.var_defs.values())
+            output_defs = list(self.output_def.var_defs.values())
         else:
-            return [
+            output_defs = [
                 x
                 for x in self.output_def.var_defs.values()
                 if x.category
@@ -411,6 +411,13 @@ class DeepEval(DeepEvalBackend):
                     OutputVariableCategory.DERV_R_DERV_R,
                 )
             ]
+        if not self.get_has_hessian():
+            output_defs = [
+                x
+                for x in output_defs
+                if x.category != OutputVariableCategory.DERV_R_DERV_R
+            ]
+        return output_defs
 
     def _eval_func(self, inner_func: Callable, numb_test: int, natoms: int) -> Callable:
         """Wrapper method with auto batch size.


### PR DESCRIPTION
I found that the inference time per atom very weird using small models (both DPA3-L3 and DPA1 attn0) on very large systems (more than 1000 atoms):

<img width="1034" height="695" alt="截屏2025-11-11 17 52 32" src="https://github.com/user-attachments/assets/71b12719-ee74-4f2b-bb50-9f5f7031ee16" />

Through profilling, I found some unnecessary memory allocation matters for keys not in the model outputs (such as hessian). 
After fix, the inference time seems good:

<img width="1067" height="693" alt="截屏2025-11-11 17 56 26" src="https://github.com/user-attachments/assets/0fe6d430-3daa-43cd-b245-0889cd1311a8" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of output definitions in model inference to ensure proper filtering for models without Hessian support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->