### PR TITLE
fix: `nan` error when all `fparam`/`aparam` have equal values

### DIFF
--- a/deepmd/utils/env_mat_stat.py
+++ b/deepmd/utils/env_mat_stat.py
@@ -90,9 +90,10 @@ class StatItem:
             return default
         val = np.sqrt(
             np.clip(
-                self.squared_sum / self.number - np.multiply(self.sum / self.number, self.sum / self.number),
+                self.squared_sum / self.number
+                - np.multiply(self.sum / self.number, self.sum / self.number),
                 a_min=0,
-                a_max=None
+                a_max=None,
             )
         )
         if np.abs(val) < protection:

--- a/deepmd/utils/env_mat_stat.py
+++ b/deepmd/utils/env_mat_stat.py
@@ -89,8 +89,11 @@ class StatItem:
         if self.number == 0:
             return default
         val = np.sqrt(
-            self.squared_sum / self.number
-            - np.multiply(self.sum / self.number, self.sum / self.number)
+            np.clip(
+                self.squared_sum / self.number - np.multiply(self.sum / self.number, self.sum / self.number),
+                a_min=0,
+                a_max=None
+            )
         )
         if np.abs(val) < protection:
             val = protection


### PR DESCRIPTION
For standard deviation of `fparam/aparam`, $\sigma = \sqrt{\frac{1}{N} \sum_{i=1}^{N} (x_i - \bar{x})^2}=\sqrt{\frac{\sum x_i^2}{N} - \left( \frac{\sum x_i}{N} \right)^2}$.
When all `fparam`/`aparam` have equal values in one dimension, $\frac{\sum x_i^2}{N} - \left( \frac{\sum x_i}{N} \right)^2$ equals zero. 

However, it sometimes becomes a very small negative number(for example, 1e-18) due to numerical instability, so $\sqrt{\frac{\sum x_i^2}{N} - \left( \frac{\sum x_i}{N} \right)^2}$ becomes `nan`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in variance/std calculations by ensuring intermediate variance values are non-negative before taking the square root. This prevents occasional floating-point underflow from producing invalid results and yields more reliable statistical outputs across edge-case inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->