### PR TITLE
fix(pt): remove compile in HybridMuon for FSDP2 compatibility use triton instead

### DIFF
--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -175,6 +175,7 @@ class Trainer:
                 "lr_adjust_coeff": params.get("lr_adjust_coeff", 0.2),
                 "muon_2d_only": params.get("muon_2d_only", True),
                 "min_2d_dim": params.get("min_2d_dim", 1),
+                "flash_muon": params.get("flash_muon", True),
             }
             return opt_type, opt_param
 
@@ -763,6 +764,7 @@ class Trainer:
                 lr_adjust_coeff=float(self.opt_param["lr_adjust_coeff"]),
                 muon_2d_only=bool(self.opt_param["muon_2d_only"]),
                 min_2d_dim=int(self.opt_param["min_2d_dim"]),
+                flash_muon=bool(self.opt_param["flash_muon"]),
             )
             if optimizer_state_dict is not None and self.restart_training:
                 self.optimizer.load_state_dict(optimizer_state_dict)

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3554,6 +3554,16 @@ def training_args(
                             "those with min(m, n) < min_2d_dim use Adam fallback. "
                             "Set to 1 to disable fallback.",
                         ),
+                        Argument(
+                            "flash_muon",
+                            bool,
+                            optional=True,
+                            default=True,
+                            doc=doc_only_pt_supported
+                            + "Enable triton-accelerated Newton-Schulz orthogonalization. "
+                            "Requires triton and CUDA. Falls back to PyTorch implementation "
+                            "when triton is unavailable or running on CPU.",
+                        ),
                     ],
                     [],
                     optional=True,

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3511,7 +3511,7 @@ def training_args(
                             optional=True,
                             default=0.001,
                             doc=doc_only_pt_supported
-                            + "Weight decay coefficient. Applied only to Muon-routed parameters",
+                            + "Weight decay coefficient. Applied to Muon-routed parameters and >=2D Adam-routed parameters (AdamW-style decoupled decay). Not applied to 1D Adam parameters.",
                         ),
                         Argument(
                             "lr_adjust",
@@ -3539,8 +3539,8 @@ def training_args(
                             default=True,
                             doc=doc_only_pt_supported
                             + "If True, only 2D parameters use Muon (matching PyTorch's torch.optim.Muon). "
-                            + "Parameters with ndim > 2 use Adam without weight decay. "
-                            + "If False, all >=2D parameters use Muon.",
+                            + "Parameters with ndim > 2 use AdamW-style updates. "
+                            + "If False, all >=2D parameters are eligible for Muon (with min_2d_dim fallback to AdamW-style updates).",
                         ),
                         Argument(
                             "min_2d_dim",
@@ -3549,8 +3549,8 @@ def training_args(
                             default=1,
                             alias=["muon_min_2d_dim"],
                             doc=doc_only_pt_supported
-                            + "Minimum min(m, n) threshold for HybridMuon on 2D matrices. "
-                            "Matrices with min(m, n) >= min_2d_dim use HybridMuon; "
+                            + "Minimum min(m, n) threshold for HybridMuon on matrix-view parameters. "
+                            "Parameters with min(m, n) >= min_2d_dim use HybridMuon; "
                             "those with min(m, n) < min_2d_dim use Adam fallback. "
                             "Set to 1 to disable fallback.",
                         ),
@@ -3570,7 +3570,7 @@ def training_args(
                     doc=doc_only_pt_supported
                     + "HybridMuon optimizer (DeePMD-kit custom implementation). "
                     + "This is a Hybrid optimizer that automatically combines Muon and Adam. "
-                    + "For >=2D params: Muon update with Newton-Schulz. "
+                    + "For >=2D params: Muon update with Newton-Schulz (or Adam fallback when matrix-view dimensions are too small). "
                     + "For 1D params: Standard Adam. "
                     + "This is DIFFERENT from PyTorch's torch.optim.Muon which ONLY supports 2D parameters.",
                 ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified orthogonalization routing to process matrix parameters per-entry and added a faster GPU path when available.

* **New Features**
  * Added optimizer option "flash_muon" (default: true) to enable an accelerated orthogonalization path with automatic fallback.

* **Tests**
  * Expanded tests to cover both accelerated and fallback paths and adjusted shape/validation cases.

* **Documentation**
  * Updated optimizer argument docs to describe flash_muon and clarified 1D/>=2D parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->