### PR TITLE
fix(pd): fix adamw for paddle backend

### DIFF
--- a/deepmd/pd/train/training.py
+++ b/deepmd/pd/train/training.py
@@ -655,7 +655,12 @@ class Trainer:
                     / self.lr_schedule.start_lr
                 ),
             )
-            self.optimizer = paddle.optimizer.Adam(
+            opt_cls = (
+                paddle.optimizer.Adam
+                if self.opt_type == "Adam"
+                else paddle.optimizer.AdamW
+            )
+            self.optimizer = opt_cls(
                 learning_rate=self.scheduler,
                 parameters=self.wrapper.parameters(),
                 beta1=float(self.opt_param["adam_beta1"]),
@@ -840,7 +845,7 @@ class Trainer:
                                 error_if_nonfinite=True,
                             )
 
-                    with nvprof_context(enable_profiling, "Adam update"):
+                    with nvprof_context(enable_profiling, "Optimizer update"):
                         self.optimizer.step()
                     self.optimizer.clear_grad(set_to_zero=False)
                     self.scheduler.step()


### PR DESCRIPTION
This pull request updates the optimizer handling in the `deepmd/pd/train/training.py` file, adding support for selecting between `Adam` and `AdamW` optimizers based on configuration, and improves profiling clarity.

**Optimizer selection improvements:**

* Refactored optimizer initialization to dynamically select between `paddle.optimizer.Adam` and `paddle.optimizer.AdamW` depending on the value of `self.opt_type`. This allows for more flexibility in choosing the optimizer.

**Profiling and logging enhancements:**

* Updated the profiling context label from `"Adam update"` to `"Optimizer update"` to accurately reflect the optimizer in use, improving the clarity of profiling output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between Adam and AdamW optimizers during training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->