### PR TITLE
refact(pt_expt): add decorator to simplify the module

### DIFF
--- a/deepmd/pt_expt/common.py
+++ b/deepmd/pt_expt/common.py
@@ -302,12 +302,12 @@ def torch_module(
 
     Parameters
     ----------
-    module : NativeOP
+    module : type[NativeOP]
         The NativeOP to convert.
 
     Returns
     -------
-    torch.nn.Module
+    type[torch.nn.Module]
         The torch.nn.Module.
 
     Examples

--- a/deepmd/pt_expt/descriptor/se_e2_a.py
+++ b/deepmd/pt_expt/descriptor/se_e2_a.py
@@ -14,7 +14,7 @@ from deepmd.pt_expt.descriptor.base_descriptor import (
 @BaseDescriptor.register("se_e2_a_expt")
 @BaseDescriptor.register("se_a_expt")
 @torch_module
-class DescrptSeA(DescrptSeADP, torch.nn.Module):
+class DescrptSeA(DescrptSeADP):
     def forward(
         self,
         extended_coord: torch.Tensor,

--- a/deepmd/pt_expt/descriptor/se_e2_a.py
+++ b/deepmd/pt_expt/descriptor/se_e2_a.py
@@ -1,13 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-from typing import (
-    Any,
-)
 
 import torch
 
 from deepmd.dpmodel.descriptor.se_e2_a import DescrptSeAArrayAPI as DescrptSeADP
 from deepmd.pt_expt.common import (
-    dpmodel_setattr,
+    torch_module,
 )
 from deepmd.pt_expt.descriptor.base_descriptor import (
     BaseDescriptor,
@@ -16,20 +13,8 @@ from deepmd.pt_expt.descriptor.base_descriptor import (
 
 @BaseDescriptor.register("se_e2_a_expt")
 @BaseDescriptor.register("se_a_expt")
+@torch_module
 class DescrptSeA(DescrptSeADP, torch.nn.Module):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        torch.nn.Module.__init__(self)
-        DescrptSeADP.__init__(self, *args, **kwargs)
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # Ensure torch.nn.Module.__call__ drives forward() for export/tracing.
-        return torch.nn.Module.__call__(self, *args, **kwargs)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        handled, value = dpmodel_setattr(self, name, value)
-        if not handled:
-            super().__setattr__(name, value)
-
     def forward(
         self,
         extended_coord: torch.Tensor,

--- a/deepmd/pt_expt/descriptor/se_r.py
+++ b/deepmd/pt_expt/descriptor/se_r.py
@@ -14,7 +14,7 @@ from deepmd.pt_expt.descriptor.base_descriptor import (
 @BaseDescriptor.register("se_e2_r_expt")
 @BaseDescriptor.register("se_r_expt")
 @torch_module
-class DescrptSeR(DescrptSeRDP, torch.nn.Module):
+class DescrptSeR(DescrptSeRDP):
     def forward(
         self,
         extended_coord: torch.Tensor,

--- a/deepmd/pt_expt/descriptor/se_r.py
+++ b/deepmd/pt_expt/descriptor/se_r.py
@@ -1,13 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-from typing import (
-    Any,
-)
 
 import torch
 
 from deepmd.dpmodel.descriptor.se_r import DescrptSeR as DescrptSeRDP
 from deepmd.pt_expt.common import (
-    dpmodel_setattr,
+    torch_module,
 )
 from deepmd.pt_expt.descriptor.base_descriptor import (
     BaseDescriptor,
@@ -16,20 +13,8 @@ from deepmd.pt_expt.descriptor.base_descriptor import (
 
 @BaseDescriptor.register("se_e2_r_expt")
 @BaseDescriptor.register("se_r_expt")
+@torch_module
 class DescrptSeR(DescrptSeRDP, torch.nn.Module):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        torch.nn.Module.__init__(self)
-        DescrptSeRDP.__init__(self, *args, **kwargs)
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # Ensure torch.nn.Module.__call__ drives forward() for export/tracing.
-        return torch.nn.Module.__call__(self, *args, **kwargs)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        handled, value = dpmodel_setattr(self, name, value)
-        if not handled:
-            super().__setattr__(name, value)
-
     def forward(
         self,
         extended_coord: torch.Tensor,

--- a/deepmd/pt_expt/descriptor/se_t.py
+++ b/deepmd/pt_expt/descriptor/se_t.py
@@ -1,13 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-from typing import (
-    Any,
-)
 
 import torch
 
 from deepmd.dpmodel.descriptor.se_t import DescrptSeT as DescrptSeTDP
 from deepmd.pt_expt.common import (
-    dpmodel_setattr,
+    torch_module,
 )
 from deepmd.pt_expt.descriptor.base_descriptor import (
     BaseDescriptor,
@@ -17,20 +14,8 @@ from deepmd.pt_expt.descriptor.base_descriptor import (
 @BaseDescriptor.register("se_e3_expt")
 @BaseDescriptor.register("se_at_expt")
 @BaseDescriptor.register("se_a_3be_expt")
-class DescrptSeT(DescrptSeTDP, torch.nn.Module):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        torch.nn.Module.__init__(self)
-        DescrptSeTDP.__init__(self, *args, **kwargs)
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # Ensure torch.nn.Module.__call__ drives forward() for export/tracing.
-        return torch.nn.Module.__call__(self, *args, **kwargs)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        handled, value = dpmodel_setattr(self, name, value)
-        if not handled:
-            super().__setattr__(name, value)
-
+@torch_module
+class DescrptSeT(DescrptSeTDP):
     def forward(
         self,
         extended_coord: torch.Tensor,

--- a/deepmd/pt_expt/descriptor/se_t_tebd.py
+++ b/deepmd/pt_expt/descriptor/se_t_tebd.py
@@ -1,13 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-from typing import (
-    Any,
-)
 
 import torch
 
 from deepmd.dpmodel.descriptor.se_t_tebd import DescrptSeTTebd as DescrptSeTTebdDP
 from deepmd.pt_expt.common import (
-    dpmodel_setattr,
+    torch_module,
 )
 from deepmd.pt_expt.descriptor.base_descriptor import (
     BaseDescriptor,
@@ -15,20 +12,8 @@ from deepmd.pt_expt.descriptor.base_descriptor import (
 
 
 @BaseDescriptor.register("se_e3_tebd_expt")
-class DescrptSeTTebd(DescrptSeTTebdDP, torch.nn.Module):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        torch.nn.Module.__init__(self)
-        DescrptSeTTebdDP.__init__(self, *args, **kwargs)
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # Ensure torch.nn.Module.__call__ drives forward() for export/tracing.
-        return torch.nn.Module.__call__(self, *args, **kwargs)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        handled, value = dpmodel_setattr(self, name, value)
-        if not handled:
-            super().__setattr__(name, value)
-
+@torch_module
+class DescrptSeTTebd(DescrptSeTTebdDP):
     def forward(
         self,
         extended_coord: torch.Tensor,

--- a/deepmd/pt_expt/descriptor/se_t_tebd_block.py
+++ b/deepmd/pt_expt/descriptor/se_t_tebd_block.py
@@ -1,7 +1,4 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-from typing import (
-    Any,
-)
 
 import torch
 
@@ -9,20 +6,36 @@ from deepmd.dpmodel.descriptor.se_t_tebd import (
     DescrptBlockSeTTebd as DescrptBlockSeTTebdDP,
 )
 from deepmd.pt_expt.common import (
-    dpmodel_setattr,
     register_dpmodel_mapping,
+    torch_module,
 )
 
 
-class DescrptBlockSeTTebd(DescrptBlockSeTTebdDP, torch.nn.Module):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        torch.nn.Module.__init__(self)
-        DescrptBlockSeTTebdDP.__init__(self, *args, **kwargs)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        handled, value = dpmodel_setattr(self, name, value)
-        if not handled:
-            super().__setattr__(name, value)
+@torch_module
+class DescrptBlockSeTTebd(DescrptBlockSeTTebdDP):
+    def forward(
+        self,
+        nlist: torch.Tensor,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        atype_embd_ext: torch.Tensor | None = None,
+        mapping: torch.Tensor | None = None,
+        type_embedding: torch.Tensor | None = None,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        return self.call(
+            nlist,
+            coord_ext,
+            atype_ext,
+            atype_embd_ext=atype_embd_ext,
+            mapping=mapping,
+            type_embedding=type_embedding,
+        )
 
 
 register_dpmodel_mapping(

--- a/deepmd/pt_expt/utils/exclude_mask.py
+++ b/deepmd/pt_expt/utils/exclude_mask.py
@@ -1,27 +1,17 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-from typing import (
-    Any,
-)
 
-import torch
 
 from deepmd.dpmodel.utils.exclude_mask import AtomExcludeMask as AtomExcludeMaskDP
 from deepmd.dpmodel.utils.exclude_mask import PairExcludeMask as PairExcludeMaskDP
 from deepmd.pt_expt.common import (
-    dpmodel_setattr,
     register_dpmodel_mapping,
+    torch_module,
 )
 
 
-class AtomExcludeMask(AtomExcludeMaskDP, torch.nn.Module):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        torch.nn.Module.__init__(self)
-        AtomExcludeMaskDP.__init__(self, *args, **kwargs)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        handled, value = dpmodel_setattr(self, name, value)
-        if not handled:
-            super().__setattr__(name, value)
+@torch_module
+class AtomExcludeMask(AtomExcludeMaskDP):
+    pass
 
 
 register_dpmodel_mapping(
@@ -30,15 +20,9 @@ register_dpmodel_mapping(
 )
 
 
-class PairExcludeMask(PairExcludeMaskDP, torch.nn.Module):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        torch.nn.Module.__init__(self)
-        PairExcludeMaskDP.__init__(self, *args, **kwargs)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        handled, value = dpmodel_setattr(self, name, value)
-        if not handled:
-            super().__setattr__(name, value)
+@torch_module
+class PairExcludeMask(PairExcludeMaskDP):
+    pass
 
 
 register_dpmodel_mapping(

--- a/deepmd/pt_expt/utils/network.py
+++ b/deepmd/pt_expt/utils/network.py
@@ -75,6 +75,10 @@ class NativeLayer(NativeLayerDP):
 
 @torch_module
 class NativeNet(make_multilayer_network(NativeLayer, NativeOP)):
+    def __init__(self, layers: list[dict] | None = None) -> None:
+        super().__init__(layers)
+        self.layers = torch.nn.ModuleList(self.layers)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.call(x)
 

--- a/deepmd/pt_expt/utils/network.py
+++ b/deepmd/pt_expt/utils/network.py
@@ -38,8 +38,15 @@ class TorchArrayParam(torch.nn.Parameter):
         return arr.astype(dtype)
 
 
-@torch_module
-class NativeLayer(NativeLayerDP):
+# do not apply torch_module until its setattr working to register parameters
+class NativeLayer(NativeLayerDP, torch.nn.Module):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        torch.nn.Module.__init__(self)
+        NativeLayerDP.__init__(self, *args, **kwargs)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return torch.nn.Module.__call__(self, *args, **kwargs)
+
     def __setattr__(self, name: str, value: Any) -> None:
         if name in {"w", "b", "idt"} and "_parameters" in self.__dict__:
             val = to_torch_array(value)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a public adapter to expose DP classes as PyTorch modules via a decorator-based API.

* **Refactor**
  * Converted multiple descriptor, network, and utility classes to decorator-driven PyTorch integration, simplifying initialization and attribute handling.

* **Breaking Changes**
  * Several descriptor forward signatures expanded to accept extended topology/embedding inputs and now return expanded tuples (update call sites accordingly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->