### PR TITLE
doc(pd): update PaddlePaddle version to 3.3.0 and 3.4.0(develop)

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -47,7 +47,7 @@ jobs:
       - run: |
           export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
           export TENSORFLOW_ROOT=$(python -c 'import importlib.util,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
-          pip install --find-links "https://www.paddlepaddle.org.cn/packages/nightly/cu126/paddlepaddle-gpu/" --index-url https://pypi.org/simple "paddlepaddle-gpu==3.3.0.dev20251204"
+          pip install --find-links "https://www.paddlepaddle.org.cn/packages/nightly/cu126/paddlepaddle-gpu/" --index-url https://pypi.org/simple "paddlepaddle-gpu==3.4.0.dev20260310"
           source/install/uv_with_retry.sh pip install --system -v -e .[gpu,test,lmp,cu12,torch,jax] mpi4py --reinstall-package deepmd-kit
           # See https://github.com/jax-ml/jax/issues/29042
           source/install/uv_with_retry.sh pip install --system -U 'nvidia-cublas-cu12>=12.9.0.13'

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -32,7 +32,7 @@ jobs:
           export TENSORFLOW_ROOT=$(python -c 'import importlib.util,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')
           export PYTORCH_ROOT=$(python -c 'import torch;print(torch.__path__[0])')
           source/install/uv_with_retry.sh pip install --system -e .[test,jax] mpi4py --group pin_jax
-          source/install/uv_with_retry.sh pip install --system --find-links "https://www.paddlepaddle.org.cn/packages/nightly/cpu/paddlepaddle/" --index-url https://pypi.org/simple paddlepaddle==3.3.0.dev20251204
+          source/install/uv_with_retry.sh pip install --system --find-links "https://www.paddlepaddle.org.cn/packages/nightly/cpu/paddlepaddle/" --index-url https://pypi.org/simple paddlepaddle==3.4.0.dev20260310
         env:
           # Please note that uv has some issues with finding
           # existing TensorFlow package. Currently, it uses

--- a/deepmd/pd/train/training.py
+++ b/deepmd/pd/train/training.py
@@ -165,7 +165,7 @@ class Trainer:
             before this function is called.
             """
             opt_type = params.get("type", "Adam")
-            if opt_type != "Adam":
+            if opt_type not in ["Adam", "AdamW"]:
                 raise ValueError(f"Not supported optimizer type '{opt_type}'")
             opt_param = dict(params)
             opt_param.pop("type", None)
@@ -647,7 +647,7 @@ class Trainer:
         # author: iProzd
         # TODO add optimizers for multitask
         # author: iProzd
-        if self.opt_type == "Adam":
+        if self.opt_type in ["Adam", "AdamW"]:
             self.scheduler = paddle.optimizer.lr.LambdaDecay(
                 learning_rate=self.lr_schedule.start_lr,
                 lr_lambda=lambda step: (
@@ -800,7 +800,7 @@ class Trainer:
                 print_str = f"Step {_step_id}: sample system{log_dict['sid']}  frame{log_dict['fid']}\n"
                 fout1.write(print_str)
                 fout1.flush()
-            if self.opt_type == "Adam":
+            if self.opt_type in ["Adam", "AdamW"]:
                 cur_lr = self.scheduler.get_lr()
                 pref_lr = cur_lr
 

--- a/doc/install/easy-install.md
+++ b/doc/install/easy-install.md
@@ -169,9 +169,9 @@ Switch to the TensorFlow {{ tensorflow_icon }} tab for more information.
 
 ```bash
 # release version
-pip install paddlepaddle-gpu==3.1.1 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
+pip install paddlepaddle-gpu==3.3.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
 # nightly-build version
-# pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+# pip install --pre -U paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
 pip install deepmd-kit
 ```
 :::
@@ -180,9 +180,9 @@ pip install deepmd-kit
 
 ```bash
 # release version
-pip install paddlepaddle==3.1.1 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
+pip install paddlepaddle==3.3.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
 # nightly-build version
-# pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
+# pip install --pre -U paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
 pip install deepmd-kit
 ```
 :::

--- a/doc/install/install-from-source.md
+++ b/doc/install/install-from-source.md
@@ -97,15 +97,15 @@ To install Paddle, run
 ```sh
 # cu126
 # release version
-pip install paddlepaddle-gpu==3.1.1 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
+pip install paddlepaddle-gpu==3.3.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
 # nightly-build version
-# pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+# pip install --pre -U paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
 
 # cpu
 # release version
-pip install paddlepaddle==3.1.1 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
+pip install paddlepaddle==3.3.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
 # nightly-build version
-# pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
+# pip install --pre -U paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
 ```
 :::
 


### PR DESCRIPTION
fix issue introduced by this pr: https://github.com/deepmodeling/deepmd-kit/pull/5157

This pull request updates the PaddlePaddle dependency versions across the codebase to ensure compatibility with the latest releases. It also improves the installation instructions in the documentation to reflect these updates and to recommend best practices for installing nightly builds.

Dependency version updates:

* Updated the `paddlepaddle-gpu` dependency in the CUDA test workflow to version `3.4.0.dev20260310` (`.github/workflows/test_cuda.yml`).
* Updated the `paddlepaddle` dependency in the Python test workflow to version `3.4.0.dev20260310` (`.github/workflows/test_python.yml`).

Documentation improvements:

* Updated installation instructions in `doc/install/easy-install.md` and `doc/install/install-from-source.md` to reference `paddlepaddle-gpu==3.3.0` and `paddlepaddle==3.3.0` as the latest stable release versions [[1]](diffhunk://#diff-8072dac581dd568fe718ff7204aae121465797d5d2890c4bc4d3ee8d978951e7L172-R174) [[2]](diffhunk://#diff-8072dac581dd568fe718ff7204aae121465797d5d2890c4bc4d3ee8d978951e7L183-R185) [[3]](diffhunk://#diff-865b1d35cff7d06cf73ebb95b0f2d93c5cc77b19c64305753008c90dfe9370c8L100-R108).
* Modified nightly build installation commands in the documentation to recommend using the `-U` (upgrade) flag for both GPU and CPU versions, ensuring users get the latest nightly build [[1]](diffhunk://#diff-8072dac581dd568fe718ff7204aae121465797d5d2890c4bc4d3ee8d978951e7L172-R174) [[2]](diffhunk://#diff-8072dac581dd568fe718ff7204aae121465797d5d2890c4bc4d3ee8d978951e7L183-R185) [[3]](diffhunk://#diff-865b1d35cff7d06cf73ebb95b0f2d93c5cc77b19c64305753008c90dfe9370c8L100-R108).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Training now supports the AdamW optimizer alongside Adam.

* **Documentation**
  * Updated installation guides with newer PaddlePaddle stable and nightly package versions and improved nightly/pre-release pip syntax.

* **Chores**
  * Bumped PaddlePaddle dependency versions used in CI workflows (Python and CUDA test pipelines).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->