### PR TITLE
fix(jax): improve JAX modules' names

### DIFF
--- a/deepmd/jax/common.py
+++ b/deepmd/jax/common.py
@@ -44,9 +44,12 @@ def to_jax_array(array: np.ndarray | None) -> jnp.ndarray | None:
     return jnp.array(array)
 
 
+T = TypeVar('T')
+
+
 def flax_module(
-    module: type[NativeOP],
-) -> type[nnx.Module]:
+    module: type[T],
+) -> type[T]:   # runtime: actually returns type[T & nnx.Module]
     """Convert a NativeOP to a Flax module.
 
     Parameters

--- a/deepmd/jax/common.py
+++ b/deepmd/jax/common.py
@@ -9,9 +9,6 @@ from typing import (
 
 import numpy as np
 
-from deepmd.dpmodel.common import (
-    NativeOP,
-)
 from deepmd.jax.env import (
     jnp,
     nnx,
@@ -44,12 +41,12 @@ def to_jax_array(array: np.ndarray | None) -> jnp.ndarray | None:
     return jnp.array(array)
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def flax_module(
     module: type[T],
-) -> type[T]:   # runtime: actually returns type[T & nnx.Module]
+) -> type[T]:  # runtime: actually returns type[T & nnx.Module]
     """Convert a NativeOP to a Flax module.
 
     Parameters

--- a/deepmd/jax/common.py
+++ b/deepmd/jax/common.py
@@ -4,6 +4,7 @@ from functools import (
 )
 from typing import (
     Any,
+    TypeVar,
     overload,
 )
 

--- a/deepmd/jax/common.py
+++ b/deepmd/jax/common.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from functools import (
+    wraps,
+)
 from typing import (
     Any,
     overload,
@@ -42,18 +45,18 @@ def to_jax_array(array: np.ndarray | None) -> jnp.ndarray | None:
 
 
 def flax_module(
-    module: NativeOP,
-) -> nnx.Module:
+    module: type[NativeOP],
+) -> type[nnx.Module]:
     """Convert a NativeOP to a Flax module.
 
     Parameters
     ----------
-    module : NativeOP
+    module : type[NativeOP]
         The NativeOP to convert.
 
     Returns
     -------
-    flax.nnx.Module
+    type[flax.nnx.Module]
         The Flax module.
 
     Examples
@@ -72,6 +75,7 @@ def flax_module(
         def __call__(self, *args: Any, **kwargs: Any) -> Any:
             return type(nnx.Module).__call__(self, *args, **kwargs)
 
+    @wraps(module, updated=())
     class FlaxModule(module, nnx.Module, metaclass=MixedMetaClass):
         def __init_subclass__(cls, **kwargs: Any) -> None:
             return super().__init_subclass__(**kwargs)


### PR DESCRIPTION
Use `wraps` to keep the modules' names, so they won't be `FlaxModule`, which cannot be regonized. I realized it when implementing #5213.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type annotations and type-safety for module wrapping to aid correctness and tooling.
  * Preserved original module metadata when creating wrapped modules, improving introspection and debugging.
  * Updated docstrings and signatures to reflect the new typing and metadata behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->