### PR TITLE
CI(deps): bump torch (cpu) to 2.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ pin_tensorflow_gpu = [
 pin_pytorch_cpu = [
   # https://github.com/pytorch/pytorch/issues/114602
   # macos x86 has been deprecated
-  "torch>=2.8,<2.10; platform_machine!='x86_64' or platform_system != 'Darwin'",
+  "torch==2.10.0; platform_machine!='x86_64' or platform_system != 'Darwin'",
   "torch; platform_machine=='x86_64' and platform_system == 'Darwin'",
 ]
 pin_pytorch_gpu = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the CPU build of PyTorch to version 2.10.0 to match existing GPU pinning; platform-specific (Darwin/Linux) handling remains unchanged, ensuring consistent runtime behavior across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->