### PR TITLE
set default timeout for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ test = [
     "pytest-cov",
     "pytest-sugar",
     "pytest-split",
+    "pytest-timeout",
     "dpgui",
     # to support Array API 2024.12
     'array-api-strict>=2.2;python_version>="3.9"',
@@ -454,6 +455,7 @@ runtime-evaluated-base-classes = ["torch.nn.Module"]
 
 [tool.pytest.ini_options]
 markers = "run"
+timeout = 1800
 
 [tool.coverage.run]
 plugins = ["source.3rdparty.coverage_plugins.jit_plugin"]


### PR DESCRIPTION
Avoid wasting time on broken test that pending the workflow for a long time like this: https://github.com/deepmodeling/deepmd-kit/actions/runs/22224311896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added test timeout configuration to prevent indefinitely hanging test runs, improving test suite reliability and execution stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->