### PR TITLE
fix(pt): Huber energy loss uses raw model energy

### DIFF
--- a/deepmd/dpmodel/loss/ener.py
+++ b/deepmd/dpmodel/loss/ener.py
@@ -131,8 +131,8 @@ class EnergyLoss(Loss):
             # E = - E(A) - E(B) + E(C) + E(D)
             # A, B, C, D could be put far away from each other
             atom_ener_coeff = label_dict["atom_ener_coeff"]
-            atom_ener_coeff = xp.reshape(atom_ener_coeff, xp.shape(atom_ener))
-            energy = xp.sum(atom_ener_coeff * atom_ener, 1)
+            atom_ener_coeff = xp.reshape(atom_ener_coeff, atom_ener.shape)
+            energy = xp.sum(atom_ener_coeff * atom_ener, axis=1)
         if self.has_f or self.has_pf or self.relative_f or self.has_gf:
             force_reshape = xp.reshape(force, (-1,))
             force_hat_reshape = xp.reshape(force_hat, (-1,))

--- a/deepmd/pd/loss/ener.py
+++ b/deepmd/pd/loss/ener.py
@@ -211,8 +211,8 @@ class EnergyStdLoss(TaskLoss):
                     loss += atom_norm * (pref_e * l2_ener_loss)
                 else:
                     l_huber_loss = custom_huber_loss(
-                        atom_norm * model_pred["energy"],
-                        atom_norm * label["energy"],
+                        atom_norm * energy_pred,
+                        atom_norm * energy_label,
                         delta=self.huber_delta,
                     )
                     loss += pref_e * l_huber_loss

--- a/deepmd/pt/loss/ener.py
+++ b/deepmd/pt/loss/ener.py
@@ -224,8 +224,8 @@ class EnergyStdLoss(TaskLoss):
                     loss += atom_norm * (pref_e * l2_ener_loss)
                 else:
                     l_huber_loss = custom_huber_loss(
-                        atom_norm * model_pred["energy"],
-                        atom_norm * label["energy"],
+                        atom_norm * energy_pred,
+                        atom_norm * energy_label,
                         delta=self.huber_delta,
                     )
                     loss += pref_e * l_huber_loss

--- a/source/tests/consistent/loss/test_ener.py
+++ b/source/tests/consistent/loss/test_ener.py
@@ -57,12 +57,15 @@ if INSTALLED_ARRAY_API_STRICT:
 
 
 @parameterized(
-    (False, True),  # use_huber
+    (False, False),  # huber, enable_atom_ener_coeff
+    (True, False),
+    (False, True),
+    (True, True),
 )
 class TestEner(CommonTest, LossTest, unittest.TestCase):
     @property
     def data(self) -> dict:
-        (use_huber,) = self.param
+        (use_huber, enable_atom_ener_coeff) = self.param
         return {
             "start_pref_e": 0.02,
             "limit_pref_e": 1.0,
@@ -75,6 +78,7 @@ class TestEner(CommonTest, LossTest, unittest.TestCase):
             "start_pref_pf": 1.0 if not use_huber else 0.0,
             "limit_pref_pf": 1.0 if not use_huber else 0.0,
             "use_huber": use_huber,
+            "enable_atom_ener_coeff": enable_atom_ener_coeff,
         }
 
     skip_tf = CommonTest.skip_tf
@@ -124,11 +128,13 @@ class TestEner(CommonTest, LossTest, unittest.TestCase):
                     self.natoms,
                 )
             ),
+            "atom_ener_coeff": rng.random((self.nframes, self.natoms)),
             "atom_pref": np.ones((self.nframes, self.natoms, 3)),
             "find_energy": 1.0,
             "find_force": 1.0,
             "find_virial": 1.0,
             "find_atom_ener": 1.0,
+            "find_atom_ener_coeff": 1.0,
             "find_atom_pref": 1.0,
         }
 

--- a/source/tests/consistent/loss/test_ener.py
+++ b/source/tests/consistent/loss/test_ener.py
@@ -57,10 +57,8 @@ if INSTALLED_ARRAY_API_STRICT:
 
 
 @parameterized(
-    (False, False),  # huber, enable_atom_ener_coeff
-    (True, False),
-    (False, True),
-    (True, True),
+    (False, True),  # huber
+    (False, True),  # enable_atom_ener_coeff
 )
 class TestEner(CommonTest, LossTest, unittest.TestCase):
     @property


### PR DESCRIPTION
Huber energy loss uses raw model energy instead of `energy_pred` that includes `atom_ener_coeff` weighting, so coefficients are silently dropped when use_huber=True

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed energy Huber loss to use the same precomputed energy values as other loss paths for consistent energy loss computation.
  * Improved energy aggregation handling to be more robust and correctly shaped during computation.

* **Tests**
  * Expanded loss tests to cover configurations with and without atom energy coefficients and updated test inputs to validate the revised behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->