### PR TITLE
feat(pt): add warmup_ratio setting to set warmup steps conveniently

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -421,7 +421,15 @@ class Trainer:
         if warmup_steps is not None:
             self.warmup_steps = warmup_steps
         elif warmup_ratio is not None:
+            if not 0 <= warmup_ratio < 1:
+                raise ValueError(f"warmup_ratio must be in [0, 1), got {warmup_ratio}")
             self.warmup_steps = int(warmup_ratio * self.num_steps)
+            if self.warmup_steps == 0 and warmup_ratio > 0:
+                log.warning(
+                    f"warmup_ratio {warmup_ratio} results in 0 warmup steps "
+                    f"due to truncation. Consider using a larger ratio or "
+                    f"specify warmup_steps directly."
+                )
         else:
             self.warmup_steps = 0
         self.warmup_start_factor = training_params.get("warmup_start_factor", 0.0)

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3226,6 +3226,7 @@ def training_args(
     doc_warmup_ratio = (
         "The ratio of warmup steps to total training steps. "
         "The actual number of warmup steps is calculated as `warmup_ratio * numb_steps`. "
+        "Valid values are in the range [0.0, 1.0). "
         "If `warmup_steps` is set, this option will be ignored."
     )
     doc_warmup_start_factor = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warmup_ratio to specify warm-up as a ratio of total steps and warmup_start_factor to control the warm-up starting scale; warmup_steps still takes precedence when provided.
* **Bug Fixes / Validation**
  * Enforced validation so warm-up values are within valid ranges and warm-up steps remain less than total steps; warns if ratio yields zero steps while >0.
* **Documentation**
  * Updated training argument docs to include the new options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->