### PR TITLE
CI: stop running Horovod tests

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -32,8 +32,6 @@ jobs:
         export TENSORFLOW_ROOT=$(python -c 'import importlib.util,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
         export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
         source/install/uv_with_retry.sh pip install --system -e .[test,jax] mpi4py --group pin_jax
-        source/install/uv_with_retry.sh pip install --system -U setuptools
-        source/install/uv_with_retry.sh pip install --system horovod --no-build-isolation
         source/install/uv_with_retry.sh pip install --system --pre "paddlepaddle==3.0.0" -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
       env:
         # Please note that uv has some issues with finding

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -273,6 +273,12 @@ It will print the help information like
 
 ### Install horovod and mpi4py {{ tensorflow_icon }}
 
+:::{warning}
+Horovod has not released a new version for a long time.
+As of December 2025, the latest Horovod release does not support the latest TensorFlow versions.
+You can check the patches required to support the latest TensorFlow at [conda-forge/horovod-feedstock](https://github.com/conda-forge/horovod-feedstock/blob/main/recipe/meta.yaml).
+:::
+
 [Horovod](https://github.com/horovod/horovod) and [mpi4py](https://github.com/mpi4py/mpi4py) are used for parallel training. For better performance on GPU, please follow the tuning steps in [Horovod on GPU](https://github.com/horovod/horovod/blob/master/docs/gpus.rst).
 
 ```bash


### PR DESCRIPTION
Horovod has not released a new version for a long time. The PR to support TF 2.20 (https://github.com/horovod/horovod/pull/4302) has never been merged, I think it has been dead,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified test workflow by removing specific installation steps.

* **Documentation**
  * Added compatibility warning regarding Horovod and TensorFlow support in installation guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->