### PR TITLE
refact(dpmodel): model output made the same as pt backend

### DIFF
--- a/deepmd/dpmodel/infer/deep_eval.py
+++ b/deepmd/dpmodel/infer/deep_eval.py
@@ -358,9 +358,7 @@ class DeepEval(DeepEvalBackend):
 
         results = []
         for odef in request_defs:
-            # it seems not doing conversion
-            # dp_name = self._OUTDEF_DP2BACKEND[odef.name]
-            dp_name = odef.name
+            dp_name = self._OUTDEF_DP2BACKEND[odef.name]
             if dp_name in batch_output:
                 shape = self._get_output_shape(odef, nframes, natoms)
                 if batch_output[dp_name] is not None:

--- a/deepmd/dpmodel/model/dipole_model.py
+++ b/deepmd/dpmodel/model/dipole_model.py
@@ -93,6 +93,8 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
             model_predict["virial"] = model_ret["dipole_derv_c_redu"]
             if do_atomic_virial and model_ret.get("dipole_derv_c") is not None:
                 model_predict["extended_virial"] = model_ret["dipole_derv_c"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
         return model_predict
 
     def translated_output_def(self) -> dict[str, Any]:

--- a/deepmd/dpmodel/model/dipole_model.py
+++ b/deepmd/dpmodel/model/dipole_model.py
@@ -3,6 +3,9 @@ from typing import (
     Any,
 )
 
+from deepmd.dpmodel.array_api import (
+    Array,
+)
 from deepmd.dpmodel.atomic_model import (
     DPDipoleAtomicModel,
 )
@@ -31,3 +34,81 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
     ) -> None:
         DPModelCommon.__init__(self)
         DPDipoleModel_.__init__(self, *args, **kwargs)
+
+    def call(
+        self,
+        coord: Array,
+        atype: Array,
+        box: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common(
+            coord,
+            atype,
+            box,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["dipole"] = model_ret["dipole"]
+        model_predict["global_dipole"] = model_ret["dipole_redu"]
+        if self.do_grad_r("dipole") and model_ret["dipole_derv_r"] is not None:
+            model_predict["force"] = model_ret["dipole_derv_r"]
+        if self.do_grad_c("dipole") and model_ret["dipole_derv_c_redu"] is not None:
+            model_predict["virial"] = model_ret["dipole_derv_c_redu"]
+            if do_atomic_virial and model_ret["dipole_derv_c"] is not None:
+                model_predict["atom_virial"] = model_ret["dipole_derv_c"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def call_lower(
+        self,
+        extended_coord: Array,
+        extended_atype: Array,
+        nlist: Array,
+        mapping: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common_lower(
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["dipole"] = model_ret["dipole"]
+        model_predict["global_dipole"] = model_ret["dipole_redu"]
+        if self.do_grad_r("dipole") and model_ret.get("dipole_derv_r") is not None:
+            model_predict["extended_force"] = model_ret["dipole_derv_r"]
+        if self.do_grad_c("dipole") and model_ret.get("dipole_derv_c_redu") is not None:
+            model_predict["virial"] = model_ret["dipole_derv_c_redu"]
+            if do_atomic_virial and model_ret.get("dipole_derv_c") is not None:
+                model_predict["extended_virial"] = model_ret["dipole_derv_c"]
+        return model_predict
+
+    def translated_output_def(self) -> dict[str, Any]:
+        out_def_data = self.model_output_def().get_data()
+        output_def = {
+            "dipole": out_def_data["dipole"],
+            "global_dipole": out_def_data["dipole_redu"],
+        }
+        if self.do_grad_r("dipole"):
+            output_def["force"] = out_def_data["dipole_derv_r"]
+            output_def["force"].squeeze(-2)
+        if self.do_grad_c("dipole"):
+            output_def["virial"] = out_def_data["dipole_derv_c_redu"]
+            output_def["virial"].squeeze(-2)
+            output_def["atom_virial"] = out_def_data["dipole_derv_c"]
+            output_def["atom_virial"].squeeze(-2)
+        if "mask" in out_def_data:
+            output_def["mask"] = out_def_data["mask"]
+        return output_def

--- a/deepmd/dpmodel/model/dos_model.py
+++ b/deepmd/dpmodel/model/dos_model.py
@@ -3,6 +3,9 @@ from typing import (
     Any,
 )
 
+from deepmd.dpmodel.array_api import (
+    Array,
+)
 from deepmd.dpmodel.atomic_model import (
     DPDOSAtomicModel,
 )
@@ -31,3 +34,63 @@ class DOSModel(DPModelCommon, DPDOSModel_):
     ) -> None:
         DPModelCommon.__init__(self)
         DPDOSModel_.__init__(self, *args, **kwargs)
+
+    def call(
+        self,
+        coord: Array,
+        atype: Array,
+        box: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common(
+            coord,
+            atype,
+            box,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["atom_dos"] = model_ret["dos"]
+        model_predict["dos"] = model_ret["dos_redu"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def call_lower(
+        self,
+        extended_coord: Array,
+        extended_atype: Array,
+        nlist: Array,
+        mapping: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common_lower(
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["atom_dos"] = model_ret["dos"]
+        model_predict["dos"] = model_ret["dos_redu"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def translated_output_def(self) -> dict[str, Any]:
+        out_def_data = self.model_output_def().get_data()
+        output_def = {
+            "atom_dos": out_def_data["dos"],
+            "dos": out_def_data["dos_redu"],
+        }
+        if "mask" in out_def_data:
+            output_def["mask"] = out_def_data["mask"]
+        return output_def

--- a/deepmd/dpmodel/model/dp_zbl_model.py
+++ b/deepmd/dpmodel/model/dp_zbl_model.py
@@ -3,6 +3,9 @@ from typing import (
     Any,
 )
 
+from deepmd.dpmodel.array_api import (
+    Array,
+)
 from deepmd.dpmodel.atomic_model.linear_atomic_model import (
     DPZBLLinearEnergyAtomicModel,
 )
@@ -33,6 +36,88 @@ class DPZBLModel(DPZBLModel_):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+
+    def call(
+        self,
+        coord: Array,
+        atype: Array,
+        box: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common(
+            coord,
+            atype,
+            box,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["atom_energy"] = model_ret["energy"]
+        model_predict["energy"] = model_ret["energy_redu"]
+        if self.do_grad_r("energy") and model_ret["energy_derv_r"] is not None:
+            model_predict["force"] = model_ret["energy_derv_r"].squeeze(-2)
+        if self.do_grad_c("energy") and model_ret["energy_derv_c_redu"] is not None:
+            model_predict["virial"] = model_ret["energy_derv_c_redu"].squeeze(-2)
+            if do_atomic_virial and model_ret["energy_derv_c"] is not None:
+                model_predict["atom_virial"] = model_ret["energy_derv_c"].squeeze(-2)
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def call_lower(
+        self,
+        extended_coord: Array,
+        extended_atype: Array,
+        nlist: Array,
+        mapping: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common_lower(
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["atom_energy"] = model_ret["energy"]
+        model_predict["energy"] = model_ret["energy_redu"]
+        if self.do_grad_r("energy") and model_ret.get("energy_derv_r") is not None:
+            model_predict["extended_force"] = model_ret["energy_derv_r"].squeeze(-2)
+        if self.do_grad_c("energy") and model_ret.get("energy_derv_c_redu") is not None:
+            model_predict["virial"] = model_ret["energy_derv_c_redu"].squeeze(-2)
+            if do_atomic_virial and model_ret.get("energy_derv_c") is not None:
+                model_predict["extended_virial"] = model_ret["energy_derv_c"].squeeze(
+                    -2
+                )
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def translated_output_def(self) -> dict[str, Any]:
+        out_def_data = self.model_output_def().get_data()
+        output_def = {
+            "atom_energy": out_def_data["energy"],
+            "energy": out_def_data["energy_redu"],
+        }
+        if self.do_grad_r("energy"):
+            output_def["force"] = out_def_data["energy_derv_r"]
+            output_def["force"].squeeze(-2)
+        if self.do_grad_c("energy"):
+            output_def["virial"] = out_def_data["energy_derv_c_redu"]
+            output_def["virial"].squeeze(-2)
+            output_def["atom_virial"] = out_def_data["energy_derv_c"]
+            output_def["atom_virial"].squeeze(-2)
+        if "mask" in out_def_data:
+            output_def["mask"] = out_def_data["mask"]
+        return output_def
 
     @classmethod
     def update_sel(

--- a/deepmd/dpmodel/model/ener_model.py
+++ b/deepmd/dpmodel/model/ener_model.py
@@ -6,6 +6,9 @@ from typing import (
     Any,
 )
 
+from deepmd.dpmodel.array_api import (
+    Array,
+)
 from deepmd.dpmodel.atomic_model import (
     DPEnergyAtomicModel,
 )
@@ -47,6 +50,72 @@ class EnergyModel(DPModelCommon, DPEnergyModel_):
         if self._enable_hessian:
             return self.hess_fitting_def
         return super().atomic_output_def()
+
+    def call(
+        self,
+        coord: Array,
+        atype: Array,
+        box: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common(
+            coord,
+            atype,
+            box,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["atom_energy"] = model_ret["energy"]
+        model_predict["energy"] = model_ret["energy_redu"]
+        if self.do_grad_r("energy") and model_ret["energy_derv_r"] is not None:
+            model_predict["force"] = model_ret["energy_derv_r"].squeeze(-2)
+        if self.do_grad_c("energy") and model_ret["energy_derv_c_redu"] is not None:
+            model_predict["virial"] = model_ret["energy_derv_c_redu"].squeeze(-2)
+            if do_atomic_virial and model_ret["energy_derv_c"] is not None:
+                model_predict["atom_virial"] = model_ret["energy_derv_c"].squeeze(-2)
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        if self._enable_hessian and model_ret.get("energy_derv_r_derv_r") is not None:
+            model_predict["hessian"] = model_ret["energy_derv_r_derv_r"].squeeze(-3)
+        return model_predict
+
+    def call_lower(
+        self,
+        extended_coord: Array,
+        extended_atype: Array,
+        nlist: Array,
+        mapping: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common_lower(
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["atom_energy"] = model_ret["energy"]
+        model_predict["energy"] = model_ret["energy_redu"]
+        if self.do_grad_r("energy") and model_ret.get("energy_derv_r") is not None:
+            model_predict["extended_force"] = model_ret["energy_derv_r"].squeeze(-2)
+        if self.do_grad_c("energy") and model_ret.get("energy_derv_c_redu") is not None:
+            model_predict["virial"] = model_ret["energy_derv_c_redu"].squeeze(-2)
+            if do_atomic_virial and model_ret.get("energy_derv_c") is not None:
+                model_predict["extended_virial"] = model_ret["energy_derv_c"].squeeze(
+                    -2
+                )
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
 
     def translated_output_def(self) -> dict[str, Any]:
         """Get the translated output definition.

--- a/deepmd/dpmodel/model/make_model.py
+++ b/deepmd/dpmodel/model/make_model.py
@@ -223,7 +223,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
                 check_frequency,
             )
 
-        def call(
+        def call_common(
             self,
             coord: Array,
             atype: Array,
@@ -262,7 +262,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             )
             del coord, box, fparam, aparam
             model_predict = model_call_from_call_lower(
-                call_lower=self.call_lower,
+                call_lower=self.call_common_lower,
                 rcut=self.get_rcut(),
                 sel=self.get_sel(),
                 mixed_types=self.mixed_types(),
@@ -277,7 +277,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             model_predict = self._output_type_cast(model_predict, input_prec)
             return model_predict
 
-        def call_lower(
+        def call_common_lower(
             self,
             extended_coord: Array,
             extended_atype: Array,
@@ -365,9 +365,11 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
                 mask=atomic_ret["mask"] if "mask" in atomic_ret else None,
             )
 
+        call = call_common
+        call_lower = call_common_lower
         forward_lower = call_lower
-        forward_common = call
-        forward_common_lower = call_lower
+        forward_common = call_common
+        forward_common_lower = call_common_lower
 
         def get_out_bias(self) -> Array:
             """Get the output bias."""

--- a/deepmd/dpmodel/model/make_model.py
+++ b/deepmd/dpmodel/model/make_model.py
@@ -367,9 +367,6 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
 
         call = call_common
         call_lower = call_common_lower
-        forward_lower = call_lower
-        forward_common = call_common
-        forward_common_lower = call_common_lower
 
         def get_out_bias(self) -> Array:
             """Get the output bias."""

--- a/deepmd/dpmodel/model/polar_model.py
+++ b/deepmd/dpmodel/model/polar_model.py
@@ -3,6 +3,9 @@ from typing import (
     Any,
 )
 
+from deepmd.dpmodel.array_api import (
+    Array,
+)
 from deepmd.dpmodel.atomic_model import (
     DPPolarAtomicModel,
 )
@@ -31,3 +34,63 @@ class PolarModel(DPModelCommon, DPPolarModel_):
     ) -> None:
         DPModelCommon.__init__(self)
         DPPolarModel_.__init__(self, *args, **kwargs)
+
+    def call(
+        self,
+        coord: Array,
+        atype: Array,
+        box: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common(
+            coord,
+            atype,
+            box,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["polar"] = model_ret["polarizability"]
+        model_predict["global_polar"] = model_ret["polarizability_redu"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def call_lower(
+        self,
+        extended_coord: Array,
+        extended_atype: Array,
+        nlist: Array,
+        mapping: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common_lower(
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_predict = {}
+        model_predict["polar"] = model_ret["polarizability"]
+        model_predict["global_polar"] = model_ret["polarizability_redu"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def translated_output_def(self) -> dict[str, Any]:
+        out_def_data = self.model_output_def().get_data()
+        output_def = {
+            "polar": out_def_data["polarizability"],
+            "global_polar": out_def_data["polarizability_redu"],
+        }
+        if "mask" in out_def_data:
+            output_def["mask"] = out_def_data["mask"]
+        return output_def

--- a/deepmd/dpmodel/model/property_model.py
+++ b/deepmd/dpmodel/model/property_model.py
@@ -3,11 +3,17 @@ from typing import (
     Any,
 )
 
+from deepmd.dpmodel.array_api import (
+    Array,
+)
 from deepmd.dpmodel.atomic_model import (
     DPPropertyAtomicModel,
 )
 from deepmd.dpmodel.model.base_model import (
     BaseModel,
+)
+from deepmd.dpmodel.output_def import (
+    OutputVariableDef,
 )
 
 from .dp_model import (
@@ -33,3 +39,66 @@ class PropertyModel(DPModelCommon, DPPropertyModel_):
     def get_var_name(self) -> str:
         """Get the name of the property."""
         return self.get_fitting_net().var_name
+
+    def call(
+        self,
+        coord: Array,
+        atype: Array,
+        box: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common(
+            coord,
+            atype,
+            box,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        var_name = self.get_var_name()
+        model_predict = {}
+        model_predict[f"atom_{var_name}"] = model_ret[var_name]
+        model_predict[var_name] = model_ret[f"{var_name}_redu"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def call_lower(
+        self,
+        extended_coord: Array,
+        extended_atype: Array,
+        nlist: Array,
+        mapping: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        model_ret = self.call_common_lower(
+            extended_coord,
+            extended_atype,
+            nlist,
+            mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        var_name = self.get_var_name()
+        model_predict = {}
+        model_predict[f"atom_{var_name}"] = model_ret[var_name]
+        model_predict[var_name] = model_ret[f"{var_name}_redu"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
+        return model_predict
+
+    def translated_output_def(self) -> dict[str, OutputVariableDef]:
+        out_def_data = self.model_output_def().get_data()
+        var_name = self.get_var_name()
+        output_def = {
+            f"atom_{var_name}": out_def_data[var_name],
+            var_name: out_def_data[f"{var_name}_redu"],
+        }
+        if "mask" in out_def_data:
+            output_def["mask"] = out_def_data["mask"]
+        return output_def

--- a/deepmd/dpmodel/model/spin_model.py
+++ b/deepmd/dpmodel/model/spin_model.py
@@ -377,7 +377,7 @@ class SpinModel(NativeOP):
         coord_updated, atype_updated = self.process_spin_input(coord, atype, spin)
         if aparam is not None:
             aparam = self.expand_aparam(aparam, nloc * 2)
-        model_predict = self.backbone_model.call(
+        model_predict = self.backbone_model.call_common(
             coord_updated,
             atype_updated,
             box,
@@ -447,7 +447,7 @@ class SpinModel(NativeOP):
         )
         if aparam is not None:
             aparam = self.expand_aparam(aparam, nloc * 2)
-        model_predict = self.backbone_model.call_lower(
+        model_predict = self.backbone_model.call_common_lower(
             extended_coord_updated,
             extended_atype_updated,
             nlist_updated,
@@ -465,5 +465,3 @@ class SpinModel(NativeOP):
         )[0]
         # for now omit the grad output
         return model_predict
-
-    forward_lower = call_lower

--- a/deepmd/dpmodel/model/spin_model.py
+++ b/deepmd/dpmodel/model/spin_model.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from copy import (
+    deepcopy,
+)
 from typing import (
     Any,
 )
@@ -311,10 +314,9 @@ class SpinModel(NativeOP):
 
     def __getattr__(self, name: str) -> Any:
         """Get attribute from the wrapped model."""
-        if name in self.__dict__:
-            return self.__dict__[name]
-        else:
-            return getattr(self.backbone_model, name)
+        if "backbone_model" not in self.__dict__:
+            raise AttributeError(name)
+        return getattr(self.backbone_model, name)
 
     def serialize(self) -> dict:
         return {
@@ -333,7 +335,7 @@ class SpinModel(NativeOP):
             spin=spin,
         )
 
-    def call(
+    def call_common(
         self,
         coord: Array,
         atype: Array,
@@ -343,7 +345,7 @@ class SpinModel(NativeOP):
         aparam: Array | None = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, Array]:
-        """Return model prediction.
+        """Return model prediction with raw internal keys.
 
         Parameters
         ----------
@@ -377,7 +379,7 @@ class SpinModel(NativeOP):
         coord_updated, atype_updated = self.process_spin_input(coord, atype, spin)
         if aparam is not None:
             aparam = self.expand_aparam(aparam, nloc * 2)
-        model_predict = self.backbone_model.call_common(
+        model_ret = self.backbone_model.call_common(
             coord_updated,
             atype_updated,
             box,
@@ -389,13 +391,104 @@ class SpinModel(NativeOP):
         if "mask" in model_output_type:
             model_output_type.pop(model_output_type.index("mask"))
         var_name = model_output_type[0]
-        model_predict[f"{var_name}"] = np.split(
-            model_predict[f"{var_name}"], [nloc], axis=1
-        )[0]
-        # for now omit the grad output
+        model_ret[f"{var_name}"] = np.split(model_ret[f"{var_name}"], [nloc], axis=1)[0]
+        if (
+            self.backbone_model.do_grad_r(var_name)
+            and model_ret.get(f"{var_name}_derv_r") is not None
+        ):
+            (
+                model_ret[f"{var_name}_derv_r"],
+                model_ret[f"{var_name}_derv_r_mag"],
+                model_ret["mask_mag"],
+            ) = self.process_spin_output(atype, model_ret[f"{var_name}_derv_r"])
+        if (
+            self.backbone_model.do_grad_c(var_name)
+            and do_atomic_virial
+            and model_ret.get(f"{var_name}_derv_c") is not None
+        ):
+            (
+                model_ret[f"{var_name}_derv_c"],
+                model_ret[f"{var_name}_derv_c_mag"],
+                model_ret["mask_mag"],
+            ) = self.process_spin_output(
+                atype,
+                model_ret[f"{var_name}_derv_c"],
+                add_mag=False,
+                virtual_scale=False,
+            )
+        # Always compute mask_mag from atom types (even when forces are unavailable)
+        if "mask_mag" not in model_ret:
+            nframes_m, nloc_m = atype.shape[:2]
+            atomic_mask = self.virtual_scale_mask[atype].reshape([nframes_m, nloc_m, 1])
+            model_ret["mask_mag"] = atomic_mask > 0.0
+        return model_ret
+
+    def call(
+        self,
+        coord: Array,
+        atype: Array,
+        spin: Array,
+        box: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        """Return model prediction with translated user-facing keys.
+
+        Parameters
+        ----------
+        coord
+            The coordinates of the atoms.
+            shape: nf x (nloc x 3)
+        atype
+            The type of atoms. shape: nf x nloc
+        spin
+            The spins of the atoms.
+            shape: nf x (nloc x 3)
+        box
+            The simulation box. shape: nf x 9
+        fparam
+            frame parameter. nf x ndf
+        aparam
+            atomic parameter. nf x nloc x nda
+        do_atomic_virial
+            If calculate the atomic virial.
+
+        Returns
+        -------
+        ret_dict
+            The result dict with translated keys, e.g.
+            ``atom_energy``, ``energy``, ``force``, ``force_mag``.
+
+        """
+        model_ret = self.call_common(
+            coord,
+            atype,
+            spin,
+            box,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_output_type = self.backbone_model.model_output_type()
+        if "mask" in model_output_type:
+            model_output_type.pop(model_output_type.index("mask"))
+        var_name = model_output_type[0]
+        model_predict = {}
+        model_predict[f"atom_{var_name}"] = model_ret[var_name]
+        model_predict[var_name] = model_ret[f"{var_name}_redu"]
+        if "mask_mag" in model_ret:
+            model_predict["mask_mag"] = model_ret["mask_mag"]
+        if (
+            self.backbone_model.do_grad_r(var_name)
+            and model_ret.get(f"{var_name}_derv_r") is not None
+        ):
+            model_predict["force"] = model_ret[f"{var_name}_derv_r"].squeeze(-2)
+            model_predict["force_mag"] = model_ret[f"{var_name}_derv_r_mag"].squeeze(-2)
+        # not support virial by far
         return model_predict
 
-    def call_lower(
+    def call_common_lower(
         self,
         extended_coord: Array,
         extended_atype: Array,
@@ -406,7 +499,7 @@ class SpinModel(NativeOP):
         aparam: Array | None = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, Array]:
-        """Return model prediction. Lower interface that takes
+        """Return model prediction with raw internal keys. Lower interface that takes
         extended atomic coordinates, types and spins, nlist, and mapping
         as input, and returns the predictions on the extended region.
         The predictions are not reduced.
@@ -447,7 +540,7 @@ class SpinModel(NativeOP):
         )
         if aparam is not None:
             aparam = self.expand_aparam(aparam, nloc * 2)
-        model_predict = self.backbone_model.call_common_lower(
+        model_ret = self.backbone_model.call_common_lower(
             extended_coord_updated,
             extended_atype_updated,
             nlist_updated,
@@ -460,8 +553,134 @@ class SpinModel(NativeOP):
         if "mask" in model_output_type:
             model_output_type.pop(model_output_type.index("mask"))
         var_name = model_output_type[0]
-        model_predict[f"{var_name}"] = np.split(
-            model_predict[f"{var_name}"], [nloc], axis=1
-        )[0]
-        # for now omit the grad output
+        model_ret[f"{var_name}"] = np.split(model_ret[f"{var_name}"], [nloc], axis=1)[0]
+        if (
+            self.backbone_model.do_grad_r(var_name)
+            and model_ret.get(f"{var_name}_derv_r") is not None
+        ):
+            (
+                model_ret[f"{var_name}_derv_r"],
+                model_ret[f"{var_name}_derv_r_mag"],
+                model_ret["mask_mag"],
+            ) = self.process_spin_output_lower(
+                extended_atype, model_ret[f"{var_name}_derv_r"], nloc
+            )
+        if (
+            self.backbone_model.do_grad_c(var_name)
+            and do_atomic_virial
+            and model_ret.get(f"{var_name}_derv_c") is not None
+        ):
+            (
+                model_ret[f"{var_name}_derv_c"],
+                model_ret[f"{var_name}_derv_c_mag"],
+                model_ret["mask_mag"],
+            ) = self.process_spin_output_lower(
+                extended_atype,
+                model_ret[f"{var_name}_derv_c"],
+                nloc,
+                add_mag=False,
+                virtual_scale=False,
+            )
+        # Always compute mask_mag from atom types (even when forces are unavailable)
+        if "mask_mag" not in model_ret:
+            nall = extended_atype.shape[1]
+            atomic_mask = self.virtual_scale_mask[extended_atype].reshape(
+                [nframes, nall, 1]
+            )
+            model_ret["mask_mag"] = atomic_mask > 0.0
+        return model_ret
+
+    def call_lower(
+        self,
+        extended_coord: Array,
+        extended_atype: Array,
+        extended_spin: Array,
+        nlist: Array,
+        mapping: Array | None = None,
+        fparam: Array | None = None,
+        aparam: Array | None = None,
+        do_atomic_virial: bool = False,
+    ) -> dict[str, Array]:
+        """Return model prediction with translated user-facing keys. Lower interface.
+
+        Parameters
+        ----------
+        extended_coord
+            coordinates in extended region. nf x (nall x 3).
+        extended_atype
+            atomic type in extended region. nf x nall.
+        extended_spin
+            spins in extended region. nf x (nall x 3).
+        nlist
+            neighbor list. nf x nloc x nsel.
+        mapping
+            maps the extended indices to local indices. nf x nall.
+        fparam
+            frame parameter. nf x ndf
+        aparam
+            atomic parameter. nf x nloc x nda
+        do_atomic_virial
+            whether calculate atomic virial
+
+        Returns
+        -------
+        result_dict
+            The result dict with translated keys, e.g.
+            ``atom_energy``, ``energy``, ``extended_force``, ``extended_force_mag``.
+
+        """
+        model_ret = self.call_common_lower(
+            extended_coord,
+            extended_atype,
+            extended_spin,
+            nlist,
+            mapping=mapping,
+            fparam=fparam,
+            aparam=aparam,
+            do_atomic_virial=do_atomic_virial,
+        )
+        model_output_type = self.backbone_model.model_output_type()
+        if "mask" in model_output_type:
+            model_output_type.pop(model_output_type.index("mask"))
+        var_name = model_output_type[0]
+        model_predict = {}
+        model_predict[f"atom_{var_name}"] = model_ret[var_name]
+        model_predict[var_name] = model_ret[f"{var_name}_redu"]
+        if "mask_mag" in model_ret:
+            model_predict["extended_mask_mag"] = model_ret["mask_mag"]
+        if (
+            self.backbone_model.do_grad_r(var_name)
+            and model_ret.get(f"{var_name}_derv_r") is not None
+        ):
+            model_predict["extended_force"] = model_ret[f"{var_name}_derv_r"].squeeze(
+                -2
+            )
+            model_predict["extended_force_mag"] = model_ret[
+                f"{var_name}_derv_r_mag"
+            ].squeeze(-2)
+        # not support virial by far
         return model_predict
+
+    def translated_output_def(self) -> dict[str, Any]:
+        """Get the translated output definition.
+
+        Maps internal output names to user-facing names, e.g.
+        ``energy`` -> ``atom_energy``, ``energy_redu`` -> ``energy``,
+        ``energy_derv_r`` -> ``force``, ``energy_derv_r_mag`` -> ``force_mag``.
+        """
+        out_def_data = self.model_output_def().get_data()
+        model_output_type = self.backbone_model.model_output_type()
+        if "mask" in model_output_type:
+            model_output_type.pop(model_output_type.index("mask"))
+        var_name = model_output_type[0]
+        output_def = {
+            f"atom_{var_name}": out_def_data[var_name],
+            var_name: out_def_data[f"{var_name}_redu"],
+            "mask_mag": out_def_data["mask_mag"],
+        }
+        if self.backbone_model.do_grad_r(var_name):
+            output_def["force"] = deepcopy(out_def_data[f"{var_name}_derv_r"])
+            output_def["force"].squeeze(-2)
+            output_def["force_mag"] = deepcopy(out_def_data[f"{var_name}_derv_r_mag"])
+            output_def["force_mag"].squeeze(-2)
+        return output_def

--- a/deepmd/jax/infer/deep_eval.py
+++ b/deepmd/jax/infer/deep_eval.py
@@ -388,7 +388,9 @@ class DeepEval(DeepEvalBackend):
 
         results = []
         for odef in request_defs:
-            dp_name = self._OUTDEF_DP2BACKEND[odef.name]
+            # HLO and TFModelWrapper return raw internal keys (not translated),
+            # so no key mapping is needed here.
+            dp_name = odef.name
             if dp_name in batch_output:
                 shape = self._get_output_shape(odef, nframes, natoms)
                 if batch_output[dp_name] is not None:

--- a/deepmd/jax/infer/deep_eval.py
+++ b/deepmd/jax/infer/deep_eval.py
@@ -388,9 +388,7 @@ class DeepEval(DeepEvalBackend):
 
         results = []
         for odef in request_defs:
-            # it seems not doing conversion
-            # dp_name = self._OUTDEF_DP2BACKEND[odef.name]
-            dp_name = odef.name
+            dp_name = self._OUTDEF_DP2BACKEND[odef.name]
             if dp_name in batch_output:
                 shape = self._get_output_shape(odef, nframes, natoms)
                 if batch_output[dp_name] is not None:

--- a/deepmd/jax/jax2tf/serialization.py
+++ b/deepmd/jax/jax2tf/serialization.py
@@ -34,7 +34,7 @@ def deserialize_to_file(model_file: str, data: dict) -> None:
     if model_file.endswith(".savedmodel"):
         model = BaseModel.deserialize(data["model"])
         model_def_script = data["model_def_script"]
-        call_lower = model.call_lower
+        call_lower = model.call_common_lower
 
         tf_model = tf.Module()
 

--- a/deepmd/jax/utils/serialization.py
+++ b/deepmd/jax/utils/serialization.py
@@ -49,7 +49,7 @@ def deserialize_to_file(model_file: str, data: dict) -> None:
     elif model_file.endswith(".hlo"):
         model = BaseModel.deserialize(data["model"])
         model_def_script = data["model_def_script"]
-        call_lower = model.call_lower
+        call_lower = model.call_common_lower
 
         nf, nloc, nghost = jax_export.symbolic_shape("nf, nloc, nghost")
 

--- a/deepmd/pt/model/model/dipole_model.py
+++ b/deepmd/pt/model/model/dipole_model.py
@@ -119,6 +119,8 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
                 model_predict["virial"] = model_ret["dipole_derv_c_redu"]
                 if do_atomic_virial:
                     model_predict["extended_virial"] = model_ret["dipole_derv_c"]
+            if "mask" in model_ret:
+                model_predict["mask"] = model_ret["mask"]
         else:
             model_predict = model_ret
         return model_predict

--- a/deepmd/pt/model/model/dipole_model.py
+++ b/deepmd/pt/model/model/dipole_model.py
@@ -74,13 +74,11 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
             model_predict["dipole"] = model_ret["dipole"]
             model_predict["global_dipole"] = model_ret["dipole_redu"]
             if self.do_grad_r("dipole"):
-                model_predict["force"] = model_ret["dipole_derv_r"].squeeze(-2)
+                model_predict["force"] = model_ret["dipole_derv_r"]
             if self.do_grad_c("dipole"):
-                model_predict["virial"] = model_ret["dipole_derv_c_redu"].squeeze(-2)
+                model_predict["virial"] = model_ret["dipole_derv_c_redu"]
                 if do_atomic_virial:
-                    model_predict["atom_virial"] = model_ret["dipole_derv_c"].squeeze(
-                        -3
-                    )
+                    model_predict["atom_virial"] = model_ret["dipole_derv_c"]
             if "mask" in model_ret:
                 model_predict["mask"] = model_ret["mask"]
         else:
@@ -116,13 +114,11 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
             model_predict["dipole"] = model_ret["dipole"]
             model_predict["global_dipole"] = model_ret["dipole_redu"]
             if self.do_grad_r("dipole"):
-                model_predict["extended_force"] = model_ret["dipole_derv_r"].squeeze(-2)
+                model_predict["extended_force"] = model_ret["dipole_derv_r"]
             if self.do_grad_c("dipole"):
-                model_predict["virial"] = model_ret["dipole_derv_c_redu"].squeeze(-2)
+                model_predict["virial"] = model_ret["dipole_derv_c_redu"]
                 if do_atomic_virial:
-                    model_predict["extended_virial"] = model_ret[
-                        "dipole_derv_c"
-                    ].squeeze(-2)
+                    model_predict["extended_virial"] = model_ret["dipole_derv_c"]
         else:
             model_predict = model_ret
         return model_predict

--- a/deepmd/pt/model/model/dos_model.py
+++ b/deepmd/pt/model/model/dos_model.py
@@ -105,7 +105,8 @@ class DOSModel(DPModelCommon, DPDOSModel_):
             model_predict = {}
             model_predict["atom_dos"] = model_ret["dos"]
             model_predict["dos"] = model_ret["dos_redu"]
-
+            if "mask" in model_ret:
+                model_predict["mask"] = model_ret["mask"]
         else:
             model_predict = model_ret
         return model_predict

--- a/deepmd/pt/model/model/dp_zbl_model.py
+++ b/deepmd/pt/model/model/dp_zbl_model.py
@@ -125,6 +125,8 @@ class DPZBLModel(DPZBLModel_):
         else:
             assert model_ret["dforce"] is not None
             model_predict["dforce"] = model_ret["dforce"]
+        if "mask" in model_ret:
+            model_predict["mask"] = model_ret["mask"]
         return model_predict
 
     @classmethod

--- a/deepmd/pt/model/model/dp_zbl_model.py
+++ b/deepmd/pt/model/model/dp_zbl_model.py
@@ -120,7 +120,7 @@ class DPZBLModel(DPZBLModel_):
             model_predict["virial"] = model_ret["energy_derv_c_redu"].squeeze(-2)
             if do_atomic_virial:
                 model_predict["extended_virial"] = model_ret["energy_derv_c"].squeeze(
-                    -3
+                    -2
                 )
         else:
             assert model_ret["dforce"] is not None

--- a/deepmd/pt/model/model/ener_model.py
+++ b/deepmd/pt/model/model/ener_model.py
@@ -168,6 +168,8 @@ class EnergyModel(DPModelCommon, DPEnergyModel_):
             else:
                 assert model_ret["dforce"] is not None
                 model_predict["dforce"] = model_ret["dforce"]
+            if "mask" in model_ret:
+                model_predict["mask"] = model_ret["mask"]
         else:
             model_predict = model_ret
         return model_predict

--- a/deepmd/pt/model/model/ener_model.py
+++ b/deepmd/pt/model/model/ener_model.py
@@ -124,7 +124,7 @@ class EnergyModel(DPModelCommon, DPEnergyModel_):
             if "mask" in model_ret:
                 model_predict["mask"] = model_ret["mask"]
             if self._hessian_enabled:
-                model_predict["hessian"] = model_ret["energy_derv_r_derv_r"].squeeze(-2)
+                model_predict["hessian"] = model_ret["energy_derv_r_derv_r"].squeeze(-3)
         else:
             model_predict = model_ret
             model_predict["updated_coord"] += coord

--- a/deepmd/pt/model/model/polar_model.py
+++ b/deepmd/pt/model/model/polar_model.py
@@ -102,6 +102,8 @@ class PolarModel(DPModelCommon, DPPolarModel_):
             model_predict = {}
             model_predict["polar"] = model_ret["polarizability"]
             model_predict["global_polar"] = model_ret["polarizability_redu"]
+            if "mask" in model_ret:
+                model_predict["mask"] = model_ret["mask"]
         else:
             model_predict = model_ret
         return model_predict

--- a/deepmd/pt_expt/model/ener_model.py
+++ b/deepmd/pt_expt/model/ener_model.py
@@ -42,7 +42,7 @@ class EnergyModel(DPModelCommon, DPEnergyModel_):
         aparam: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
-        model_ret = self.call(
+        model_ret = self.call_common(
             coord,
             atype,
             box,
@@ -73,7 +73,7 @@ class EnergyModel(DPModelCommon, DPEnergyModel_):
         aparam: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
     ) -> dict[str, torch.Tensor]:
-        model_ret = self.call_lower(
+        model_ret = self.call_common_lower(
             extended_coord,
             extended_atype,
             nlist,

--- a/deepmd/pt_expt/model/make_model.py
+++ b/deepmd/pt_expt/model/make_model.py
@@ -46,6 +46,16 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             """
             return self.call(*args, **kwargs)
 
+        def forward_common(self, *args: Any, **kwargs: Any) -> dict[str, torch.Tensor]:
+            """Forward common delegates to call_common()."""
+            return self.call_common(*args, **kwargs)
+
+        def forward_common_lower(
+            self, *args: Any, **kwargs: Any
+        ) -> dict[str, torch.Tensor]:
+            """Forward common lower delegates to call_common_lower()."""
+            return self.call_common_lower(*args, **kwargs)
+
         def forward_common_atomic(
             self,
             extended_coord: torch.Tensor,

--- a/source/tests/common/dpmodel/test_dp_model.py
+++ b/source/tests/common/dpmodel/test_dp_model.py
@@ -49,8 +49,8 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         ret0 = md0.call_lower(self.coord_ext, self.atype_ext, self.nlist)
         ret1 = md1.call_lower(self.coord_ext, self.atype_ext, self.nlist)
 
+        np.testing.assert_allclose(ret0["atom_energy"], ret1["atom_energy"])
         np.testing.assert_allclose(ret0["energy"], ret1["energy"])
-        np.testing.assert_allclose(ret0["energy_redu"], ret1["energy_redu"])
 
     def test_prec_consistency(self) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)
@@ -83,10 +83,12 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         model_l_ret_64 = md1.call_lower(*args64, fparam=fparam, aparam=aparam)
         model_l_ret_32 = md1.call_lower(*args32, fparam=fparam, aparam=aparam)
 
+        # After translation, reduced keys are "energy" and "virial"
+        _REDUCED_KEYS = {"energy", "virial"}
         for ii in model_l_ret_32.keys():
             if model_l_ret_32[ii] is None:
                 continue
-            if ii[-4:] == "redu":
+            if ii in _REDUCED_KEYS:
                 self.assertEqual(model_l_ret_32[ii].dtype, np.float64)
             else:
                 self.assertEqual(model_l_ret_32[ii].dtype, np.float32)
@@ -137,10 +139,12 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         model_l_ret_64 = md1.call(*args64, fparam=fparam, aparam=aparam)
         model_l_ret_32 = md1.call(*args32, fparam=fparam, aparam=aparam)
 
+        # After translation, reduced keys are "energy" and "virial"
+        _REDUCED_KEYS = {"energy", "virial"}
         for ii in model_l_ret_32.keys():
             if model_l_ret_32[ii] is None:
                 continue
-            if ii[-4:] == "redu":
+            if ii in _REDUCED_KEYS:
                 self.assertEqual(model_l_ret_32[ii].dtype, np.float64)
             else:
                 self.assertEqual(model_l_ret_32[ii].dtype, np.float32)

--- a/source/tests/common/dpmodel/test_padding_atoms.py
+++ b/source/tests/common/dpmodel/test_padding_atoms.py
@@ -69,8 +69,8 @@ class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         result = model.call(*args)
         # test intensive
         np.testing.assert_allclose(
-            result[f"{var_name}_redu"],
-            np.mean(result[f"{var_name}"], axis=1),
+            result[var_name],
+            np.mean(result[f"atom_{var_name}"], axis=1),
             atol=self.atol,
         )
         # test padding atoms
@@ -93,8 +93,8 @@ class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
             args = [coord_padding, atype_padding, self.cell]
             result_padding = model.call(*args)
             np.testing.assert_allclose(
-                result[f"{var_name}_redu"],
-                result_padding[f"{var_name}_redu"],
+                result[var_name],
+                result_padding[var_name],
                 atol=self.atol,
             )
 

--- a/source/tests/consistent/model/test_dipole.py
+++ b/source/tests/consistent/model/test_dipole.py
@@ -188,20 +188,19 @@ class TestDipole(CommonTest, ModelTest, unittest.TestCase):
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
-        if backend in {self.RefBackend.DP, self.RefBackend.JAX}:
-            return (
-                ret["dipole_redu"].ravel(),
-                ret["dipole"].ravel(),
-            )
-        elif backend is self.RefBackend.PT:
-            return (
-                ret["global_dipole"].ravel(),
-                ret["dipole"].ravel(),
-            )
-        elif backend is self.RefBackend.TF:
+        if backend is self.RefBackend.TF:
             return (
                 ret[0].ravel(),
                 ret[1].ravel(),
+            )
+        elif backend in {
+            self.RefBackend.DP,
+            self.RefBackend.PT,
+            self.RefBackend.JAX,
+        }:
+            return (
+                ret["global_dipole"].ravel(),
+                ret["dipole"].ravel(),
             )
         raise ValueError(f"Unknown backend: {backend}")
 

--- a/source/tests/consistent/model/test_dos.py
+++ b/source/tests/consistent/model/test_dos.py
@@ -182,19 +182,18 @@ class TestDOS(CommonTest, ModelTest, unittest.TestCase):
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
-        if backend in {self.RefBackend.DP, self.RefBackend.JAX}:
-            return (
-                ret["dos_redu"].ravel(),
-                ret["dos"].ravel(),
-            )
-        elif backend is self.RefBackend.PT:
-            return (
-                ret["dos"].ravel(),
-                ret["atom_dos"].ravel(),
-            )
-        elif backend is self.RefBackend.TF:
+        if backend is self.RefBackend.TF:
             return (
                 ret[0].ravel(),
                 ret[1].ravel(),
+            )
+        elif backend in {
+            self.RefBackend.DP,
+            self.RefBackend.PT,
+            self.RefBackend.JAX,
+        }:
+            return (
+                ret["dos"].ravel(),
+                ret["atom_dos"].ravel(),
             )
         raise ValueError(f"Unknown backend: {backend}")

--- a/source/tests/consistent/model/test_dpa1.py
+++ b/source/tests/consistent/model/test_dpa1.py
@@ -221,23 +221,7 @@ class TestDPA1Ener(CommonTest, ModelTest, unittest.TestCase):
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
-        if backend is self.RefBackend.DP:
-            return (
-                ret["energy_redu"].ravel(),
-                ret["energy"].ravel(),
-                SKIP_FLAG,
-                SKIP_FLAG,
-                SKIP_FLAG,
-            )
-        elif backend is self.RefBackend.PT:
-            return (
-                ret["energy"].ravel(),
-                ret["atom_energy"].ravel(),
-                ret["force"].ravel(),
-                ret["virial"].ravel(),
-                ret["atom_virial"].ravel(),
-            )
-        elif backend is self.RefBackend.TF:
+        if backend is self.RefBackend.TF:
             return (
                 ret[0].ravel(),
                 ret[1].ravel(),
@@ -245,20 +229,24 @@ class TestDPA1Ener(CommonTest, ModelTest, unittest.TestCase):
                 ret[3].ravel(),
                 ret[4].ravel(),
             )
-        elif backend is self.RefBackend.PD:
+        elif backend is self.RefBackend.DP:
             return (
-                ret["energy"].flatten(),
-                ret["atom_energy"].flatten(),
-                ret["force"].flatten(),
-                ret["virial"].flatten(),
-                ret["atom_virial"].flatten(),
-            )
-        elif backend is self.RefBackend.JAX:
-            return (
-                ret["energy_redu"].ravel(),
                 ret["energy"].ravel(),
-                ret["energy_derv_r"].ravel(),
-                ret["energy_derv_c_redu"].ravel(),
-                ret["energy_derv_c"].ravel(),
+                ret["atom_energy"].ravel(),
+                SKIP_FLAG,
+                SKIP_FLAG,
+                SKIP_FLAG,
+            )
+        elif backend in {
+            self.RefBackend.PT,
+            self.RefBackend.PD,
+            self.RefBackend.JAX,
+        }:
+            return (
+                ret["energy"].ravel(),
+                ret["atom_energy"].ravel(),
+                ret["force"].ravel(),
+                ret["virial"].ravel(),
+                ret["atom_virial"].ravel(),
             )
         raise ValueError(f"Unknown backend: {backend}")

--- a/source/tests/consistent/model/test_ener.py
+++ b/source/tests/consistent/model/test_ener.py
@@ -269,31 +269,7 @@ class TestEner(CommonTest, ModelTest, unittest.TestCase):
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
-        if backend is self.RefBackend.DP:
-            return (
-                ret["energy_redu"].ravel(),
-                ret["energy"].ravel(),
-                SKIP_FLAG,
-                SKIP_FLAG,
-                SKIP_FLAG,
-            )
-        elif backend is self.RefBackend.PT:
-            return (
-                ret["energy"].ravel(),
-                ret["atom_energy"].ravel(),
-                ret["force"].ravel(),
-                ret["virial"].ravel(),
-                ret["atom_virial"].ravel(),
-            )
-        elif backend is self.RefBackend.PT_EXPT:
-            return (
-                ret["energy"].ravel(),
-                ret["atom_energy"].ravel(),
-                ret["force"].ravel(),
-                ret["virial"].ravel(),
-                ret["atom_virial"].ravel(),
-            )
-        elif backend is self.RefBackend.TF:
+        if backend is self.RefBackend.TF:
             return (
                 ret[0].ravel(),
                 ret[1].ravel(),
@@ -301,21 +277,26 @@ class TestEner(CommonTest, ModelTest, unittest.TestCase):
                 ret[3].ravel(),
                 ret[4].ravel(),
             )
-        elif backend is self.RefBackend.JAX:
+        elif backend is self.RefBackend.DP:
             return (
-                ret["energy_redu"].ravel(),
                 ret["energy"].ravel(),
-                ret["energy_derv_r"].ravel(),
-                ret["energy_derv_c_redu"].ravel(),
-                ret["energy_derv_c"].ravel(),
+                ret["atom_energy"].ravel(),
+                SKIP_FLAG,
+                SKIP_FLAG,
+                SKIP_FLAG,
             )
-        elif backend is self.RefBackend.PD:
+        elif backend in {
+            self.RefBackend.PT,
+            self.RefBackend.PT_EXPT,
+            self.RefBackend.JAX,
+            self.RefBackend.PD,
+        }:
             return (
-                ret["energy"].flatten(),
-                ret["atom_energy"].flatten(),
-                ret["force"].flatten(),
-                ret["virial"].flatten(),
-                ret["atom_virial"].flatten(),
+                ret["energy"].ravel(),
+                ret["atom_energy"].ravel(),
+                ret["force"].ravel(),
+                ret["virial"].ravel(),
+                ret["atom_virial"].ravel(),
             )
         raise ValueError(f"Unknown backend: {backend}")
 
@@ -536,19 +517,11 @@ class TestEnerLower(CommonTest, ModelTest, unittest.TestCase):
         # shape not matched. ravel...
         if backend is self.RefBackend.DP:
             return (
-                ret["energy_redu"].ravel(),
-                ret["energy"].ravel(),
-                SKIP_FLAG,
-                SKIP_FLAG,
-                SKIP_FLAG,
-            )
-        elif backend is self.RefBackend.PT:
-            return (
                 ret["energy"].ravel(),
                 ret["atom_energy"].ravel(),
-                ret["extended_force"].ravel(),
-                ret["virial"].ravel(),
-                ret["extended_virial"].ravel(),
+                SKIP_FLAG,
+                SKIP_FLAG,
+                SKIP_FLAG,
             )
         elif backend is self.RefBackend.PT_EXPT:
             return (
@@ -558,21 +531,17 @@ class TestEnerLower(CommonTest, ModelTest, unittest.TestCase):
                 ret["energy_derv_c_redu"].ravel(),
                 ret["energy_derv_c"].ravel(),
             )
-        elif backend is self.RefBackend.JAX:
+        elif backend in {
+            self.RefBackend.PT,
+            self.RefBackend.JAX,
+            self.RefBackend.PD,
+        }:
             return (
-                ret["energy_redu"].ravel(),
                 ret["energy"].ravel(),
-                ret["energy_derv_r"].ravel(),
-                ret["energy_derv_c_redu"].ravel(),
-                ret["energy_derv_c"].ravel(),
-            )
-        elif backend is self.RefBackend.PD:
-            return (
-                ret["energy"].flatten(),
-                ret["atom_energy"].flatten(),
-                ret["extended_force"].flatten(),
-                ret["virial"].flatten(),
-                ret["extended_virial"].flatten(),
+                ret["atom_energy"].ravel(),
+                ret["extended_force"].ravel(),
+                ret["virial"].ravel(),
+                ret["extended_virial"].ravel(),
             )
         raise ValueError(f"Unknown backend: {backend}")
 
@@ -726,8 +695,8 @@ class TestEnerModelAPIs(unittest.TestCase):
         )
 
     def test_forward_common_alias(self) -> None:
-        """forward_common should be the same as call on dpmodel."""
-        ret_call = self.dp_model.call(
+        """forward_common should be the same as call_common on dpmodel."""
+        ret_call = self.dp_model.call_common(
             self.coords,
             self.atype,
             box=self.box,
@@ -741,8 +710,8 @@ class TestEnerModelAPIs(unittest.TestCase):
             np.testing.assert_equal(ret_call[key], ret_fc[key])
 
     def test_forward_common_lower_alias(self) -> None:
-        """forward_common_lower should be the same as call_lower on dpmodel."""
-        ret_call = self.dp_model.call_lower(
+        """forward_common_lower should be the same as call_common_lower on dpmodel."""
+        ret_call = self.dp_model.call_common_lower(
             self.extended_coord,
             self.extended_atype,
             self.nlist,

--- a/source/tests/consistent/model/test_ener.py
+++ b/source/tests/consistent/model/test_ener.py
@@ -694,38 +694,6 @@ class TestEnerModelAPIs(unittest.TestCase):
             atol=1e-10,
         )
 
-    def test_forward_common_alias(self) -> None:
-        """forward_common should be the same as call_common on dpmodel."""
-        ret_call = self.dp_model.call_common(
-            self.coords,
-            self.atype,
-            box=self.box,
-        )
-        ret_fc = self.dp_model.forward_common(
-            self.coords,
-            self.atype,
-            box=self.box,
-        )
-        for key in ret_call:
-            np.testing.assert_equal(ret_call[key], ret_fc[key])
-
-    def test_forward_common_lower_alias(self) -> None:
-        """forward_common_lower should be the same as call_common_lower on dpmodel."""
-        ret_call = self.dp_model.call_common_lower(
-            self.extended_coord,
-            self.extended_atype,
-            self.nlist,
-            self.mapping,
-        )
-        ret_fc = self.dp_model.forward_common_lower(
-            self.extended_coord,
-            self.extended_atype,
-            self.nlist,
-            self.mapping,
-        )
-        for key in ret_call:
-            np.testing.assert_equal(ret_call[key], ret_fc[key])
-
     def test_model_output_def(self) -> None:
         """model_output_def should return the same keys and shapes on dp and pt."""
         dp_def = self.dp_model.model_output_def().get_data()

--- a/source/tests/consistent/model/test_frozen.py
+++ b/source/tests/consistent/model/test_frozen.py
@@ -150,10 +150,8 @@ class TestFrozen(CommonTest, ModelTest, unittest.TestCase):
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
-        if backend is self.RefBackend.DP:
-            return (ret["energy_redu"].ravel(), ret["energy"].ravel())
-        elif backend is self.RefBackend.PT:
-            return (ret["energy"].ravel(), ret["atom_energy"].ravel())
-        elif backend is self.RefBackend.TF:
+        if backend is self.RefBackend.TF:
             return (ret[0].ravel(), ret[1].ravel())
+        elif backend in {self.RefBackend.PT}:
+            return (ret["energy"].ravel(), ret["atom_energy"].ravel())
         raise ValueError(f"Unknown backend: {backend}")

--- a/source/tests/consistent/model/test_polar.py
+++ b/source/tests/consistent/model/test_polar.py
@@ -182,20 +182,19 @@ class TestPolar(CommonTest, ModelTest, unittest.TestCase):
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
-        if backend in {self.RefBackend.DP, self.RefBackend.JAX}:
-            return (
-                ret["polarizability_redu"].ravel(),
-                ret["polarizability"].ravel(),
-            )
-        elif backend is self.RefBackend.PT:
-            return (
-                ret["global_polar"].ravel(),
-                ret["polar"].ravel(),
-            )
-        elif backend is self.RefBackend.TF:
+        if backend is self.RefBackend.TF:
             return (
                 ret[0].ravel(),
                 ret[1].ravel(),
+            )
+        elif backend in {
+            self.RefBackend.DP,
+            self.RefBackend.PT,
+            self.RefBackend.JAX,
+        }:
+            return (
+                ret["global_polar"].ravel(),
+                ret["polar"].ravel(),
             )
         raise ValueError(f"Unknown backend: {backend}")
 

--- a/source/tests/consistent/model/test_property.py
+++ b/source/tests/consistent/model/test_property.py
@@ -184,12 +184,7 @@ class TestProperty(CommonTest, ModelTest, unittest.TestCase):
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
         property_name = self.data["fitting_net"]["property_name"]
-        if backend in {self.RefBackend.DP, self.RefBackend.JAX}:
-            return (
-                ret[f"{property_name}_redu"].ravel(),
-                ret[property_name].ravel(),
-            )
-        elif backend is self.RefBackend.PT:
+        if backend in {self.RefBackend.DP, self.RefBackend.PT, self.RefBackend.JAX}:
             return (
                 ret[property_name].ravel(),
                 ret[f"atom_{property_name}"].ravel(),

--- a/source/tests/consistent/model/test_spin_ener.py
+++ b/source/tests/consistent/model/test_spin_ener.py
@@ -333,7 +333,6 @@ class TestSpinEnerLower(CommonTest, ModelTest, unittest.TestCase):
         self.mapping = mapping
 
         # Build extended spin from mapping
-        nall = extended_coord.shape[1]
         self.extended_spin = np.take_along_axis(
             self.spin,
             np.repeat(mapping[:, :, np.newaxis], 3, axis=2),

--- a/source/tests/consistent/model/test_spin_ener.py
+++ b/source/tests/consistent/model/test_spin_ener.py
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+import copy
+import unittest
+from typing import (
+    Any,
+)
+
+import numpy as np
+
+from deepmd.dpmodel.model.model import get_model as get_model_dp
+from deepmd.dpmodel.model.spin_model import SpinModel as SpinModelDP
+from deepmd.dpmodel.utils.nlist import (
+    build_neighbor_list,
+    extend_coord_with_ghosts,
+)
+from deepmd.dpmodel.utils.region import (
+    normalize_coord,
+)
+from deepmd.env import (
+    GLOBAL_NP_FLOAT_PRECISION,
+)
+
+from ..common import (
+    INSTALLED_PT,
+    CommonTest,
+)
+from .common import (
+    ModelTest,
+)
+
+if INSTALLED_PT:
+    from deepmd.pt.model.model import get_model as get_model_pt
+    from deepmd.pt.model.model.spin_model import SpinEnergyModel as SpinEnergyModelPT
+    from deepmd.pt.utils.utils import to_numpy_array as torch_to_numpy
+    from deepmd.pt.utils.utils import to_torch_tensor as numpy_to_torch
+else:
+    SpinEnergyModelPT = None
+
+from deepmd.utils.argcheck import (
+    model_args,
+)
+
+SPIN_DATA = {
+    "type_map": ["O", "H", "B"],
+    "descriptor": {
+        "type": "se_e2_a",
+        "sel": [20, 20, 20],
+        "rcut_smth": 0.50,
+        "rcut": 4.00,
+        "neuron": [
+            3,
+            6,
+        ],
+        "resnet_dt": False,
+        "axis_neuron": 2,
+        "precision": "float64",
+        "type_one_side": True,
+        "seed": 1,
+    },
+    "fitting_net": {
+        "neuron": [
+            5,
+            5,
+        ],
+        "resnet_dt": True,
+        "precision": "float64",
+        "seed": 1,
+    },
+    "spin": {
+        "use_spin": [True, False, False],
+        "virtual_scale": [0.3140],
+    },
+}
+
+
+class TestSpinEner(CommonTest, ModelTest, unittest.TestCase):
+    @property
+    def data(self) -> dict:
+        return SPIN_DATA
+
+    tf_class = None
+    dp_class = SpinModelDP
+    pt_class = SpinEnergyModelPT
+    pd_class = None
+    pt_expt_class = None
+    jax_class = None
+    args = model_args()
+
+    skip_tf = True
+    skip_jax = True
+    skip_pt_expt = True
+    skip_pd = True
+
+    def get_reference_backend(self):
+        """Get the reference backend.
+
+        We need a reference backend that can reproduce forces.
+        """
+        if not self.skip_pt:
+            return self.RefBackend.PT
+        if not self.skip_dp:
+            return self.RefBackend.DP
+        raise ValueError("No available reference")
+
+    def pass_data_to_cls(self, cls, data) -> Any:
+        """Pass data to the class."""
+        data = copy.deepcopy(data)
+        if cls is SpinModelDP:
+            return get_model_dp(data)
+        elif cls is SpinEnergyModelPT:
+            return get_model_pt(data)
+        return cls(**data, **self.additional_data)
+
+    def setUp(self) -> None:
+        CommonTest.setUp(self)
+
+        self.ntypes = 3
+        self.coords = np.array(
+            [
+                12.83,
+                2.56,
+                2.18,
+                12.09,
+                2.87,
+                2.74,
+                00.25,
+                3.32,
+                1.68,
+                3.36,
+                3.00,
+                1.81,
+                3.51,
+                2.51,
+                2.60,
+                4.27,
+                3.22,
+                1.56,
+            ],
+            dtype=GLOBAL_NP_FLOAT_PRECISION,
+        ).reshape(1, -1, 3)
+        self.atype = np.array([0, 0, 1, 0, 1, 1], dtype=np.int32).reshape(1, -1)
+        self.box = np.array(
+            [13.0, 0.0, 0.0, 0.0, 13.0, 0.0, 0.0, 0.0, 13.0],
+            dtype=GLOBAL_NP_FLOAT_PRECISION,
+        ).reshape(1, 9)
+        self.natoms = np.array([6, 6, 3, 3, 0], dtype=np.int32)
+        self.spin = np.array(
+            [
+                0.50,
+                0.30,
+                0.20,
+                0.40,
+                0.25,
+                0.15,
+                0.10,
+                0.05,
+                0.08,
+                0.12,
+                0.07,
+                0.09,
+                0.45,
+                0.35,
+                0.28,
+                0.11,
+                0.06,
+                0.03,
+            ],
+            dtype=GLOBAL_NP_FLOAT_PRECISION,
+        ).reshape(1, -1, 3)
+
+    def build_tf(self, obj: Any, suffix: str) -> tuple[list, dict]:
+        raise NotImplementedError("no TF in this test")
+
+    def eval_dp(self, dp_obj: Any) -> Any:
+        return dp_obj(
+            self.coords,
+            self.atype,
+            self.spin,
+            box=self.box,
+        )
+
+    def eval_pt(self, pt_obj: Any) -> Any:
+        return {
+            kk: torch_to_numpy(vv)
+            for kk, vv in pt_obj(
+                numpy_to_torch(self.coords),
+                numpy_to_torch(self.atype),
+                numpy_to_torch(self.spin),
+                box=numpy_to_torch(self.box),
+            ).items()
+        }
+
+    def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
+        # shape not matched. ravel...
+        from ..common import (
+            SKIP_FLAG,
+        )
+
+        if backend is self.RefBackend.DP:
+            return (
+                ret["energy"].ravel(),
+                ret["atom_energy"].ravel(),
+                ret["mask_mag"].ravel(),
+                SKIP_FLAG,
+                SKIP_FLAG,
+            )
+        elif backend is self.RefBackend.PT:
+            return (
+                ret["energy"].ravel(),
+                ret["atom_energy"].ravel(),
+                ret["mask_mag"].ravel(),
+                ret["force"].ravel(),
+                ret["force_mag"].ravel(),
+            )
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+class TestSpinEnerLower(CommonTest, ModelTest, unittest.TestCase):
+    @property
+    def data(self) -> dict:
+        return SPIN_DATA
+
+    tf_class = None
+    dp_class = SpinModelDP
+    pt_class = SpinEnergyModelPT
+    pd_class = None
+    pt_expt_class = None
+    jax_class = None
+    args = model_args()
+
+    skip_tf = True
+    skip_jax = True
+    skip_pt_expt = True
+    skip_pd = True
+
+    def get_reference_backend(self):
+        """Get the reference backend.
+
+        We need a reference backend that can reproduce forces.
+        """
+        if not self.skip_pt:
+            return self.RefBackend.PT
+        if not self.skip_dp:
+            return self.RefBackend.DP
+        raise ValueError("No available reference")
+
+    def pass_data_to_cls(self, cls, data) -> Any:
+        """Pass data to the class."""
+        data = copy.deepcopy(data)
+        if cls is SpinModelDP:
+            return get_model_dp(data)
+        elif cls is SpinEnergyModelPT:
+            return get_model_pt(data)
+        return cls(**data, **self.additional_data)
+
+    def setUp(self) -> None:
+        CommonTest.setUp(self)
+
+        self.ntypes = 3
+        coords = np.array(
+            [
+                12.83,
+                2.56,
+                2.18,
+                12.09,
+                2.87,
+                2.74,
+                00.25,
+                3.32,
+                1.68,
+                3.36,
+                3.00,
+                1.81,
+                3.51,
+                2.51,
+                2.60,
+                4.27,
+                3.22,
+                1.56,
+            ],
+            dtype=GLOBAL_NP_FLOAT_PRECISION,
+        ).reshape(1, -1, 3)
+        atype = np.array([0, 0, 1, 0, 1, 1], dtype=np.int32).reshape(1, -1)
+        box = np.array(
+            [13.0, 0.0, 0.0, 0.0, 13.0, 0.0, 0.0, 0.0, 13.0],
+            dtype=GLOBAL_NP_FLOAT_PRECISION,
+        ).reshape(1, 9)
+        self.spin = np.array(
+            [
+                0.50,
+                0.30,
+                0.20,
+                0.40,
+                0.25,
+                0.15,
+                0.10,
+                0.05,
+                0.08,
+                0.12,
+                0.07,
+                0.09,
+                0.45,
+                0.35,
+                0.28,
+                0.11,
+                0.06,
+                0.03,
+            ],
+            dtype=GLOBAL_NP_FLOAT_PRECISION,
+        ).reshape(1, -1, 3)
+
+        rcut = 4.0
+        nframes, nloc = atype.shape[:2]
+        coord_normalized = normalize_coord(
+            coords.reshape(nframes, nloc, 3),
+            box.reshape(nframes, 3, 3),
+        )
+        extended_coord, extended_atype, mapping = extend_coord_with_ghosts(
+            coord_normalized, atype, box, rcut
+        )
+        nlist = build_neighbor_list(
+            extended_coord,
+            extended_atype,
+            nloc,
+            rcut,
+            [20, 20, 20],
+            distinguish_types=True,
+        )
+        extended_coord = extended_coord.reshape(nframes, -1, 3)
+        self.nlist = nlist
+        self.extended_coord = extended_coord
+        self.extended_atype = extended_atype
+        self.mapping = mapping
+
+        # Build extended spin from mapping
+        nall = extended_coord.shape[1]
+        self.extended_spin = np.take_along_axis(
+            self.spin,
+            np.repeat(mapping[:, :, np.newaxis], 3, axis=2),
+            axis=1,
+        )
+
+    def build_tf(self, obj: Any, suffix: str) -> tuple[list, dict]:
+        raise NotImplementedError("no TF in this test")
+
+    def eval_dp(self, dp_obj: Any) -> Any:
+        return dp_obj.call_lower(
+            self.extended_coord,
+            self.extended_atype,
+            self.extended_spin,
+            self.nlist,
+            self.mapping,
+        )
+
+    def eval_pt(self, pt_obj: Any) -> Any:
+        return {
+            kk: torch_to_numpy(vv)
+            for kk, vv in pt_obj.forward_lower(
+                numpy_to_torch(self.extended_coord),
+                numpy_to_torch(self.extended_atype),
+                numpy_to_torch(self.extended_spin),
+                numpy_to_torch(self.nlist),
+                numpy_to_torch(self.mapping),
+            ).items()
+        }
+
+    def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
+        # shape not matched. ravel...
+        from ..common import (
+            SKIP_FLAG,
+        )
+
+        if backend is self.RefBackend.DP:
+            return (
+                ret["energy"].ravel(),
+                ret["atom_energy"].ravel(),
+                ret["extended_mask_mag"].ravel(),
+                SKIP_FLAG,
+                SKIP_FLAG,
+            )
+        elif backend is self.RefBackend.PT:
+            return (
+                ret["energy"].ravel(),
+                ret["atom_energy"].ravel(),
+                ret["extended_mask_mag"].ravel(),
+                ret["extended_force"].ravel(),
+                ret["extended_force_mag"].ravel(),
+            )
+        raise ValueError(f"Unknown backend: {backend}")

--- a/source/tests/consistent/model/test_zbl_ener.py
+++ b/source/tests/consistent/model/test_zbl_ener.py
@@ -207,27 +207,23 @@ class TestEner(CommonTest, ModelTest, unittest.TestCase):
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:
         # shape not matched. ravel...
-        if backend is self.RefBackend.DP:
+        if backend is self.RefBackend.TF:
+            return (ret[0].ravel(), ret[1].ravel(), ret[2].ravel(), ret[3].ravel())
+        elif backend is self.RefBackend.DP:
             return (
-                ret["energy_redu"].ravel(),
                 ret["energy"].ravel(),
+                ret["atom_energy"].ravel(),
                 SKIP_FLAG,
                 SKIP_FLAG,
             )
-        elif backend is self.RefBackend.PT:
+        elif backend in {
+            self.RefBackend.PT,
+            self.RefBackend.JAX,
+        }:
             return (
                 ret["energy"].ravel(),
                 ret["atom_energy"].ravel(),
                 ret["force"].ravel(),
                 ret["virial"].ravel(),
-            )
-        elif backend is self.RefBackend.TF:
-            return (ret[0].ravel(), ret[1].ravel(), ret[2].ravel(), ret[3].ravel())
-        elif backend is self.RefBackend.JAX:
-            return (
-                ret["energy_redu"].ravel(),
-                ret["energy"].ravel(),
-                ret["energy_derv_r"].ravel(),
-                ret["energy_derv_c_redu"].ravel(),
             )
         raise ValueError(f"Unknown backend: {backend}")

--- a/source/tests/jax/test_dp_hessian_model.py
+++ b/source/tests/jax/test_dp_hessian_model.py
@@ -82,34 +82,34 @@ class TestEnergyHessianModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist)
         ret0 = md0.call(*args)
         ret1 = md1.call(*args)
         np.testing.assert_allclose(
+            to_numpy_array(ret0["atom_energy"]),
+            to_numpy_array(ret1["atom_energy"]),
+            atol=self.atol,
+        )
+        np.testing.assert_allclose(
             to_numpy_array(ret0["energy"]),
             to_numpy_array(ret1["energy"]),
             atol=self.atol,
         )
         np.testing.assert_allclose(
-            to_numpy_array(ret0["energy_redu"]),
-            to_numpy_array(ret1["energy_redu"]),
+            to_numpy_array(ret0["force"]),
+            to_numpy_array(ret1["force"]),
             atol=self.atol,
         )
         np.testing.assert_allclose(
-            to_numpy_array(ret0["energy_derv_r"]),
-            to_numpy_array(ret1["energy_derv_r"]),
+            to_numpy_array(ret0["virial"]),
+            to_numpy_array(ret1["virial"]),
             atol=self.atol,
         )
         np.testing.assert_allclose(
-            to_numpy_array(ret0["energy_derv_c_redu"]),
-            to_numpy_array(ret1["energy_derv_c_redu"]),
-            atol=self.atol,
-        )
-        np.testing.assert_allclose(
-            to_numpy_array(ret0["energy_derv_r_derv_r"]),
-            to_numpy_array(ret1["energy_derv_r_derv_r"]),
+            to_numpy_array(ret0["hessian"]),
+            to_numpy_array(ret1["hessian"]),
             atol=self.atol,
         )
         ret0 = md0.call(*args, do_atomic_virial=True)
         ret1 = md1.call(*args, do_atomic_virial=True)
         np.testing.assert_allclose(
-            to_numpy_array(ret0["energy_derv_c"]),
-            to_numpy_array(ret1["energy_derv_c"]),
+            to_numpy_array(ret0["atom_virial"]),
+            to_numpy_array(ret1["atom_virial"]),
             atol=self.atol,
         )

--- a/source/tests/jax/test_make_hessian_model.py
+++ b/source/tests/jax/test_make_hessian_model.py
@@ -100,7 +100,7 @@ class HessianTest:
         )
         # compare hess and value models
         np.testing.assert_allclose(ret_dict0["energy"], ret_dict1["energy"])
-        ana_hess = ret_dict0["energy_derv_r_derv_r"]
+        ana_hess = ret_dict0["hessian"]
 
         # compute finite difference
         fnt_hess = []
@@ -121,13 +121,13 @@ class HessianTest:
                 return ret
 
             def ff(xx):
-                return np_infer(xx)["energy_redu"]
+                return np_infer(xx)["energy"]
 
             xx = to_numpy_array(coord[ii])
             fnt_hess.append(finite_hessian(ff, xx, delta=delta).squeeze())
 
         # compare finite difference with autodiff
-        fnt_hess = np.stack(fnt_hess).reshape([nf, nv, natoms * 3, natoms * 3])
+        fnt_hess = np.stack(fnt_hess).reshape([nf, natoms * 3, natoms * 3])
         np.testing.assert_almost_equal(
             fnt_hess, to_numpy_array(ana_hess), decimal=places
         )

--- a/source/tests/jax/test_padding_atoms.py
+++ b/source/tests/jax/test_padding_atoms.py
@@ -89,8 +89,8 @@ class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         result = model.call(*args)
         # test intensive
         np.testing.assert_allclose(
-            to_numpy_array(result[f"{var_name}_redu"]),
-            np.mean(to_numpy_array(result[f"{var_name}"]), axis=1),
+            to_numpy_array(result[var_name]),
+            np.mean(to_numpy_array(result[f"atom_{var_name}"]), axis=1),
             atol=self.atol,
         )
         # test padding atoms
@@ -115,8 +115,8 @@ class TestPaddingAtoms(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
             ]
             result_padding = model.call(*args)
             np.testing.assert_allclose(
-                to_numpy_array(result[f"{var_name}_redu"]),
-                to_numpy_array(result_padding[f"{var_name}_redu"]),
+                to_numpy_array(result[var_name]),
+                to_numpy_array(result_padding[var_name]),
                 atol=self.atol,
             )
 

--- a/source/tests/pd/model/test_dp_model.py
+++ b/source/tests/pd/model/test_dp_model.py
@@ -140,7 +140,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         args1 = [to_paddle_tensor(ii) for ii in [self.coord, self.atype, self.cell]]
         kwargs0 = {"fparam": fparam, "aparam": aparam}
         kwargs1 = {kk: to_paddle_tensor(vv) for kk, vv in kwargs0.items()}
-        ret0 = md0.call(*args0, **kwargs0)
+        ret0 = md0.call_common(*args0, **kwargs0)
         ret1 = md1.forward_common(*args1, **kwargs1)
         np.testing.assert_allclose(
             ret0["energy"],
@@ -179,7 +179,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         args1 = [to_paddle_tensor(ii) for ii in args0]
         kwargs0 = {"fparam": fparam, "aparam": aparam}
         kwargs1 = {kk: to_paddle_tensor(vv) for kk, vv in kwargs0.items()}
-        ret0 = md0.call(*args0, **kwargs0)
+        ret0 = md0.call_common(*args0, **kwargs0)
         ret1 = md1.forward_common(*args1, **kwargs1)
         np.testing.assert_allclose(
             ret0["energy"],
@@ -313,7 +313,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         args1 = [
             to_paddle_tensor(ii) for ii in [self.coord_ext, self.atype_ext, self.nlist]
         ]
-        ret0 = md0.call_lower(*args0)
+        ret0 = md0.call_common_lower(*args0)
         ret1 = md1.forward_common_lower(*args1)
         np.testing.assert_allclose(
             ret0["energy"],

--- a/source/tests/pt/model/test_dp_model.py
+++ b/source/tests/pt/model/test_dp_model.py
@@ -140,7 +140,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         args1 = [to_torch_tensor(ii) for ii in [self.coord, self.atype, self.cell]]
         kwargs0 = {"fparam": fparam, "aparam": aparam}
         kwargs1 = {kk: to_torch_tensor(vv) for kk, vv in kwargs0.items()}
-        ret0 = md0.call(*args0, **kwargs0)
+        ret0 = md0.call_common(*args0, **kwargs0)
         ret1 = md1.forward_common(*args1, **kwargs1)
         np.testing.assert_allclose(
             ret0["energy"],
@@ -179,7 +179,7 @@ class TestDPModel(unittest.TestCase, TestCaseSingleFrameWithoutNlist):
         args1 = [to_torch_tensor(ii) for ii in args0]
         kwargs0 = {"fparam": fparam, "aparam": aparam}
         kwargs1 = {kk: to_torch_tensor(vv) for kk, vv in kwargs0.items()}
-        ret0 = md0.call(*args0, **kwargs0)
+        ret0 = md0.call_common(*args0, **kwargs0)
         ret1 = md1.forward_common(*args1, **kwargs1)
         np.testing.assert_allclose(
             ret0["energy"],
@@ -313,7 +313,7 @@ class TestDPModelLower(unittest.TestCase, TestCaseSingleFrameWithNlist):
         args1 = [
             to_torch_tensor(ii) for ii in [self.coord_ext, self.atype_ext, self.nlist]
         ]
-        ret0 = md0.call_lower(*args0)
+        ret0 = md0.call_common_lower(*args0)
         ret1 = md1.forward_common_lower(*args1)
         np.testing.assert_allclose(
             ret0["energy"],

--- a/source/tests/pt/model/test_ener_spin_model.py
+++ b/source/tests/pt/model/test_ener_spin_model.py
@@ -313,7 +313,7 @@ class SpinTest:
             return
         dp_model = DPSpinModel.deserialize(self.model.serialize())
         # test call
-        dp_ret = dp_model.call(
+        dp_ret = dp_model.call_common(
             to_numpy_array(self.coord),
             to_numpy_array(self.atype),
             to_numpy_array(self.spin),
@@ -355,7 +355,7 @@ class SpinTest:
         extended_spin = torch.gather(
             self.spin, index=mapping.unsqueeze(-1).tile((1, 1, 3)), dim=1
         )
-        dp_ret_lower = dp_model.call_lower(
+        dp_ret_lower = dp_model.call_common_lower(
             to_numpy_array(extended_coord),
             to_numpy_array(extended_atype),
             to_numpy_array(extended_spin),

--- a/source/tests/pt_expt/model/test_ener_model.py
+++ b/source/tests/pt_expt/model/test_ener_model.py
@@ -364,13 +364,13 @@ class TestEnergyModel(unittest.TestCase):
         ret_pt = md_pt(coord, self.atype, self.cell.reshape(1, 9))
 
         np.testing.assert_allclose(
-            ret_dp["energy_redu"],
+            ret_dp["energy"],
             ret_pt["energy"].detach().cpu().numpy(),
             rtol=1e-10,
             atol=1e-10,
         )
         np.testing.assert_allclose(
-            ret_dp["energy"],
+            ret_dp["atom_energy"],
             ret_pt["atom_energy"].detach().cpu().numpy(),
             rtol=1e-10,
             atol=1e-10,

--- a/source/tests/universal/dpmodel/backend.py
+++ b/source/tests/universal/dpmodel/backend.py
@@ -21,6 +21,8 @@ class DPTestCase(BackendTestCase):
     """DP module to test."""
 
     def forward_wrapper(self, x):
+        if not hasattr(x, "forward_lower") and hasattr(x, "call_lower"):
+            x.forward_lower = x.call_lower
         return x
 
     def forward_wrapper_cpu_ref(self, x):

--- a/source/tests/universal/dpmodel/model/test_model.py
+++ b/source/tests/universal/dpmodel/model/test_model.py
@@ -164,7 +164,7 @@ class TestEnergyModelDP(unittest.TestCase, EnerModelTest, DPTestCase):
             ft,
             type_map=cls.expected_type_map,
         )
-        cls.output_def = cls.module.model_output_def().get_data()
+        cls.output_def = cls.module.translated_output_def()
         cls.expected_has_message_passing = ds.has_message_passing()
         cls.expected_sel_type = ft.get_sel_type()
         cls.expected_dim_fparam = ft.get_dim_fparam()

--- a/source/tests/universal/dpmodel/model/test_model.py
+++ b/source/tests/universal/dpmodel/model/test_model.py
@@ -164,7 +164,7 @@ class TestEnergyModelDP(unittest.TestCase, EnerModelTest, DPTestCase):
             ft,
             type_map=cls.expected_type_map,
         )
-        cls.output_def = cls.module.translated_output_def()
+        cls.output_def = cls.module.model_output_def().get_data()
         cls.expected_has_message_passing = ds.has_message_passing()
         cls.expected_sel_type = ft.get_sel_type()
         cls.expected_dim_fparam = ft.get_dim_fparam()
@@ -271,7 +271,7 @@ class TestSpinEnergyModelDP(unittest.TestCase, SpinEnerModelTest, DPTestCase):
             pair_exclude_types=pair_exclude_types,
         )
         cls.module = SpinModel(backbone_model=backbone_model, spin=spin)
-        cls.output_def = cls.module.model_output_def().get_data()
+        cls.output_def = cls.module.translated_output_def()
         cls.expected_has_message_passing = ds.has_message_passing()
         cls.expected_sel_type = ft.get_sel_type()
         cls.expected_dim_fparam = ft.get_dim_fparam()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models expose unified high-level prediction APIs with additional outputs (atom-level, reduced, extended) and conditional mask propagation; spin-energy prediction tests added.

* **Refactor**
  * Standardized output key naming and backend return shapes; consolidated backend dispatch and adjusted tensor squeeze/shape behavior for gradients, virials, and Hessians.

* **Tests**
  * Updated and reorganized tests to align with new keys, shapes, and backend groupings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->