### PR TITLE
feat(pt_expt): add dp compress support for pt_expt backend

### DIFF
--- a/deepmd/dpmodel/descriptor/dpa1.py
+++ b/deepmd/dpmodel/descriptor/dpa1.py
@@ -344,6 +344,7 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
         self.concat_output_tebd = concat_output_tebd
         self.trainable = trainable
         self.precision = precision
+        self.compress = False
 
     def get_rcut(self) -> float:
         """Returns the cut-off radius."""

--- a/deepmd/dpmodel/descriptor/dpa1.py
+++ b/deepmd/dpmodel/descriptor/dpa1.py
@@ -558,7 +558,7 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
         data = {
             "@class": "Descriptor",
             "type": "dpa1",
-            "@version": 2,
+            "@version": 3 if self.compress else 2,
             "rcut": obj.rcut,
             "rcut_smth": obj.rcut_smth,
             "sel": obj.sel,
@@ -603,13 +603,28 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
         }
         if obj.tebd_input_mode in ["strip"]:
             data.update({"embeddings_strip": obj.embeddings_strip.serialize()})
+        if self.compress:
+            compress_dict: dict = {
+                "@variables": {
+                    "type_embd_data": to_numpy_array(self.type_embd_data),
+                },
+                "geo_compress": self.geo_compress,
+            }
+            if self.geo_compress:
+                compress_dict["@variables"]["compress_data"] = [
+                    to_numpy_array(d) for d in self.compress_data
+                ]
+                compress_dict["@variables"]["compress_info"] = [
+                    to_numpy_array(i) for i in self.compress_info
+                ]
+            data["compress"] = compress_dict
         return data
 
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptDPA1":
         """Deserialize from dict."""
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 2, 1)
+        check_version_compatibility(data.pop("@version"), 3, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
@@ -617,6 +632,7 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
         type_embedding = data.pop("type_embedding")
         attention_layers = data.pop("attention_layers")
         env_mat = data.pop("env_mat")
+        compress = data.pop("compress", None)
         tebd_input_mode = data["tebd_input_mode"]
         if tebd_input_mode in ["strip"]:
             embeddings_strip = data.pop("embeddings_strip")
@@ -638,7 +654,19 @@ class DescrptDPA1(NativeOP, BaseDescriptor):
         obj.se_atten.dpa1_attention = NeighborGatedAttention.deserialize(
             attention_layers
         )
+        if compress is not None:
+            obj._load_compress_data(compress)
         return obj
+
+    def _load_compress_data(self, compress: dict) -> None:
+        """Load compression state from serialized data."""
+        variables = compress["@variables"]
+        self.type_embd_data = variables["type_embd_data"]
+        self.geo_compress = compress.get("geo_compress", False)
+        if self.geo_compress:
+            self.compress_data = variables["compress_data"]
+            self.compress_info = variables["compress_info"]
+        self.compress = True
 
     @classmethod
     def update_sel(

--- a/deepmd/dpmodel/descriptor/dpa2.py
+++ b/deepmd/dpmodel/descriptor/dpa2.py
@@ -596,6 +596,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
         self.rcut_smth = self.repinit.get_rcut_smth()
         self.trainable = trainable
         self.add_tebd_to_repinit_out = add_tebd_to_repinit_out
+        self.compress = False
 
         self.repinit_out_dim = self.repinit.dim_out
         if self.repinit_args.use_three_body:

--- a/deepmd/dpmodel/descriptor/dpa2.py
+++ b/deepmd/dpmodel/descriptor/dpa2.py
@@ -939,7 +939,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
         data = {
             "@class": "Descriptor",
             "type": "dpa2",
-            "@version": 3,
+            "@version": 4 if self.compress else 3,
             "ntypes": self.ntypes,
             "repinit_args": self.repinit_args.serialize(),
             "repformer_args": self.repformer_args.serialize(),
@@ -974,6 +974,21 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
             repinit_variable.update(
                 {"embeddings_strip": repinit.embeddings_strip.serialize()}
             )
+        if self.compress:
+            compress_dict: dict = {
+                "@variables": {
+                    "type_embd_data": to_numpy_array(self.type_embd_data),
+                },
+                "geo_compress": self.geo_compress,
+            }
+            if self.geo_compress:
+                compress_dict["@variables"]["compress_data"] = [
+                    to_numpy_array(d) for d in self.compress_data
+                ]
+                compress_dict["@variables"]["compress_info"] = [
+                    to_numpy_array(i) for i in self.compress_info
+                ]
+            repinit_variable["compress"] = compress_dict
         repformers_variable = {
             "g2_embd": repformers.g2_embd.serialize(),
             "repformer_layers": [layer.serialize() for layer in repformers.layers],
@@ -1017,7 +1032,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
     def deserialize(cls, data: dict) -> "DescrptDPA2":
         data = data.copy()
         version = data.pop("@version")
-        check_version_compatibility(version, 3, 1)
+        check_version_compatibility(version, 4, 1)
         data.pop("@class")
         data.pop("type")
         repinit_variable = data.pop("repinit_variable").copy()
@@ -1041,6 +1056,7 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
         # compat with version 1
         if "use_tebd_bias" not in data:
             data["use_tebd_bias"] = True
+        compress = repinit_variable.pop("compress", None)
         obj = cls(**data)
         obj.type_embedding = TypeEmbedNet.deserialize(type_embedding)
         if add_tebd_to_repinit_out:
@@ -1090,7 +1106,19 @@ class DescrptDPA2(NativeOP, BaseDescriptor):
         obj.repformers.layers = [
             RepformerLayer.deserialize(layer) for layer in repformer_layers
         ]
+        if compress is not None:
+            obj._load_compress_data(compress)
         return obj
+
+    def _load_compress_data(self, compress: dict) -> None:
+        """Load compression state from serialized data."""
+        variables = compress["@variables"]
+        self.type_embd_data = variables["type_embd_data"]
+        self.geo_compress = compress.get("geo_compress", False)
+        if self.geo_compress:
+            self.compress_data = variables["compress_data"]
+            self.compress_info = variables["compress_info"]
+        self.compress = True
 
     @classmethod
     def update_sel(

--- a/deepmd/dpmodel/descriptor/se_atten_v2.py
+++ b/deepmd/dpmodel/descriptor/se_atten_v2.py
@@ -204,7 +204,7 @@ class DescrptSeAttenV2(DescrptDPA1):
         data = {
             "@class": "Descriptor",
             "type": "se_atten_v2",
-            "@version": 2,
+            "@version": 3 if self.compress else 2,
             "rcut": obj.rcut,
             "rcut_smth": obj.rcut_smth,
             "sel": obj.sel,
@@ -246,13 +246,28 @@ class DescrptSeAttenV2(DescrptDPA1):
             "trainable": self.trainable,
             "spin": None,
         }
+        if self.compress:
+            compress_dict: dict = {
+                "@variables": {
+                    "type_embd_data": to_numpy_array(self.type_embd_data),
+                },
+                "geo_compress": self.geo_compress,
+            }
+            if self.geo_compress:
+                compress_dict["@variables"]["compress_data"] = [
+                    to_numpy_array(d) for d in self.compress_data
+                ]
+                compress_dict["@variables"]["compress_info"] = [
+                    to_numpy_array(i) for i in self.compress_info
+                ]
+            data["compress"] = compress_dict
         return data
 
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeAttenV2":
         """Deserialize from dict."""
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 2, 1)
+        check_version_compatibility(data.pop("@version"), 3, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
@@ -261,6 +276,7 @@ class DescrptSeAttenV2(DescrptDPA1):
         attention_layers = data.pop("attention_layers")
         data.pop("env_mat")
         embeddings_strip = data.pop("embeddings_strip")
+        compress = data.pop("compress", None)
         # compat with version 1
         if "use_tebd_bias" not in data:
             data["use_tebd_bias"] = True
@@ -274,4 +290,16 @@ class DescrptSeAttenV2(DescrptDPA1):
         obj.se_atten.dpa1_attention = NeighborGatedAttention.deserialize(
             attention_layers
         )
+        if compress is not None:
+            obj._load_compress_data(compress)
         return obj
+
+    def _load_compress_data(self, compress: dict) -> None:
+        """Load compression state from serialized data."""
+        variables = compress["@variables"]
+        self.type_embd_data = variables["type_embd_data"]
+        self.geo_compress = compress.get("geo_compress", False)
+        if self.geo_compress:
+            self.compress_data = variables["compress_data"]
+            self.compress_info = variables["compress_info"]
+        self.compress = True

--- a/deepmd/dpmodel/descriptor/se_atten_v2.py
+++ b/deepmd/dpmodel/descriptor/se_atten_v2.py
@@ -196,6 +196,7 @@ class DescrptSeAttenV2(DescrptDPA1):
             # consistent with argcheck, not used though
             seed=seed,
         )
+        self.compress = False
 
     def serialize(self) -> dict:
         """Serialize the descriptor to dict."""

--- a/deepmd/dpmodel/descriptor/se_e2_a.py
+++ b/deepmd/dpmodel/descriptor/se_e2_a.py
@@ -515,10 +515,24 @@ class DescrptSeA(NativeOP, BaseDescriptor):
                 if embedding_idx in self.emask:
                     self.embeddings[embedding_idx].clear()
 
-        return {
+        # Serialization version history:
+        #   v2: original format
+        #   v3: added optional "compress" key for model compression state
+        #       (tabulated embedding-net polynomial coefficients).
+        #       Uncompressed models stay at v2 for full backward compatibility.
+        #
+        # Why serialize compression state here:
+        #   The pt and tf backends persist compression via their native
+        #   framework save mechanisms (torch.jit.save / tf.saved_model),
+        #   which capture the full runtime state including tabulated data.
+        #   The pt_expt backend uses serialize() -> model.json -> deserialize()
+        #   as the primary persistence path (.pte files), so compression state
+        #   must survive this round-trip.  All backends accept v3 in
+        #   deserialize() to allow cross-backend loading of compressed models.
+        data = {
             "@class": "Descriptor",
             "type": "se_e2_a",
-            "@version": 2,
+            "@version": 3 if self.compress else 2,
             "rcut": self.rcut,
             "rcut_smth": self.rcut_smth,
             "sel": self.sel,
@@ -542,23 +556,49 @@ class DescrptSeA(NativeOP, BaseDescriptor):
             },
             "type_map": self.type_map,
         }
+        if self.compress:
+            data["compress"] = {
+                "@variables": {
+                    "compress_data": [to_numpy_array(d) for d in self.compress_data],
+                    "compress_info": [to_numpy_array(i) for i in self.compress_info],
+                },
+            }
+        return data
 
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeA":
         """Deserialize from dict."""
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         env_mat = data.pop("env_mat")
+        compress = data.pop("compress", None)
         obj = cls(**data)
 
         obj["davg"] = variables["davg"]
         obj["dstd"] = variables["dstd"]
         obj.embeddings = NetworkCollection.deserialize(embeddings)
+        if compress is not None:
+            obj._load_compress_data(compress)
         return obj
+
+    def _load_compress_data(self, compress: dict) -> None:
+        """Load compression state from serialized data.
+
+        Parameters
+        ----------
+        compress : dict
+            Must contain "@variables" with "compress_data" (list of arrays,
+            one per embedding network) and "compress_info" (list of arrays
+            with table bounds).
+        """
+        variables = compress["@variables"]
+        self.compress_data = variables["compress_data"]
+        self.compress_info = variables["compress_info"]
+        self.compress = True
 
     @classmethod
     def update_sel(

--- a/deepmd/dpmodel/descriptor/se_e2_a.py
+++ b/deepmd/dpmodel/descriptor/se_e2_a.py
@@ -192,6 +192,7 @@ class DescrptSeA(NativeOP, BaseDescriptor):
         self.precision = precision
         self.spin = spin
         self.type_map = type_map
+        self.compress = False
         # order matters, placed after the assignment of self.ntypes
         self.reinit_exclude(exclude_types)
 

--- a/deepmd/dpmodel/descriptor/se_r.py
+++ b/deepmd/dpmodel/descriptor/se_r.py
@@ -439,10 +439,10 @@ class DescrptSeR(NativeOP, BaseDescriptor):
 
     def serialize(self) -> dict:
         """Serialize the descriptor to dict."""
-        return {
+        data = {
             "@class": "Descriptor",
             "type": "se_r",
-            "@version": 2,
+            "@version": 3 if self.compress else 2,
             "rcut": self.rcut,
             "rcut_smth": self.rcut_smth,
             "sel": self.sel,
@@ -465,23 +465,41 @@ class DescrptSeR(NativeOP, BaseDescriptor):
             },
             "type_map": self.type_map,
         }
+        if self.compress:
+            data["compress"] = {
+                "@variables": {
+                    "compress_data": [to_numpy_array(d) for d in self.compress_data],
+                    "compress_info": [to_numpy_array(i) for i in self.compress_info],
+                },
+            }
+        return data
 
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeR":
         """Deserialize from dict."""
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         env_mat = data.pop("env_mat")
+        compress = data.pop("compress", None)
         obj = cls(**data)
 
         obj["davg"] = variables["davg"]
         obj["dstd"] = variables["dstd"]
         obj.embeddings = NetworkCollection.deserialize(embeddings)
+        if compress is not None:
+            obj._load_compress_data(compress)
         return obj
+
+    def _load_compress_data(self, compress: dict) -> None:
+        """Load compression state from serialized data."""
+        variables = compress["@variables"]
+        self.compress_data = variables["compress_data"]
+        self.compress_info = variables["compress_info"]
+        self.compress = True
 
     @classmethod
     def update_sel(

--- a/deepmd/dpmodel/descriptor/se_r.py
+++ b/deepmd/dpmodel/descriptor/se_r.py
@@ -173,6 +173,7 @@ class DescrptSeR(NativeOP, BaseDescriptor):
         self.type_map = type_map
         self.emask = PairExcludeMask(self.ntypes, self.exclude_types)
         self.env_protection = env_protection
+        self.compress = False
 
         in_dim = 1  # not considiering type embedding
         embeddings = NetworkCollection(

--- a/deepmd/dpmodel/descriptor/se_t.py
+++ b/deepmd/dpmodel/descriptor/se_t.py
@@ -442,10 +442,10 @@ class DescrptSeT(NativeOP, BaseDescriptor):
             if (self.exclude_types and embedding_idx in self.emask) or tj < ti:
                 self.embeddings[embedding_idx].clear()
 
-        return {
+        data = {
             "@class": "Descriptor",
             "type": "se_e3",
-            "@version": 2,
+            "@version": 3 if self.compress else 2,
             "rcut": self.rcut,
             "rcut_smth": self.rcut_smth,
             "sel": self.sel,
@@ -465,23 +465,41 @@ class DescrptSeT(NativeOP, BaseDescriptor):
             "type_map": self.type_map,
             "trainable": self.trainable,
         }
+        if self.compress:
+            data["compress"] = {
+                "@variables": {
+                    "compress_data": [to_numpy_array(d) for d in self.compress_data],
+                    "compress_info": [to_numpy_array(i) for i in self.compress_info],
+                },
+            }
+        return data
 
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeT":
         """Deserialize from dict."""
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         env_mat = data.pop("env_mat")
+        compress = data.pop("compress", None)
         obj = cls(**data)
 
         obj["davg"] = variables["davg"]
         obj["dstd"] = variables["dstd"]
         obj.embeddings = NetworkCollection.deserialize(embeddings)
+        if compress is not None:
+            obj._load_compress_data(compress)
         return obj
+
+    def _load_compress_data(self, compress: dict) -> None:
+        """Load compression state from serialized data."""
+        variables = compress["@variables"]
+        self.compress_data = variables["compress_data"]
+        self.compress_info = variables["compress_info"]
+        self.compress = True
 
     @classmethod
     def update_sel(

--- a/deepmd/dpmodel/descriptor/se_t.py
+++ b/deepmd/dpmodel/descriptor/se_t.py
@@ -154,6 +154,7 @@ class DescrptSeT(NativeOP, BaseDescriptor):
         self.reinit_exclude(exclude_types)
         self.trainable = trainable
         self.sel_cumsum = [0, *np.cumsum(self.sel).tolist()]
+        self.compress = False
 
         in_dim = 1  # not considiering type embedding
         embeddings = NetworkCollection(

--- a/deepmd/dpmodel/descriptor/se_t_tebd.py
+++ b/deepmd/dpmodel/descriptor/se_t_tebd.py
@@ -203,6 +203,7 @@ class DescrptSeTTebd(NativeOP, BaseDescriptor):
         self.concat_output_tebd = concat_output_tebd
         self.trainable = trainable
         self.precision = precision
+        self.compress = False
 
     def get_rcut(self) -> float:
         """Returns the cut-off radius."""

--- a/deepmd/dpmodel/descriptor/se_t_tebd.py
+++ b/deepmd/dpmodel/descriptor/se_t_tebd.py
@@ -417,7 +417,7 @@ class DescrptSeTTebd(NativeOP, BaseDescriptor):
         data = {
             "@class": "Descriptor",
             "type": "se_e3_tebd",
-            "@version": 1,
+            "@version": 2 if self.compress else 1,
             "rcut": obj.rcut,
             "rcut_smth": obj.rcut_smth,
             "sel": obj.sel,
@@ -447,19 +447,32 @@ class DescrptSeTTebd(NativeOP, BaseDescriptor):
         }
         if obj.tebd_input_mode in ["strip"]:
             data.update({"embeddings_strip": obj.embeddings_strip.serialize()})
+        if self.compress:
+            compress_dict: dict = {
+                "@variables": {
+                    "compress_data": [to_numpy_array(d) for d in self.compress_data],
+                    "compress_info": [to_numpy_array(i) for i in self.compress_info],
+                },
+            }
+            if hasattr(self, "type_embd_data"):
+                compress_dict["@variables"]["type_embd_data"] = to_numpy_array(
+                    self.type_embd_data
+                )
+            data["compress"] = compress_dict
         return data
 
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeTTebd":
         """Deserialize from dict."""
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 1, 1)
+        check_version_compatibility(data.pop("@version"), 2, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         type_embedding = data.pop("type_embedding")
         env_mat = data.pop("env_mat")
+        compress = data.pop("compress", None)
         tebd_input_mode = data["tebd_input_mode"]
         if tebd_input_mode in ["strip"]:
             embeddings_strip = data.pop("embeddings_strip")
@@ -475,8 +488,19 @@ class DescrptSeTTebd(NativeOP, BaseDescriptor):
             obj.se_ttebd.embeddings_strip = NetworkCollection.deserialize(
                 embeddings_strip
             )
+        if compress is not None:
+            obj._load_compress_data(compress)
 
         return obj
+
+    def _load_compress_data(self, compress: dict) -> None:
+        """Load compression state from serialized data."""
+        variables = compress["@variables"]
+        self.compress_data = variables["compress_data"]
+        self.compress_info = variables["compress_info"]
+        if "type_embd_data" in variables:
+            self.type_embd_data = variables["type_embd_data"]
+        self.compress = True
 
     @classmethod
     def update_sel(

--- a/deepmd/pd/model/descriptor/dpa1.py
+++ b/deepmd/pd/model/descriptor/dpa1.py
@@ -556,7 +556,7 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptDPA1":
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 2, 1)
+        check_version_compatibility(data.pop("@version"), 3, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
@@ -564,6 +564,7 @@ class DescrptDPA1(BaseDescriptor, paddle.nn.Layer):
         type_embedding = data.pop("type_embedding")
         attention_layers = data.pop("attention_layers")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # pd uses state_dict for compression
         tebd_input_mode = data["tebd_input_mode"]
         if tebd_input_mode in ["strip"]:
             embeddings_strip = data.pop("embeddings_strip")

--- a/deepmd/pd/model/descriptor/dpa2.py
+++ b/deepmd/pd/model/descriptor/dpa2.py
@@ -643,10 +643,11 @@ class DescrptDPA2(BaseDescriptor, paddle.nn.Layer):
     def deserialize(cls, data: dict) -> "DescrptDPA2":
         data = data.copy()
         version = data.pop("@version")
-        check_version_compatibility(version, 3, 1)
+        check_version_compatibility(version, 4, 1)
         data.pop("@class")
         data.pop("type")
         repinit_variable = data.pop("repinit_variable").copy()
+        repinit_variable.pop("compress", None)  # pd uses state_dict for compression
         repformers_variable = data.pop("repformers_variable").copy()
         repinit_three_body_variable = (
             data.pop("repinit_three_body_variable").copy()

--- a/deepmd/pd/model/descriptor/se_a.py
+++ b/deepmd/pd/model/descriptor/se_a.py
@@ -383,12 +383,13 @@ class DescrptSeA(BaseDescriptor, paddle.nn.Layer):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeA":
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # compression not supported in pd backend
         obj = cls(**data)
 
         def t_cvt(xx: np.ndarray) -> paddle.Tensor:

--- a/deepmd/pd/model/descriptor/se_atten_v2.py
+++ b/deepmd/pd/model/descriptor/se_atten_v2.py
@@ -239,7 +239,7 @@ class DescrptSeAttenV2(DescrptDPA1):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeAttenV2":
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 2, 1)
+        check_version_compatibility(data.pop("@version"), 3, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
@@ -248,6 +248,7 @@ class DescrptSeAttenV2(DescrptDPA1):
         attention_layers = data.pop("attention_layers")
         data.pop("env_mat")
         embeddings_strip = data.pop("embeddings_strip")
+        data.pop("compress", None)  # pd uses state_dict for compression
         # compat with version 1
         if "use_tebd_bias" not in data:
             data["use_tebd_bias"] = True

--- a/deepmd/pd/model/descriptor/se_t_tebd.py
+++ b/deepmd/pd/model/descriptor/se_t_tebd.py
@@ -400,13 +400,14 @@ class DescrptSeTTebd(BaseDescriptor, paddle.nn.Layer):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeTTebd":
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 1, 1)
+        check_version_compatibility(data.pop("@version"), 2, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         type_embedding = data.pop("type_embedding")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # pd uses state_dict for compression
         tebd_input_mode = data["tebd_input_mode"]
         if tebd_input_mode in ["strip"]:
             embeddings_strip = data.pop("embeddings_strip")

--- a/deepmd/pt/model/descriptor/dpa1.py
+++ b/deepmd/pt/model/descriptor/dpa1.py
@@ -535,7 +535,7 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptDPA1":
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 2, 1)
+        check_version_compatibility(data.pop("@version"), 3, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
@@ -543,6 +543,7 @@ class DescrptDPA1(BaseDescriptor, torch.nn.Module):
         type_embedding = data.pop("type_embedding")
         attention_layers = data.pop("attention_layers")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # pt uses state_dict for compression
         tebd_input_mode = data["tebd_input_mode"]
         if tebd_input_mode in ["strip"]:
             embeddings_strip = data.pop("embeddings_strip")

--- a/deepmd/pt/model/descriptor/dpa2.py
+++ b/deepmd/pt/model/descriptor/dpa2.py
@@ -626,10 +626,11 @@ class DescrptDPA2(BaseDescriptor, torch.nn.Module):
     def deserialize(cls, data: dict) -> "DescrptDPA2":
         data = data.copy()
         version = data.pop("@version")
-        check_version_compatibility(version, 3, 1)
+        check_version_compatibility(version, 4, 1)
         data.pop("@class")
         data.pop("type")
         repinit_variable = data.pop("repinit_variable").copy()
+        repinit_variable.pop("compress", None)  # pt uses state_dict for compression
         repformers_variable = data.pop("repformers_variable").copy()
         repinit_three_body_variable = (
             data.pop("repinit_three_body_variable").copy()

--- a/deepmd/pt/model/descriptor/se_a.py
+++ b/deepmd/pt/model/descriptor/se_a.py
@@ -412,12 +412,13 @@ class DescrptSeA(BaseDescriptor, torch.nn.Module):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeA":
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # pt uses state_dict for compression
         obj = cls(**data)
 
         def t_cvt(xx: Any) -> torch.Tensor:

--- a/deepmd/pt/model/descriptor/se_atten_v2.py
+++ b/deepmd/pt/model/descriptor/se_atten_v2.py
@@ -242,7 +242,7 @@ class DescrptSeAttenV2(DescrptDPA1):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeAttenV2":
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 2, 1)
+        check_version_compatibility(data.pop("@version"), 3, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
@@ -251,6 +251,7 @@ class DescrptSeAttenV2(DescrptDPA1):
         attention_layers = data.pop("attention_layers")
         data.pop("env_mat")
         embeddings_strip = data.pop("embeddings_strip")
+        data.pop("compress", None)  # pt uses state_dict for compression
         # compat with version 1
         if "use_tebd_bias" not in data:
             data["use_tebd_bias"] = True

--- a/deepmd/pt/model/descriptor/se_r.py
+++ b/deepmd/pt/model/descriptor/se_r.py
@@ -579,10 +579,11 @@ class DescrptSeR(BaseDescriptor, torch.nn.Module):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeR":
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # pt uses state_dict for compression
         obj = cls(**data)
 
         def t_cvt(xx: Any) -> torch.Tensor:

--- a/deepmd/pt/model/descriptor/se_t.py
+++ b/deepmd/pt/model/descriptor/se_t.py
@@ -441,12 +441,13 @@ class DescrptSeT(BaseDescriptor, torch.nn.Module):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeT":
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # pt uses state_dict for compression
         obj = cls(**data)
 
         def t_cvt(xx: Any) -> torch.Tensor:

--- a/deepmd/pt/model/descriptor/se_t_tebd.py
+++ b/deepmd/pt/model/descriptor/se_t_tebd.py
@@ -387,13 +387,14 @@ class DescrptSeTTebd(BaseDescriptor, torch.nn.Module):
     @classmethod
     def deserialize(cls, data: dict) -> "DescrptSeTTebd":
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 1, 1)
+        check_version_compatibility(data.pop("@version"), 2, 1)
         data.pop("@class")
         data.pop("type")
         variables = data.pop("@variables")
         embeddings = data.pop("embeddings")
         type_embedding = data.pop("type_embedding")
         env_mat = data.pop("env_mat")
+        data.pop("compress", None)  # pt uses state_dict for compression
         tebd_input_mode = data["tebd_input_mode"]
         if tebd_input_mode in ["strip"]:
             embeddings_strip = data.pop("embeddings_strip")

--- a/deepmd/pt_expt/common.py
+++ b/deepmd/pt_expt/common.py
@@ -461,6 +461,25 @@ def torch_module(
 
         TorchModule.forward_lower = forward_lower
 
+    # Auto-register dpmodel base → pt_expt converter so that auto-wrapped
+    # parent objects (e.g. atomic models) get pt_expt sub-components instead
+    # of generic dpmodel wrappers (which lack methods like enable_compression).
+    if hasattr(TorchModule, "deserialize"):
+        for base in module.__bases__:
+            if (
+                base is not NativeOP
+                and issubclass(base, NativeOP)
+                and hasattr(base, "serialize")
+                and base not in _DPMODEL_TO_PT_EXPT
+            ):
+                # Capture TorchModule in closure via default arg
+                def _converter(
+                    v: NativeOP, _cls: type = TorchModule
+                ) -> torch.nn.Module:
+                    return _cls.deserialize(v.serialize())
+
+                _DPMODEL_TO_PT_EXPT[base] = _converter
+
     return TorchModule
 
 

--- a/deepmd/pt_expt/descriptor/dpa1.py
+++ b/deepmd/pt_expt/descriptor/dpa1.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
 
+import torch
+
+from deepmd.dpmodel.common import (
+    cast_precision,
+)
 from deepmd.dpmodel.descriptor.dpa1 import DescrptDPA1 as DescrptDPA1DP
 from deepmd.pt_expt.common import (
     torch_module,
@@ -17,3 +25,262 @@ from deepmd.pt_expt.utils.update_sel import (
 @torch_module
 class DescrptDPA1(DescrptDPA1DP):
     _update_sel_cls = UpdateSel
+
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        """Enable compression for the DPA1 descriptor.
+
+        Parameters
+        ----------
+        min_nbor_dist
+            The nearest distance between atoms
+        table_extrapolate
+            The scale of model extrapolation
+        table_stride_1
+            The uniform stride of the first table
+        table_stride_2
+            The uniform stride of the second table
+        check_frequency
+            The overflow check frequency
+        """
+        from deepmd.pt.utils.utils import (
+            ActivationFn,
+        )
+        from deepmd.pt_expt.utils.tabulate import (
+            DPTabulate,
+        )
+
+        if self.compress:
+            raise ValueError("Compression is already enabled.")
+        if self.se_atten.tebd_input_mode != "strip":
+            raise RuntimeError("Type embedding compression only works in strip mode")
+        assert not self.se_atten.resnet_dt, (
+            "Model compression error: descriptor resnet_dt must be false!"
+        )
+
+        data = self.serialize()
+        self.table = DPTabulate(
+            self,
+            data["neuron"],
+            data["type_one_side"],
+            data["exclude_types"],
+            ActivationFn(data["activation_function"]),
+        )
+        self.table_config = [
+            table_extrapolate,
+            table_stride_1,
+            table_stride_2,
+            check_frequency,
+        ]
+
+        # Precompute type embedding data
+        self._store_type_embd_data()
+
+        if self.se_atten.attn_layer == 0:
+            # Build geometric embedding table
+            self.lower, self.upper = self.table.build(
+                min_nbor_dist, table_extrapolate, table_stride_1, table_stride_2
+            )
+            self._store_compress_data()
+            self.geo_compress = True
+        else:
+            self.geo_compress = False
+
+        self.compress = True
+
+    def _store_compress_data(self) -> None:
+        """Store tabulated data as buffers for the compressed geometric embedding."""
+        table_data = self.table.data
+        table_config = self.table_config
+        lower = self.lower
+        upper = self.upper
+        prec = self.se_atten.mean.dtype
+
+        net_key = "filter_net"
+        info = torch.as_tensor(
+            [
+                lower[net_key],
+                upper[net_key],
+                upper[net_key] * table_config[0],
+                table_config[1],
+                table_config[2],
+                table_config[3],
+            ],
+            dtype=prec,
+            device="cpu",
+        )
+        tensor_data = table_data[net_key].to(dtype=prec)
+        self.compress_data = torch.nn.ParameterList(
+            [torch.nn.Parameter(tensor_data, requires_grad=False)]
+        )
+        self.compress_info = torch.nn.ParameterList(
+            [torch.nn.Parameter(info, requires_grad=False)]
+        )
+
+    def _store_type_embd_data(self) -> None:
+        """Precompute type embedding outputs and store as a buffer."""
+        with torch.no_grad():
+            # type_embedding.call() returns (ntypes+1) x tebd_dim (with padding)
+            full_embd = self.type_embedding.call()
+            nt, t_dim = full_embd.shape
+            ng = self.se_atten.neuron[-1]
+
+            if self.se_atten.type_one_side:
+                # One-side: only neighbor types
+                # (ntypes+1) x tebd_dim -> (ntypes+1) x ng
+                embd_tensor = self.se_atten.embeddings_strip[0].call(full_embd).detach()
+            else:
+                # Two-side: all (ntypes+1)^2 type pair combinations
+                # Build [neighbor, center] combinations
+                embd_nei = full_embd.view(1, nt, t_dim).expand(nt, nt, t_dim)
+                embd_center = full_embd.view(nt, 1, t_dim).expand(nt, nt, t_dim)
+                two_side_embd = torch.cat([embd_nei, embd_center], dim=-1).reshape(
+                    -1, t_dim * 2
+                )
+                # ((ntypes+1)^2) x ng
+                embd_tensor = (
+                    self.se_atten.embeddings_strip[0].call(two_side_embd).detach()
+                )
+
+            torch.nn.Module.register_buffer(self, "type_embd_data", embd_tensor)
+
+    @cast_precision
+    def call(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+    ) -> Any:
+        if not self.compress:
+            return DescrptDPA1DP.call.__wrapped__(
+                self, coord_ext, atype_ext, nlist, mapping
+            )
+        return self._call_compressed(coord_ext, atype_ext, nlist)
+
+    def _call_compressed(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+    ) -> Any:
+        """Compressed forward for DPA1 descriptor."""
+        # env_mat: nf x nloc x nnei x 4
+        rr, diff, sw = self.se_atten.env_mat.call(
+            coord_ext,
+            atype_ext,
+            nlist,
+            self.se_atten.mean[...],
+            self.se_atten.stddev[...],
+        )
+        nf, nloc, nnei, _ = rr.shape
+        ng = self.se_atten.neuron[-1]
+        nfnl = nf * nloc
+
+        # Exclude mask and nlist processing
+        exclude_mask = self.se_atten.emask.build_type_exclude_mask(nlist, atype_ext)
+        exclude_mask = exclude_mask.view(nfnl, nnei)
+        nlist = nlist.view(nfnl, nnei)
+        exclude_mask = exclude_mask.to(torch.bool)
+        nlist = torch.where(exclude_mask, nlist, torch.full_like(nlist, -1))
+        nlist_mask = nlist != -1
+        nlist_masked = torch.where(nlist_mask, nlist, torch.zeros_like(nlist))
+        # nfnl x nnei x 1
+        sw = torch.where(
+            nlist_mask[:, :, None],
+            sw.view(nfnl, nnei, 1),
+            torch.zeros(nfnl, nnei, 1, dtype=sw.dtype, device=sw.device),
+        )
+
+        # nfnl x nnei x 4
+        rr = rr.view(nfnl, nnei, 4)
+        rr = rr * exclude_mask[:, :, None].to(rr.dtype)
+        # nfnl x nnei x 1
+        ss = rr[:, :, :1]
+
+        # Type embedding lookup from precomputed buffer
+        type_embedding = self.type_embedding.call()
+        ntypes_with_padding = type_embedding.shape[0]
+        # nf x (nloc x nnei)
+        nlist_index = nlist_masked.view(nf, nloc * nnei)
+        # nf x (nloc x nnei)
+        nei_type = torch.gather(atype_ext, dim=1, index=nlist_index)
+
+        if self.se_atten.type_one_side:
+            # (nf*nl*nnei,) -> (nf*nl*nnei, ng)
+            gg_t = self.type_embd_data[nei_type.view(-1).to(torch.long)]
+        else:
+            atype = atype_ext[:, :nloc]
+            idx_i = torch.tile(
+                atype.reshape(-1, 1) * ntypes_with_padding, [1, nnei]
+            ).view(-1)
+            idx_j = nei_type.view(-1)
+            idx = (idx_i + idx_j).to(torch.long)
+            # (nf x nl x nnei) x ng
+            gg_t = self.type_embd_data[idx]
+
+        # (nf x nl) x nnei x ng
+        gg_t = gg_t.view(nfnl, nnei, ng)
+        if self.se_atten.smooth:
+            gg_t = gg_t * sw.view(nfnl, self.se_atten.nnei, 1)
+
+        if self.geo_compress:
+            # Flatten for tabulate op
+            ss_flat = ss.reshape(-1, 1)
+            gg_t_flat = gg_t.reshape(-1, gg_t.size(-1))
+            is_sorted = len(self.se_atten.exclude_types) == 0
+            xyz_scatter = torch.ops.deepmd.tabulate_fusion_se_atten(
+                self.compress_data[0].contiguous(),
+                self.compress_info[0].cpu().contiguous(),
+                ss_flat.contiguous(),
+                rr.contiguous(),
+                gg_t_flat.contiguous(),
+                self.se_atten.neuron[-1],
+                is_sorted,
+            )[0]
+        else:
+            # No geometric compression, run embedding net + attention
+            # nfnl x nnei x ng
+            gg_s = self.se_atten.embeddings[0].call(ss)
+            # nfnl x nnei x ng
+            gg = gg_s * gg_t + gg_s
+            input_r = torch.nn.functional.normalize(
+                rr.view(-1, self.se_atten.nnei, 4)[:, :, 1:4], dim=-1
+            )
+            gg = self.se_atten.dpa1_attention(gg, nlist_mask, input_r=input_r, sw=sw)
+            # nfnl x 4 x ng
+            xyz_scatter = torch.matmul(rr.permute(0, 2, 1), gg)
+
+        xyz_scatter = xyz_scatter / self.se_atten.nnei
+        # nfnl x ng x 4
+        xyz_scatter_1 = xyz_scatter.permute(0, 2, 1)
+        # nfnl x ng x 3
+        rot_mat = xyz_scatter_1[:, :, 1:4]
+        # nfnl x 4 x axis_neuron
+        xyz_scatter_2 = xyz_scatter[:, :, 0 : self.se_atten.axis_neuron]
+        # nfnl x ng x axis_neuron
+        result = torch.matmul(xyz_scatter_1, xyz_scatter_2)
+        # nf x nloc x (ng x axis_neuron)
+        result = result.view(nf, nloc, ng * self.se_atten.axis_neuron)
+        # nf x nloc x ng x 3
+        rot_mat = rot_mat.view(nf, nloc, ng, 3)
+
+        # Concat type embedding at output if needed
+        if self.concat_output_tebd:
+            nall = coord_ext.view(nf, -1).shape[1] // 3
+            atype_embd_ext = type_embedding[atype_ext.reshape(-1)].view(
+                nf, nall, self.tebd_dim
+            )
+            atype_embd = atype_embd_ext[:, :nloc, :]
+            result = torch.cat(
+                [result, atype_embd.view(nf, nloc, self.tebd_dim)], dim=-1
+            )
+
+        return result, rot_mat, None, None, sw.view(nf, nloc, nnei, 1)

--- a/deepmd/pt_expt/descriptor/dpa1.py
+++ b/deepmd/pt_expt/descriptor/dpa1.py
@@ -60,9 +60,10 @@ class DescrptDPA1(DescrptDPA1DP):
             raise ValueError("Compression is already enabled.")
         if self.se_atten.tebd_input_mode != "strip":
             raise RuntimeError("Type embedding compression only works in strip mode")
-        assert not self.se_atten.resnet_dt, (
-            "Model compression error: descriptor resnet_dt must be false!"
-        )
+        if self.se_atten.resnet_dt:
+            raise RuntimeError(
+                "Model compression error: descriptor resnet_dt must be false!"
+            )
 
         data = self.serialize()
         self.table = DPTabulate(
@@ -172,7 +173,7 @@ class DescrptDPA1(DescrptDPA1DP):
     ) -> Any:
         """Compressed forward for DPA1 descriptor."""
         # env_mat: nf x nloc x nnei x 4
-        rr, diff, sw = self.se_atten.env_mat.call(
+        rr, _diff, sw = self.se_atten.env_mat.call(
             coord_ext,
             atype_ext,
             nlist,

--- a/deepmd/pt_expt/descriptor/dpa1.py
+++ b/deepmd/pt_expt/descriptor/dpa1.py
@@ -129,7 +129,6 @@ class DescrptDPA1(DescrptDPA1DP):
             # type_embedding.call() returns (ntypes+1) x tebd_dim (with padding)
             full_embd = self.type_embedding.call()
             nt, t_dim = full_embd.shape
-            ng = self.se_atten.neuron[-1]
 
             if self.se_atten.type_one_side:
                 # One-side: only neighbor types

--- a/deepmd/pt_expt/descriptor/dpa2.py
+++ b/deepmd/pt_expt/descriptor/dpa2.py
@@ -1,6 +1,19 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import warnings
+from typing import (
+    Any,
+)
 
+import torch
+
+from deepmd.dpmodel.common import (
+    cast_precision,
+)
 from deepmd.dpmodel.descriptor.dpa2 import DescrptDPA2 as DescrptDPA2DP
+from deepmd.dpmodel.descriptor.dpa2 import (
+    build_multiple_neighbor_list,
+    get_multiple_nlist_key,
+)
 from deepmd.pt_expt.common import (
     torch_module,
 )
@@ -16,3 +29,393 @@ from deepmd.pt_expt.utils.update_sel import (
 @torch_module
 class DescrptDPA2(DescrptDPA2DP):
     _update_sel_cls = UpdateSel
+
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        """Enable compression for the DPA2 descriptor.
+
+        Compression applies to the repinit block (DescrptBlockSeAtten).
+        When attn_layer == 0, the geometric embedding is tabulated.
+        Type embedding outputs are always precomputed.
+
+        Parameters
+        ----------
+        min_nbor_dist
+            The nearest distance between atoms
+        table_extrapolate
+            The scale of model extrapolation
+        table_stride_1
+            The uniform stride of the first table
+        table_stride_2
+            The uniform stride of the second table
+        check_frequency
+            The overflow check frequency
+        """
+        from deepmd.pt.utils.utils import (
+            ActivationFn,
+        )
+        from deepmd.pt_expt.utils.tabulate import (
+            DPTabulate,
+        )
+
+        if self.compress:
+            raise ValueError("Compression is already enabled.")
+        assert not self.repinit.resnet_dt, (
+            "Model compression error: repinit resnet_dt must be false!"
+        )
+        for tt in self.repinit.exclude_types:
+            if (tt[0] not in range(self.repinit.ntypes)) or (
+                tt[1] not in range(self.repinit.ntypes)
+            ):
+                raise RuntimeError(
+                    "Repinit exclude types"
+                    + str(tt)
+                    + " must within the number of atomic types "
+                    + str(self.repinit.ntypes)
+                    + "!"
+                )
+        if (
+            self.repinit.ntypes * self.repinit.ntypes - len(self.repinit.exclude_types)
+            == 0
+        ):
+            raise RuntimeError(
+                "Repinit empty embedding-nets are not supported in model compression!"
+            )
+
+        if self.repinit.tebd_input_mode != "strip":
+            raise RuntimeError(
+                "Cannot compress model when repinit tebd_input_mode != 'strip'"
+            )
+
+        # Precompute type embedding data for repinit
+        self._store_type_embd_data()
+
+        if self.repinit.attn_layer == 0:
+            # Build geometric embedding table
+            data = self.serialize()
+            self.table = DPTabulate(
+                self,
+                data["repinit_args"]["neuron"],
+                data["repinit_args"]["type_one_side"],
+                data["exclude_types"],
+                ActivationFn(data["repinit_args"]["activation_function"]),
+            )
+            self.table_config = [
+                table_extrapolate,
+                table_stride_1,
+                table_stride_2,
+                check_frequency,
+            ]
+            self.lower, self.upper = self.table.build(
+                min_nbor_dist, table_extrapolate, table_stride_1, table_stride_2
+            )
+            self._store_compress_data()
+            self.geo_compress = True
+        else:
+            warnings.warn(
+                "Attention layer is not 0, only type embedding is compressed. "
+                "Geometric part is not compressed.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.geo_compress = False
+
+        self.compress = True
+
+    def _store_compress_data(self) -> None:
+        """Store tabulated data as buffers for the compressed geometric embedding."""
+        table_data = self.table.data
+        table_config = self.table_config
+        lower = self.lower
+        upper = self.upper
+        prec = self.repinit.mean.dtype
+
+        net_key = "filter_net"
+        info = torch.as_tensor(
+            [
+                lower[net_key],
+                upper[net_key],
+                upper[net_key] * table_config[0],
+                table_config[1],
+                table_config[2],
+                table_config[3],
+            ],
+            dtype=prec,
+            device="cpu",
+        )
+        tensor_data = table_data[net_key].to(dtype=prec)
+        self.compress_data = torch.nn.ParameterList(
+            [torch.nn.Parameter(tensor_data, requires_grad=False)]
+        )
+        self.compress_info = torch.nn.ParameterList(
+            [torch.nn.Parameter(info, requires_grad=False)]
+        )
+
+    def _store_type_embd_data(self) -> None:
+        """Precompute type embedding outputs for repinit and store as a buffer."""
+        with torch.no_grad():
+            # type_embedding.call() returns (ntypes+1) x tebd_dim (with padding)
+            full_embd = self.type_embedding.call()
+            nt, t_dim = full_embd.shape
+            ng = self.repinit.neuron[-1]
+
+            if self.repinit.type_one_side:
+                # One-side: only neighbor types
+                # (ntypes+1) x tebd_dim -> (ntypes+1) x ng
+                embd_tensor = self.repinit.embeddings_strip[0].call(full_embd).detach()
+            else:
+                # Two-side: all (ntypes+1)^2 type pair combinations
+                # Build [neighbor, center] combinations
+                embd_nei = full_embd.view(1, nt, t_dim).expand(nt, nt, t_dim)
+                embd_center = full_embd.view(nt, 1, t_dim).expand(nt, nt, t_dim)
+                two_side_embd = torch.cat([embd_nei, embd_center], dim=-1).reshape(
+                    -1, t_dim * 2
+                )
+                # ((ntypes+1)^2) x ng
+                embd_tensor = (
+                    self.repinit.embeddings_strip[0].call(two_side_embd).detach()
+                )
+
+            torch.nn.Module.register_buffer(self, "type_embd_data", embd_tensor)
+
+    @cast_precision
+    def call(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+    ) -> Any:
+        if not self.compress:
+            return DescrptDPA2DP.call.__wrapped__(
+                self, coord_ext, atype_ext, nlist, mapping
+            )
+        return self._call_compressed(coord_ext, atype_ext, nlist, mapping)
+
+    def _call_compressed(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+    ) -> Any:
+        """Compressed forward for DPA2 descriptor.
+
+        The repinit forward is done inline with compressed ops,
+        then the rest (g1_shape_transform, repformers, etc.) proceeds normally.
+        """
+        use_three_body = self.use_three_body
+        nframes, nloc, nnei = nlist.shape
+        nall = coord_ext.view(nframes, -1).shape[1] // 3
+
+        # Build multiple neighbor lists
+        nlist_dict = build_multiple_neighbor_list(
+            coord_ext,
+            nlist,
+            self.rcut_list,
+            self.nsel_list,
+        )
+
+        # Type embedding
+        type_embedding = self.type_embedding.call()
+        g1_ext = type_embedding[atype_ext.reshape(-1).to(torch.long)].reshape(
+            nframes, nall, self.tebd_dim
+        )
+        g1_inp = g1_ext[:, :nloc, :]
+
+        # Compressed repinit forward
+        nlist_repinit = nlist_dict[
+            get_multiple_nlist_key(self.repinit.get_rcut(), self.repinit.get_nsel())
+        ]
+        g1 = self._compressed_repinit_forward(
+            coord_ext, atype_ext, nlist_repinit, nframes, nloc, nall, type_embedding
+        )
+
+        # Three-body (not compressed, call normally)
+        if use_three_body:
+            assert self.repinit_three_body is not None
+            g1_three_body, __, __, __, __ = self.repinit_three_body(
+                nlist_dict[
+                    get_multiple_nlist_key(
+                        self.repinit_three_body.get_rcut(),
+                        self.repinit_three_body.get_nsel(),
+                    )
+                ],
+                coord_ext,
+                atype_ext,
+                g1_ext,
+                mapping,
+                type_embedding=type_embedding,
+            )
+            g1 = torch.cat([g1, g1_three_body], dim=-1)
+
+        # Linear to change shape
+        g1 = self.g1_shape_tranform(g1)
+        if self.add_tebd_to_repinit_out:
+            assert self.tebd_transform is not None
+            g1 = g1 + self.tebd_transform(g1_inp)
+
+        # Mapping g1 to extended region for repformers
+        assert mapping is not None
+        mapping_ext = mapping.view(nframes, nall, 1).expand(-1, -1, g1.shape[-1])
+        g1_ext = torch.gather(g1, 1, mapping_ext)
+
+        # Repformers (not compressed)
+        g1, g2, h2, rot_mat, sw = self.repformers(
+            nlist_dict[
+                get_multiple_nlist_key(
+                    self.repformers.get_rcut(), self.repformers.get_nsel()
+                )
+            ],
+            coord_ext,
+            atype_ext,
+            g1_ext,
+            mapping,
+        )
+
+        # Concat type embedding at output if needed
+        if self.concat_output_tebd:
+            g1 = torch.cat([g1, g1_inp], dim=-1)
+
+        return g1, rot_mat, g2, h2, sw
+
+    def _compressed_repinit_forward(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        nframes: int,
+        nloc: int,
+        nall: int,
+        type_embedding: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compressed forward for the repinit block.
+
+        Same logic as DPA1's _call_compressed but only produces the g1 output
+        (nf x nloc x (ng x axis_neuron)), without rot_mat/sw returns.
+
+        Parameters
+        ----------
+        coord_ext
+            Extended coordinates. shape: nf x (nall x 3)
+        atype_ext
+            Extended atom types. shape: nf x nall
+        nlist
+            Neighbor list for repinit. shape: nf x nloc x nnei_repinit
+        nframes
+            Number of frames.
+        nloc
+            Number of local atoms.
+        nall
+            Number of all atoms (local + ghost).
+        type_embedding
+            Full type embedding. shape: (ntypes+1) x tebd_dim
+
+        Returns
+        -------
+        torch.Tensor
+            Repinit output. shape: nf x nloc x (ng x axis_neuron)
+        """
+        # env_mat: nf x nloc x nnei x 4
+        rr, diff, sw = self.repinit.env_mat.call(
+            coord_ext,
+            atype_ext,
+            nlist,
+            self.repinit.mean[...],
+            self.repinit.stddev[...],
+        )
+        nf, nloc_r, nnei, _ = rr.shape
+        ng = self.repinit.neuron[-1]
+        nfnl = nf * nloc_r
+
+        # Exclude mask and nlist processing
+        exclude_mask = self.repinit.emask.build_type_exclude_mask(nlist, atype_ext)
+        exclude_mask = exclude_mask.view(nfnl, nnei)
+        nlist = nlist.view(nfnl, nnei)
+        exclude_mask = exclude_mask.to(torch.bool)
+        nlist = torch.where(exclude_mask, nlist, torch.full_like(nlist, -1))
+        nlist_mask = nlist != -1
+        nlist_masked = torch.where(nlist_mask, nlist, torch.zeros_like(nlist))
+        # nfnl x nnei x 1
+        sw = torch.where(
+            nlist_mask[:, :, None],
+            sw.view(nfnl, nnei, 1),
+            torch.zeros(nfnl, nnei, 1, dtype=sw.dtype, device=sw.device),
+        )
+
+        # nfnl x nnei x 4
+        rr = rr.view(nfnl, nnei, 4)
+        rr = rr * exclude_mask[:, :, None].to(rr.dtype)
+        # nfnl x nnei x 1
+        ss = rr[:, :, :1]
+
+        # Type embedding lookup from precomputed buffer
+        ntypes_with_padding = type_embedding.shape[0]
+        # nf x (nloc x nnei)
+        nlist_index = nlist_masked.view(nf, nloc_r * nnei)
+        # nf x (nloc x nnei)
+        nei_type = torch.gather(atype_ext, dim=1, index=nlist_index)
+
+        if self.repinit.type_one_side:
+            # (nf*nl*nnei,) -> (nf*nl*nnei, ng)
+            gg_t = self.type_embd_data[nei_type.view(-1).to(torch.long)]
+        else:
+            atype = atype_ext[:, :nloc_r]
+            idx_i = torch.tile(
+                atype.reshape(-1, 1) * ntypes_with_padding, [1, nnei]
+            ).view(-1)
+            idx_j = nei_type.view(-1)
+            idx = (idx_i + idx_j).to(torch.long)
+            # (nf x nl x nnei) x ng
+            gg_t = self.type_embd_data[idx]
+
+        # (nf x nl) x nnei x ng
+        gg_t = gg_t.view(nfnl, nnei, ng)
+        if self.repinit.smooth:
+            gg_t = gg_t * sw.view(nfnl, self.repinit.nnei, 1)
+
+        if self.geo_compress:
+            # Flatten for tabulate op
+            ss_flat = ss.reshape(-1, 1)
+            gg_t_flat = gg_t.reshape(-1, gg_t.size(-1))
+            is_sorted = len(self.repinit.exclude_types) == 0
+            xyz_scatter = torch.ops.deepmd.tabulate_fusion_se_atten(
+                self.compress_data[0].contiguous(),
+                self.compress_info[0].cpu().contiguous(),
+                ss_flat.contiguous(),
+                rr.contiguous(),
+                gg_t_flat.contiguous(),
+                self.repinit.neuron[-1],
+                is_sorted,
+            )[0]
+        else:
+            # No geometric compression, run embedding net + attention
+            # nfnl x nnei x ng
+            gg_s = self.repinit.embeddings[0].call(ss)
+            # nfnl x nnei x ng
+            gg = gg_s * gg_t + gg_s
+            input_r = torch.nn.functional.normalize(
+                rr.view(-1, self.repinit.nnei, 4)[:, :, 1:4], dim=-1
+            )
+            gg = self.repinit.dpa1_attention(gg, nlist_mask, input_r=input_r, sw=sw)
+            # nfnl x 4 x ng
+            xyz_scatter = torch.matmul(rr.permute(0, 2, 1), gg)
+
+        xyz_scatter = xyz_scatter / self.repinit.nnei
+        # nfnl x ng x 4
+        xyz_scatter_1 = xyz_scatter.permute(0, 2, 1)
+        # nfnl x 4 x axis_neuron
+        xyz_scatter_2 = xyz_scatter[:, :, 0 : self.repinit.axis_neuron]
+        # nfnl x ng x axis_neuron
+        result = torch.matmul(xyz_scatter_1, xyz_scatter_2)
+        # nf x nloc x (ng x axis_neuron)
+        result = result.view(nf, nloc_r, ng * self.repinit.axis_neuron)
+
+        return result

--- a/deepmd/pt_expt/descriptor/dpa2.py
+++ b/deepmd/pt_expt/descriptor/dpa2.py
@@ -163,7 +163,6 @@ class DescrptDPA2(DescrptDPA2DP):
             # type_embedding.call() returns (ntypes+1) x tebd_dim (with padding)
             full_embd = self.type_embedding.call()
             nt, t_dim = full_embd.shape
-            ng = self.repinit.neuron[-1]
 
             if self.repinit.type_one_side:
                 # One-side: only neighbor types
@@ -212,7 +211,7 @@ class DescrptDPA2(DescrptDPA2DP):
         then the rest (g1_shape_transform, repformers, etc.) proceeds normally.
         """
         use_three_body = self.use_three_body
-        nframes, nloc, nnei = nlist.shape
+        nframes, nloc, _nnei = nlist.shape
         nall = coord_ext.view(nframes, -1).shape[1] // 3
 
         # Build multiple neighbor lists
@@ -324,7 +323,7 @@ class DescrptDPA2(DescrptDPA2DP):
             Repinit output. shape: nf x nloc x (ng x axis_neuron)
         """
         # env_mat: nf x nloc x nnei x 4
-        rr, diff, sw = self.repinit.env_mat.call(
+        rr, _diff, sw = self.repinit.env_mat.call(
             coord_ext,
             atype_ext,
             nlist,

--- a/deepmd/pt_expt/descriptor/dpa2.py
+++ b/deepmd/pt_expt/descriptor/dpa2.py
@@ -66,9 +66,10 @@ class DescrptDPA2(DescrptDPA2DP):
 
         if self.compress:
             raise ValueError("Compression is already enabled.")
-        assert not self.repinit.resnet_dt, (
-            "Model compression error: repinit resnet_dt must be false!"
-        )
+        if self.repinit.resnet_dt:
+            raise RuntimeError(
+                "Model compression error: repinit resnet_dt must be false!"
+            )
         for tt in self.repinit.exclude_types:
             if (tt[0] not in range(self.repinit.ntypes)) or (
                 tt[1] not in range(self.repinit.ntypes)

--- a/deepmd/pt_expt/descriptor/se_atten_v2.py
+++ b/deepmd/pt_expt/descriptor/se_atten_v2.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
 
 from deepmd.dpmodel.descriptor.se_atten_v2 import DescrptSeAttenV2 as DescrptSeAttenV2DP
 from deepmd.pt_expt.common import (
@@ -15,4 +18,41 @@ from deepmd.pt_expt.utils.update_sel import (
 @BaseDescriptor.register("se_atten_v2")
 @torch_module
 class DescrptSeAttenV2(DescrptSeAttenV2DP):
+    """se_atten_v2 inherits from DPA1 in dpmodel, so compression reuses DPA1 methods."""
+
     _update_sel_cls = UpdateSel
+
+    def enable_compression(self, *args: Any, **kwargs: Any) -> None:
+        from deepmd.pt_expt.descriptor.dpa1 import (
+            DescrptDPA1,
+        )
+
+        return DescrptDPA1.enable_compression(self, *args, **kwargs)
+
+    def _store_compress_data(self) -> None:
+        from deepmd.pt_expt.descriptor.dpa1 import (
+            DescrptDPA1,
+        )
+
+        return DescrptDPA1._store_compress_data(self)
+
+    def _store_type_embd_data(self) -> None:
+        from deepmd.pt_expt.descriptor.dpa1 import (
+            DescrptDPA1,
+        )
+
+        return DescrptDPA1._store_type_embd_data(self)
+
+    def call(self, *args: Any, **kwargs: Any) -> Any:
+        from deepmd.pt_expt.descriptor.dpa1 import (
+            DescrptDPA1,
+        )
+
+        return DescrptDPA1.call(self, *args, **kwargs)
+
+    def _call_compressed(self, *args: Any, **kwargs: Any) -> Any:
+        from deepmd.pt_expt.descriptor.dpa1 import (
+            DescrptDPA1,
+        )
+
+        return DescrptDPA1._call_compressed(self, *args, **kwargs)

--- a/deepmd/pt_expt/descriptor/se_e2_a.py
+++ b/deepmd/pt_expt/descriptor/se_e2_a.py
@@ -130,7 +130,7 @@ class DescrptSeA(DescrptSeADP):
     ) -> Any:
         """Compressed forward using tabulate_fusion_se_a custom op."""
         # env_mat: nf x nloc x nnei x 4
-        rr, diff, ww = self.env_mat.call(
+        rr, _diff, ww = self.env_mat.call(
             coord_ext,
             atype_ext,
             nlist,
@@ -153,7 +153,7 @@ class DescrptSeA(DescrptSeADP):
 
         if self.type_one_side:
             for embedding_idx, (compress_data_ii, compress_info_ii) in enumerate(
-                zip(self.compress_data, self.compress_info)
+                zip(self.compress_data, self.compress_info, strict=True)
             ):
                 ii = embedding_idx
                 mm = exclude_mask[:, sec[ii] : sec[ii + 1]]
@@ -172,7 +172,7 @@ class DescrptSeA(DescrptSeADP):
         else:
             atype_loc = atype_ext[:, :nloc].reshape(nfnl)
             for embedding_idx, (compress_data_ii, compress_info_ii) in enumerate(
-                zip(self.compress_data, self.compress_info)
+                zip(self.compress_data, self.compress_info, strict=True)
             ):
                 ii = embedding_idx // self.ntypes
                 ti = embedding_idx % self.ntypes

--- a/deepmd/pt_expt/descriptor/se_e2_a.py
+++ b/deepmd/pt_expt/descriptor/se_e2_a.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
 
+import torch
+
+from deepmd.dpmodel.common import (
+    cast_precision,
+)
 from deepmd.dpmodel.descriptor.se_e2_a import DescrptSeA as DescrptSeADP
 from deepmd.pt_expt.common import (
     torch_module,
@@ -17,3 +25,177 @@ from deepmd.pt_expt.utils.update_sel import (
 @torch_module
 class DescrptSeA(DescrptSeADP):
     _update_sel_cls = UpdateSel
+
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        from deepmd.pt.utils.utils import (
+            ActivationFn,
+        )
+        from deepmd.pt_expt.utils.tabulate import (
+            DPTabulate,
+        )
+
+        if self.compress:
+            raise ValueError("Compression is already enabled.")
+        data = self.serialize()
+        self.table = DPTabulate(
+            self,
+            data["neuron"],
+            data["type_one_side"],
+            data["exclude_types"],
+            ActivationFn(data["activation_function"]),
+        )
+        self.table_config = [
+            table_extrapolate,
+            table_stride_1,
+            table_stride_2,
+            check_frequency,
+        ]
+        self.lower, self.upper = self.table.build(
+            min_nbor_dist, table_extrapolate, table_stride_1, table_stride_2
+        )
+        self._store_compress_data()
+        self.compress = True
+
+    def _store_compress_data(self) -> None:
+        """Store tabulated data as buffers for the compressed forward path."""
+        table_data = self.table.data
+        table_config = self.table_config
+        lower = self.lower
+        upper = self.upper
+        prec = self.davg.dtype
+
+        compress_data_list = []
+        compress_info_list = []
+
+        ndim = 1 if self.type_one_side else 2
+        n_networks = self.ntypes**ndim
+        for embedding_idx in range(n_networks):
+            if self.type_one_side:
+                ii = embedding_idx
+                ti = -1
+            else:
+                ii = embedding_idx // self.ntypes
+                ti = embedding_idx % self.ntypes
+            if self.type_one_side:
+                net = "filter_-1_net_" + str(ii)
+            else:
+                net = "filter_" + str(ti) + "_net_" + str(ii)
+            info_ii = torch.as_tensor(
+                [
+                    lower[net],
+                    upper[net],
+                    upper[net] * table_config[0],
+                    table_config[1],
+                    table_config[2],
+                    table_config[3],
+                ],
+                dtype=prec,
+                device="cpu",
+            )
+            tensor_data_ii = table_data[net].to(dtype=prec)
+            compress_data_list.append(
+                torch.nn.Parameter(tensor_data_ii, requires_grad=False)
+            )
+            compress_info_list.append(torch.nn.Parameter(info_ii, requires_grad=False))
+        self.compress_data = torch.nn.ParameterList(compress_data_list)
+        self.compress_info = torch.nn.ParameterList(compress_info_list)
+
+    @cast_precision
+    def call(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+    ) -> Any:
+        if not self.compress:
+            return DescrptSeADP.call.__wrapped__(
+                self, coord_ext, atype_ext, nlist, mapping
+            )
+        return self._call_compressed(coord_ext, atype_ext, nlist)
+
+    def _call_compressed(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+    ) -> Any:
+        """Compressed forward using tabulate_fusion_se_a custom op."""
+        # env_mat: nf x nloc x nnei x 4
+        rr, diff, ww = self.env_mat.call(
+            coord_ext,
+            atype_ext,
+            nlist,
+            self.davg[...],
+            self.dstd[...],
+        )
+        nf, nloc, nnei, _ = rr.shape
+        sec = self.sel_cumsum
+        ng = self.neuron[-1]
+
+        nfnl = nf * nloc
+        xyz_scatter = torch.zeros(
+            [nfnl, 4, ng],
+            dtype=coord_ext.dtype,
+            device=coord_ext.device,
+        )
+        exclude_mask = self.emask.build_type_exclude_mask(nlist, atype_ext)
+        exclude_mask = exclude_mask.view(nfnl, nnei)
+        rr = rr.view(nfnl, nnei, 4)
+
+        if self.type_one_side:
+            for embedding_idx, (compress_data_ii, compress_info_ii) in enumerate(
+                zip(self.compress_data, self.compress_info)
+            ):
+                ii = embedding_idx
+                mm = exclude_mask[:, sec[ii] : sec[ii + 1]]
+                rr_i = rr[:, sec[ii] : sec[ii + 1], :]
+                rr_i = rr_i * mm[:, :, None]
+                ss = rr_i[:, :, :1]
+                ss = ss.reshape(-1, 1)
+                gr = torch.ops.deepmd.tabulate_fusion_se_a(
+                    compress_data_ii.contiguous(),
+                    compress_info_ii.cpu().contiguous(),
+                    ss.contiguous(),
+                    rr_i.contiguous(),
+                    ng,
+                )[0]
+                xyz_scatter += gr
+        else:
+            atype_loc = atype_ext[:, :nloc].reshape(nfnl)
+            for embedding_idx, (compress_data_ii, compress_info_ii) in enumerate(
+                zip(self.compress_data, self.compress_info)
+            ):
+                ii = embedding_idx // self.ntypes
+                ti = embedding_idx % self.ntypes
+                ti_mask = atype_loc.eq(ti)
+                mm = exclude_mask[ti_mask, sec[ii] : sec[ii + 1]]
+                rr_i = rr[ti_mask, sec[ii] : sec[ii + 1], :]
+                rr_i = rr_i * mm[:, :, None]
+                ss = rr_i[:, :, :1]
+                ss = ss.reshape(-1, 1)
+                gr = torch.ops.deepmd.tabulate_fusion_se_a(
+                    compress_data_ii.contiguous(),
+                    compress_info_ii.cpu().contiguous(),
+                    ss.contiguous(),
+                    rr_i.contiguous(),
+                    ng,
+                )[0]
+                xyz_scatter[ti_mask] += gr
+
+        xyz_scatter /= self.nnei
+        xyz_scatter_1 = xyz_scatter.permute(0, 2, 1)
+        rot_mat = xyz_scatter_1[:, :, 1:4]
+        xyz_scatter_2 = xyz_scatter[:, :, 0 : self.axis_neuron]
+        result = torch.matmul(xyz_scatter_1, xyz_scatter_2)
+        result = result.view(nf, nloc, ng * self.axis_neuron)
+        rot_mat = rot_mat.view(nf, nloc, ng, 3)
+        return result, rot_mat, None, None, ww

--- a/deepmd/pt_expt/descriptor/se_r.py
+++ b/deepmd/pt_expt/descriptor/se_r.py
@@ -119,7 +119,7 @@ class DescrptSeR(DescrptSeRDP):
     ) -> Any:
         """Compressed forward using tabulate_fusion_se_r custom op."""
         # env_mat: nf x nloc x nnei x 1 (radial only)
-        rr, diff, ww = self.env_mat.call(
+        rr, _diff, ww = self.env_mat.call(
             coord_ext,
             atype_ext,
             nlist,
@@ -138,7 +138,7 @@ class DescrptSeR(DescrptSeRDP):
 
         xyz_scatter_total = []
         for ii, (compress_data_ii, compress_info_ii) in enumerate(
-            zip(self.compress_data, self.compress_info)
+            zip(self.compress_data, self.compress_info, strict=True)
         ):
             mm = exclude_mask[:, sec[ii] : sec[ii + 1]]
             ss = rr[:, sec[ii] : sec[ii + 1], :]

--- a/deepmd/pt_expt/descriptor/se_r.py
+++ b/deepmd/pt_expt/descriptor/se_r.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
 
+import torch
+
+from deepmd.dpmodel.common import (
+    cast_precision,
+)
 from deepmd.dpmodel.descriptor.se_r import DescrptSeR as DescrptSeRDP
 from deepmd.pt_expt.common import (
     torch_module,
@@ -17,3 +25,135 @@ from deepmd.pt_expt.utils.update_sel import (
 @torch_module
 class DescrptSeR(DescrptSeRDP):
     _update_sel_cls = UpdateSel
+
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        from deepmd.pt.utils.utils import (
+            ActivationFn,
+        )
+        from deepmd.pt_expt.utils.tabulate import (
+            DPTabulate,
+        )
+
+        if self.compress:
+            raise ValueError("Compression is already enabled.")
+        data = self.serialize()
+        self.table = DPTabulate(
+            self,
+            data["neuron"],
+            data["type_one_side"],
+            data["exclude_types"],
+            ActivationFn(data["activation_function"]),
+        )
+        self.table_config = [
+            table_extrapolate,
+            table_stride_1,
+            table_stride_2,
+            check_frequency,
+        ]
+        self.lower, self.upper = self.table.build(
+            min_nbor_dist, table_extrapolate, table_stride_1, table_stride_2
+        )
+        self._store_compress_data()
+        self.compress = True
+
+    def _store_compress_data(self) -> None:
+        """Store tabulated data as buffers for the compressed forward path."""
+        table_data = self.table.data
+        table_config = self.table_config
+        lower = self.lower
+        upper = self.upper
+        prec = self.davg.dtype
+
+        compress_data_list = []
+        compress_info_list = []
+
+        for ii in range(self.ntypes):
+            net = "filter_-1_net_" + str(ii)
+            info_ii = torch.as_tensor(
+                [
+                    lower[net],
+                    upper[net],
+                    upper[net] * table_config[0],
+                    table_config[1],
+                    table_config[2],
+                    table_config[3],
+                ],
+                dtype=prec,
+                device="cpu",
+            )
+            tensor_data_ii = table_data[net].to(dtype=prec)
+            compress_data_list.append(
+                torch.nn.Parameter(tensor_data_ii, requires_grad=False)
+            )
+            compress_info_list.append(torch.nn.Parameter(info_ii, requires_grad=False))
+        self.compress_data = torch.nn.ParameterList(compress_data_list)
+        self.compress_info = torch.nn.ParameterList(compress_info_list)
+
+    @cast_precision
+    def call(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+    ) -> Any:
+        if not self.compress:
+            return DescrptSeRDP.call.__wrapped__(
+                self, coord_ext, atype_ext, nlist, mapping
+            )
+        return self._call_compressed(coord_ext, atype_ext, nlist)
+
+    def _call_compressed(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+    ) -> Any:
+        """Compressed forward using tabulate_fusion_se_r custom op."""
+        # env_mat: nf x nloc x nnei x 1 (radial only)
+        rr, diff, ww = self.env_mat.call(
+            coord_ext,
+            atype_ext,
+            nlist,
+            self.davg[...],
+            self.dstd[...],
+            True,
+        )
+        nf, nloc, nnei, _ = rr.shape
+        sec = self.sel_cumsum
+        ng = self.neuron[-1]
+        nfnl = nf * nloc
+
+        exclude_mask = self.emask.build_type_exclude_mask(nlist, atype_ext)
+        exclude_mask = exclude_mask.view(nfnl, nnei)
+        rr = rr.view(nfnl, nnei, 1)
+
+        xyz_scatter_total = []
+        for ii, (compress_data_ii, compress_info_ii) in enumerate(
+            zip(self.compress_data, self.compress_info)
+        ):
+            mm = exclude_mask[:, sec[ii] : sec[ii + 1]]
+            ss = rr[:, sec[ii] : sec[ii + 1], :]
+            ss = ss * mm[:, :, None]
+            ss = ss.squeeze(-1)
+            xyz_scatter = torch.ops.deepmd.tabulate_fusion_se_r(
+                compress_data_ii.contiguous(),
+                compress_info_ii.cpu().contiguous(),
+                ss,
+                ng,
+            )[0]
+            xyz_scatter_total.append(xyz_scatter)
+
+        res_rescale = 1.0 / 5.0
+        xyz_scatter = torch.cat(xyz_scatter_total, dim=1)
+        result = torch.mean(xyz_scatter, dim=1) * res_rescale
+        result = result.view(nf, nloc, ng)
+        return result, None, None, None, ww

--- a/deepmd/pt_expt/descriptor/se_t.py
+++ b/deepmd/pt_expt/descriptor/se_t.py
@@ -130,7 +130,7 @@ class DescrptSeT(DescrptSeTDP):
     ) -> Any:
         """Compressed forward using tabulate_fusion_se_t custom op."""
         # env_mat: nf x nloc x nnei x 4
-        rr, diff, ww = self.env_mat.call(
+        rr, _diff, ww = self.env_mat.call(
             coord_ext,
             atype_ext,
             nlist,
@@ -152,7 +152,7 @@ class DescrptSeT(DescrptSeTDP):
         rr = rr.view(nfnl, nnei, 4)
 
         for embedding_idx, (compress_data_ii, compress_info_ii) in enumerate(
-            zip(self.compress_data, self.compress_info)
+            zip(self.compress_data, self.compress_info, strict=True)
         ):
             ti = embedding_idx % self.ntypes
             tj = embedding_idx // self.ntypes

--- a/deepmd/pt_expt/descriptor/se_t.py
+++ b/deepmd/pt_expt/descriptor/se_t.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
 
+import torch
+
+from deepmd.dpmodel.common import (
+    cast_precision,
+)
 from deepmd.dpmodel.descriptor.se_t import DescrptSeT as DescrptSeTDP
 from deepmd.pt_expt.common import (
     torch_module,
@@ -18,3 +26,159 @@ from deepmd.pt_expt.utils.update_sel import (
 @torch_module
 class DescrptSeT(DescrptSeTDP):
     _update_sel_cls = UpdateSel
+
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        from deepmd.pt.utils.utils import (
+            ActivationFn,
+        )
+        from deepmd.pt_expt.utils.tabulate import (
+            DPTabulate,
+        )
+
+        if self.compress:
+            raise ValueError("Compression is already enabled.")
+        data = self.serialize()
+        self.table = DPTabulate(
+            self,
+            data["neuron"],
+            exclude_types=data["exclude_types"],
+            activation_fn=ActivationFn(data["activation_function"]),
+        )
+        # SE_T scales strides by 10
+        stride_1_scaled = table_stride_1 * 10
+        stride_2_scaled = table_stride_2 * 10
+        self.table_config = [
+            table_extrapolate,
+            stride_1_scaled,
+            stride_2_scaled,
+            check_frequency,
+        ]
+        self.lower, self.upper = self.table.build(
+            min_nbor_dist, table_extrapolate, stride_1_scaled, stride_2_scaled
+        )
+        self._store_compress_data()
+        self.compress = True
+
+    def _store_compress_data(self) -> None:
+        """Store tabulated data as buffers for the compressed forward path."""
+        table_data = self.table.data
+        table_config = self.table_config
+        lower = self.lower
+        upper = self.upper
+        prec = self.davg.dtype
+
+        compress_data_list = []
+        compress_info_list = []
+
+        n_networks = self.ntypes * self.ntypes
+        for embedding_idx in range(n_networks):
+            ti = embedding_idx % self.ntypes
+            tj = embedding_idx // self.ntypes
+            if ti <= tj:
+                net = "filter_" + str(ti) + "_net_" + str(tj)
+                info_ii = torch.as_tensor(
+                    [
+                        lower[net],
+                        upper[net],
+                        upper[net] * table_config[0],
+                        table_config[1],
+                        table_config[2],
+                        table_config[3],
+                    ],
+                    dtype=prec,
+                    device="cpu",
+                )
+                tensor_data_ii = table_data[net].to(dtype=prec)
+            else:
+                # Placeholder for ti > tj (not used, but keeps indexing consistent)
+                info_ii = torch.zeros(6, dtype=prec, device="cpu")
+                tensor_data_ii = torch.zeros(0, dtype=prec, device="cpu")
+            compress_data_list.append(
+                torch.nn.Parameter(tensor_data_ii, requires_grad=False)
+            )
+            compress_info_list.append(torch.nn.Parameter(info_ii, requires_grad=False))
+        self.compress_data = torch.nn.ParameterList(compress_data_list)
+        self.compress_info = torch.nn.ParameterList(compress_info_list)
+
+    @cast_precision
+    def call(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+    ) -> Any:
+        if not self.compress:
+            return DescrptSeTDP.call.__wrapped__(
+                self, coord_ext, atype_ext, nlist, mapping
+            )
+        return self._call_compressed(coord_ext, atype_ext, nlist)
+
+    def _call_compressed(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+    ) -> Any:
+        """Compressed forward using tabulate_fusion_se_t custom op."""
+        # env_mat: nf x nloc x nnei x 4
+        rr, diff, ww = self.env_mat.call(
+            coord_ext,
+            atype_ext,
+            nlist,
+            self.davg[...],
+            self.dstd[...],
+        )
+        nf, nloc, nnei, _ = rr.shape
+        sec = self.sel_cumsum
+        ng = self.neuron[-1]
+        nfnl = nf * nloc
+
+        result = torch.zeros(
+            [nfnl, ng],
+            dtype=coord_ext.dtype,
+            device=coord_ext.device,
+        )
+        exclude_mask = self.emask.build_type_exclude_mask(nlist, atype_ext)
+        exclude_mask = exclude_mask.view(nfnl, nnei)
+        rr = rr.view(nfnl, nnei, 4)
+
+        for embedding_idx, (compress_data_ii, compress_info_ii) in enumerate(
+            zip(self.compress_data, self.compress_info)
+        ):
+            ti = embedding_idx % self.ntypes
+            tj = embedding_idx // self.ntypes
+            if ti <= tj:
+                nei_type_i = self.sel[tj]
+                nei_type_j = self.sel[ti]
+                # nfnl x nt_i x 3
+                rr_i = rr[:, sec[ti] : sec[ti + 1], 1:]
+                mm_i = exclude_mask[:, sec[ti] : sec[ti + 1]]
+                rr_i = rr_i * mm_i[:, :, None]
+                # nfnl x nt_j x 3
+                rr_j = rr[:, sec[tj] : sec[tj + 1], 1:]
+                mm_j = exclude_mask[:, sec[tj] : sec[tj + 1]]
+                rr_j = rr_j * mm_j[:, :, None]
+                # nfnl x nt_i x nt_j
+                env_ij = torch.einsum("ijm,ikm->ijk", rr_i, rr_j)
+                ebd_env_ij = env_ij.view(-1, 1)
+                res_ij = torch.ops.deepmd.tabulate_fusion_se_t(
+                    compress_data_ii.contiguous(),
+                    compress_info_ii.cpu().contiguous(),
+                    ebd_env_ij.contiguous(),
+                    env_ij.contiguous(),
+                    ng,
+                )[0]
+                res_ij = res_ij * (1.0 / float(nei_type_i) / float(nei_type_j))
+                result += res_ij
+
+        result = result.view(nf, nloc, ng)
+        return result, None, None, None, ww

--- a/deepmd/pt_expt/descriptor/se_t_tebd.py
+++ b/deepmd/pt_expt/descriptor/se_t_tebd.py
@@ -156,7 +156,7 @@ class DescrptSeTTebd(DescrptSeTTebdDP):
     ) -> Any:
         """Compressed forward using tabulate_fusion_se_t_tebd custom op."""
         # env_mat: nf x nloc x nnei x 4
-        rr, diff, sw = self.se_ttebd.env_mat.call(
+        rr, _diff, sw = self.se_ttebd.env_mat.call(
             coord_ext,
             atype_ext,
             nlist,

--- a/deepmd/pt_expt/descriptor/se_t_tebd.py
+++ b/deepmd/pt_expt/descriptor/se_t_tebd.py
@@ -243,4 +243,4 @@ class DescrptSeTTebd(DescrptSeTTebdDP):
                 [result, atype_embd.view(nf, nloc, self.tebd_dim)], dim=-1
             )
 
-        return result, None, None, None, sw
+        return result, None, None, None, sw.view(nf, nloc, nnei, 1)

--- a/deepmd/pt_expt/descriptor/se_t_tebd.py
+++ b/deepmd/pt_expt/descriptor/se_t_tebd.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    Any,
+)
 
+import torch
+
+from deepmd.dpmodel.common import (
+    cast_precision,
+)
 from deepmd.dpmodel.descriptor.se_t_tebd import DescrptSeTTebd as DescrptSeTTebdDP
 from deepmd.pt_expt.common import (
     torch_module,
@@ -16,3 +24,223 @@ from deepmd.pt_expt.utils.update_sel import (
 @torch_module
 class DescrptSeTTebd(DescrptSeTTebdDP):
     _update_sel_cls = UpdateSel
+
+    def enable_compression(
+        self,
+        min_nbor_dist: float,
+        table_extrapolate: float = 5,
+        table_stride_1: float = 0.01,
+        table_stride_2: float = 0.1,
+        check_frequency: int = -1,
+    ) -> None:
+        """Enable compression for the SE_T_TEBD descriptor.
+
+        Parameters
+        ----------
+        min_nbor_dist
+            The nearest distance between atoms
+        table_extrapolate
+            The scale of model extrapolation
+        table_stride_1
+            The uniform stride of the first table
+        table_stride_2
+            The uniform stride of the second table
+        check_frequency
+            The overflow check frequency
+        """
+        from deepmd.pt.utils.utils import (
+            ActivationFn,
+        )
+        from deepmd.pt_expt.utils.tabulate import (
+            DPTabulate,
+        )
+
+        if self.compress:
+            raise ValueError("Compression is already enabled.")
+        if self.se_ttebd.tebd_input_mode != "strip":
+            raise RuntimeError("Cannot compress model when tebd_input_mode != 'strip'")
+
+        data = self.serialize()
+        self.table = DPTabulate(
+            self,
+            data["neuron"],
+            exclude_types=data["exclude_types"],
+            activation_fn=ActivationFn(data["activation_function"]),
+        )
+        # SE_T scales strides by 10
+        stride_1_scaled = table_stride_1 * 10
+        stride_2_scaled = table_stride_2 * 10
+        self.table_config = [
+            table_extrapolate,
+            stride_1_scaled,
+            stride_2_scaled,
+            check_frequency,
+        ]
+        self.lower, self.upper = self.table.build(
+            min_nbor_dist, table_extrapolate, stride_1_scaled, stride_2_scaled
+        )
+
+        # Store geometric embedding compress data
+        self._store_compress_data()
+
+        # Precompute type embedding data
+        self._store_type_embd_data()
+
+        self.compress = True
+
+    def _store_compress_data(self) -> None:
+        """Store tabulated data as buffers for the compressed forward path."""
+        table_data = self.table.data
+        table_config = self.table_config
+        lower = self.lower
+        upper = self.upper
+        prec = self.se_ttebd.mean.dtype
+
+        net_key = "filter_net"
+        info = torch.as_tensor(
+            [
+                lower[net_key],
+                upper[net_key],
+                upper[net_key] * table_config[0],
+                table_config[1],
+                table_config[2],
+                table_config[3],
+            ],
+            dtype=prec,
+            device="cpu",
+        )
+        tensor_data = table_data[net_key].to(dtype=prec)
+        self.compress_data = torch.nn.ParameterList(
+            [torch.nn.Parameter(tensor_data, requires_grad=False)]
+        )
+        self.compress_info = torch.nn.ParameterList(
+            [torch.nn.Parameter(info, requires_grad=False)]
+        )
+
+    def _store_type_embd_data(self) -> None:
+        """Precompute type embedding pairs and store as a buffer."""
+        with torch.no_grad():
+            # type_embedding.call() returns (ntypes+1) x tebd_dim (with padding)
+            full_embd = self.type_embedding.call()
+            nt, t_dim = full_embd.shape
+            # Build all (i, j) type embedding pairs
+            type_embedding_i = full_embd.view(nt, 1, t_dim).expand(nt, nt, t_dim)
+            type_embedding_j = full_embd.view(1, nt, t_dim).expand(nt, nt, t_dim)
+            two_side = torch.cat([type_embedding_i, type_embedding_j], dim=-1).reshape(
+                -1, t_dim * 2
+            )
+            # Run through the strip embedding network
+            embd_tensor = self.se_ttebd.embeddings_strip[0].call(two_side).detach()
+            torch.nn.Module.register_buffer(self, "type_embd_data", embd_tensor)
+
+    @cast_precision
+    def call(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+        mapping: torch.Tensor | None = None,
+        fparam: torch.Tensor | None = None,
+    ) -> Any:
+        if not self.compress:
+            return DescrptSeTTebdDP.call.__wrapped__(
+                self, coord_ext, atype_ext, nlist, mapping
+            )
+        return self._call_compressed(coord_ext, atype_ext, nlist)
+
+    def _call_compressed(
+        self,
+        coord_ext: torch.Tensor,
+        atype_ext: torch.Tensor,
+        nlist: torch.Tensor,
+    ) -> Any:
+        """Compressed forward using tabulate_fusion_se_t_tebd custom op."""
+        # env_mat: nf x nloc x nnei x 4
+        rr, diff, sw = self.se_ttebd.env_mat.call(
+            coord_ext,
+            atype_ext,
+            nlist,
+            self.se_ttebd.mean[...],
+            self.se_ttebd.stddev[...],
+        )
+        nf, nloc, nnei, _ = rr.shape
+        ng = self.se_ttebd.neuron[-1]
+        nfnl = nf * nloc
+
+        # Exclude mask and nlist processing
+        exclude_mask = self.se_ttebd.emask.build_type_exclude_mask(nlist, atype_ext)
+        exclude_mask = exclude_mask.view(nfnl, nnei)
+        nlist = nlist.view(nfnl, nnei)
+        exclude_mask = exclude_mask.to(torch.bool)
+        nlist = torch.where(exclude_mask, nlist, torch.full_like(nlist, -1))
+        nlist_mask = nlist != -1
+        # nfnl x nnei x 1
+        sw = torch.where(
+            nlist_mask[:, :, None],
+            sw.view(nfnl, nnei, 1),
+            torch.zeros(nfnl, nnei, 1, dtype=sw.dtype, device=sw.device),
+        )
+
+        # nfnl x nnei x 4
+        rr = rr.view(nfnl, nnei, 4)
+        rr = rr * exclude_mask[:, :, None].to(rr.dtype)
+        # nfnl x nnei x 3
+        rr_i = rr[:, :, 1:]
+        # nfnl x nnei x nnei
+        env_ij = torch.einsum("ijm,ikm->ijk", rr_i, rr_i)
+
+        # Geometric embedding via tabulation
+        ebd_env_ij = env_ij.view(-1, 1)
+        gg_s = torch.ops.deepmd.tabulate_fusion_se_t_tebd(
+            self.compress_data[0].contiguous(),
+            self.compress_info[0].cpu().contiguous(),
+            ebd_env_ij.contiguous(),
+            env_ij.contiguous(),
+            ng,
+        )[0]
+        # nfnl x nnei x nnei x ng
+        gg_s = gg_s.view(nfnl, nnei, nnei, ng)
+
+        # Type embedding lookup from precomputed buffer
+        nlist_masked = torch.where(nlist_mask, nlist, torch.zeros_like(nlist))
+        type_embedding = self.type_embedding.call()
+        ntypes_with_padding = type_embedding.shape[0]
+        # nf x (nloc x nnei)
+        nlist_index = nlist_masked.view(nf, nloc * nnei)
+        # nf x (nloc x nnei)
+        nei_type = torch.gather(atype_ext, dim=1, index=nlist_index)
+        # nfnl x nnei
+        nei_type = nei_type.view(nfnl, nnei)
+        # nfnl x nnei x nnei
+        nei_type_i = nei_type.unsqueeze(2).expand(-1, -1, nnei)
+        nei_type_j = nei_type.unsqueeze(1).expand(-1, nnei, -1)
+        idx = (nei_type_i * ntypes_with_padding + nei_type_j).reshape(-1).to(torch.long)
+
+        # (nfnl x nnei x nnei) x ng
+        gg_t = self.type_embd_data[idx]
+        # nfnl x nnei x nnei x ng
+        gg_t = gg_t.view(nfnl, nnei, nnei, ng)
+        if self.se_ttebd.smooth:
+            gg_t = gg_t * sw.view(nfnl, nnei, 1, 1) * sw.view(nfnl, 1, nnei, 1)
+
+        # Combine geometric and type embeddings: gg_s * (1 + gg_t)
+        gg = gg_s * gg_t + gg_s
+
+        # Contract: nfnl x ng
+        res_ij = torch.einsum("ijk,ijkm->im", env_ij, gg)
+        res_ij = res_ij * (1.0 / float(nnei) / float(nnei))
+        # nf x nloc x ng
+        result = res_ij.view(nf, nloc, ng)
+
+        # Concat type embedding at output if needed
+        nall = coord_ext.view(nf, -1).shape[1] // 3
+        if self.concat_output_tebd:
+            atype_embd_ext = type_embedding[atype_ext.reshape(-1)].view(
+                nf, nall, self.tebd_dim
+            )
+            atype_embd = atype_embd_ext[:, :nloc, :]
+            result = torch.cat(
+                [result, atype_embd.view(nf, nloc, self.tebd_dim)], dim=-1
+            )
+
+        return result, None, None, None, sw

--- a/deepmd/pt_expt/entrypoints/compress.py
+++ b/deepmd/pt_expt/entrypoints/compress.py
@@ -48,6 +48,8 @@ def enable_compression(
     # 2. Get or compute min_nbor_dist
     min_nbor_dist = model.get_min_nbor_dist()
     if min_nbor_dist is None:
+        min_nbor_dist = model_dict.get("min_nbor_dist")
+    if min_nbor_dist is None:
         log.info(
             "Minimal neighbor distance is not saved in the model, "
             "compute it from the training data."
@@ -83,10 +85,7 @@ def enable_compression(
         update_sel = UpdateSel()
         min_nbor_dist = update_sel.get_min_nbor_dist(train_data)
 
-    if isinstance(min_nbor_dist, (int, float)):
-        min_nbor_dist_val = float(min_nbor_dist)
-    else:
-        min_nbor_dist_val = float(min_nbor_dist.item())
+    model.min_nbor_dist = min_nbor_dist
 
     # 3. Enable compression
     log.info("Enabling compression...")
@@ -99,9 +98,8 @@ def enable_compression(
 
     # 4. Re-serialize and export
     log.info("Re-serializing compressed model...")
-    new_model_dict = model.serialize()
     data = {
-        "model": new_model_dict,
+        "model": model.serialize(),
         "model_def_script": model_dict.get("model_def_script"),
     }
     deserialize_to_file(output, data)

--- a/deepmd/pt_expt/entrypoints/compress.py
+++ b/deepmd/pt_expt/entrypoints/compress.py
@@ -101,6 +101,7 @@ def enable_compression(
     data = {
         "model": model.serialize(),
         "model_def_script": model_dict.get("model_def_script"),
+        "min_nbor_dist": float(min_nbor_dist),
     }
     deserialize_to_file(output, data)
     log.info("Compressed model saved to %s", output)

--- a/deepmd/pt_expt/entrypoints/compress.py
+++ b/deepmd/pt_expt/entrypoints/compress.py
@@ -87,7 +87,14 @@ def enable_compression(
 
     model.min_nbor_dist = min_nbor_dist
 
-    # 3. Enable compression
+    # 3. Enable compression (also ensures fake ops are registered now that
+    #    the C++ custom op library is loaded via enable_compression imports)
+    from deepmd.pt_expt.utils.tabulate_ops import (
+        ensure_fake_registered,
+    )
+
+    ensure_fake_registered()
+
     log.info("Enabling compression...")
     model.enable_compression(
         extrapolate,

--- a/deepmd/pt_expt/entrypoints/compress.py
+++ b/deepmd/pt_expt/entrypoints/compress.py
@@ -96,12 +96,25 @@ def enable_compression(
         check_frequency,
     )
 
-    # 4. Re-serialize and export
-    log.info("Re-serializing compressed model...")
-    data = {
-        "model": model.serialize(),
+    # 4. Serialize the compressed model dict (includes tabulated data)
+    compressed_model_dict = model.serialize()
+
+    # 5. Re-export: trace an UNCOMPRESSED model for the exported program
+    #    (make_fx cannot trace through custom tabulate ops), but store
+    #    the full compressed dict in model.json so that deserialize()
+    #    restores compression state.
+    log.info("Re-exporting compressed model...")
+    uncompressed_data = {
+        "model": model_dict["model"],  # original uncompressed model
         "model_def_script": model_dict.get("model_def_script"),
-        "min_nbor_dist": float(min_nbor_dist),
     }
-    deserialize_to_file(output, data)
+    deserialize_to_file(
+        output,
+        uncompressed_data,
+        model_json_override={
+            "model": compressed_model_dict,
+            "model_def_script": model_dict.get("model_def_script"),
+            "min_nbor_dist": float(min_nbor_dist),
+        },
+    )
     log.info("Compressed model saved to %s", output)

--- a/deepmd/pt_expt/entrypoints/compress.py
+++ b/deepmd/pt_expt/entrypoints/compress.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Compress a pt_expt model (.pte) by tabulating embedding nets."""
+
+import logging
+
+from deepmd.pt_expt.utils.serialization import (
+    deserialize_to_file,
+    serialize_from_file,
+)
+
+log = logging.getLogger(__name__)
+
+
+def enable_compression(
+    input_file: str,
+    output: str,
+    stride: float = 0.01,
+    extrapolate: int = 5,
+    check_frequency: int = -1,
+    training_script: str | None = None,
+) -> None:
+    """Compress a .pte model by tabulating embedding nets.
+
+    Parameters
+    ----------
+    input_file : str
+        Path to the input .pte model file.
+    output : str
+        Path to the output compressed .pte model file.
+    stride : float
+        The uniform stride of the first table.
+    extrapolate : int
+        The scale of model extrapolation.
+    check_frequency : int
+        The overflow check frequency.
+    training_script : str or None
+        Path to training script, used to compute min_nbor_dist if not
+        stored in the model.
+    """
+    from deepmd.pt_expt.model.model import (
+        BaseModel,
+    )
+
+    # 1. Load the .pte model
+    model_dict = serialize_from_file(input_file)
+    model = BaseModel.deserialize(model_dict["model"])
+
+    # 2. Get or compute min_nbor_dist
+    min_nbor_dist = model.get_min_nbor_dist()
+    if min_nbor_dist is None:
+        log.info(
+            "Minimal neighbor distance is not saved in the model, "
+            "compute it from the training data."
+        )
+        if training_script is None:
+            raise ValueError(
+                "The model does not have a minimum neighbor distance, "
+                "so the training script and data must be provided "
+                "(via -t,--training-script)."
+            )
+        from deepmd.common import (
+            j_loader,
+        )
+        from deepmd.pt_expt.utils.update_sel import (
+            UpdateSel,
+        )
+        from deepmd.utils.compat import (
+            update_deepmd_input,
+        )
+        from deepmd.utils.data_system import (
+            get_data,
+        )
+
+        jdata = j_loader(training_script)
+        jdata = update_deepmd_input(jdata)
+        type_map = jdata["model"].get("type_map", None)
+        train_data = get_data(
+            jdata["training"]["training_data"],
+            0,
+            type_map,
+            None,
+        )
+        update_sel = UpdateSel()
+        min_nbor_dist = update_sel.get_min_nbor_dist(train_data)
+
+    if isinstance(min_nbor_dist, (int, float)):
+        min_nbor_dist_val = float(min_nbor_dist)
+    else:
+        min_nbor_dist_val = float(min_nbor_dist.item())
+
+    # 3. Enable compression
+    log.info("Enabling compression...")
+    model.enable_compression(
+        extrapolate,
+        stride,
+        stride * 10,
+        check_frequency,
+    )
+
+    # 4. Re-serialize and export
+    log.info("Re-serializing compressed model...")
+    new_model_dict = model.serialize()
+    data = {
+        "model": new_model_dict,
+        "model_def_script": model_dict.get("model_def_script"),
+    }
+    deserialize_to_file(output, data)
+    log.info("Compressed model saved to %s", output)

--- a/deepmd/pt_expt/entrypoints/main.py
+++ b/deepmd/pt_expt/entrypoints/main.py
@@ -195,6 +195,19 @@ def main(args: list[str] | argparse.Namespace | None = None) -> None:
             skip_neighbor_stat=FLAGS.skip_neighbor_stat,
             output=FLAGS.output,
         )
+    elif FLAGS.command == "compress":
+        from deepmd.pt_expt.entrypoints.compress import (
+            enable_compression,
+        )
+
+        enable_compression(
+            input_file=FLAGS.INPUT,
+            output=FLAGS.output,
+            stride=FLAGS.step,
+            extrapolate=FLAGS.extrapolate,
+            check_frequency=FLAGS.frequency,
+            training_script=FLAGS.training_script,
+        )
     else:
         raise RuntimeError(
             f"Unsupported command '{FLAGS.command}' for the pt_expt backend."

--- a/deepmd/pt_expt/entrypoints/main.py
+++ b/deepmd/pt_expt/entrypoints/main.py
@@ -280,8 +280,12 @@ def main(args: list[str] | argparse.Namespace | None = None) -> None:
             enable_compression,
         )
 
+        if not FLAGS.input.endswith((".pte", ".pt2")):
+            FLAGS.input = str(Path(FLAGS.input).with_suffix(".pte"))
+        if not FLAGS.output.endswith((".pte", ".pt2")):
+            FLAGS.output = str(Path(FLAGS.output).with_suffix(".pte"))
         enable_compression(
-            input_file=FLAGS.INPUT,
+            input_file=FLAGS.input,
             output=FLAGS.output,
             stride=FLAGS.step,
             extrapolate=FLAGS.extrapolate,

--- a/deepmd/pt_expt/model/make_model.py
+++ b/deepmd/pt_expt/model/make_model.py
@@ -199,14 +199,26 @@ def make_model(
 
         @min_nbor_dist.setter
         def min_nbor_dist(self, value: float | None) -> None:
-            from deepmd.pt_expt.utils.env import (
-                DEVICE,
-            )
+            # Infer device from existing buffer or model parameters,
+            # falling back to env.DEVICE only if nothing is available yet.
+            buf = self.__dict__.get("_buffers", {}).get("_min_nbor_dist")
+            if buf is not None:
+                device = buf.device
+            else:
+                p = next(self.parameters(), None) or next(self.buffers(), None)
+                if p is not None:
+                    device = p.device
+                else:
+                    from deepmd.pt_expt.utils.env import (
+                        DEVICE,
+                    )
+
+                    device = DEVICE
 
             t = torch.tensor(
                 -1.0 if value is None else float(value),
                 dtype=torch.float64,
-                device=DEVICE,
+                device=device,
             )
             if "_buffers" in self.__dict__ and "_min_nbor_dist" in self._buffers:
                 self._buffers["_min_nbor_dist"] = t

--- a/deepmd/pt_expt/model/make_model.py
+++ b/deepmd/pt_expt/model/make_model.py
@@ -186,6 +186,38 @@ def make_model(
 
     @torch_module
     class CM(DPModel, *T_Bases):
+        @property  # type: ignore[override]
+        def min_nbor_dist(self) -> float | None:
+            """Minimum neighbor distance, stored as a buffer (survives serialization).
+
+            Uses ``-1.0`` as sentinel for "not set", matching the pt backend.
+            """
+            buf = self.__dict__.get("_buffers", {}).get("_min_nbor_dist")
+            if buf is None or buf.item() == -1.0:
+                return None
+            return buf.item()
+
+        @min_nbor_dist.setter
+        def min_nbor_dist(self, value: float | None) -> None:
+            from deepmd.pt_expt.utils.env import (
+                DEVICE,
+            )
+
+            t = torch.tensor(
+                -1.0 if value is None else float(value),
+                dtype=torch.float64,
+                device=DEVICE,
+            )
+            if "_buffers" in self.__dict__ and "_min_nbor_dist" in self._buffers:
+                self._buffers["_min_nbor_dist"] = t
+            elif "_buffers" in self.__dict__:
+                self.register_buffer("_min_nbor_dist", t)
+            # else: too early (before Module.__init__), will be set again later
+
+        def get_min_nbor_dist(self) -> float | None:
+            """Get the minimum distance between two atoms."""
+            return self.min_nbor_dist
+
         def forward(self, *args: Any, **kwargs: Any) -> dict[str, torch.Tensor]:
             """Default forward delegates to call().
 

--- a/deepmd/pt_expt/utils/__init__.py
+++ b/deepmd/pt_expt/utils/__init__.py
@@ -22,6 +22,9 @@ from .type_embed import (
 # as it's a stateless utility class
 register_dpmodel_mapping(EnvMat, lambda v: v)
 
+# Register fake tensor implementations for custom tabulate ops
+from deepmd.pt_expt.utils import tabulate_ops  # noqa: F401
+
 __all__ = [
     "AtomExcludeMask",
     "NetworkCollection",

--- a/deepmd/pt_expt/utils/serialization.py
+++ b/deepmd/pt_expt/utils/serialization.py
@@ -220,7 +220,11 @@ def serialize_from_file(model_file: str) -> dict:
     return model_dict
 
 
-def deserialize_to_file(model_file: str, data: dict) -> None:
+def deserialize_to_file(
+    model_file: str,
+    data: dict,
+    model_json_override: dict | None = None,
+) -> None:
     """Deserialize a dictionary to a .pte model file.
 
     Builds a pt_expt model from the dict, traces it via make_fx,
@@ -233,6 +237,10 @@ def deserialize_to_file(model_file: str, data: dict) -> None:
     data : dict
         The dictionary to be deserialized (same format as dpmodel's
         serialize output, with "model" and optionally "model_def_script" keys).
+    model_json_override : dict or None
+        If provided, this dict is stored in model.json instead of ``data``.
+        Used by ``dp compress`` to store the compressed model dict while
+        tracing the uncompressed model (make_fx cannot trace custom ops).
     """
     from deepmd.pt_expt.model.model import (
         BaseModel,
@@ -283,7 +291,8 @@ def deserialize_to_file(model_file: str, data: dict) -> None:
         deepcopy,
     )
 
-    data_for_json = deepcopy(data)
+    json_source = model_json_override if model_json_override is not None else data
+    data_for_json = deepcopy(json_source)
     data_for_json = _numpy_to_json_serializable(data_for_json)
 
     extra_files = {

--- a/deepmd/pt_expt/utils/tabulate.py
+++ b/deepmd/pt_expt/utils/tabulate.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""DPTabulate for the pt_expt backend.
+
+Subclasses the pt backend's DPTabulate, overriding _get_descrpt_type() to
+detect descriptor types via serialized data rather than isinstance checks
+against pt-specific classes. Also overrides __init__ to handle the DPA2
+repinit_variable extraction without isinstance.
+"""
+
+from typing import (
+    Any,
+)
+
+from deepmd.pt.utils.tabulate import DPTabulate as DPTabulatePT
+from deepmd.pt.utils.utils import (
+    ActivationFn,
+)
+from deepmd.utils.tabulate import (
+    BaseTabulate,
+)
+
+
+class DPTabulate(DPTabulatePT):
+    """Tabulation helper for pt_expt descriptors.
+
+    Parameters
+    ----------
+    descrpt
+        The pt_expt descriptor instance.
+    neuron
+        Number of neurons in each hidden layer of the embedding net.
+    type_one_side
+        Whether to use one-side type embedding.
+    exclude_types
+        Excluded type pairs.
+    activation_fn
+        The activation function used in the embedding net.
+    """
+
+    def __init__(
+        self,
+        descrpt: Any,
+        neuron: list[int],
+        type_one_side: bool = False,
+        exclude_types: list[list[int]] = [],
+        activation_fn: ActivationFn = ActivationFn("tanh"),
+    ) -> None:
+        # Call BaseTabulate.__init__ directly (skip DPTabulatePT.__init__)
+        # to avoid the isinstance(descrpt, DescrptDPA2) check.
+        BaseTabulate.__init__(
+            self,
+            descrpt,
+            neuron,
+            type_one_side,
+            exclude_types,
+            True,
+        )
+        self.descrpt_type = self._get_descrpt_type()
+
+        supported_descrpt_type = ("Atten", "A", "T", "T_TEBD", "R")
+        if self.descrpt_type in supported_descrpt_type:
+            self.sel_a = self.descrpt.get_sel()
+            self.rcut = self.descrpt.get_rcut()
+            self.rcut_smth = self.descrpt.get_rcut_smth()
+        else:
+            raise RuntimeError("Unsupported descriptor")
+
+        activation_map = {
+            "tanh": 1,
+            "gelu": 2,
+            "gelu_tf": 2,
+            "relu": 3,
+            "relu6": 4,
+            "softplus": 5,
+            "sigmoid": 6,
+            "silu": 7,
+        }
+        activation = activation_fn.activation
+        if activation in activation_map:
+            self.functype = activation_map[activation]
+        else:
+            raise RuntimeError("Unknown activation function type!")
+
+        self.activation_fn = activation_fn
+        serialized = self.descrpt.serialize()
+        # For DPA2, use repinit_variable (detected by presence of key)
+        if "repinit_variable" in serialized:
+            serialized = serialized["repinit_variable"]
+        self.davg = serialized["@variables"]["davg"]
+        self.dstd = serialized["@variables"]["dstd"]
+        self.embedding_net_nodes = serialized["embeddings"]["networks"]
+
+        self.ntypes = self.descrpt.get_ntypes()
+
+        self.layer_size = self._get_layer_size()
+        self.table_size = self._get_table_size()
+
+        self.bias = self._get_bias()
+        self.matrix = self._get_matrix()
+
+        self.data_type = self._get_data_type()
+        self.last_layer_size = self._get_last_layer_size()
+
+    def _get_descrpt_type(self) -> str:
+        """Determine descriptor type from serialized data.
+
+        Instead of isinstance checks against pt classes, use the "type" key
+        from the serialized descriptor dict.
+        """
+        data = self.descrpt.serialize()
+        type_str = data.get("type", "")
+
+        type_map = {
+            "se_e2_a": "A",
+            "se_r": "R",
+            "se_e3": "T",
+            "se_e3_tebd": "T_TEBD",
+            "dpa1": "Atten",
+            "se_atten_v2": "Atten",
+            "dpa2": "Atten",
+        }
+
+        descrpt_type = type_map.get(type_str)
+        if descrpt_type is None:
+            raise RuntimeError(f"Unsupported descriptor type: {type_str}")
+        return descrpt_type

--- a/deepmd/pt_expt/utils/tabulate.py
+++ b/deepmd/pt_expt/utils/tabulate.py
@@ -4,10 +4,6 @@
 Subclasses the pt backend's DPTabulate, overriding _get_descrpt_type() to
 detect descriptor types via serialized data rather than isinstance checks
 against pt-specific classes.
-
-The __init__ is overridden to avoid the parent's isinstance check against
-pt-specific descriptor classes (which may not be importable in the pt_expt
-context).
 """
 
 from typing import (
@@ -17,9 +13,6 @@ from typing import (
 from deepmd.pt.utils.tabulate import DPTabulate as DPTabulatePT
 from deepmd.pt.utils.utils import (
     ActivationFn,
-)
-from deepmd.utils.tabulate import (
-    BaseTabulate,
 )
 
 
@@ -53,59 +46,11 @@ class DPTabulate(DPTabulatePT):
         exclude_types: list[list[int]] = [],
         activation_fn: ActivationFn = ActivationFn("tanh"),
     ) -> None:
-        # Skip DPTabulatePT.__init__ to avoid its isinstance check against
-        # pt-specific classes (deepmd.pt.model.descriptor.DescrptDPA2).
-        # Call BaseTabulate.__init__ + replicate the rest of the init logic.
-        BaseTabulate.__init__(
-            self,
-            descrpt,
-            neuron,
-            type_one_side,
-            exclude_types,
-            True,
-        )
-        self.descrpt_type = self._get_descrpt_type()
-
-        supported_descrpt_type = ("Atten", "A", "T", "T_TEBD", "R")
-        if self.descrpt_type in supported_descrpt_type:
-            self.sel_a = self.descrpt.get_sel()
-            self.rcut = self.descrpt.get_rcut()
-            self.rcut_smth = self.descrpt.get_rcut_smth()
-        else:
-            raise RuntimeError("Unsupported descriptor")
-
-        activation_map = {
-            "tanh": 1,
-            "gelu": 2,
-            "gelu_tf": 2,
-            "relu": 3,
-            "relu6": 4,
-            "softplus": 5,
-            "sigmoid": 6,
-            "silu": 7,
-        }
-        activation = activation_fn.activation
-        if activation in activation_map:
-            self.functype = activation_map[activation]
-        else:
-            raise RuntimeError("Unknown activation function type!")
-
-        self.activation_fn = activation_fn
-        serialized = self.descrpt.serialize()
-        self.davg = serialized["@variables"]["davg"]
-        self.dstd = serialized["@variables"]["dstd"]
-        self.embedding_net_nodes = serialized["embeddings"]["networks"]
-
-        self.ntypes = self.descrpt.get_ntypes()
-
-        self.layer_size = self._get_layer_size()
-        self.table_size = self._get_table_size()
-
-        self.bias = self._get_bias()
-        self.matrix = self._get_matrix()
-
-        self.data_type = self._get_data_type()
-        self.last_layer_size = self._get_last_layer_size()
+        # DPTabulatePT.__init__ works here because:
+        # 1. _get_descrpt_type is overridden to use serialized data (not isinstance)
+        # 2. The isinstance(descrpt, DescrptDPA2) check in parent just returns False
+        #    for pt_expt descriptors — callers pass the repinit block directly.
+        super().__init__(descrpt, neuron, type_one_side, exclude_types, activation_fn)
 
     def _get_descrpt_type(self) -> str:
         """Determine descriptor type from serialized data.

--- a/deepmd/pt_expt/utils/tabulate_ops.py
+++ b/deepmd/pt_expt/utils/tabulate_ops.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Register fake tensor implementations for deepmd custom tabulate ops.
+
+These registrations enable torch.export and make_fx to trace through the
+compressed forward path, which uses C++ custom ops (tabulate_fusion_se_*).
+Without fake implementations, torch.export cannot determine output shapes.
+
+This module is imported at package init time (via utils/__init__.py) so
+registrations happen before any descriptor code runs.
+
+When the C++ custom op library is loaded, the ops already have
+implementations, and register_fake will raise RuntimeError. We silently
+skip registration in that case.
+"""
+
+from collections.abc import (
+    Callable,
+)
+from typing import (
+    Any,
+)
+
+import torch
+
+# Ensure the custom op library is loaded (if available)
+try:
+    torch.ops.deepmd
+except AttributeError:
+    pass
+
+
+def _try_register_fake(op_name: str, fn: Callable[..., Any]) -> None:
+    """Register a fake implementation, silently skipping if already registered."""
+    try:
+        torch.library.register_fake(op_name)(fn)
+    except RuntimeError:
+        pass
+
+
+def _register_fake_if_available() -> None:
+    """Register fake implementations for all tabulate custom ops.
+
+    Only registers for ops that exist (i.e., the custom op library is loaded).
+    Uses torch.library.register_fake which is the standard way to provide
+    meta/fake tensor implementations for custom ops.
+    """
+    # --- tabulate_fusion_se_a ---
+    if hasattr(torch.ops.deepmd, "tabulate_fusion_se_a"):
+
+        def _fake_se_a(
+            table: torch.Tensor,
+            table_info: torch.Tensor,
+            em_x: torch.Tensor,
+            em: torch.Tensor,
+            last_layer_size: int,
+        ) -> list[torch.Tensor]:
+            return [table.new_empty([em.size(0), 4, last_layer_size])]
+
+        _try_register_fake("deepmd::tabulate_fusion_se_a", _fake_se_a)
+
+    # --- tabulate_fusion_se_r ---
+    if hasattr(torch.ops.deepmd, "tabulate_fusion_se_r"):
+
+        def _fake_se_r(
+            table: torch.Tensor,
+            table_info: torch.Tensor,
+            em: torch.Tensor,
+            last_layer_size: int,
+        ) -> list[torch.Tensor]:
+            return [table.new_empty([em.size(0), em.size(1), last_layer_size])]
+
+        _try_register_fake("deepmd::tabulate_fusion_se_r", _fake_se_r)
+
+    # --- tabulate_fusion_se_t ---
+    if hasattr(torch.ops.deepmd, "tabulate_fusion_se_t"):
+
+        def _fake_se_t(
+            table: torch.Tensor,
+            table_info: torch.Tensor,
+            em_x: torch.Tensor,
+            em: torch.Tensor,
+            last_layer_size: int,
+        ) -> list[torch.Tensor]:
+            return [table.new_empty([em.size(0), last_layer_size])]
+
+        _try_register_fake("deepmd::tabulate_fusion_se_t", _fake_se_t)
+
+    # --- tabulate_fusion_se_t_tebd ---
+    if hasattr(torch.ops.deepmd, "tabulate_fusion_se_t_tebd"):
+
+        def _fake_se_t_tebd(
+            table: torch.Tensor,
+            table_info: torch.Tensor,
+            em_x: torch.Tensor,
+            em: torch.Tensor,
+            last_layer_size: int,
+        ) -> list[torch.Tensor]:
+            return [
+                table.new_empty([em.size(0), em.size(1), em.size(2), last_layer_size])
+            ]
+
+        _try_register_fake("deepmd::tabulate_fusion_se_t_tebd", _fake_se_t_tebd)
+
+    # --- tabulate_fusion_se_atten ---
+    if hasattr(torch.ops.deepmd, "tabulate_fusion_se_atten"):
+
+        def _fake_se_atten(
+            table: torch.Tensor,
+            table_info: torch.Tensor,
+            em_x: torch.Tensor,
+            em: torch.Tensor,
+            two_embed: torch.Tensor,
+            last_layer_size: int,
+            is_sorted: bool,
+        ) -> list[torch.Tensor]:
+            return [table.new_empty([em.size(0), 4, last_layer_size])]
+
+        _try_register_fake("deepmd::tabulate_fusion_se_atten", _fake_se_atten)
+
+
+_register_fake_if_available()

--- a/deepmd/pt_expt/utils/tabulate_ops.py
+++ b/deepmd/pt_expt/utils/tabulate_ops.py
@@ -6,7 +6,10 @@ compressed forward path, which uses C++ custom ops (tabulate_fusion_se_*).
 Without fake implementations, torch.export cannot determine output shapes.
 
 This module is imported at package init time (via utils/__init__.py) so
-registrations happen before any descriptor code runs.
+registrations happen before any descriptor code runs.  If the C++ custom
+op library hasn't been loaded yet at that point, `ensure_fake_registered()`
+can be called again later (it is idempotent) — e.g. from the compression
+entry point after the ops become available.
 
 When the C++ custom op library is loaded, the ops already have
 implementations, and register_fake will raise RuntimeError. We silently
@@ -22,29 +25,36 @@ from typing import (
 
 import torch
 
-# Ensure the custom op library is loaded (if available)
-try:
-    torch.ops.deepmd
-except AttributeError:
-    pass
+# Track which ops already have fake implementations so we don't re-register.
+_registered: set[str] = set()
 
 
 def _try_register_fake(op_name: str, fn: Callable[..., Any]) -> None:
     """Register a fake implementation, silently skipping if already registered."""
+    if op_name in _registered:
+        return
     try:
         torch.library.register_fake(op_name)(fn)
     except RuntimeError:
         # Op already has an implementation (e.g. C++ library loaded).
         pass
+    _registered.add(op_name)
 
 
-def _register_fake_if_available() -> None:
+def ensure_fake_registered() -> None:
     """Register fake implementations for all tabulate custom ops.
 
     Only registers for ops that exist (i.e., the custom op library is loaded).
-    Uses torch.library.register_fake which is the standard way to provide
-    meta/fake tensor implementations for custom ops.
+    Idempotent — safe to call multiple times; already-registered ops are
+    skipped via the ``_registered`` set.
+
+    Called automatically at import time and should also be called from any
+    code path that needs fake ops after the C++ library has been loaded
+    (e.g. the compression entry point).
     """
+    if not hasattr(torch.ops, "deepmd"):
+        return
+
     # --- tabulate_fusion_se_a ---
     if hasattr(torch.ops.deepmd, "tabulate_fusion_se_a"):
 
@@ -119,4 +129,5 @@ def _register_fake_if_available() -> None:
         _try_register_fake("deepmd::tabulate_fusion_se_atten", _fake_se_atten)
 
 
-_register_fake_if_available()
+# Best-effort at import time — ops may not be loaded yet.
+ensure_fake_registered()

--- a/deepmd/pt_expt/utils/tabulate_ops.py
+++ b/deepmd/pt_expt/utils/tabulate_ops.py
@@ -35,10 +35,13 @@ def _try_register_fake(op_name: str, fn: Callable[..., Any]) -> None:
         return
     try:
         torch.library.register_fake(op_name)(fn)
-    except RuntimeError:
-        # Op already has an implementation (e.g. C++ library loaded).
-        pass
-    _registered.add(op_name)
+        _registered.add(op_name)
+    except RuntimeError as e:
+        if "already has" in str(e) or "already registered" in str(e):
+            # Op already has an implementation (e.g. C++ library loaded).
+            _registered.add(op_name)
+        else:
+            raise
 
 
 def ensure_fake_registered() -> None:

--- a/deepmd/pt_expt/utils/tabulate_ops.py
+++ b/deepmd/pt_expt/utils/tabulate_ops.py
@@ -34,6 +34,7 @@ def _try_register_fake(op_name: str, fn: Callable[..., Any]) -> None:
     try:
         torch.library.register_fake(op_name)(fn)
     except RuntimeError:
+        # Op already has an implementation (e.g. C++ library loaded).
         pass
 
 

--- a/deepmd/tf/descriptor/se_a.py
+++ b/deepmd/tf/descriptor/se_a.py
@@ -1481,7 +1481,7 @@ class DescrptSeA(DescrptSe):
         if cls is not DescrptSeA:
             raise NotImplementedError(f"Not implemented in class {cls.__name__}")
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         embedding_net_variables = cls.deserialize_network(
@@ -1489,6 +1489,7 @@ class DescrptSeA(DescrptSe):
         )
         data.pop("env_mat")
         variables = data.pop("@variables")
+        data.pop("compress", None)  # tf uses frozen graph for compression
         descriptor = cls(**data)
         descriptor.embedding_net_variables = embedding_net_variables
         descriptor.davg = variables["davg"].reshape(

--- a/deepmd/tf/descriptor/se_atten_v2.py
+++ b/deepmd/tf/descriptor/se_atten_v2.py
@@ -136,7 +136,7 @@ class DescrptSeAttenV2(DescrptSeAtten):
         if cls is not DescrptSeAttenV2:
             raise NotImplementedError(f"Not implemented in class {cls.__name__}")
         data = data.copy()
-        check_version_compatibility(data.pop("@version"), 2, 1)
+        check_version_compatibility(data.pop("@version"), 3, 1)
         data.pop("@class")
         data.pop("type")
         embedding_net_variables = cls.deserialize_network(
@@ -147,6 +147,7 @@ class DescrptSeAttenV2(DescrptSeAtten):
         )
         data.pop("env_mat")
         variables = data.pop("@variables")
+        data.pop("compress", None)  # tf uses frozen graph for compression
         type_one_side = data["type_one_side"]
         two_side_embeeding_net_variables = cls.deserialize_network_strip(
             data.pop("embeddings_strip"),

--- a/deepmd/tf/descriptor/se_r.py
+++ b/deepmd/tf/descriptor/se_r.py
@@ -746,12 +746,13 @@ class DescrptSeR(DescrptSe):
         if cls is not DescrptSeR:
             raise NotImplementedError(f"Not implemented in class {cls.__name__}")
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         embedding_net_variables = cls.deserialize_network(
             data.pop("embeddings"), suffix=suffix
         )
         data.pop("env_mat")
         variables = data.pop("@variables")
+        data.pop("compress", None)  # tf uses frozen graph for compression
         descriptor = cls(**data)
         descriptor.embedding_net_variables = embedding_net_variables
         descriptor.davg = variables["davg"].reshape(

--- a/deepmd/tf/descriptor/se_t.py
+++ b/deepmd/tf/descriptor/se_t.py
@@ -900,7 +900,7 @@ class DescrptSeT(DescrptSe):
         if cls is not DescrptSeT:
             raise NotImplementedError(f"Not implemented in class {cls.__name__}")
         data = data.copy()
-        check_version_compatibility(data.pop("@version", 1), 2, 1)
+        check_version_compatibility(data.pop("@version", 1), 3, 1)
         data.pop("@class", None)
         data.pop("type", None)
         embedding_net_variables = cls.deserialize_network(
@@ -908,6 +908,7 @@ class DescrptSeT(DescrptSe):
         )
         data.pop("env_mat")
         variables = data.pop("@variables")
+        data.pop("compress", None)  # tf uses frozen graph for compression
         descriptor = cls(**data)
         descriptor.embedding_net_variables = embedding_net_variables
         descriptor.davg = variables["davg"].reshape(

--- a/source/tests/pt_expt/descriptor/test_dpa1.py
+++ b/source/tests/pt_expt/descriptor/test_dpa1.py
@@ -132,6 +132,52 @@ class TestDescrptDPA1(TestCaseSingleFrameWithNlist):
         )
         torch.export.export(dd0, inputs)
 
+    @pytest.mark.parametrize("prec", ["float64", "float32"])  # precision
+    def test_compressed_forward(self, prec) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            pytest.skip("Custom OP library not built")
+        rng = np.random.default_rng(GLOBAL_SEED)
+        _, _, nnei = self.nlist.shape
+        davg = rng.normal(size=(self.nt, nnei, 4))
+        dstd = rng.normal(size=(self.nt, nnei, 4))
+        dstd = 0.1 + np.abs(dstd)
+
+        dtype = PRECISION_DICT[prec]
+        atol = 1e-5 if prec == "float32" else 1e-10
+        dd0 = DescrptDPA1(
+            self.rcut,
+            self.rcut_smth,
+            self.sel_mix,
+            self.nt,
+            precision=prec,
+            tebd_input_mode="strip",
+            attn_layer=0,
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        dd0.se_atten.mean = torch.tensor(davg, dtype=dtype, device=self.device)
+        dd0.se_atten.stddev = torch.tensor(dstd, dtype=dtype, device=self.device)
+
+        coord_ext = torch.tensor(self.coord_ext, dtype=dtype, device=self.device)
+        atype_ext = torch.tensor(self.atype_ext, dtype=int, device=self.device)
+        nlist = torch.tensor(self.nlist, dtype=int, device=self.device)
+
+        # uncompressed forward
+        rd0, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        # enable compression and forward again
+        dd0.enable_compression(0.5)
+        rd1, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+
+        assert rd0.shape == rd1.shape
+        np.testing.assert_allclose(
+            rd0.detach().cpu().numpy(),
+            rd1.detach().cpu().numpy(),
+            atol=atol,
+        )
+
     @pytest.mark.parametrize("prec", ["float64"])  # precision
     def test_make_fx(self, prec) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)

--- a/source/tests/pt_expt/descriptor/test_dpa2.py
+++ b/source/tests/pt_expt/descriptor/test_dpa2.py
@@ -232,6 +232,94 @@ class TestDescrptDPA2(TestCaseSingleFrameWithNlist):
         )
         torch.export.export(dd0, inputs)
 
+    @pytest.mark.parametrize("prec", ["float64", "float32"])  # precision
+    def test_compressed_forward(self, prec) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            pytest.skip("Custom OP library not built")
+        rng = np.random.default_rng(GLOBAL_SEED)
+        nf, nloc, nnei = self.nlist.shape
+        davg = rng.normal(size=(self.nt, nnei, 4))
+        dstd = rng.normal(size=(self.nt, nnei, 4))
+        davg_2 = rng.normal(size=(self.nt, nnei // 2, 4))
+        dstd_2 = rng.normal(size=(self.nt, nnei // 2, 4))
+        dstd = 0.1 + np.abs(dstd)
+        dstd_2 = 0.1 + np.abs(dstd_2)
+
+        dtype = PRECISION_DICT[prec]
+        atol = 1e-5 if prec == "float32" else 1e-10
+
+        repinit = RepinitArgs(
+            rcut=self.rcut,
+            rcut_smth=self.rcut_smth,
+            nsel=self.sel_mix,
+            tebd_input_mode="strip",
+            set_davg_zero=True,
+        )
+        repformer = RepformerArgs(
+            rcut=self.rcut / 2,
+            rcut_smth=self.rcut_smth,
+            nsel=nnei // 2,
+            nlayers=3,
+            g1_dim=20,
+            g2_dim=10,
+            axis_neuron=4,
+            update_g1_has_conv=True,
+            update_g1_has_drrd=True,
+            update_g1_has_grrg=True,
+            update_g1_has_attn=False,
+            update_g2_has_g1g1=False,
+            update_g2_has_attn=True,
+            update_h2=False,
+            attn1_hidden=20,
+            attn1_nhead=2,
+            attn2_hidden=10,
+            attn2_nhead=2,
+            attn2_has_gate=True,
+            update_style="res_avg",
+            set_davg_zero=True,
+            use_sqrt_nnei=True,
+            g1_out_conv=True,
+            g1_out_mlp=True,
+        )
+
+        dd0 = DescrptDPA2(
+            self.nt,
+            repinit=repinit,
+            repformer=repformer,
+            smooth=True,
+            exclude_types=[],
+            add_tebd_to_repinit_out=False,
+            precision=prec,
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+
+        dd0.repinit.mean = torch.tensor(davg, dtype=dtype, device=self.device)
+        dd0.repinit.stddev = torch.tensor(dstd, dtype=dtype, device=self.device)
+        dd0.repformers.mean = torch.tensor(davg_2, dtype=dtype, device=self.device)
+        dd0.repformers.stddev = torch.tensor(dstd_2, dtype=dtype, device=self.device)
+
+        coord_ext = torch.tensor(self.coord_ext, dtype=dtype, device=self.device)
+        atype_ext = torch.tensor(self.atype_ext, dtype=int, device=self.device)
+        nlist = torch.tensor(self.nlist, dtype=int, device=self.device)
+        mapping = torch.tensor(self.mapping, dtype=int, device=self.device)
+
+        # uncompressed forward
+        rd0_out, _, _, _, _ = dd0(coord_ext, atype_ext, nlist, mapping)
+        # enable compression and forward again
+        dd0.enable_compression(0.5)
+        rd1_out, _, _, _, _ = dd0(coord_ext, atype_ext, nlist, mapping)
+
+        assert rd0_out.shape == rd1_out.shape
+        np.testing.assert_allclose(
+            rd0_out.detach().cpu().numpy(),
+            rd1_out.detach().cpu().numpy(),
+            atol=atol,
+        )
+
     @pytest.mark.parametrize("prec", ["float64"])  # precision
     def test_make_fx(self, prec) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)

--- a/source/tests/pt_expt/descriptor/test_dpa2.py
+++ b/source/tests/pt_expt/descriptor/test_dpa2.py
@@ -241,7 +241,7 @@ class TestDescrptDPA2(TestCaseSingleFrameWithNlist):
         if not ENABLE_CUSTOMIZED_OP:
             pytest.skip("Custom OP library not built")
         rng = np.random.default_rng(GLOBAL_SEED)
-        nf, nloc, nnei = self.nlist.shape
+        _, _, nnei = self.nlist.shape
         davg = rng.normal(size=(self.nt, nnei, 4))
         dstd = rng.normal(size=(self.nt, nnei, 4))
         davg_2 = rng.normal(size=(self.nt, nnei // 2, 4))

--- a/source/tests/pt_expt/descriptor/test_se_atten_v2.py
+++ b/source/tests/pt_expt/descriptor/test_se_atten_v2.py
@@ -128,6 +128,51 @@ class TestDescrptSeAttenV2(TestCaseSingleFrameWithNlist):
         )
         torch.export.export(dd0, inputs)
 
+    @pytest.mark.parametrize("prec", ["float64", "float32"])  # precision
+    def test_compressed_forward(self, prec) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            pytest.skip("Custom OP library not built")
+        rng = np.random.default_rng(GLOBAL_SEED)
+        _, _, nnei = self.nlist.shape
+        davg = rng.normal(size=(self.nt, nnei, 4))
+        dstd = rng.normal(size=(self.nt, nnei, 4))
+        dstd = 0.1 + np.abs(dstd)
+
+        dtype = PRECISION_DICT[prec]
+        atol = 1e-5 if prec == "float32" else 1e-10
+        dd0 = DescrptSeAttenV2(
+            self.rcut,
+            self.rcut_smth,
+            self.sel_mix,
+            self.nt,
+            precision=prec,
+            attn_layer=0,
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        dd0.se_atten.mean = torch.tensor(davg, dtype=dtype, device=self.device)
+        dd0.se_atten.stddev = torch.tensor(dstd, dtype=dtype, device=self.device)
+
+        coord_ext = torch.tensor(self.coord_ext, dtype=dtype, device=self.device)
+        atype_ext = torch.tensor(self.atype_ext, dtype=int, device=self.device)
+        nlist = torch.tensor(self.nlist, dtype=int, device=self.device)
+
+        # uncompressed forward
+        rd0, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        # enable compression and forward again
+        dd0.enable_compression(0.5)
+        rd1, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+
+        assert rd0.shape == rd1.shape
+        np.testing.assert_allclose(
+            rd0.detach().cpu().numpy(),
+            rd1.detach().cpu().numpy(),
+            atol=atol,
+        )
+
     @pytest.mark.parametrize("prec", ["float64"])  # precision
     def test_make_fx(self, prec) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)

--- a/source/tests/pt_expt/descriptor/test_se_e2_a.py
+++ b/source/tests/pt_expt/descriptor/test_se_e2_a.py
@@ -132,6 +132,36 @@ class TestDescrptSeA(TestCaseSingleFrameWithNlist):
         )
         torch.export.export(dd0, inputs)
 
+    @pytest.mark.parametrize("tos", [True, False])  # type_one_side
+    @pytest.mark.parametrize("prec", ["float64", "float32"])  # precision
+    def test_compressed_forward(self, tos, prec) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            pytest.skip("Custom OP library not built")
+        atol = 1e-5 if prec == "float32" else 1e-10
+        dtype = PRECISION_DICT[prec]
+        # Use default davg/dstd (zeros/ones) so env matrix values
+        # stay within the tabulation range.
+        dd0 = DescrptSeA(
+            self.rcut,
+            self.rcut_smth,
+            self.sel,
+            precision=prec,
+            type_one_side=tos,
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        coord_ext = torch.tensor(self.coord_ext, dtype=dtype, device=self.device)
+        atype_ext = torch.tensor(self.atype_ext, dtype=int, device=self.device)
+        nlist = torch.tensor(self.nlist, dtype=int, device=self.device)
+        result_ref, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        dd0.enable_compression(0.5)
+        result_cmp, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        assert result_ref.shape == result_cmp.shape
+        torch.testing.assert_close(result_ref, result_cmp, atol=atol, rtol=atol)
+
     @pytest.mark.parametrize("prec", ["float64"])  # precision
     def test_make_fx(self, prec) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)

--- a/source/tests/pt_expt/descriptor/test_se_r.py
+++ b/source/tests/pt_expt/descriptor/test_se_r.py
@@ -127,6 +127,36 @@ class TestDescrptSeR(TestCaseSingleFrameWithNlist):
         )
         torch.export.export(dd0, inputs)
 
+    @pytest.mark.parametrize("prec", ["float64", "float32"])  # precision
+    def test_compressed_forward(self, prec) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            pytest.skip("Custom OP library not built")
+        dtype = PRECISION_DICT[prec]
+        atol = 1e-5 if prec == "float32" else 1e-10
+        dd0 = DescrptSeR(
+            self.rcut,
+            self.rcut_smth,
+            self.sel,
+            precision=prec,
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        coord_ext = torch.tensor(self.coord_ext, dtype=dtype, device=self.device)
+        atype_ext = torch.tensor(self.atype_ext, dtype=int, device=self.device)
+        nlist = torch.tensor(self.nlist, dtype=int, device=self.device)
+        rd0, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        dd0.enable_compression(0.5)
+        rd1, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        assert rd0.shape == rd1.shape
+        np.testing.assert_allclose(
+            rd0.detach().cpu().numpy(),
+            rd1.detach().cpu().numpy(),
+            atol=atol,
+        )
+
     @pytest.mark.parametrize("prec", ["float64"])  # precision
     def test_make_fx(self, prec) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)

--- a/source/tests/pt_expt/descriptor/test_se_t.py
+++ b/source/tests/pt_expt/descriptor/test_se_t.py
@@ -131,6 +131,36 @@ class TestDescrptSeT(TestCaseSingleFrameWithNlist):
         )
         torch.export.export(dd0, inputs)
 
+    @pytest.mark.parametrize("prec", ["float64", "float32"])  # precision
+    def test_compressed_forward(self, prec) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            pytest.skip("Custom OP library not built")
+        dtype = PRECISION_DICT[prec]
+        atol = 1e-5 if prec == "float32" else 1e-10
+        dd0 = DescrptSeT(
+            self.rcut,
+            self.rcut_smth,
+            self.sel,
+            precision=prec,
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        coord_ext = torch.tensor(self.coord_ext, dtype=dtype, device=self.device)
+        atype_ext = torch.tensor(self.atype_ext, dtype=int, device=self.device)
+        nlist = torch.tensor(self.nlist, dtype=int, device=self.device)
+        rd0, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        dd0.enable_compression(0.5)
+        rd1, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        assert rd0.shape == rd1.shape
+        np.testing.assert_allclose(
+            rd0.detach().cpu().numpy(),
+            rd1.detach().cpu().numpy(),
+            atol=atol,
+        )
+
     @pytest.mark.parametrize("prec", ["float64"])  # precision
     def test_make_fx(self, prec) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)

--- a/source/tests/pt_expt/descriptor/test_se_t_tebd.py
+++ b/source/tests/pt_expt/descriptor/test_se_t_tebd.py
@@ -144,6 +144,51 @@ class TestDescrptSeTTebd(TestCaseSingleFrameWithNlist):
         )
         torch.export.export(dd0, inputs)
 
+    @pytest.mark.parametrize("prec", ["float64", "float32"])  # precision
+    def test_compressed_forward(self, prec) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            pytest.skip("Custom OP library not built")
+        rng = np.random.default_rng(GLOBAL_SEED)
+        _, _, nnei = self.nlist.shape
+        davg = rng.normal(size=(self.nt, nnei, 4))
+        dstd = rng.normal(size=(self.nt, nnei, 4))
+        dstd = 0.1 + np.abs(dstd)
+
+        dtype = PRECISION_DICT[prec]
+        atol = 1e-5 if prec == "float32" else 1e-10
+        dd0 = DescrptSeTTebd(
+            self.rcut,
+            self.rcut_smth,
+            self.sel,
+            self.nt,
+            precision=prec,
+            tebd_input_mode="strip",
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        dd0.davg = torch.tensor(davg, dtype=dtype, device=self.device)
+        dd0.dstd = torch.tensor(dstd, dtype=dtype, device=self.device)
+
+        coord_ext = torch.tensor(self.coord_ext, dtype=dtype, device=self.device)
+        atype_ext = torch.tensor(self.atype_ext, dtype=int, device=self.device)
+        nlist = torch.tensor(self.nlist, dtype=int, device=self.device)
+
+        # uncompressed forward
+        rd0, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+        # enable compression and forward again
+        dd0.enable_compression(0.5)
+        rd1, _, _, _, _ = dd0(coord_ext, atype_ext, nlist)
+
+        assert rd0.shape == rd1.shape
+        np.testing.assert_allclose(
+            rd0.detach().cpu().numpy(),
+            rd1.detach().cpu().numpy(),
+            atol=atol,
+        )
+
     @pytest.mark.parametrize("prec", ["float64"])  # precision
     def test_make_fx(self, prec) -> None:
         rng = np.random.default_rng(GLOBAL_SEED)

--- a/source/tests/pt_expt/model/test_model_compression.py
+++ b/source/tests/pt_expt/model/test_model_compression.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""End-to-end model compression test for the pt_expt backend.
+
+Tests the full pipeline: build → freeze (.pte) → compress → eval,
+verifying consistency between frozen and compressed models.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+
+from deepmd.pt_expt.descriptor.se_e2_a import (
+    DescrptSeA,
+)
+from deepmd.pt_expt.fitting import (
+    EnergyFittingNet,
+)
+from deepmd.pt_expt.model import (
+    EnergyModel,
+)
+from deepmd.pt_expt.utils import (
+    env,
+)
+from deepmd.pt_expt.utils.serialization import (
+    deserialize_to_file,
+    serialize_from_file,
+)
+
+from ...seed import (
+    GLOBAL_SEED,
+)
+
+
+class TestModelCompression(unittest.TestCase):
+    def setUp(self) -> None:
+        from deepmd.pt.cxx_op import (
+            ENABLE_CUSTOMIZED_OP,
+        )
+
+        if not ENABLE_CUSTOMIZED_OP:
+            self.skipTest("Custom OP library not built")
+
+        self.device = env.DEVICE
+        self.natoms = 5
+        self.rcut = 4.0
+        self.rcut_smth = 0.5
+        self.sel = [8, 6]
+        self.nt = 2
+        self.type_map = ["foo", "bar"]
+
+        generator = torch.Generator(device=self.device).manual_seed(GLOBAL_SEED)
+        cell = torch.rand(
+            [3, 3], dtype=torch.float64, device=self.device, generator=generator
+        )
+        cell = (cell + cell.T) + 5.0 * torch.eye(3, device=self.device)
+        self.cell = cell.unsqueeze(0)
+        coord = torch.rand(
+            [self.natoms, 3],
+            dtype=torch.float64,
+            device=self.device,
+            generator=generator,
+        )
+        coord = torch.matmul(coord, cell)
+        self.coord = coord.unsqueeze(0).to(self.device)
+        self.atype = torch.tensor(
+            [[0, 0, 0, 1, 1]], dtype=torch.int64, device=self.device
+        )
+
+    def _make_model(self) -> EnergyModel:
+        ds = DescrptSeA(
+            self.rcut,
+            self.rcut_smth,
+            self.sel,
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        ft = EnergyFittingNet(
+            self.nt,
+            ds.get_dim_out(),
+            mixed_types=ds.mixed_types(),
+            seed=GLOBAL_SEED,
+        ).to(self.device)
+        return EnergyModel(ds, ft, type_map=self.type_map).to(self.device)
+
+    def _eval_model(self, model):
+        model.eval()
+        coord = self.coord.clone().requires_grad_(True)
+        ret = model(coord, self.atype, self.cell.reshape(1, 9))
+        return {k: v.detach().cpu().numpy() for k, v in ret.items()}
+
+    def test_model_enable_compression(self) -> None:
+        """Test that model.enable_compression preserves energy/force/virial."""
+        md = self._make_model()
+        md.min_nbor_dist = 0.5
+        ret_ref = self._eval_model(md)
+
+        md.enable_compression(5, 0.01, 0.1, -1)
+        ret_cmp = self._eval_model(md)
+
+        for key in ("energy", "force", "virial"):
+            np.testing.assert_allclose(
+                ret_ref[key], ret_cmp[key], atol=1e-7, err_msg=key
+            )
+
+    def test_freeze_compress_eval(self) -> None:
+        """Test full pipeline: build → freeze → compress → eval.
+
+        The frozen (uncompressed) and compressed models must produce
+        consistent energy, force, and virial.
+        """
+        from deepmd.pt_expt.entrypoints.compress import (
+            enable_compression as compress_entry,
+        )
+
+        # 1. Build and freeze to .pte
+        md = self._make_model()
+        md.min_nbor_dist = 0.5
+        md.eval()
+        ret_frozen = self._eval_model(md)
+
+        model_data = {"model": md.serialize(), "min_nbor_dist": 0.5}
+        with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
+            frozen_path = f.name
+        with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
+            compressed_path = f.name
+        try:
+            deserialize_to_file(frozen_path, model_data)
+
+            # 2. Compress via entry point (same as `dp --pt_expt compress`)
+            compress_entry(
+                input_file=frozen_path,
+                output=compressed_path,
+                stride=0.01,
+                extrapolate=5,
+                check_frequency=-1,
+            )
+
+            # 3. Load compressed .pte and eval
+            compressed_data = serialize_from_file(compressed_path)
+            md_cmp = EnergyModel.deserialize(compressed_data["model"])
+            md_cmp = md_cmp.to(self.device)
+            ret_compressed = self._eval_model(md_cmp)
+
+            # 4. Compare frozen vs compressed
+            for key in ("energy", "force", "virial"):
+                np.testing.assert_allclose(
+                    ret_frozen[key], ret_compressed[key], atol=1e-7, err_msg=key
+                )
+        finally:
+            os.unlink(frozen_path)
+            os.unlink(compressed_path)
+
+    def test_descriptor_preserved_in_model(self) -> None:
+        """Test that pt_expt descriptor type is preserved inside the model."""
+        md = self._make_model()
+        desc = md.atomic_model.descriptor
+        self.assertTrue(hasattr(desc, "enable_compression"))
+        self.assertIsInstance(desc, torch.nn.Module)
+
+    def test_min_nbor_dist_roundtrip(self) -> None:
+        """Test that min_nbor_dist survives freeze → load round-trip."""
+        md = self._make_model()
+        self.assertIsNone(md.get_min_nbor_dist())
+
+        md.min_nbor_dist = 0.5
+        self.assertAlmostEqual(md.get_min_nbor_dist(), 0.5)
+
+        # Freeze to .pte
+        model_data = {"model": md.serialize(), "min_nbor_dist": 0.5}
+        with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
+            frozen_path = f.name
+        try:
+            deserialize_to_file(frozen_path, model_data)
+            loaded_data = serialize_from_file(frozen_path)
+            self.assertAlmostEqual(loaded_data["min_nbor_dist"], 0.5)
+        finally:
+            os.unlink(frozen_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/tests/pt_expt/model/test_model_compression.py
+++ b/source/tests/pt_expt/model/test_model_compression.py
@@ -211,11 +211,6 @@ class TestModelCompression(unittest.TestCase):
 
         # Compressed forward should match
         dtype = torch.float64
-        coord_ext = torch.tensor(
-            self.coord.detach().cpu().numpy().reshape(1, -1),
-            dtype=dtype,
-            device=self.device,
-        )
         # Build proper inputs for descriptor-level test
         from deepmd.dpmodel.utils.nlist import (
             build_neighbor_list,

--- a/source/tests/pt_expt/model/test_model_compression.py
+++ b/source/tests/pt_expt/model/test_model_compression.py
@@ -137,13 +137,22 @@ class TestModelCompression(unittest.TestCase):
                 check_frequency=-1,
             )
 
-            # 3. Load compressed .pte and eval
+            # 3. Verify compressed .pte has compression state in model.json
             compressed_data = serialize_from_file(compressed_path)
+            descrpt_data = compressed_data["model"]["descriptor"]
+            self.assertIn("compress", descrpt_data)
+            self.assertGreaterEqual(descrpt_data["@version"], 3)
+            self.assertIn("min_nbor_dist", compressed_data)
+
+            # 4. Deserialize and verify the model is actually compressed
             md_cmp = EnergyModel.deserialize(compressed_data["model"])
             md_cmp = md_cmp.to(self.device)
-            ret_compressed = self._eval_model(md_cmp)
+            desc = md_cmp.atomic_model.descriptor
+            self.assertTrue(desc.compress)
+            self.assertTrue(hasattr(desc, "compress_data"))
 
-            # 4. Compare frozen vs compressed
+            # 5. Inference with compressed model matches frozen
+            ret_compressed = self._eval_model(md_cmp)
             for key in ("energy", "force", "virial"):
                 np.testing.assert_allclose(
                     ret_frozen[key], ret_compressed[key], atol=1e-7, err_msg=key
@@ -177,6 +186,73 @@ class TestModelCompression(unittest.TestCase):
             self.assertAlmostEqual(loaded_data["min_nbor_dist"], 0.5)
         finally:
             os.unlink(frozen_path)
+
+    def test_compress_state_serialized(self) -> None:
+        """Test that compression state persists through serialize/deserialize.
+
+        After enable_compression, the descriptor's compress flag and tabulated
+        data must survive serialize → deserialize round-trip.
+        """
+        md = self._make_model()
+        md.min_nbor_dist = 0.5
+        desc = md.atomic_model.descriptor
+        desc.enable_compression(0.5)
+        self.assertTrue(desc.compress)
+
+        # Serialize and deserialize
+        data = desc.serialize()
+        from deepmd.pt_expt.descriptor.se_e2_a import (
+            DescrptSeA,
+        )
+
+        desc2 = DescrptSeA.deserialize(data)
+        self.assertTrue(desc2.compress)
+        self.assertTrue(hasattr(desc2, "compress_data"))
+
+        # Compressed forward should match
+        dtype = torch.float64
+        coord_ext = torch.tensor(
+            self.coord.detach().cpu().numpy().reshape(1, -1),
+            dtype=dtype,
+            device=self.device,
+        )
+        # Build proper inputs for descriptor-level test
+        from deepmd.dpmodel.utils.nlist import (
+            build_neighbor_list,
+            extend_coord_with_ghosts,
+        )
+        from deepmd.dpmodel.utils.region import (
+            normalize_coord,
+        )
+
+        coord_np = self.coord.detach().cpu().numpy().reshape(1, self.natoms, 3)
+        atype_np = self.atype.detach().cpu().numpy()
+        cell_np = self.cell.reshape(1, 9).detach().cpu().numpy()
+        coord_normalized = normalize_coord(coord_np, cell_np.reshape(1, 3, 3))
+        ext_coord, ext_atype, _ = extend_coord_with_ghosts(
+            coord_normalized, atype_np, cell_np, self.rcut
+        )
+        nlist_np = build_neighbor_list(
+            ext_coord,
+            ext_atype,
+            self.natoms,
+            self.rcut,
+            self.sel,
+            distinguish_types=True,
+        )
+        ext_coord_t = torch.tensor(
+            ext_coord.reshape(1, -1, 3), dtype=dtype, device=self.device
+        )
+        ext_atype_t = torch.tensor(ext_atype, dtype=torch.int64, device=self.device)
+        nlist_t = torch.tensor(nlist_np, dtype=torch.int64, device=self.device)
+
+        rd1, _, _, _, _ = desc(ext_coord_t, ext_atype_t, nlist_t)
+        rd2, _, _, _, _ = desc2(ext_coord_t, ext_atype_t, nlist_t)
+        np.testing.assert_allclose(
+            rd1.detach().cpu().numpy(),
+            rd2.detach().cpu().numpy(),
+            atol=1e-10,
+        )
 
     def test_compress_cli_entry_point(self) -> None:
         """Test that the CLI entry point (main) dispatches compress correctly.

--- a/source/tests/pt_expt/model/test_model_compression.py
+++ b/source/tests/pt_expt/model/test_model_compression.py
@@ -178,6 +178,47 @@ class TestModelCompression(unittest.TestCase):
         finally:
             os.unlink(frozen_path)
 
+    def test_compress_cli_entry_point(self) -> None:
+        """Test that the CLI entry point (main) dispatches compress correctly.
+
+        This exercises the FLAGS.input argument parsing path, which previously
+        had a bug (FLAGS.INPUT instead of FLAGS.input).
+        """
+        from deepmd.pt_expt.entrypoints.main import (
+            main,
+        )
+
+        md = self._make_model()
+        md.min_nbor_dist = 0.5
+        md.eval()
+
+        model_data = {"model": md.serialize(), "min_nbor_dist": 0.5}
+        with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
+            frozen_path = f.name
+        with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
+            compressed_path = f.name
+        try:
+            deserialize_to_file(frozen_path, model_data)
+
+            # Call via CLI entry point
+            main(
+                [
+                    "compress",
+                    "-i",
+                    frozen_path,
+                    "-o",
+                    compressed_path,
+                ]
+            )
+
+            # Verify the compressed file was created and is loadable
+            compressed_data = serialize_from_file(compressed_path)
+            self.assertIn("model", compressed_data)
+        finally:
+            os.unlink(frozen_path)
+            if os.path.exists(compressed_path):
+                os.unlink(compressed_path)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add model compression (embedding net tabulation) for the pt_expt backend, matching the existing pt backend capability
- Compressed models replace embedding net forward passes with polynomial lookup tables via C++ custom ops (`tabulate_fusion_se_*`), significantly speeding up inference
- Support all compressible descriptors: `se_e2_a`, `se_r`, `se_t`, `se_t_tebd`, `dpa1`, `se_atten_v2`, `dpa2` (hybrid delegates automatically)

### Key changes

**Infrastructure:**
- `deepmd/pt_expt/utils/tabulate_ops.py` — Register `torch.library.register_fake` for all 5 custom ops to enable `torch.export`/`make_fx` tracing through compressed forward paths
- `deepmd/pt_expt/utils/tabulate.py` — `DPTabulate` subclass that detects descriptor type via serialized data (avoids `isinstance` checks against pt-specific classes)
- `deepmd/pt_expt/entrypoints/compress.py` — Entry point: load `.pte` → deserialize → `enable_compression()` → re-export `.pte`

**Descriptors:** Each gets `enable_compression()` + `@cast_precision` `call()` override with compressed branch using the appropriate custom op.

**dpmodel — compression state serialization (breaking version bumps):**

The pt_expt backend persists models via `serialize()` → `model.json` → `deserialize()` (the `.pte` format), unlike pt/tf which use native framework save mechanisms (torch.jit.save / tf.saved_model) that capture the full runtime state. This means compression state (tabulated polynomial coefficients, precomputed type embeddings) must survive the serialize/deserialize round-trip for compressed `.pte` models to work.

Each compressible descriptor's serialization version is bumped when the model is compressed. **Uncompressed models continue to use the old version**, so there is no breakage for existing uncompressed model files. All backends (pt, pd, tf) accept the new version in `deserialize()` and simply ignore the `"compress"` key.

| Descriptor | Version bump | Added fields |
|---|---|---|
| `se_e2_a` | 2 → 3 | `compress_data`, `compress_info` |
| `se_r` | 2 → 3 | `compress_data`, `compress_info` |
| `se_t` | 2 → 3 | `compress_data`, `compress_info` |
| `se_t_tebd` | 1 → 2 | `compress_data`, `compress_info`, `type_embd_data` |
| `dpa1` | 2 → 3 | `type_embd_data`, `geo_compress`, `compress_data`/`info` (if geo) |
| `se_atten_v2` | 2 → 3 | `type_embd_data`, `geo_compress`, `compress_data`/`info` (if geo) |
| `dpa2` | 3 → 4 | compress dict inside `repinit_variable` |

**dpmodel:** Initialize `self.compress = False` in all descriptor `__init__` methods.

## Test plan

- [x] `source/tests/pt_expt/model/test_model_compression.py` — end-to-end compress → serialize → deserialize → eval
- [x] `source/tests/pt_expt/descriptor/` — compressed forward, consistency, exportable, make_fx tests for all descriptors
- [x] `source/tests/consistent/descriptor/` — cross-backend consistency tests pass with bumped versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptor compression functionality to reduce model size and optimize memory usage during inference.
  * Introduced `compress` CLI command to enable tabulated embedding optimization on frozen trained models.
  * Enhanced descriptor serialization with improved version compatibility across multiple backends.

* **Tests**
  * Added comprehensive test coverage for compressed descriptor forward passes and model compression workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->