### PR TITLE
test(common): add regression for atom type remap

### DIFF
--- a/source/tests/common/test_deepmd_data.py
+++ b/source/tests/common/test_deepmd_data.py
@@ -20,15 +20,15 @@ class TestDeepmdDataTypeMap(unittest.TestCase):
         self.set_dir.mkdir()
 
         # minimal required dataset
-        self._atom_types = np.array([0, 1, 0, 1], dtype=np.int32)
-        np.savetxt(self.root / "type.raw", self._atom_types, fmt="%d")
+        atom_types = np.array([0, 1, 0, 1], dtype=np.int32)
+        np.savetxt(self.root / "type.raw", atom_types, fmt="%d")
         np.savetxt(
             self.root / "type_map.raw",
             np.array(["O", "H", "Si"], dtype=object),
             fmt="%s",
         )
 
-        coord = np.zeros((1, self._atom_types.size * 3), dtype=np.float32)
+        coord = np.zeros((1, atom_types.size * 3), dtype=np.float32)
         box = np.eye(3, dtype=np.float32).reshape(1, 9)
         np.save(self.set_dir / "coord.npy", coord)
         np.save(self.set_dir / "box.npy", box)


### PR DESCRIPTION
  ## Summary
  - add a regression test that reproduces the original atom-type remapping failure when the training system contains fewer atom types than the provided type_map
  - ensure the fix from commit 4ec04370fd5c7c5bd4bbdbd6f7a30de8e7c3fff0 remains covered going forward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for DeepmdData that validate atom-type remapping, handling of unused types, and correct loading/formatting of type arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->