### PR TITLE
style: re-enable cmake-format JSON formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     rev: v21.1.7
     hooks:
       - id: clang-format
-        exclude: ^(source/3rdparty|source/lib/src/gpu/cudart/.+\.inc|.+\.ipynb$|.+\.json$)
+        exclude: ^(source/3rdparty|source/lib/src/gpu/cudart/.+\.inc|.+\.ipynb$|source/tests/infer/.+\.json$)
   # markdown, yaml, CSS, javascript
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/examples/water_multi_task/pytorch_example/input_torch_with_alias.json
+++ b/examples/water_multi_task/pytorch_example/input_torch_with_alias.json
@@ -57,20 +57,31 @@
         "type_map": "type_map_all",
         "descriptor": "dpa3_descriptor",
         "fitting_net": "shared_fit_with_id",
-        "model_branch_alias": ["Default","Water"],
+        "model_branch_alias": [
+          "Default",
+          "Water"
+        ],
         "info": {
-            "description": "Water model with DPA3 descriptor and shared fitting net",
-            "observed_type": ["H", "O"]
+          "description": "Water model with DPA3 descriptor and shared fitting net",
+          "observed_type": [
+            "H",
+            "O"
+          ]
         }
       },
       "water_2": {
         "type_map": "type_map_all",
         "descriptor": "dpa3_descriptor",
         "fitting_net": "shared_fit_with_id",
-        "model_branch_alias": ["Water2"],
+        "model_branch_alias": [
+          "Water2"
+        ],
         "info": {
-            "description": "Water duplicated model with DPA3 descriptor and shared fitting net",
-            "observed_type": ["H", "O"]
+          "description": "Water duplicated model with DPA3 descriptor and shared fitting net",
+          "observed_type": [
+            "H",
+            "O"
+          ]
         }
       }
     }


### PR DESCRIPTION
#4467 disabled the JSON formatter. Now it is turned on again, but ignores files added by #4467.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined formatting configuration to apply formatter to more JSON files (narrower exclusions).
  * Reformatted JSON content for readability without changing any data or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->