### PR TITLE
fix(pd): update model interface for dpa3 paddle backend

### DIFF
--- a/deepmd/pd/model/atomic_model/base_atomic_model.py
+++ b/deepmd/pd/model/atomic_model/base_atomic_model.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
+import functools
 import logging
 from collections.abc import (
     Callable,
@@ -99,6 +100,45 @@ class BaseAtomicModel(paddle.nn.Layer, BaseAtomicModel_):
         self.rcond = rcond
         self.preset_out_bias = preset_out_bias
         self.data_stat_protect = data_stat_protect
+        self._observed_type: list[str] | None = None
+
+    @property
+    def observed_type(self) -> list[str] | None:
+        """Get the observed element type list from data statistics."""
+        return self._observed_type
+
+    def _collect_and_set_observed_type(
+        self,
+        sampled_func: Callable[[], list[dict]],
+        stat_file_path: "DPPath | None",
+        preset_observed_type: list[str] | None,
+    ) -> None:
+        """Collect observed types with priority: preset > stat_file > compute.
+
+        Parameters
+        ----------
+        sampled_func
+            The lazy sampled function to get data frames.
+        stat_file_path
+            The path to the statistics files (should already include type_map suffix).
+        preset_observed_type
+            User-specified observed types that take highest priority.
+        """
+        from deepmd.dpmodel.utils.stat import (
+            _restore_observed_type_from_file,
+            _save_observed_type_to_file,
+            collect_observed_types,
+        )
+
+        if preset_observed_type is not None:
+            self._observed_type = preset_observed_type
+        else:
+            observed = _restore_observed_type_from_file(stat_file_path)
+            if observed is None:
+                sampled = sampled_func()
+                observed = collect_observed_types(sampled, self.type_map)
+                _save_observed_type_to_file(stat_file_path, observed)
+            self._observed_type = observed
 
     def init_out_stat(self) -> None:
         """Initialize the output bias."""
@@ -112,7 +152,12 @@ class BaseAtomicModel(paddle.nn.Layer, BaseAtomicModel_):
         self.register_buffer("out_bias", out_bias_data)
         self.register_buffer("out_std", out_std_data)
 
+    def get_out_bias(self) -> paddle.Tensor:
+        """Get the output bias."""
+        return self.out_bias
+
     def set_out_bias(self, out_bias: paddle.Tensor) -> None:
+        """Set the output bias."""
         self.out_bias = out_bias
 
     def __setitem__(self, key: str, value: paddle.Tensor) -> None:
@@ -159,12 +204,62 @@ class BaseAtomicModel(paddle.nn.Layer, BaseAtomicModel_):
         """Check if the model has default frame parameters."""
         return False
 
+    def get_default_fparam(self) -> paddle.Tensor | None:
+        """Get the default frame parameters."""
+        return None
+
+    def _make_wrapped_sampler(
+        self,
+        sampled_func: Callable[[], list[dict]],
+    ) -> Callable[[], list[dict]]:
+        """Wrap the sampled function with exclusion types and default fparam.
+
+        The returned callable is cached so that the sampling (which may be
+        expensive) is performed at most once.
+
+        Parameters
+        ----------
+        sampled_func
+            The lazy sampled function to get data frames from different data
+            systems.
+
+        Returns
+        -------
+        Callable[[], list[dict]]
+            A cached wrapper around *sampled_func* that additionally sets
+            ``pair_exclude_types``, ``atom_exclude_types`` and default
+            ``fparam`` on every sample dict when applicable.
+        """
+
+        @functools.lru_cache
+        def wrapped_sampler() -> list[dict]:
+            sampled = sampled_func()
+            if self.pair_excl is not None:
+                pair_exclude_types = self.pair_excl.get_exclude_types()
+                for sample in sampled:
+                    sample["pair_exclude_types"] = list(pair_exclude_types)
+            if self.atom_excl is not None:
+                atom_exclude_types = self.atom_excl.get_exclude_types()
+                for sample in sampled:
+                    sample["atom_exclude_types"] = list(atom_exclude_types)
+            if (
+                "find_fparam" not in sampled[0]
+                and "fparam" not in sampled[0]
+                and self.has_default_fparam()
+            ):
+                default_fparam = self.get_default_fparam()
+                if default_fparam is not None:
+                    for sample in sampled:
+                        nframe = sample["atype"].shape[0]
+                        sample["fparam"] = default_fparam.repeat(nframe, 1)
+            return sampled
+
+        return wrapped_sampler
+
     def reinit_atom_exclude(
         self,
         exclude_types: list[int] | None = None,
     ) -> None:
-        if exclude_types is None:
-            exclude_types = []
         self.atom_exclude_types = exclude_types
         if exclude_types == []:
             self.atom_excl = None
@@ -284,6 +379,7 @@ class BaseAtomicModel(paddle.nn.Layer, BaseAtomicModel_):
             comm_dict=comm_dict,
         )
         ret_dict = self.apply_out_stat(ret_dict, atype)
+
         # nf x nloc
         atom_mask = ext_atom_mask[:, :nloc].astype(paddle.int32)
         if self.atom_excl is not None:
@@ -299,7 +395,7 @@ class BaseAtomicModel(paddle.nn.Layer, BaseAtomicModel_):
                 * atom_mask[:, :, None].astype(ret_dict[kk].dtype)
             ).reshape(out_shape)
         ret_dict["mask"] = atom_mask
-        # raise
+
         return ret_dict
 
     def forward(
@@ -393,6 +489,7 @@ class BaseAtomicModel(paddle.nn.Layer, BaseAtomicModel_):
         merged: Callable[[], list[dict]] | list[dict],
         stat_file_path: DPPath | None = None,
         compute_or_load_out_stat: bool = True,
+        preset_observed_type: list[str] | None = None,
     ) -> NoReturn:
         """
         Compute or load the statistics parameters of the model,
@@ -499,6 +596,8 @@ class BaseAtomicModel(paddle.nn.Layer, BaseAtomicModel_):
                 model_forward=self._get_forward_wrapper_func(),
                 rcond=self.rcond,
                 preset_bias=self.preset_out_bias,
+                stats_distinguish_types=self.get_compute_stats_distinguish_types(),
+                intensive=self.get_intensive(),
             )
             self._store_out_stat(delta_bias, out_std, add=True)
         elif bias_adjust_mode == "set-by-statistic":

--- a/deepmd/pd/model/atomic_model/dp_atomic_model.py
+++ b/deepmd/pd/model/atomic_model/dp_atomic_model.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import functools
-import logging
 from collections.abc import (
     Callable,
 )
@@ -31,12 +30,24 @@ from .base_atomic_model import (
     BaseAtomicModel,
 )
 
-log = logging.getLogger(__name__)
-
 
 @BaseAtomicModel.register("standard")
 class DPAtomicModel(BaseAtomicModel):
-    """Model give atomic prediction of some physical property.
+    r"""Model give atomic prediction of some physical property.
+
+    The atomic model computes atomic properties by first extracting a descriptor
+    from the atomic environment, then passing it through a fitting network:
+
+    .. math::
+        \mathcal{D}^i = \mathcal{D}(\mathbf{R}^i, \mathbf{R}_j, \alpha_j),
+
+    .. math::
+        \mathbf{y}^i = \mathcal{F}(\mathcal{D}^i),
+
+    where :math:`\mathcal{D}^i` is the descriptor for atom :math:`i`,
+    :math:`\alpha_j` is the atom type of neighbor :math:`j`,
+    :math:`\mathcal{F}` is the fitting network, and
+    :math:`\mathbf{y}^i` is the predicted atomic property (energy, dipole, etc.).
 
     Parameters
     ----------
@@ -47,6 +58,7 @@ class DPAtomicModel(BaseAtomicModel):
     type_map
             Mapping atom type to the name (str) of the type.
             For example `type_map[1]` gives the name of the type 1.
+
     """
 
     def __init__(
@@ -64,6 +76,12 @@ class DPAtomicModel(BaseAtomicModel):
         self.rcut = self.descriptor.get_rcut()
         self.sel = self.descriptor.get_sel()
         self.fitting_net = fitting
+        if hasattr(self.fitting_net, "reinit_exclude"):
+            self.fitting_net.reinit_exclude(self.atom_exclude_types)
+        self.type_map = type_map
+        self.add_chg_spin_ebd: bool = getattr(
+            self.descriptor, "add_chg_spin_ebd", False
+        )
         super().init_out_stat()
         self.enable_eval_descriptor_hook = False
         self.enable_eval_fitting_last_layer_hook = False
@@ -233,8 +251,8 @@ class DPAtomicModel(BaseAtomicModel):
         dd.update(
             {
                 "@class": "Model",
-                "@version": 2,
                 "type": "standard",
+                "@version": 2,
                 "type_map": self.type_map,
                 "descriptor": self.descriptor.serialize(),
                 "fitting": self.fitting_net.serialize(),
@@ -245,7 +263,7 @@ class DPAtomicModel(BaseAtomicModel):
     @classmethod
     def deserialize(cls, data: dict) -> "DPAtomicModel":
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 2, 2)
         data.pop("@class", None)
         data.pop("type", None)
         descriptor_obj = BaseDescriptor.deserialize(data.pop("descriptor"))
@@ -360,6 +378,7 @@ class DPAtomicModel(BaseAtomicModel):
         sampled_func: Callable[[], list[dict]],
         stat_file_path: DPPath | None = None,
         compute_or_load_out_stat: bool = True,
+        preset_observed_type: list[str] | None = None,
     ) -> None:
         """
         Compute or load the statistics parameters of the model,
@@ -398,9 +417,15 @@ class DPAtomicModel(BaseAtomicModel):
             return sampled
 
         self.descriptor.compute_input_stats(wrapped_sampler, stat_file_path)
-        self.compute_fitting_input_stat(wrapped_sampler, stat_file_path)
+        self.fitting_net.compute_input_stats(
+            wrapped_sampler, stat_file_path=stat_file_path
+        )
         if compute_or_load_out_stat:
             self.compute_or_load_out_stat(wrapped_sampler, stat_file_path)
+
+        self._collect_and_set_observed_type(
+            wrapped_sampler, stat_file_path, preset_observed_type
+        )
 
     def compute_fitting_input_stat(
         self,
@@ -413,19 +438,24 @@ class DPAtomicModel(BaseAtomicModel):
         ----------
         sample_merged : Union[Callable[[], list[dict]], list[dict]]
             - list[dict]: A list of data samples from various data systems.
-                Each element, `merged[i]`, is a data dictionary containing `keys`: `paddle.Tensor`
-                originating from the `i`-th data system.
-            - Callable[[], list[dict]]: A lazy function that returns data samples in the above format
-                only when needed. Since the sampling process can be slow and memory-intensive,
-                the lazy function helps by only sampling once.
+                Each element, ``merged[i]``, is a data dictionary containing
+                ``keys``: ``np.ndarray`` originating from the ``i``-th data system.
+            - Callable[[], list[dict]]: A lazy function that returns data samples
+                in the above format only when needed.
         stat_file_path : Optional[DPPath]
-            The dictionary of paths to the statistics files.
+            The path to the stat file.
         """
         self.fitting_net.compute_input_stats(
             sample_merged,
             protection=self.data_stat_protect,
             stat_file_path=stat_file_path,
         )
+
+    # for subclass overridden
+    base_descriptor_cls = BaseDescriptor
+    """The base descriptor class."""
+    base_fitting_cls = BaseFitting
+    """The base fitting class."""
 
     def get_dim_fparam(self) -> int:
         """Get the number (dimension) of frame parameters of this atomic model."""

--- a/deepmd/pd/model/atomic_model/dp_atomic_model.py
+++ b/deepmd/pd/model/atomic_model/dp_atomic_model.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import functools
+import logging
 from collections.abc import (
     Callable,
 )
@@ -29,6 +29,8 @@ from deepmd.utils.version import (
 from .base_atomic_model import (
     BaseAtomicModel,
 )
+
+log = logging.getLogger(__name__)
 
 
 @BaseAtomicModel.register("standard")
@@ -78,11 +80,10 @@ class DPAtomicModel(BaseAtomicModel):
         self.fitting_net = fitting
         if hasattr(self.fitting_net, "reinit_exclude"):
             self.fitting_net.reinit_exclude(self.atom_exclude_types)
-        self.type_map = type_map
+        super().init_out_stat()
         self.add_chg_spin_ebd: bool = getattr(
             self.descriptor, "add_chg_spin_ebd", False
         )
-        super().init_out_stat()
         self.enable_eval_descriptor_hook = False
         self.enable_eval_fitting_last_layer_hook = False
         self.eval_descriptor_list = []
@@ -149,6 +150,11 @@ class DPAtomicModel(BaseAtomicModel):
 
     def eval_descriptor(self) -> paddle.Tensor:
         """Evaluate the descriptor."""
+        if not self.eval_descriptor_list:
+            raise RuntimeError(
+                "eval_descriptor_list is empty. "
+                "Call set_eval_descriptor_hook(True) and perform a forward pass first."
+            )
         return paddle.concat(self.eval_descriptor_list)
 
     def set_eval_fitting_last_layer_hook(self, enable: bool) -> None:
@@ -160,6 +166,11 @@ class DPAtomicModel(BaseAtomicModel):
 
     def eval_fitting_last_layer(self) -> paddle.Tensor:
         """Evaluate the fitting last layer output."""
+        if not self.eval_fitting_last_layer_list:
+            raise RuntimeError(
+                "eval_fitting_last_layer_list is empty. "
+                "Call set_eval_fitting_last_layer_hook(True) and perform a forward pass first."
+            )
         return paddle.concat(self.eval_fitting_last_layer_list)
 
     def fitting_output_def(self) -> FittingOutputDef:
@@ -237,6 +248,9 @@ class DPAtomicModel(BaseAtomicModel):
             else None,
         )
         self.fitting_net.change_type_map(type_map=type_map)
+        # Reinitialize fitting to get correct sel_type
+        if hasattr(self.fitting_net, "reinit_exclude"):
+            self.fitting_net.reinit_exclude(self.atom_exclude_types)
 
     def has_message_passing(self) -> bool:
         """Returns whether the atomic model has message passing."""
@@ -251,8 +265,8 @@ class DPAtomicModel(BaseAtomicModel):
         dd.update(
             {
                 "@class": "Model",
-                "type": "standard",
                 "@version": 2,
+                "type": "standard",
                 "type_map": self.type_map,
                 "descriptor": self.descriptor.serialize(),
                 "fitting": self.fitting_net.serialize(),
@@ -263,7 +277,7 @@ class DPAtomicModel(BaseAtomicModel):
     @classmethod
     def deserialize(cls, data: dict) -> "DPAtomicModel":
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 2)
+        check_version_compatibility(data.pop("@version", 1), 2, 1)
         data.pop("@class", None)
         data.pop("type", None)
         descriptor_obj = BaseDescriptor.deserialize(data.pop("descriptor"))
@@ -341,12 +355,29 @@ class DPAtomicModel(BaseAtomicModel):
         atype = extended_atype[:, :nloc]
         if self.do_grad_r() or self.do_grad_c():
             extended_coord.stop_gradient = False
+
+        # Handle default fparam if fitting net supports it
+        if (
+            hasattr(self.fitting_net, "get_dim_fparam")
+            and self.fitting_net.get_dim_fparam() > 0
+            and fparam is None
+        ):
+            # use default fparam
+            default_fparam_tensor = self.fitting_net.get_default_fparam()
+            assert default_fparam_tensor is not None
+            fparam_input_for_des = paddle.tile(
+                default_fparam_tensor.unsqueeze(0), [nframes, 1]
+            )
+        else:
+            fparam_input_for_des = fparam
+
         descriptor, rot_mat, g2, h2, sw = self.descriptor(
             extended_coord,
             extended_atype,
             nlist,
             mapping=mapping,
             comm_dict=comm_dict,
+            fparam=fparam_input_for_des if self.add_chg_spin_ebd else None,
         )
         assert descriptor is not None
         if self.enable_eval_descriptor_hook:
@@ -403,23 +434,9 @@ class DPAtomicModel(BaseAtomicModel):
             # should not share the same parameters
             stat_file_path /= " ".join(self.type_map)
 
-        @functools.lru_cache
-        def wrapped_sampler() -> list[dict]:
-            sampled = sampled_func()
-            if self.pair_excl is not None:
-                pair_exclude_types = self.pair_excl.get_exclude_types()
-                for sample in sampled:
-                    sample["pair_exclude_types"] = list(pair_exclude_types)
-            if self.atom_excl is not None:
-                atom_exclude_types = self.atom_excl.get_exclude_types()
-                for sample in sampled:
-                    sample["atom_exclude_types"] = list(atom_exclude_types)
-            return sampled
-
+        wrapped_sampler = self._make_wrapped_sampler(sampled_func)
         self.descriptor.compute_input_stats(wrapped_sampler, stat_file_path)
-        self.fitting_net.compute_input_stats(
-            wrapped_sampler, stat_file_path=stat_file_path
-        )
+        self.compute_fitting_input_stat(wrapped_sampler, stat_file_path)
         if compute_or_load_out_stat:
             self.compute_or_load_out_stat(wrapped_sampler, stat_file_path)
 
@@ -438,12 +455,13 @@ class DPAtomicModel(BaseAtomicModel):
         ----------
         sample_merged : Union[Callable[[], list[dict]], list[dict]]
             - list[dict]: A list of data samples from various data systems.
-                Each element, ``merged[i]``, is a data dictionary containing
-                ``keys``: ``np.ndarray`` originating from the ``i``-th data system.
-            - Callable[[], list[dict]]: A lazy function that returns data samples
-                in the above format only when needed.
+                Each element, `merged[i]`, is a data dictionary containing `keys`: `paddle.Tensor`
+                originating from the `i`-th data system.
+            - Callable[[], list[dict]]: A lazy function that returns data samples in the above format
+                only when needed. Since the sampling process can be slow and memory-intensive,
+                the lazy function helps by only sampling once.
         stat_file_path : Optional[DPPath]
-            The path to the stat file.
+            The dictionary of paths to the statistics files.
         """
         self.fitting_net.compute_input_stats(
             sample_merged,
@@ -451,23 +469,17 @@ class DPAtomicModel(BaseAtomicModel):
             stat_file_path=stat_file_path,
         )
 
-    # for subclass overridden
-    base_descriptor_cls = BaseDescriptor
-    """The base descriptor class."""
-    base_fitting_cls = BaseFitting
-    """The base fitting class."""
-
     def get_dim_fparam(self) -> int:
         """Get the number (dimension) of frame parameters of this atomic model."""
         return self.fitting_net.get_dim_fparam()
 
-    def get_buffer_dim_fparam(self) -> paddle.Tensor:
-        """Get the number (dimension) of frame parameters of this atomic model as a buffer-style Tensor."""
-        return self.fitting_net.get_buffer_dim_fparam()
-
     def has_default_fparam(self) -> bool:
         """Check if the model has default frame parameters."""
         return self.fitting_net.has_default_fparam()
+
+    def get_buffer_dim_fparam(self) -> paddle.Tensor:
+        """Get the number (dimension) of frame parameters of this atomic model as a buffer-style Tensor."""
+        return self.fitting_net.get_buffer_dim_fparam()
 
     def get_dim_aparam(self) -> int:
         """Get the number (dimension) of atomic parameters of this atomic model."""

--- a/deepmd/pd/model/descriptor/dpa1.py
+++ b/deepmd/pd/model/descriptor/dpa1.py
@@ -245,7 +245,7 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
         use_tebd_bias: bool = False,
         type_map: list[str] | None = None,
         # not implemented
-        spin: Any = None,
+        spin: Any | None = None,
         type: str | None = None,
     ) -> None:
         super().__init__()
@@ -298,12 +298,13 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
         self.use_econf_tebd = use_econf_tebd
         self.use_tebd_bias = use_tebd_bias
         self.type_map = type_map
+        self.tebd_compress = False
         if type_map is not None:
             self.register_buffer(
                 "buffer_type_map",
                 paddle.to_tensor([ord(c) for c in " ".join(type_map)]),
             )
-        self.compress = False
+        self.geo_compress = False
         self.type_embedding = TypeEmbedNet(
             ntypes,
             tebd_dim,
@@ -474,7 +475,7 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
         return self.se_atten.mean, self.se_atten.stddev
 
     def change_type_map(
-        self, type_map: list[str], model_with_new_type_stat: Any = None
+        self, type_map: list[str], model_with_new_type_stat: Any | None = None
     ) -> None:
         """Change the type related params to new ones, according to `type_map` and the original one in the model.
         If there are new types in `type_map`, statistics will be updated accordingly to `model_with_new_type_stat` for these new types.
@@ -625,7 +626,14 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
         nlist: paddle.Tensor,
         mapping: paddle.Tensor | None = None,
         comm_dict: list[paddle.Tensor] | None = None,
-    ) -> paddle.Tensor:
+        fparam: paddle.Tensor | None = None,
+    ) -> tuple[
+        paddle.Tensor,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+    ]:
         """Compute the descriptor.
 
         Parameters
@@ -682,10 +690,12 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
 
         return (
             g1.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            rot_mat.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
+            rot_mat.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION)
+            if rot_mat is not None
+            else None,
             g2.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if g2 is not None else None,
-            h2.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            sw.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
+            h2.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if h2 is not None else None,
+            sw.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if sw is not None else None,
         )
 
     @classmethod

--- a/deepmd/pd/model/descriptor/dpa2.py
+++ b/deepmd/pd/model/descriptor/dpa2.py
@@ -441,7 +441,7 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
             raise NotImplementedError
 
     def change_type_map(
-        self, type_map: list[str], model_with_new_type_stat: Any = None
+        self, type_map: list[str], model_with_new_type_stat: Any | None = None
     ) -> None:
         """Change the type related params to new ones, according to `type_map` and the original one in the model.
         If there are new types in `type_map`, statistics will be updated accordingly to `model_with_new_type_stat` for these new types.
@@ -732,7 +732,14 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
         nlist: paddle.Tensor,
         mapping: paddle.Tensor | None = None,
         comm_dict: list[paddle.Tensor] | None = None,
-    ) -> paddle.Tensor:
+        fparam: paddle.Tensor | None = None,
+    ) -> tuple[
+        paddle.Tensor,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+    ]:
         """Compute the descriptor.
 
         Parameters
@@ -843,11 +850,13 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
         if self.concat_output_tebd:
             g1 = paddle.concat([g1, g1_inp], axis=-1)
         return (
-            g1.astype(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            rot_mat.astype(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            g2.astype(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            h2.astype(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            sw.astype(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
+            g1.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
+            rot_mat.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION)
+            if rot_mat is not None
+            else None,
+            g2.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if g2 is not None else None,
+            h2.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if h2 is not None else None,
+            sw.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if sw is not None else None,
         )
 
     @classmethod

--- a/deepmd/pd/model/descriptor/dpa3.py
+++ b/deepmd/pd/model/descriptor/dpa3.py
@@ -32,6 +32,7 @@ from deepmd.pd.utils.update_sel import (
     UpdateSel,
 )
 from deepmd.pd.utils.utils import (
+    ActivationFn,
     to_numpy_array,
 )
 from deepmd.utils.data_system import (
@@ -120,6 +121,7 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
         use_tebd_bias: bool = False,
         use_loc_mapping: bool = True,
         type_map: list[str] | None = None,
+        add_chg_spin_ebd: bool = False,
     ) -> None:
         super().__init__()
 
@@ -174,6 +176,7 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
         )
 
         self.use_econf_tebd = use_econf_tebd
+        self.add_chg_spin_ebd = add_chg_spin_ebd
         self.use_loc_mapping = use_loc_mapping
         self.use_tebd_bias = use_tebd_bias
         self.type_map = type_map
@@ -196,6 +199,34 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
         self.concat_output_tebd = concat_output_tebd
         self.precision = precision
         self.prec = PRECISION_DICT[self.precision]
+
+        if self.add_chg_spin_ebd:
+            self.act = ActivationFn(activation_function)
+            # -100 ~ 100 is a conservative bound
+            self.chg_embedding = TypeEmbedNet(
+                200,
+                self.tebd_dim,
+                precision=precision,
+                seed=child_seed(seed, 3),
+            )
+            # 100 is a conservative upper bound
+            self.spin_embedding = TypeEmbedNet(
+                100,
+                self.tebd_dim,
+                precision=precision,
+                seed=child_seed(seed, 4),
+            )
+            self.mix_cs_mlp = MLPLayer(
+                2 * self.tebd_dim,
+                self.tebd_dim,
+                precision=precision,
+                seed=child_seed(seed, 5),
+            )
+        else:
+            self.chg_embedding = None
+            self.spin_embedding = None
+            self.mix_cs_mlp = None
+
         self.exclude_types = exclude_types
         self.env_protection = env_protection
         self.trainable = trainable
@@ -433,9 +464,14 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
             "use_econf_tebd": self.use_econf_tebd,
             "use_tebd_bias": self.use_tebd_bias,
             "use_loc_mapping": self.use_loc_mapping,
+            "add_chg_spin_ebd": self.add_chg_spin_ebd,
             "type_map": self.type_map,
             "type_embedding": self.type_embedding.embedding.serialize(),
         }
+        if self.add_chg_spin_ebd:
+            data["chg_embedding"] = self.chg_embedding.embedding.serialize()
+            data["spin_embedding"] = self.spin_embedding.embedding.serialize()
+            data["mix_cs_mlp"] = self.mix_cs_mlp.serialize()
         repflow_variable = {
             "edge_embd": repflows.edge_embd.serialize(),
             "angle_embd": repflows.angle_embd.serialize(),
@@ -462,11 +498,23 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
         data.pop("type")
         repflow_variable = data.pop("repflow_variable").copy()
         type_embedding = data.pop("type_embedding")
+        chg_embedding = data.pop("chg_embedding", None)
+        spin_embedding = data.pop("spin_embedding", None)
+        mix_cs_mlp = data.pop("mix_cs_mlp", None)
         data["repflow"] = RepFlowArgs(**data.pop("repflow_args"))
         obj = cls(**data)
         obj.type_embedding.embedding = TypeEmbedNetConsistent.deserialize(
             type_embedding
         )
+
+        if obj.add_chg_spin_ebd and chg_embedding is not None:
+            obj.chg_embedding.embedding = TypeEmbedNetConsistent.deserialize(
+                chg_embedding
+            )
+            obj.spin_embedding.embedding = TypeEmbedNetConsistent.deserialize(
+                spin_embedding
+            )
+            obj.mix_cs_mlp = MLPLayer.deserialize(mix_cs_mlp)
 
         def t_cvt(xx: Any) -> paddle.Tensor:
             return paddle.to_tensor(xx, dtype=obj.repflows.prec, place=env.DEVICE)
@@ -493,7 +541,14 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
         nlist: paddle.Tensor,
         mapping: paddle.Tensor | None = None,
         comm_dict: list[paddle.Tensor] | None = None,
-    ) -> paddle.Tensor:
+        fparam: paddle.Tensor | None = None,
+    ) -> tuple[
+        paddle.Tensor,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+    ]:
         """Compute the descriptor.
 
         Parameters
@@ -536,6 +591,20 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
             node_ebd_ext = self.type_embedding(extended_atype[:, :nloc])
         else:
             node_ebd_ext = self.type_embedding(extended_atype)
+
+        if self.add_chg_spin_ebd:
+            assert fparam is not None
+            assert self.chg_embedding is not None
+            assert self.spin_embedding is not None
+            charge = fparam[:, 0].to(dtype=paddle.int64) + 100
+            spin = fparam[:, 1].to(dtype=paddle.int64)
+            chg_ebd = self.chg_embedding(charge)
+            spin_ebd = self.spin_embedding(spin)
+            sys_cs_embd = self.act(
+                self.mix_cs_mlp(paddle.cat((chg_ebd, spin_ebd), dim=-1))
+            )
+            node_ebd_ext = node_ebd_ext + sys_cs_embd.unsqueeze(1)
+
         node_ebd_inp = node_ebd_ext[:, :nloc, :]
         # repflows
         node_ebd, edge_ebd, h2, rot_mat, sw = self.repflows(
@@ -550,10 +619,14 @@ class DescrptDPA3(BaseDescriptor, paddle.nn.Layer):
             node_ebd = paddle.concat([node_ebd, node_ebd_inp], axis=-1)
         return (
             node_ebd.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            rot_mat.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            edge_ebd.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            h2.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
-            sw.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION),
+            rot_mat.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION)
+            if rot_mat is not None
+            else None,
+            edge_ebd.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION)
+            if edge_ebd is not None
+            else None,
+            h2.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if h2 is not None else None,
+            sw.to(dtype=env.GLOBAL_PD_FLOAT_PRECISION) if sw is not None else None,
         )
 
     @classmethod

--- a/deepmd/pd/model/descriptor/repflows.py
+++ b/deepmd/pd/model/descriptor/repflows.py
@@ -571,7 +571,6 @@ class DescrptBlockRepflows(DescriptorBlock):
             # n_angle x 1
             a_sw = (a_sw[:, :, :, None] * a_sw[:, :, None, :])[a_nlist_mask]
         else:
-            # avoid jit assertion
             edge_index = paddle.zeros([2, 1], dtype=nlist.dtype)
             angle_index = paddle.zeros([3, 1], dtype=nlist.dtype)
         # get edge and angle embedding

--- a/deepmd/pd/model/descriptor/se_a.py
+++ b/deepmd/pd/model/descriptor/se_a.py
@@ -4,6 +4,7 @@ from collections.abc import (
     Callable,
 )
 from typing import (
+    Any,
     ClassVar,
 )
 
@@ -88,7 +89,7 @@ class DescrptSeA(BaseDescriptor, paddle.nn.Layer):
         ntypes: int | None = None,  # to be compat with input
         type_map: list[str] | None = None,
         # not implemented
-        spin: object = None,
+        spin: Any | None = None,
     ) -> None:
         del ntypes
         if spin is not None:
@@ -190,7 +191,7 @@ class DescrptSeA(BaseDescriptor, paddle.nn.Layer):
         return self.sea.get_env_protection()
 
     def share_params(
-        self, base_class: object, shared_level: int, resume: bool = False
+        self, base_class: Any, shared_level: int, resume: bool = False
     ) -> None:
         """
         Share the parameters of self to the base_class with shared_level during multitask training.
@@ -288,7 +289,14 @@ class DescrptSeA(BaseDescriptor, paddle.nn.Layer):
         nlist: paddle.Tensor,
         mapping: paddle.Tensor | None = None,
         comm_dict: list[paddle.Tensor] | None = None,
-    ) -> paddle.Tensor:
+        fparam: paddle.Tensor | None = None,
+    ) -> tuple[
+        paddle.Tensor,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+    ]:
         """Compute the descriptor.
 
         Parameters
@@ -727,7 +735,13 @@ class DescrptBlockSeA(DescriptorBlock):
         extended_atype_embd: paddle.Tensor | None = None,
         mapping: paddle.Tensor | None = None,
         type_embedding: paddle.Tensor | None = None,
-    ) -> paddle.Tensor:
+    ) -> tuple[
+        paddle.Tensor,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+    ]:
         """Calculate decoded embedding for each atom.
 
         Args:

--- a/deepmd/pd/model/descriptor/se_t_tebd.py
+++ b/deepmd/pd/model/descriptor/se_t_tebd.py
@@ -177,15 +177,16 @@ class DescrptSeTTebd(BaseDescriptor, paddle.nn.Layer):
             tebd_dim,
             precision=precision,
             seed=child_seed(seed, 2),
+            trainable=trainable,
             use_econf_tebd=use_econf_tebd,
             type_map=type_map,
             use_tebd_bias=use_tebd_bias,
-            trainable=trainable,
         )
         self.tebd_dim = tebd_dim
         self.tebd_input_mode = tebd_input_mode
         self.concat_output_tebd = concat_output_tebd
         self.trainable = trainable
+        self.compress = False
         # set trainable
         for param in self.parameters():
             param.stop_gradient = not trainable
@@ -436,7 +437,14 @@ class DescrptSeTTebd(BaseDescriptor, paddle.nn.Layer):
         nlist: paddle.Tensor,
         mapping: paddle.Tensor | None = None,
         comm_dict: list[paddle.Tensor] | None = None,
-    ) -> paddle.Tensor:
+        fparam: paddle.Tensor | None = None,
+    ) -> tuple[
+        paddle.Tensor,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+    ]:
         """Compute the descriptor.
 
         Parameters
@@ -788,7 +796,13 @@ class DescrptBlockSeTTebd(DescriptorBlock):
         extended_atype_embd: paddle.Tensor | None = None,
         mapping: paddle.Tensor | None = None,
         type_embedding: paddle.Tensor | None = None,
-    ) -> paddle.Tensor:
+    ) -> tuple[
+        paddle.Tensor,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+        paddle.Tensor | None,
+    ]:
         """Compute the descriptor.
 
         Parameters

--- a/deepmd/pd/model/model/make_model.py
+++ b/deepmd/pd/model/model/make_model.py
@@ -70,14 +70,14 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
             self,
             *args: Any,
             # underscore to prevent conflict with normal inputs
-            atomic_model_: T_AtomicModel | None = None,
+            atomic_model_: T_AtomicModel | None = None,  # type: ignore
             **kwargs: Any,
         ) -> None:
             super().__init__(*args, **kwargs)
             if atomic_model_ is not None:
-                self.atomic_model: T_AtomicModel = atomic_model_
+                self.atomic_model: T_AtomicModel = atomic_model_  # type: ignore
             else:
-                self.atomic_model: T_AtomicModel = T_AtomicModel(*args, **kwargs)
+                self.atomic_model: T_AtomicModel = T_AtomicModel(*args, **kwargs)  # type: ignore
             self.precision_dict = PRECISION_DICT
             self.reverse_precision_dict = RESERVED_PRECISION_DICT
             self.global_pd_float_precision = GLOBAL_PD_FLOAT_PRECISION
@@ -136,6 +136,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
             fparam: paddle.Tensor | None = None,
             aparam: paddle.Tensor | None = None,
             do_atomic_virial: bool = False,
+            coord_corr_for_virial: paddle.Tensor | None = None,
         ) -> dict[str, paddle.Tensor]:
             """Return model prediction.
 
@@ -154,6 +155,9 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
                 atomic parameter. nf x nloc x nda
             do_atomic_virial
                 If calculate the atomic virial.
+            coord_corr_for_virial
+                The coordinates correction of the atoms for virial.
+                shape: nf x (nloc x 3)
 
             Returns
             -------
@@ -181,6 +185,14 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
                 mixed_types=True,
                 box=bb,
             )
+            if coord_corr_for_virial is not None:
+                coord_corr_for_virial = coord_corr_for_virial.to(cc.dtype)
+                extended_coord_corr = paddle.gather(
+                    coord_corr_for_virial, 1, mapping.unsqueeze(-1).expand(-1, -1, 3)
+                )
+            else:
+                extended_coord_corr = None
+
             model_predict_lower = self.forward_common_lower(
                 extended_coord,
                 extended_atype,
@@ -189,6 +201,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
                 do_atomic_virial=do_atomic_virial,
                 fparam=fp,
                 aparam=ap,
+                extended_coord_corr=extended_coord_corr,
             )
             model_predict = communicate_extended_output(
                 model_predict_lower,
@@ -201,24 +214,6 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
 
         def get_out_bias(self) -> paddle.Tensor:
             return self.atomic_model.get_out_bias()
-
-        def get_observed_type_list(self) -> list[str]:
-            """Get observed types (elements) of the model during data statistics.
-
-            Returns
-            -------
-            list[str]
-                A list of the observed type names in this model.
-            """
-            type_map = self.get_type_map()
-            out_bias = self.get_out_bias()[0]
-            assert out_bias is not None, "No out_bias found in the model."
-            assert out_bias.ndim == 2, "The supported out_bias should be a 2D array."
-            assert out_bias.shape[0] == len(type_map), (
-                "The out_bias shape does not match the type_map length."
-            )
-            bias_mask = paddle.any(paddle.abs(out_bias) > 1e-6, axis=-1)
-            return [type_map[i] for i in range(len(type_map)) if bias_mask[i]]
 
         def set_out_bias(self, out_bias: paddle.Tensor) -> None:
             self.atomic_model.set_out_bias(out_bias)
@@ -261,6 +256,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
             do_atomic_virial: bool = False,
             comm_dict: list[paddle.Tensor] | None = None,
             extra_nlist_sort: bool = False,
+            extended_coord_corr: paddle.Tensor | None = None,
         ) -> dict[str, paddle.Tensor]:
             """Return model prediction. Lower interface that takes
             extended atomic coordinates and types, nlist, and mapping
@@ -287,6 +283,8 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
                 The data needed for communication for parallel inference.
             extra_nlist_sort
                 whether to forcibly sort the nlist.
+            extended_coord_corr
+                coordinates correction for virial in extended region. nf x (nall x 3)
 
             Returns
             -------
@@ -318,6 +316,8 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
                 cc_ext,
                 do_atomic_virial=do_atomic_virial,
                 create_graph=self.training,
+                mask=atomic_ret["mask"] if "mask" in atomic_ret else None,
+                extended_coord_corr=extended_coord_corr,
             )
             model_predict = self._output_type_cast(model_predict, input_prec)
             return model_predict
@@ -466,6 +466,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
                         * paddle.ones(
                             [n_nf, n_nloc, nnei - n_nnei],
                             dtype=nlist.dtype,
+                            device=nlist.device,
                         ),
                     ],
                     axis=-1,
@@ -546,6 +547,13 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
             """Get the number (dimension) of frame parameters of this atomic model."""
             return self.atomic_model.get_dim_fparam()
 
+        def has_default_fparam(self) -> bool:
+            """Check if the model has default frame parameters."""
+            return self.atomic_model.has_default_fparam()
+
+        def get_default_fparam(self) -> paddle.Tensor | None:
+            return self.atomic_model.get_default_fparam()
+
         def get_dim_aparam(self) -> int:
             """Get the number (dimension) of atomic parameters of this atomic model."""
             return self.atomic_model.get_dim_aparam()
@@ -612,11 +620,42 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type[BaseModel]:
 
         def compute_or_load_stat(
             self,
-            sampled_func: Callable,
+            sampled_func: Callable[[], Any],
             stat_file_path: DPPath | None = None,
+            preset_observed_type: list[str] | None = None,
         ) -> None:
             """Compute or load the statistics."""
-            return self.atomic_model.compute_or_load_stat(sampled_func, stat_file_path)
+            return self.atomic_model.compute_or_load_stat(
+                sampled_func,
+                stat_file_path,
+                preset_observed_type=preset_observed_type,
+            )
+
+        def get_observed_type_list(self) -> list[str]:
+            """Get observed types (elements) of the model during data statistics.
+
+            Returns
+            -------
+            list[str]
+                A list of the observed type names in this model.
+            """
+            type_map = self.get_type_map()
+            out_bias = self.atomic_model.get_out_bias()[0]
+
+            assert out_bias is not None, "No out_bias found in the model."
+            assert out_bias.ndim == 2, "The supported out_bias should be a 2D array."
+            assert out_bias.shape[0] == len(type_map), (
+                "The out_bias shape does not match the type_map length."
+            )
+            bias_mask = (
+                paddle.gt(paddle.abs(out_bias), 1e-6).any(axis=-1).detach().cpu()
+            )  # 1e-6 for stability
+
+            observed_type_list: list[str] = []
+            for i in range(len(type_map)):
+                if bias_mask[i]:
+                    observed_type_list.append(type_map[i])
+            return observed_type_list
 
         def get_sel(self) -> list[int]:
             """Returns the number of selected atoms for each type."""

--- a/deepmd/pd/model/model/transform_output.py
+++ b/deepmd/pd/model/model/transform_output.py
@@ -155,6 +155,8 @@ def fit_output_to_model_output(
     coord_ext: paddle.Tensor,
     do_atomic_virial: bool = False,
     create_graph: bool = True,
+    mask: paddle.Tensor | None = None,
+    extended_coord_corr: paddle.Tensor | None = None,
 ) -> dict[str, paddle.Tensor]:
     """Transform the output of the fitting network to
     the model output.
@@ -169,7 +171,12 @@ def fit_output_to_model_output(
         if vdef.reducible:
             kk_redu = get_reduce_name(kk)
             if vdef.intensive:
-                model_ret[kk_redu] = paddle.mean(vv.astype(redu_prec), axis=atom_axis)
+                if mask is not None:
+                    model_ret[kk_redu] = paddle.sum(
+                        vv.to(redu_prec), axis=atom_axis
+                    ) / paddle.sum(mask, axis=-1, keepdim=True)
+                else:
+                    model_ret[kk_redu] = paddle.mean(vv.to(redu_prec), axis=atom_axis)
             else:
                 model_ret[kk_redu] = paddle.sum(vv.astype(redu_prec), axis=atom_axis)
             if vdef.r_differentiable:
@@ -186,6 +193,12 @@ def fit_output_to_model_output(
                 model_ret[kk_derv_r] = dr
                 if vdef.c_differentiable:
                     assert dc is not None
+                    if extended_coord_corr is not None:
+                        dc_corr = (
+                            dr.squeeze(-2).unsqueeze(-1)
+                            @ extended_coord_corr.unsqueeze(-2).to(dr.dtype)
+                        ).reshape(list(dc.shape[:-2]) + [1, 9])  # noqa: RUF005
+                        dc = dc + dc_corr
                     model_ret[kk_derv_c] = dc
                     model_ret[kk_derv_c + "_redu"] = paddle.sum(
                         model_ret[kk_derv_c].astype(redu_prec), axis=1
@@ -223,7 +236,9 @@ def communicate_extended_output(
                 mapping = mapping.reshape(mldims + [1] * len(derv_r_ext_dims)).expand(
                     [-1] * len(mldims) + derv_r_ext_dims
                 )
-                force = paddle.zeros(vldims + derv_r_ext_dims, dtype=vv.dtype)
+                force = paddle.zeros(
+                    vldims + derv_r_ext_dims, dtype=vv.dtype, device=vv.device
+                )
                 # nf x nloc x nvar x 3
                 new_ret[kk_derv_r] = decomp.scatter_reduce(
                     force,
@@ -240,7 +255,9 @@ def communicate_extended_output(
                     mapping,
                     [1] * (len(mldims) + len(vdef.shape)) + [3],
                 )
-                virial = paddle.zeros(vldims + derv_c_ext_dims, dtype=vv.dtype)
+                virial = paddle.zeros(
+                    vldims + derv_c_ext_dims, dtype=vv.dtype, device=vv.device
+                )
                 # nf x nloc x nvar x 9
                 new_ret[kk_derv_c] = decomp.scatter_reduce(
                     virial,

--- a/deepmd/pd/model/task/ener.py
+++ b/deepmd/pd/model/task/ener.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-import copy
 import logging
 from typing import (
     Any,
@@ -47,6 +46,7 @@ class EnergyFittingNet(InvarFitting):
         mixed_types: bool = True,
         seed: int | list[int] | None = None,
         type_map: list[str] | None = None,
+        default_fparam: list | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -65,12 +65,13 @@ class EnergyFittingNet(InvarFitting):
             mixed_types=mixed_types,
             seed=seed,
             type_map=type_map,
+            default_fparam=default_fparam,
             **kwargs,
         )
 
     @classmethod
     def deserialize(cls, data: dict) -> "GeneralFitting":
-        data = copy.deepcopy(data)
+        data = data.copy()
         check_version_compatibility(data.pop("@version", 1), 4, 1)
         data.pop("var_name")
         data.pop("dim_out")

--- a/deepmd/pd/model/task/fitting.py
+++ b/deepmd/pd/model/task/fitting.py
@@ -8,6 +8,7 @@ from collections.abc import (
 )
 from typing import (
     Any,
+    Optional,
 )
 
 import numpy as np
@@ -40,6 +41,9 @@ from deepmd.pd.utils.utils import (
     to_numpy_array,
     to_paddle_tensor,
 )
+from deepmd.utils.env_mat_stat import (
+    StatItem,
+)
 from deepmd.utils.finetune import (
     get_index_between_two_maps,
     map_atom_exclude_types,
@@ -63,7 +67,12 @@ class Fitting(paddle.nn.Layer, BaseFitting):
         return super().__new__(cls)
 
     def share_params(
-        self, base_class: "Fitting", shared_level: int, resume: bool = False
+        self,
+        base_class: "Fitting",
+        shared_level: int,
+        model_prob: float = 1.0,
+        protection: float = 1e-2,
+        resume: bool = False,
     ) -> None:
         """
         Share the parameters of self to the base_class with shared_level during multitask training.
@@ -75,11 +84,158 @@ class Fitting(paddle.nn.Layer, BaseFitting):
         )
         if shared_level == 0:
             # only not share the bias_atom_e and the case_embd
+            # link fparam buffers
+            if self.numb_fparam > 0:
+                if not resume:
+                    base_fparam = base_class.stats["fparam"]
+                    assert len(base_fparam) == self.numb_fparam
+                    for ii in range(self.numb_fparam):
+                        base_fparam[ii] += self.get_stats()["fparam"][ii] * model_prob
+                    fparam_avg = np.array([ii.compute_avg() for ii in base_fparam])
+                    fparam_std = np.array(
+                        [ii.compute_std(protection=protection) for ii in base_fparam]
+                    )
+                    fparam_inv_std = 1.0 / fparam_std
+                    base_class.fparam_avg.copy_(
+                        paddle.tensor(
+                            fparam_avg,
+                            device=env.DEVICE,
+                            dtype=base_class.fparam_avg.dtype,
+                        )
+                    )
+                    base_class.fparam_inv_std.copy_(
+                        paddle.tensor(
+                            fparam_inv_std,
+                            device=env.DEVICE,
+                            dtype=base_class.fparam_inv_std.dtype,
+                        )
+                    )
+                self.fparam_avg = base_class.fparam_avg
+                self.fparam_inv_std = base_class.fparam_inv_std
+
+            # link aparam buffers
+            if self.numb_aparam > 0:
+                if not resume:
+                    base_aparam = base_class.stats["aparam"]
+                    assert len(base_aparam) == self.numb_aparam
+                    for ii in range(self.numb_aparam):
+                        base_aparam[ii] += self.get_stats()["aparam"][ii] * model_prob
+                    aparam_avg = np.array([ii.compute_avg() for ii in base_aparam])
+                    aparam_std = np.array(
+                        [ii.compute_std(protection=protection) for ii in base_aparam]
+                    )
+                    aparam_inv_std = 1.0 / aparam_std
+                    base_class.aparam_avg.copy_(
+                        paddle.tensor(
+                            aparam_avg,
+                            device=env.DEVICE,
+                            dtype=base_class.aparam_avg.dtype,
+                        )
+                    )
+                    base_class.aparam_inv_std.copy_(
+                        paddle.tensor(
+                            aparam_inv_std,
+                            device=env.DEVICE,
+                            dtype=base_class.aparam_inv_std.dtype,
+                        )
+                    )
+                self.aparam_avg = base_class.aparam_avg
+                self.aparam_inv_std = base_class.aparam_inv_std
             # the following will successfully link all the params except buffers, which need manually link.
             for item in self._sub_layers:
                 self._sub_layers[item] = base_class._sub_layers[item]
         else:
             raise NotImplementedError
+
+    def save_to_file_fparam(
+        self,
+        stat_file_path: DPPath,
+    ) -> None:
+        """Save the statistics of fparam.
+
+        Parameters
+        ----------
+        stat_file_path : DPPath
+            The path to save the statistics of fparam.
+        """
+        assert stat_file_path is not None
+        stat_file_path.mkdir(exist_ok=True, parents=True)
+        if len(self.stats) == 0:
+            raise ValueError("The statistics hasn't been computed.")
+        fp = stat_file_path / "fparam"
+        _fparam_stat = []
+        for ii in range(self.numb_fparam):
+            _tmp_stat = self.stats["fparam"][ii]
+            _fparam_stat.append(
+                [_tmp_stat.number, _tmp_stat.sum, _tmp_stat.squared_sum]
+            )
+        _fparam_stat = np.array(_fparam_stat)
+        fp.save_numpy(_fparam_stat)
+        log.info(f"Save fparam stats to {fp}.")
+
+    def save_to_file_aparam(
+        self,
+        stat_file_path: DPPath,
+    ) -> None:
+        """Save the statistics of aparam.
+
+        Parameters
+        ----------
+        stat_file_path : DPPath
+            The path to save the statistics of aparam.
+        """
+        assert stat_file_path is not None
+        stat_file_path.mkdir(exist_ok=True, parents=True)
+        if len(self.stats) == 0:
+            raise ValueError("The statistics hasn't been computed.")
+        fp = stat_file_path / "aparam"
+        _aparam_stat = []
+        for ii in range(self.numb_aparam):
+            _tmp_stat = self.stats["aparam"][ii]
+            _aparam_stat.append(
+                [_tmp_stat.number, _tmp_stat.sum, _tmp_stat.squared_sum]
+            )
+        _aparam_stat = np.array(_aparam_stat)
+        fp.save_numpy(_aparam_stat)
+        log.info(f"Save aparam stats to {fp}.")
+
+    def restore_fparam_from_file(self, stat_file_path: DPPath) -> None:
+        """Load the statistics of fparam.
+
+        Parameters
+        ----------
+        stat_file_path : DPPath
+            The path to load the statistics of fparam.
+        """
+        fp = stat_file_path / "fparam"
+        arr = fp.load_numpy()
+        assert arr.shape == (self.numb_fparam, 3)
+        _fparam_stat = []
+        for ii in range(self.numb_fparam):
+            _fparam_stat.append(
+                StatItem(number=arr[ii][0], sum=arr[ii][1], squared_sum=arr[ii][2])
+            )
+        self.stats["fparam"] = _fparam_stat
+        log.info(f"Load fparam stats from {fp}.")
+
+    def restore_aparam_from_file(self, stat_file_path: DPPath) -> None:
+        """Load the statistics of aparam.
+
+        Parameters
+        ----------
+        stat_file_path : DPPath
+            The path to load the statistics of aparam.
+        """
+        fp = stat_file_path / "aparam"
+        arr = fp.load_numpy()
+        assert arr.shape == (self.numb_aparam, 3)
+        _aparam_stat = []
+        for ii in range(self.numb_aparam):
+            _aparam_stat.append(
+                StatItem(number=arr[ii][0], sum=arr[ii][1], squared_sum=arr[ii][2])
+            )
+        self.stats["aparam"] = _aparam_stat
+        log.info(f"Load aparam stats from {fp}.")
 
     def compute_input_stats(
         self,
@@ -106,23 +262,46 @@ class Fitting(paddle.nn.Layer, BaseFitting):
         """
         if self.numb_fparam == 0 and self.numb_aparam == 0:
             # skip data statistics
+            self.stats = None
             return
-        if callable(merged):
-            sampled = merged()
-        else:
-            sampled = merged
+
+        self.stats = {}
+
         # stat fparam
         if self.numb_fparam > 0:
-            cat_data = paddle.concat([frame["fparam"] for frame in sampled], axis=0)
-            cat_data = paddle.reshape(cat_data, [-1, self.numb_fparam])
-            fparam_avg = paddle.mean(cat_data, axis=0)
-            fparam_std = paddle.std(cat_data, axis=0, unbiased=False)
-            fparam_std = paddle.where(
-                fparam_std < protection,
-                paddle.to_tensor(protection, dtype=fparam_std.dtype),
-                fparam_std,
+            if (
+                stat_file_path is not None
+                and stat_file_path.is_dir()
+                and (stat_file_path / "fparam").is_file()
+            ):
+                self.restore_fparam_from_file(stat_file_path)
+            else:
+                sampled = merged() if callable(merged) else merged
+                self.stats["fparam"] = []
+                cat_data = to_numpy_array(
+                    paddle.concat([frame["fparam"] for frame in sampled], axis=0)
+                )
+                cat_data = np.reshape(cat_data, [-1, self.numb_fparam])
+                sumv = np.sum(cat_data, axis=0)
+                sumv2 = np.sum(cat_data * cat_data, axis=0)
+                sumn = cat_data.shape[0]
+                for ii in range(self.numb_fparam):
+                    self.stats["fparam"].append(
+                        StatItem(
+                            number=sumn,
+                            sum=sumv[ii],
+                            squared_sum=sumv2[ii],
+                        )
+                    )
+                if stat_file_path is not None:
+                    self.save_to_file_fparam(stat_file_path)
+
+            fparam_avg = np.array([ii.compute_avg() for ii in self.stats["fparam"]])
+            fparam_std = np.array(
+                [ii.compute_std(protection=protection) for ii in self.stats["fparam"]]
             )
             fparam_inv_std = 1.0 / fparam_std
+            log.info(f"fparam_avg is {fparam_avg}, fparam_inv_std is {fparam_inv_std}")
             paddle.assign(
                 paddle.to_tensor(
                     fparam_avg, place=env.DEVICE, dtype=self.fparam_avg.dtype
@@ -137,27 +316,43 @@ class Fitting(paddle.nn.Layer, BaseFitting):
             )
         # stat aparam
         if self.numb_aparam > 0:
-            sys_sumv = []
-            sys_sumv2 = []
-            sys_sumn = []
-            for ss_ in [frame["aparam"] for frame in sampled]:
-                ss = paddle.reshape(ss_, [-1, self.numb_aparam])
-                sys_sumv.append(paddle.sum(ss, axis=0))
-                sys_sumv2.append(paddle.sum(ss * ss, axis=0))
-                sys_sumn.append(ss.shape[0])
-            sumv = paddle.sum(paddle.stack(sys_sumv), axis=0)
-            sumv2 = paddle.sum(paddle.stack(sys_sumv2), axis=0)
-            sumn = sum(sys_sumn)
-            aparam_avg = sumv / sumn
-            aparam_std = paddle.sqrt(sumv2 / sumn - (sumv / sumn) ** 2)
-            aparam_std = paddle.where(
-                aparam_std < protection,
-                paddle.to_tensor(
-                    protection, dtype=aparam_std.dtype, place=aparam_std.device
-                ),
-                aparam_std,
+            if (
+                stat_file_path is not None
+                and stat_file_path.is_dir()
+                and (stat_file_path / "aparam").is_file()
+            ):
+                self.restore_aparam_from_file(stat_file_path)
+            else:
+                sampled = merged() if callable(merged) else merged
+                self.stats["aparam"] = []
+                sys_sumv = []
+                sys_sumv2 = []
+                sys_sumn = []
+                for ss_ in [frame["aparam"] for frame in sampled]:
+                    ss = np.reshape(to_numpy_array(ss_), [-1, self.numb_aparam])
+                    sys_sumv.append(np.sum(ss, axis=0))
+                    sys_sumv2.append(np.sum(ss * ss, axis=0))
+                    sys_sumn.append(ss.shape[0])
+                sumv = np.sum(np.stack(sys_sumv), axis=0)
+                sumv2 = np.sum(np.stack(sys_sumv2), axis=0)
+                sumn = sum(sys_sumn)
+                for ii in range(self.numb_aparam):
+                    self.stats["aparam"].append(
+                        StatItem(
+                            number=sumn,
+                            sum=sumv[ii],
+                            squared_sum=sumv2[ii],
+                        )
+                    )
+                if stat_file_path is not None:
+                    self.save_to_file_aparam(stat_file_path)
+
+            aparam_avg = np.array([ii.compute_avg() for ii in self.stats["aparam"]])
+            aparam_std = np.array(
+                [ii.compute_std(protection=protection) for ii in self.stats["aparam"]]
             )
             aparam_inv_std = 1.0 / aparam_std
+            log.info(f"aparam_avg is {aparam_avg}, aparam_inv_std is {aparam_inv_std}")
             paddle.assign(
                 paddle.to_tensor(
                     aparam_avg, place=env.DEVICE, dtype=self.aparam_avg.dtype
@@ -195,10 +390,6 @@ class GeneralFitting(Fitting):
         Number of frame parameters.
     numb_aparam : int
         Number of atomic parameters.
-    default_fparam: list[float], optional
-        The default frame parameter. If set, when `fparam.npy` files are not included in the data system,
-        this value will be used as the default value for the frame parameter in the fitting net.
-        This parameter is not supported in PaddlePaddle.
     dim_case_embd : int
         Dimension of case specific embedding.
     activation_function : str
@@ -226,6 +417,9 @@ class GeneralFitting(Fitting):
         A list of strings. Give the name to each type of atoms.
     use_aparam_as_mask: bool
         If True, the aparam will not be used in fitting net for embedding.
+    default_fparam: list[float], optional
+        The default frame parameter. If set, when `fparam.npy` files are not included in the data system,
+        this value will be used as the default value for the frame parameter in the fitting net.
     """
 
     def __init__(
@@ -334,6 +528,20 @@ class GeneralFitting(Fitting):
         else:
             self.case_embd = None
 
+        if self.default_fparam is not None:
+            if self.numb_fparam > 0:
+                assert len(self.default_fparam) == self.numb_fparam, (
+                    "default_fparam length mismatch!"
+                )
+            self.register_buffer(
+                "default_fparam_tensor",
+                paddle.tensor(
+                    np.array(self.default_fparam), dtype=self.prec, device=device
+                ),
+            )
+        else:
+            self.default_fparam_tensor = None
+
         in_dim = (
             self.dim_descrpt
             + self.numb_fparam
@@ -355,6 +563,7 @@ class GeneralFitting(Fitting):
                     self.precision,
                     bias_out=True,
                     seed=child_seed(self.seed, ii),
+                    trainable=trainable,
                 )
                 for ii in range(self.ntypes if not self.mixed_types else 1)
             ],
@@ -373,7 +582,9 @@ class GeneralFitting(Fitting):
         self.emask = AtomExcludeMask(self.ntypes, self.exclude_types)
 
     def change_type_map(
-        self, type_map: list[str], model_with_new_type_stat: "Fitting | None" = None
+        self,
+        type_map: list[str],
+        model_with_new_type_stat: Optional["GeneralFitting"] = None,
     ) -> None:
         """Change the type related params to new ones, according to `type_map` and the original one in the model.
         If there are new types in `type_map`, statistics will be updated accordingly to `model_with_new_type_stat` for these new types.
@@ -454,6 +665,13 @@ class GeneralFitting(Fitting):
         """Get the number (dimension) of frame parameters of this atomic model."""
         return self.numb_fparam
 
+    def has_default_fparam(self) -> bool:
+        """Check if the fitting has default frame parameters."""
+        return self.default_fparam is not None
+
+    def get_default_fparam(self) -> paddle.Tensor | None:
+        return self.default_fparam_tensor
+
     def get_dim_aparam(self) -> int:
         """Get the number (dimension) of atomic parameters of this atomic model."""
         return self.numb_aparam
@@ -527,6 +745,8 @@ class GeneralFitting(Fitting):
             self.case_embd = value
         elif key in ["scale"]:
             self.scale = value
+        elif key in ["default_fparam_tensor"]:
+            self.default_fparam_tensor = value
         else:
             raise KeyError(key)
 
@@ -545,6 +765,8 @@ class GeneralFitting(Fitting):
             return self.case_embd
         elif key in ["scale"]:
             return self.scale
+        elif key in ["default_fparam_tensor"]:
+            return self.default_fparam_tensor
         else:
             raise KeyError(key)
 
@@ -568,11 +790,18 @@ class GeneralFitting(Fitting):
         h2: paddle.Tensor | None = None,
         fparam: paddle.Tensor | None = None,
         aparam: paddle.Tensor | None = None,
-    ) -> tuple[paddle.Tensor, paddle.Tensor | None]:
+    ) -> dict[str, paddle.Tensor]:
         # cast the input to internal precsion
         xx = descriptor.astype(self.prec)
-        fparam = fparam.astype(self.prec) if fparam is not None else None
-        aparam = aparam.astype(self.prec) if aparam is not None else None
+        nf, nloc, nd = xx.shape
+
+        if self.numb_fparam > 0 and fparam is None:
+            # use default fparam
+            assert self.default_fparam_tensor is not None
+            fparam = paddle.tile(self.default_fparam_tensor.unsqueeze(0), [nf, 1])
+
+        fparam = fparam.to(self.prec) if fparam is not None else None
+        aparam = aparam.to(self.prec) if aparam is not None else None
 
         if self.remove_vaccum_contribution is not None:
             # TODO: compute the input for vaccm when remove_vaccum_contribution is set
@@ -583,7 +812,6 @@ class GeneralFitting(Fitting):
             xx_zeros = paddle.zeros_like(xx)
         else:
             xx_zeros = None
-        nf, nloc, nd = xx.shape
         net_dim_out = self._net_out_dim()
 
         if nd != self.dim_descrpt:
@@ -657,6 +885,7 @@ class GeneralFitting(Fitting):
         outs = paddle.zeros(
             (nf, nloc, net_dim_out),
             dtype=env.GLOBAL_PD_FLOAT_PRECISION,
+            device=descriptor.device,
         )
         results = {}
 
@@ -676,7 +905,7 @@ class GeneralFitting(Fitting):
                 outs_middle = paddle.zeros(
                     (nf, nloc, self.neuron[-1]),
                     dtype=self.prec,
-                ).to(device=descriptor.place)  # jit assertion
+                ).to(device=descriptor.place)
                 for type_i, ll in enumerate(self.filter_layers.networks):
                     mask = (atype == type_i).unsqueeze(-1)
                     mask = paddle.tile(mask, (1, 1, net_dim_out))

--- a/deepmd/pt/model/descriptor/repflows.py
+++ b/deepmd/pt/model/descriptor/repflows.py
@@ -556,7 +556,6 @@ class DescrptBlockRepflows(DescriptorBlock):
             # n_angle x 1
             a_sw = (a_sw[:, :, :, None] * a_sw[:, :, None, :])[a_nlist_mask]
         else:
-            # avoid jit assertion
             edge_index = torch.zeros([2, 1], device=nlist.device, dtype=nlist.dtype)
             angle_index = torch.zeros([3, 1], device=nlist.device, dtype=nlist.dtype)
         # get edge and angle embedding

--- a/deepmd/pt/model/task/ener.py
+++ b/deepmd/pt/model/task/ener.py
@@ -232,14 +232,14 @@ class EnergyFittingNetDirect(Fitting):
                 torch.bmm(vec_out, gr).squeeze(-2).view(nframes, nloc, 3)
             )  # Shape is [nframes, nloc, 3]
         else:
-            vec_out = torch.zeros_like(atype).unsqueeze(-1)  # jit assertion
+            vec_out = torch.zeros_like(atype).unsqueeze(-1)
             for type_i, filter_layer in enumerate(self.filter_layers_dipole):
                 mask = atype == type_i
                 vec_out_type = filter_layer(inputs)  # Shape is [nframes, nloc, m1]
                 vec_out_type = vec_out_type * mask.unsqueeze(-1)
                 vec_out = vec_out + vec_out_type  # Shape is [nframes, natoms[0], 1]
 
-        outs = torch.zeros_like(atype).unsqueeze(-1)  # jit assertion
+        outs = torch.zeros_like(atype).unsqueeze(-1)
         if self.return_energy:
             if self.use_tebd:
                 atom_energy = self.filter_layers[0](inputs) + self.bias_atom_e[

--- a/deepmd/pt/model/task/fitting.py
+++ b/deepmd/pt/model/task/fitting.py
@@ -841,7 +841,7 @@ class GeneralFitting(Fitting):
             (nf, nloc, net_dim_out),
             dtype=self.prec,
             device=descriptor.device,
-        )  # jit assertion
+        )
         results = {}
 
         if self.mixed_types:
@@ -861,7 +861,7 @@ class GeneralFitting(Fitting):
                     (nf, nloc, self.neuron[-1]),
                     dtype=self.prec,
                     device=descriptor.device,
-                )  # jit assertion
+                )
                 for type_i, ll in enumerate(self.filter_layers.networks):
                     mask = (atype == type_i).unsqueeze(-1)
                     mask = torch.tile(mask, (1, 1, net_dim_out))

--- a/source/tests/pd/model/test_dpa3.py
+++ b/source/tests/pd/model/test_dpa3.py
@@ -55,6 +55,7 @@ class TestDescrptDPA3(unittest.TestCase, TestCaseSingleFrameWithNlist):
             nme,
             prec,
             ect,
+            add_chg_spin,
         ) in itertools.product(
             [True, False],  # update_angle
             ["res_residual"],  # update_style
@@ -65,15 +66,13 @@ class TestDescrptDPA3(unittest.TestCase, TestCaseSingleFrameWithNlist):
             [1, 2],  # n_multi_edge_message
             ["float64"],  # precision
             [False],  # use_econf_tebd
+            [False, True],  # add_chg_spin_ebd
         ):
             dtype = PRECISION_DICT[prec]
             rtol, atol = get_tols(prec)
             if prec == "float64":
                 atol = 1e-8  # marginal GPU test cases...
-            coord_ext = np.concatenate([self.coord_ext[:1], self.coord_ext[:1]], axis=0)
-            atype_ext = np.concatenate([self.atype_ext[:1], self.atype_ext[:1]], axis=0)
-            nlist = np.concatenate([self.nlist[:1], self.nlist[:1]], axis=0)
-            mapping = np.concatenate([self.mapping[:1], self.mapping[:1]], axis=0)
+
             repflow = RepFlowArgs(
                 n_dim=20,
                 e_dim=10,
@@ -105,24 +104,37 @@ class TestDescrptDPA3(unittest.TestCase, TestCaseSingleFrameWithNlist):
                 precision=prec,
                 use_econf_tebd=ect,
                 type_map=["O", "H"] if ect else None,
+                add_chg_spin_ebd=add_chg_spin,
                 seed=GLOBAL_SEED,
             ).to(env.DEVICE)
 
             dd0.repflows.mean = paddle.to_tensor(davg, dtype=dtype, place=env.DEVICE)
             dd0.repflows.stddev = paddle.to_tensor(dstd, dtype=dtype, place=env.DEVICE)
+
+            # Prepare fparam if needed
+            fparam = None
+            fparam_np = None
+            if add_chg_spin:
+                fparam = paddle.to_tensor(
+                    [[5, 1]], dtype=dtype, place=env.DEVICE
+                ).expand(nf, -1)
+                fparam_np = np.array([[5, 1]], dtype=np.float64).repeat(nf, axis=0)
+
             rd0, _, _, _, _ = dd0(
-                paddle.to_tensor(coord_ext, dtype=dtype, place=env.DEVICE),
-                paddle.to_tensor(atype_ext, dtype=paddle.int64, place=env.DEVICE),
-                paddle.to_tensor(nlist, dtype=paddle.int64, place=env.DEVICE),
-                paddle.to_tensor(mapping, dtype=paddle.int64, place=env.DEVICE),
+                paddle.to_tensor(self.coord_ext, dtype=dtype, place=env.DEVICE),
+                paddle.to_tensor(self.atype_ext, dtype=paddle.int64, place=env.DEVICE),
+                paddle.to_tensor(self.nlist, dtype=paddle.int64, place=env.DEVICE),
+                paddle.to_tensor(self.mapping, dtype=paddle.int64, place=env.DEVICE),
+                fparam=fparam,
             )
             # serialization
             dd1 = DescrptDPA3.deserialize(dd0.serialize())
             rd1, _, _, _, _ = dd1(
-                paddle.to_tensor(coord_ext, dtype=dtype, place=env.DEVICE),
-                paddle.to_tensor(atype_ext, dtype=paddle.int64, place=env.DEVICE),
-                paddle.to_tensor(nlist, dtype=paddle.int64, place=env.DEVICE),
-                paddle.to_tensor(mapping, dtype=paddle.int64, place=env.DEVICE),
+                paddle.to_tensor(self.coord_ext, dtype=dtype, place=env.DEVICE),
+                paddle.to_tensor(self.atype_ext, dtype=paddle.int64, place=env.DEVICE),
+                paddle.to_tensor(self.nlist, dtype=paddle.int64, place=env.DEVICE),
+                paddle.to_tensor(self.mapping, dtype=paddle.int64, place=env.DEVICE),
+                fparam=fparam,
             )
             np.testing.assert_allclose(
                 rd0.numpy(),
@@ -132,7 +144,13 @@ class TestDescrptDPA3(unittest.TestCase, TestCaseSingleFrameWithNlist):
             )
             # dp impl
             dd2 = DPDescrptDPA3.deserialize(dd0.serialize())
-            rd2, _, _, _, _ = dd2.call(coord_ext, atype_ext, nlist, mapping)
+            rd2, _, _, _, _ = dd2.call(
+                self.coord_ext,
+                self.atype_ext,
+                self.nlist,
+                self.mapping,
+                fparam=fparam_np,
+            )
             np.testing.assert_allclose(
                 rd0.numpy(),
                 rd2,


### PR DESCRIPTION
This pull request introduces support for charge and spin embeddings in the atomic descriptor model (`DescrptDPA3`) and integrates this feature into the atomic model (`DPAtomicModel`). The changes improve the model's ability to handle additional atomic properties and update serialization, deserialization, and testing to accommodate these enhancements. The most important changes are grouped below by theme.

### Charge and Spin Embedding Support

* Added `add_chg_spin_ebd` parameter to `DescrptDPA3`, enabling charge and spin embedding layers (`chg_embedding`, `spin_embedding`, `mix_cs_mlp`) and activation function. The forward method now incorporates charge and spin embeddings when enabled. (F5ea4df3L121R121, F5ea4df3L176R176, F5ea4df3L199R199, F5ea4df3L591R591)
* Updated serialization and deserialization logic in `DescrptDPA3` to handle charge and spin embedding layers, ensuring proper model checkpointing and restoration. (F5ea4df3L464R464, F5ea4df3L498R498)

### Integration with Atomic Model

* Propagated `add_chg_spin_ebd` from descriptor to `DPAtomicModel`, initializing relevant layers and updating the constructor. (F41ff152L76R76)
* Updated model statistics computation and serialization/deserialization to support new observed types and charge/spin embeddings. (F41ff152L378R378, F41ff152L417R417, F41ff152L438R438, F41ff152L251R251, F41ff152L263R263)

### Testing Enhancements

* Extended `test_consistency` in `test_dpa3.py` to include charge and spin embedding scenarios, ensuring correctness across serialization, deserialization, and model inference. ([source/tests/pd/model/test_dpa3.pyR58](diffhunk://#diff-96198e667d1d0633f40a189affefef65ea484d1e52c051bd39421a52a2789734R58), F2294b18L66R66, F2294b18L104R104, F2294b18L144R144)

### Miscellaneous Improvements

* Improved documentation and math rendering in `DPAtomicModel` docstring for clarity. (F41ff152L30R30)
* Updated tensor handling and output formatting in `DescrptDPA3.forward` to support optional outputs and maintain precision. (F5ea4df3L619R619)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional charge/spin-based system embedding for descriptors; descriptors and fitting now accept an optional frame-parameter (fparam) and may return extended outputs.
  * Models expose default fparam accessors, buffer-dimension accessor for fparam, and observed-element-type reporting.
  * Forward/virial flow supports coordinate-correction propagation and masked reductions.

* **Bug Fixes**
  * Clearer runtime errors when descriptor/fitting evaluation is invoked before a forward pass.
  * Reinitialization on type-map changes to ensure correct type-sensitive state.

* **Tests**
  * Expanded tests to cover charge/spin embedding, fparam handling, and serialization.

* **Chores**
  * Improved statistics orchestration, save/restore of fitting buffers, parameter-sharing hygiene, and I/O for stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->