### PR TITLE
chore: move Ruff excludes to `ruff.extend-exclude`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,6 +354,11 @@ ignore = "D413, D416, D203, D107, D213"
 profile = "black"
 force_grid_wrap = 1
 
+[tool.ruff]
+extend-exclude = [
+    "source/3rdparty/**",
+]
+
 [tool.ruff.format]
 docstring-code-format = true
 
@@ -395,10 +400,6 @@ ignore = [
     "D205", # 1 blank line required between summary line and description
     "D401", # TODO: first line should be in imperative mood
     "D404", # TODO: first word of the docstring should not be This
-]
-
-exclude = [
-    "source/3rdparty/**",
 ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
Previously, it was in `ruff.lint.exclude`, so exclusions were not applied to `ruff format`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to enhance code quality standards and consistency checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->