### PR TITLE
fix: pass mixed_type to eval_descriptor in cli

### DIFF
--- a/deepmd/entrypoints/eval_desc.py
+++ b/deepmd/entrypoints/eval_desc.py
@@ -128,6 +128,7 @@ def eval_desc(
             atype,
             fparam=fparam,
             aparam=aparam,
+            mixed_type=mixed_type,
         )
 
         # descriptors are kept in 3D format (nframes, natoms, ndesc)


### PR DESCRIPTION
Fix #5176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mixed_type parameter not being properly forwarded during descriptor evaluation, ensuring the flag is now correctly propagated through the evaluation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->