### PR TITLE
fix(pt): expansion of get_default_nthreads()

### DIFF
--- a/deepmd/env.py
+++ b/deepmd/env.py
@@ -138,7 +138,7 @@ def get_default_nthreads() -> tuple[int, int]:
     ), int(
         os.environ.get(
             "DP_INTER_OP_PARALLELISM_THREADS",
-            os.environ.get("TF_INTRA_OP_PARALLELISM_THREADS", "0"),
+            os.environ.get("TF_INTER_OP_PARALLELISM_THREADS", "0"),
         )
     )
 

--- a/deepmd/pt/utils/env.py
+++ b/deepmd/pt/utils/env.py
@@ -91,7 +91,7 @@ DEFAULT_PRECISION = "float64"
 
 # throw warnings if threads not set
 set_default_nthreads()
-inter_nthreads, intra_nthreads = get_default_nthreads()
+intra_nthreads, inter_nthreads = get_default_nthreads()
 if inter_nthreads > 0:  # the behavior of 0 is not documented
     torch.set_num_interop_threads(inter_nthreads)
 if intra_nthreads > 0:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread configuration so inter-op and intra-op thread counts are assigned and applied correctly, improving multi-threaded performance behavior.
  * Updated fallback for inter-op thread count to use the appropriate inter-op environment variable when the primary value is unset, preserving expected defaults across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->