### PR TITLE
chore(CI/dev): use prek to replace pre-commit

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,7 +13,7 @@ The following packages are installed into the Python environment `.venv`:
 - LAMMPS
 - MPICH
 - CMake
-- pre-commit (including hooks)
+- prek (including hooks)
 - Test packages including pytest
 - Doc packages including sphinx
 

--- a/.devcontainer/build_py.sh
+++ b/.devcontainer/build_py.sh
@@ -5,4 +5,4 @@ SCRIPT_PATH=$(dirname $(realpath -s $0))
 cd ${SCRIPT_PATH}/..
 
 uv sync --dev --python 3.12 --extra cpu --extra torch --extra jax --extra lmp --extra test --extra docs
-pre-commit install
+prek install

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": ".devcontainer/build_py.sh && .devcontainer/download_libtorch.sh && .devcontainer/build_cxx.sh && pre-commit install-hooks",
+  "postCreateCommand": ".devcontainer/build_py.sh && .devcontainer/download_libtorch.sh && .devcontainer/build_cxx.sh && prek install-hooks",
   "remoteEnv": {
     "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/.venv/bin",
     "DP_ENABLE_PYTORCH": "1",

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -54,10 +54,10 @@ jobs:
       - name: Build Python package
         run: uv pip install -e .[cpu,test]
 
-      - name: Install pre-commit tools
+      - name: Install prek tools
         run: uv tool install prek
 
-      - name: Install pre-commit hooks
+      - name: Install prek hooks
         run: prek install --install-hooks
 
       - name: Verify installation

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -55,10 +55,10 @@ jobs:
         run: uv pip install -e .[cpu,test]
 
       - name: Install pre-commit tools
-        run: uv tool install pre-commit
+        run: uv tool install prek
 
       - name: Install pre-commit hooks
-        run: pre-commit install --install-hooks
+        run: prek install --install-hooks
 
       - name: Verify installation
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - torchfix==0.6.0
+          - torchfix==0.7.0
           - flake8-pyproject==1.2.3
   # numpydoc
   - repo: https://github.com/Carreau/velin

--- a/doc/development/coding-conventions.rst
+++ b/doc/development/coding-conventions.rst
@@ -145,12 +145,12 @@ style with some modifications.
 Run scripts to check the code
 =============================
 
-It's a good idea to install `pre-commit <https://pre-commit.com>`_ on your repository:
+It's a good idea to install `prek <https://github.com/j178/prek>`_ on your repository:
 
 .. code-block:: bash
 
-    $ pip install pre-commit
-    $ pre-commit install
+    $ uv tool install prek
+    $ prek install
 
 The scripts will be run automatically before each commit and will fix the code style
 issues automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ dp = "deepmd.main:main"
 
 [dependency-groups]
 dev = [
-  "pre-commit",
+  "prek",
   "cmake",
   "mpich",
 ]


### PR DESCRIPTION
`prek` is `pre-commit` written in Rust, just like `uv pip` and `pip`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development setup guidance and commands to reflect the new recommended tooling.

* **Chores**
  * Migrated development tooling configuration across container setup, scripts, and CI workflow to use the new tool.
  * Bumped torchfix dependency to 0.7.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->