### PR TITLE
feat: add WSD LR Scheduler

### DIFF
--- a/deepmd/dpmodel/utils/learning_rate.py
+++ b/deepmd/dpmodel/utils/learning_rate.py
@@ -511,18 +511,10 @@ class LearningRateWSD(BaseLR):
         # === Derive stable and decay phase lengths ===
         self.decay_phase_ratio = decay_phase_ratio
         self.decay_type = decay_type
-        self.decay_phase_steps = int(self.decay_phase_ratio * self.num_steps)
-        if self.decay_phase_steps <= 0:
-            raise ValueError(
-                "decay_phase_ratio results in zero decay steps. "
-                "Increase num_steps or decay_phase_ratio."
-            )
-        if self.decay_phase_steps > self.decay_num_steps:
-            raise ValueError(
-                "decay phase steps must not exceed the post-warmup steps. "
-                f"Got decay_phase_steps={self.decay_phase_steps}, "
-                f"post_warmup_steps={self.decay_num_steps}."
-            )
+        # Clamp decay_phase_steps to valid range [1, decay_num_steps]
+        self.decay_phase_steps = max(
+            1, min(int(self.decay_phase_ratio * self.num_steps), self.decay_num_steps)
+        )
         self.stable_steps = self.decay_num_steps - self.decay_phase_steps
 
     def _decay_value(self, step: int | Array) -> Array:
@@ -556,7 +548,6 @@ class LearningRateWSD(BaseLR):
         stop_lr = xp.asarray(self.stop_lr, dtype=step_dtype)
         stable_steps = xp.asarray(self.stable_steps, dtype=step_dtype)
         decay_phase_steps = xp.asarray(self.decay_phase_steps, dtype=step_dtype)
-        decay_num_steps = xp.asarray(self.decay_num_steps, dtype=step_dtype)
 
         # === Step 2. Keep a constant learning rate in the stable phase ===
         decay_progress = (typed_step - stable_steps) / decay_phase_steps

--- a/deepmd/dpmodel/utils/learning_rate.py
+++ b/deepmd/dpmodel/utils/learning_rate.py
@@ -393,6 +393,189 @@ class LearningRateExp(BaseLR):
         return step_lr
 
 
+@BaseLR.register("wsd")
+class LearningRateWSD(BaseLR):
+    r"""
+    Warmup-stable-decay learning rate schedule with configurable decay rules.
+
+    The schedule uses the shared warmup implementation from :class:`BaseLR`,
+    then keeps the learning rate at ``start_lr`` during the stable phase, and
+    finally applies one of the supported decay rules.
+
+    Let :math:`\tau \in [0, 1]` denote the normalized progress within the
+    decay phase.
+
+    **Inverse-linear mode (``decay_type="inverse_linear"``):**
+
+    .. math::
+
+        lr(t) = \frac{1}{
+            \tau / lr_{\text{stop}} + (1 - \tau) / lr_0
+        }
+
+    **Cosine mode (``decay_type="cosine"``):**
+
+    .. math::
+
+        lr(t) = lr_{\text{stop}} +
+        \frac{lr_0 - lr_{\text{stop}}}{2}
+        \left(1 + \cos(\pi \tau)\right)
+
+    **Linear mode (``decay_type="linear"``):**
+
+    .. math::
+
+        lr(t) = lr_0 + \left(lr_{\text{stop}} - lr_0\right)\tau
+    """
+
+    def __init__(
+        self,
+        start_lr: float,
+        num_steps: int,
+        stop_lr: float | None = None,
+        stop_lr_ratio: float | None = None,
+        warmup_steps: int = 0,
+        warmup_ratio: float | None = None,
+        warmup_start_factor: float = 0.0,
+        decay_phase_ratio: float = 0.1,
+        decay_type: str = "inverse_linear",
+        **kwargs: Any,
+    ) -> None:
+        """
+        Construct a warmup-stable-decay learning rate schedule.
+
+        Parameters
+        ----------
+        start_lr : float
+            The learning rate at the start of the stable phase.
+        num_steps : int
+            The total training steps (including warmup).
+        stop_lr : float, optional
+            The final learning rate at the end of training.
+            Mutually exclusive with stop_lr_ratio.
+        stop_lr_ratio : float, optional
+            The ratio of stop_lr to start_lr.
+            Mutually exclusive with stop_lr.
+        warmup_steps : int, optional
+            The number of warmup steps.
+            Mutually exclusive with warmup_ratio. Default is 0.
+        warmup_ratio : float, optional
+            The ratio of warmup steps to total training steps.
+            Mutually exclusive with warmup_steps.
+        warmup_start_factor : float, optional
+            The factor of start_lr for the initial warmup learning rate.
+            Default is 0.0.
+        decay_phase_ratio : float, optional
+            The ratio of the decay phase to total training steps.
+            Default is 0.1.
+        decay_type : str, optional
+            The decay rule used in the decay phase.
+            Supported values are ``inverse_linear``, ``cosine`` and ``linear``.
+            Default is ``inverse_linear``.
+
+        Raises
+        ------
+        ValueError
+            If the learning rates are non-positive.
+            If decay_phase_ratio is not in (0, 1].
+            If decay_type is invalid.
+            If the derived decay phase is empty or exceeds post-warmup steps.
+        """
+        super().__init__(
+            start_lr=start_lr,
+            stop_lr=stop_lr,
+            stop_lr_ratio=stop_lr_ratio,
+            num_steps=num_steps,
+            warmup_steps=warmup_steps,
+            warmup_ratio=warmup_ratio,
+            warmup_start_factor=warmup_start_factor,
+            **kwargs,
+        )
+
+        # === Validate WSD-specific invariants ===
+        if self._start_lr <= 0:
+            raise ValueError(f"start_lr ({self._start_lr}) must be positive.")
+        if self.stop_lr <= 0:
+            raise ValueError(f"stop_lr ({self.stop_lr}) must be positive.")
+        if decay_phase_ratio <= 0 or decay_phase_ratio > 1:
+            raise ValueError(
+                f"decay_phase_ratio ({decay_phase_ratio}) must be in (0, 1]."
+            )
+        if decay_type not in ("inverse_linear", "cosine", "linear"):
+            raise ValueError(
+                "decay_type must be one of "
+                f"{('inverse_linear', 'cosine', 'linear')}. "
+                f"Got decay_type={decay_type}."
+            )
+
+        # === Derive stable and decay phase lengths ===
+        self.decay_phase_ratio = decay_phase_ratio
+        self.decay_type = decay_type
+        self.decay_phase_steps = int(self.decay_phase_ratio * self.num_steps)
+        if self.decay_phase_steps <= 0:
+            raise ValueError(
+                "decay_phase_ratio results in zero decay steps. "
+                "Increase num_steps or decay_phase_ratio."
+            )
+        if self.decay_phase_steps > self.decay_num_steps:
+            raise ValueError(
+                "decay phase steps must not exceed the post-warmup steps. "
+                f"Got decay_phase_steps={self.decay_phase_steps}, "
+                f"post_warmup_steps={self.decay_num_steps}."
+            )
+        self.stable_steps = self.decay_num_steps - self.decay_phase_steps
+
+    def _decay_value(self, step: int | Array) -> Array:
+        """
+        Get the warmup-stable-decay learning rate at the given step.
+
+        Parameters
+        ----------
+        step : int or Array
+            The step index relative to the end of warmup.
+
+        Returns
+        -------
+        Array
+            The learning rate (absolute value).
+        """
+        if not array_api_compat.is_array_api_obj(step):
+            step = np.asarray(step)
+        xp = array_api_compat.array_namespace(step)
+        step_dtype = (
+            step.dtype
+            if xp.isdtype(step.dtype, "real floating")
+            else get_xp_precision(xp, "global")
+        )
+
+        # === Step 1. Build typed scalar constants ===
+        typed_step = xp.astype(step, step_dtype)
+        zero = xp.asarray(0.0, dtype=step_dtype)
+        one = xp.asarray(1.0, dtype=step_dtype)
+        start_lr = xp.asarray(self._start_lr, dtype=step_dtype)
+        stop_lr = xp.asarray(self.stop_lr, dtype=step_dtype)
+        stable_steps = xp.asarray(self.stable_steps, dtype=step_dtype)
+        decay_phase_steps = xp.asarray(self.decay_phase_steps, dtype=step_dtype)
+        decay_num_steps = xp.asarray(self.decay_num_steps, dtype=step_dtype)
+
+        # === Step 2. Keep a constant learning rate in the stable phase ===
+        decay_progress = (typed_step - stable_steps) / decay_phase_steps
+        tau = xp.clip(decay_progress, zero, one)
+
+        # === Step 3. Apply the selected interpolation in the decay phase ===
+        if self.decay_type == "inverse_linear":
+            decay_lr = one / (tau / stop_lr + (one - tau) / start_lr)
+        elif self.decay_type == "cosine":
+            decay_lr = stop_lr + (start_lr - stop_lr) * 0.5 * (
+                one + xp.cos(xp.asarray(xp.pi * tau, dtype=step_dtype))
+            )
+        else:
+            decay_lr = start_lr + (stop_lr - start_lr) * tau
+        step_lr = xp.where(step < self.stable_steps, start_lr, decay_lr)
+        step_lr = xp.where(step >= self.decay_num_steps, stop_lr, step_lr)
+        return step_lr
+
+
 @BaseLR.register("cosine")
 class LearningRateCosine(BaseLR):
     r"""

--- a/deepmd/pd/utils/learning_rate.py
+++ b/deepmd/pd/utils/learning_rate.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 from deepmd.dpmodel.utils.learning_rate import (
     LearningRateExp,
+    LearningRateWSD,
 )
 
 __all__ = [
     "LearningRateExp",
+    "LearningRateWSD",
 ]

--- a/deepmd/pt/utils/learning_rate.py
+++ b/deepmd/pt/utils/learning_rate.py
@@ -3,10 +3,12 @@ from deepmd.dpmodel.utils.learning_rate import (
     BaseLR,
     LearningRateCosine,
     LearningRateExp,
+    LearningRateWSD,
 )
 
 __all__ = [
     "BaseLR",
     "LearningRateCosine",
     "LearningRateExp",
+    "LearningRateWSD",
 ]

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -2594,6 +2594,61 @@ def _check_decay_steps_args(data: dict[str, Any]) -> bool:
     return True
 
 
+def _check_wsd_args(data: dict[str, Any]) -> bool:
+    """
+    Check WSD-specific learning rate arguments.
+
+    Parameters
+    ----------
+    data : dict[str, Any]
+        The learning rate configuration dictionary.
+
+    Returns
+    -------
+    bool
+        True if validation passes.
+
+    Raises
+    ------
+    ValueError
+        If the WSD-specific arguments are invalid.
+    """
+    lr_type = data.get("type", "exp")
+    if lr_type != "wsd":
+        return True
+
+    start_lr = data.get("start_lr")
+    if start_lr is not None and start_lr <= 0:
+        raise ValueError(f"start_lr ({start_lr}) must be positive for WSD.")
+
+    stop_lr = data.get("stop_lr")
+    if stop_lr is not None and stop_lr <= 0:
+        raise ValueError(f"stop_lr ({stop_lr}) must be positive for WSD.")
+
+    stop_lr_ratio = data.get("stop_lr_ratio")
+    if stop_lr_ratio is not None and stop_lr_ratio <= 0:
+        raise ValueError(f"stop_lr_ratio ({stop_lr_ratio}) must be positive for WSD.")
+
+    decay_phase_ratio = data.get("decay_phase_ratio")
+    if decay_phase_ratio is not None and (
+        decay_phase_ratio <= 0 or decay_phase_ratio > 1
+    ):
+        raise ValueError(f"decay_phase_ratio ({decay_phase_ratio}) must be in (0, 1].")
+
+    decay_type = data.get("decay_type")
+    if decay_type is not None and decay_type not in (
+        "inverse_linear",
+        "cosine",
+        "linear",
+    ):
+        raise ValueError(
+            "decay_type must be one of "
+            f"{('inverse_linear', 'cosine', 'linear')}. "
+            f"Got decay_type={decay_type}."
+        )
+    return True
+
+
 @lr_args_plugin.register("exp")
 def learning_rate_exp() -> list[Argument]:
     """
@@ -2645,6 +2700,42 @@ def learning_rate_cosine() -> list[Argument]:
     return []
 
 
+@lr_args_plugin.register("wsd")
+def learning_rate_wsd() -> list[Argument]:
+    """
+    Defines a warmup-stable-decay learning rate schedule with configurable
+    decay rules.
+
+    The learning rate stays at `start_lr` during the stable phase and then
+    decays to `stop_lr` with the selected decay rule.
+    """
+    doc_decay_phase_ratio = (
+        "The ratio of the decay phase to total training steps. "
+        "The remaining post-warmup steps are used as the stable phase. "
+        "Default is 0.1."
+    )
+    doc_decay_type = (
+        "The decay rule used in the decay phase. "
+        "Supported values are `inverse_linear` (default), `cosine`, and `linear`."
+    )
+    return [
+        Argument(
+            "decay_phase_ratio",
+            float,
+            optional=True,
+            default=0.1,
+            doc=doc_decay_phase_ratio,
+        ),
+        Argument(
+            "decay_type",
+            str,
+            optional=True,
+            default="inverse_linear",
+            doc=doc_decay_type,
+        ),
+    ]
+
+
 def learning_rate_variant_type_args() -> Variant:
     doc_lr = "The type of the learning rate."
 
@@ -2694,6 +2785,8 @@ def learning_rate_args(fold_subdoc: bool = False) -> Argument:
         _check_warmup_args(data)
         # Check decay_steps and decay_rate
         _check_decay_steps_args(data)
+        # Check WSD-specific arguments
+        _check_wsd_args(data)
         return True
 
     # Common arguments for all learning rate types (outside Variant)

--- a/doc/train/learning-rate.md
+++ b/doc/train/learning-rate.md
@@ -1,11 +1,12 @@
 # Learning rate
 
-DeePMD-kit supports two learning rate schedules:
+DeePMD-kit supports three learning rate schedules:
 
 - **`exp`**: Exponential decay with optional stepped or smooth mode
 - **`cosine`**: Cosine annealing for smooth decay curve
+- **`wsd`**: Warmup-stable-decay with configurable final decay rule
 
-Both schedules support an optional warmup phase where the learning rate gradually increases from a small initial value to the target {ref}`start_lr <learning_rate/start_lr>`.
+All schedules support an optional warmup phase where the learning rate gradually increases from a small initial value to the target {ref}`start_lr <learning_rate/start_lr>`.
 
 This page focuses on schedule behavior, examples, and formulas. For the canonical argument definitions, see {ref}`learning_rate <learning_rate>`.
 
@@ -32,14 +33,26 @@ This page focuses on schedule behavior, examples, and formulas. For the canonica
 }
 ```
 
+### Warmup-stable-decay
+
+```json
+"learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.001,
+    "stop_lr": 1e-6,
+    "decay_phase_ratio": 0.1
+}
+```
+
 ## Common parameters
 
 Use {ref}`learning_rate <learning_rate>` as the canonical parameter reference. This page only highlights the argument combinations that matter when choosing a schedule:
 
-- Shared by both {ref}`exp <learning_rate[exp]>` and {ref}`cosine <learning_rate[cosine]>`: {ref}`start_lr <learning_rate/start_lr>` plus exactly one of {ref}`stop_lr <learning_rate/stop_lr>` or {ref}`stop_lr_ratio <learning_rate/stop_lr_ratio>`.
-- Optional warmup for both schedules: {ref}`warmup_steps <learning_rate/warmup_steps>` or {ref}`warmup_ratio <learning_rate/warmup_ratio>`, with optional {ref}`warmup_start_factor <learning_rate/warmup_start_factor>`.
-- Optional distributed scaling for both schedules: {ref}`scale_by_worker <learning_rate/scale_by_worker>`.
+- Shared by {ref}`exp <learning_rate[exp]>`, {ref}`cosine <learning_rate[cosine]>`, and {ref}`wsd <learning_rate[wsd]>`: {ref}`start_lr <learning_rate/start_lr>` plus exactly one of {ref}`stop_lr <learning_rate/stop_lr>` or {ref}`stop_lr_ratio <learning_rate/stop_lr_ratio>`.
+- Optional warmup for all schedules: {ref}`warmup_steps <learning_rate/warmup_steps>` or {ref}`warmup_ratio <learning_rate/warmup_ratio>`, with optional {ref}`warmup_start_factor <learning_rate/warmup_start_factor>`.
+- Optional distributed scaling for all schedules: {ref}`scale_by_worker <learning_rate/scale_by_worker>`.
 - Additional options for {ref}`exp <learning_rate[exp]>`: {ref}`decay_steps <learning_rate[exp]/decay_steps>`, {ref}`decay_rate <learning_rate[exp]/decay_rate>`, and {ref}`smooth <learning_rate[exp]/smooth>`.
+- Additional options for {ref}`wsd <learning_rate[wsd]>`: {ref}`decay_phase_ratio <learning_rate[wsd]/decay_phase_ratio>` and {ref}`decay_type <learning_rate[wsd]/decay_type>`.
 - {ref}`cosine <learning_rate[cosine]>` has no extra schedule-specific arguments beyond the shared ones.
 
 See [Mathematical Theory](#mathematical-theory) for complete formulas.
@@ -163,6 +176,79 @@ After warmup, the learning rate follows a cosine curve from {ref}`start_lr <lear
 }
 ```
 
+## Warmup-Stable-Decay Schedule
+
+The warmup-stable-decay ({ref}`wsd <learning_rate[wsd]>`) schedule keeps the learning rate at {ref}`start_lr <learning_rate/start_lr>` for most of the post-warmup training steps and then applies a shorter final decay phase.
+
+The length of the final decay phase is controlled by {ref}`decay_phase_ratio <learning_rate[wsd]/decay_phase_ratio>`. The remaining post-warmup steps form the stable phase. The decay rule is selected by {ref}`decay_type <learning_rate[wsd]/decay_type>`, which supports `inverse_linear` (default), `cosine`, and `linear`.
+
+### Examples
+
+**Basic WSD with default inverse-linear decay:**
+
+```json
+"learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.001,
+    "stop_lr": 1e-6,
+    "decay_phase_ratio": 0.1
+}
+```
+
+This configuration uses a stable phase for most of the post-warmup training and reserves the final 10% of total training steps for the decay phase.
+
+**Using {ref}`stop_lr_ratio <learning_rate/stop_lr_ratio>`:**
+
+```json
+"learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.001,
+    "stop_lr_ratio": 1e-3,
+    "decay_phase_ratio": 0.1
+}
+```
+
+Equivalent to `stop_lr: 1e-6` (i.e., `0.001 * 1e-3`).
+
+**With warmup:**
+
+```json
+"learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.001,
+    "stop_lr": 1e-6,
+    "decay_phase_ratio": 0.1,
+    "warmup_steps": 5000,
+    "warmup_start_factor": 0.0
+}
+```
+
+Warmup first increases the learning rate to {ref}`start_lr <learning_rate/start_lr>`. After warmup, the schedule enters the stable phase and finally decays during the last WSD decay phase.
+
+**WSD with cosine decay phase:**
+
+```json
+"learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.001,
+    "stop_lr": 1e-6,
+    "decay_phase_ratio": 0.1,
+    "decay_type": "cosine"
+}
+```
+
+**WSD with linear decay phase:**
+
+```json
+"learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.001,
+    "stop_lr": 1e-6,
+    "decay_phase_ratio": 0.1,
+    "decay_type": "linear"
+}
+```
+
 ## Warmup Mechanism
 
 Warmup is a technique to stabilize training in early stages by gradually increasing the learning rate from {ref}`warmup_start_factor <learning_rate/warmup_start_factor>` `*` {ref}`start_lr <learning_rate/start_lr>` to {ref}`start_lr <learning_rate/start_lr>`.
@@ -185,6 +271,10 @@ The exact piecewise warmup formula is given in [Mathematical Theory](#mathematic
 | $f^{\text{warmup}}$    | {ref}`warmup_start_factor <learning_rate/warmup_start_factor>`: Initial warmup LR factor   |
 | $s$                    | {ref}`decay_steps <learning_rate[exp]/decay_steps>`: Decay period for exponential schedule |
 | $r$                    | {ref}`decay_rate <learning_rate[exp]/decay_rate>`: Decay rate for exponential schedule     |
+| $\rho^{\text{wsd}}$    | {ref}`decay_phase_ratio <learning_rate[wsd]/decay_phase_ratio>`: Ratio of WSD decay phase  |
+| $\tau^{\text{wsd}}$    | Number of WSD decay-phase steps                                                            |
+| $\tau^{\text{stable}}$ | Number of WSD stable-phase steps                                                           |
+| $\hat{\tau}$           | Normalized progress within the WSD decay phase                                             |
 
 ### Complete warmup formula
 
@@ -229,6 +319,67 @@ Equivalently, using $\alpha = \gamma^{\text{stop}} / \gamma^0$:
 ```math
 \gamma(\tau) = \gamma^0 \cdot \left[\alpha + \frac{1 - \alpha}{2}\left(1 + \cos\left(\frac{\pi \cdot (\tau - \tau^{\text{warmup}})}{\tau^{\text{decay}}}\right)\right)\right]
 ```
+
+### Warmup-stable-decay
+
+For WSD, define the final decay-phase length as:
+
+```math
+\tau^{\text{wsd}} = \left\lfloor \rho^{\text{wsd}} \cdot \tau^{\text{stop}} \right\rfloor
+```
+
+and the stable-phase length as:
+
+```math
+\tau^{\text{stable}} = \tau^{\text{decay}} - \tau^{\text{wsd}}
+```
+
+For steps in the stable phase,
+
+```math
+\gamma(\tau) = \gamma^0, \qquad
+\tau^{\text{warmup}} \leq \tau < \tau^{\text{warmup}} + \tau^{\text{stable}}
+```
+
+For steps in the final decay phase, define the normalized decay progress:
+
+```math
+\hat{\tau} =
+\frac{
+\tau - \tau^{\text{warmup}} - \tau^{\text{stable}}
+}{
+\tau^{\text{wsd}}
+}
+```
+
+Then the decay-phase formulas are:
+
+**Inverse-linear decay (`decay_type: "inverse_linear"`):**
+
+```math
+\gamma(\tau) =
+\frac{1}{
+\hat{\tau} / \gamma^{\text{stop}} + (1 - \hat{\tau}) / \gamma^0
+}
+```
+
+**Cosine decay (`decay_type: "cosine"`):**
+
+```math
+\gamma(\tau) =
+\gamma^{\text{stop}} +
+\frac{\gamma^0 - \gamma^{\text{stop}}}{2}
+\left(1 + \cos\left(\pi \hat{\tau}\right)\right)
+```
+
+**Linear decay (`decay_type: "linear"`):**
+
+```math
+\gamma(\tau) =
+\gamma^0 + \left(\gamma^{\text{stop}} - \gamma^0\right)\hat{\tau}
+```
+
+For steps beyond the end of the decay phase, the learning rate stays at $\gamma^{\text{stop}}$.
 
 ## Migration from versions before 3.1.3
 

--- a/source/tests/consistent/test_learning_rate.py
+++ b/source/tests/consistent/test_learning_rate.py
@@ -51,6 +51,32 @@ if INSTALLED_ARRAY_API_STRICT:
             "num_steps": 1000000,
             "warmup_steps": 10000,
         },
+        {
+            "type": "wsd",
+            "start_lr": 1e-3,
+            "stop_lr": 1e-8,
+            "num_steps": 1000000,
+            "warmup_steps": 10000,
+            "decay_phase_ratio": 0.1,
+        },
+        {
+            "type": "wsd",
+            "start_lr": 1e-3,
+            "stop_lr": 1e-8,
+            "num_steps": 1000000,
+            "warmup_steps": 10000,
+            "decay_phase_ratio": 0.1,
+            "decay_type": "cosine",
+        },
+        {
+            "type": "wsd",
+            "start_lr": 1e-3,
+            "stop_lr": 1e-8,
+            "num_steps": 1000000,
+            "warmup_steps": 10000,
+            "decay_phase_ratio": 0.1,
+            "decay_type": "linear",
+        },
     ),
 )
 class TestLearningRateConsistent(unittest.TestCase):
@@ -59,7 +85,14 @@ class TestLearningRateConsistent(unittest.TestCase):
     def setUp(self) -> None:
         (lr_param,) = self.param
         self.lr = BaseLR(**lr_param)
-        self.step = 500000
+        if hasattr(self.lr, "stable_steps") and hasattr(self.lr, "decay_phase_steps"):
+            self.step = (
+                self.lr.warmup_steps
+                + self.lr.stable_steps
+                + self.lr.decay_phase_steps // 2
+            )
+        else:
+            self.step = 500000
         self.ref = self.lr.value(self.step)
         self.warmup_step = None
         self.warmup_ref = None

--- a/source/tests/pd/test_lr.py
+++ b/source/tests/pd/test_lr.py
@@ -9,6 +9,9 @@ tf.disable_eager_execution()
 from deepmd.dpmodel.utils.learning_rate import (
     LearningRateExp,
 )
+from deepmd.pd.utils.learning_rate import (
+    LearningRateWSD,
+)
 from deepmd.tf.utils.learning_rate import (
     LearningRateSchedule,
 )
@@ -111,6 +114,62 @@ class TestLearningRate(unittest.TestCase):
         self.assertTrue(
             np.allclose(my_vals_decay_trunc, np.clip(my_vals, a_min=min_lr, a_max=None))
         )
+
+
+class TestLearningRateWSD(unittest.TestCase):
+    def test_basic_curve(self):
+        start_lr = 1.0
+        stop_lr = 0.1
+        stop_steps = 10
+        lr = LearningRateWSD(
+            start_lr=start_lr,
+            stop_lr=stop_lr,
+            num_steps=stop_steps,
+            decay_phase_ratio=0.2,
+        )
+
+        expected_mid = 1.0 / (0.5 / stop_lr + 0.5 / start_lr)
+        self.assertTrue(np.allclose(lr.value(0), start_lr))
+        self.assertTrue(np.allclose(lr.value(8), start_lr))
+        self.assertTrue(np.allclose(lr.value(9), expected_mid))
+        self.assertTrue(np.allclose(lr.value(stop_steps), stop_lr))
+        self.assertTrue(np.allclose(lr.value(stop_steps + 5), stop_lr))
+
+    def test_cosine_curve(self):
+        start_lr = 1.0
+        stop_lr = 0.1
+        stop_steps = 10
+        lr = LearningRateWSD(
+            start_lr=start_lr,
+            stop_lr=stop_lr,
+            num_steps=stop_steps,
+            decay_phase_ratio=0.2,
+            decay_type="cosine",
+        )
+
+        expected_mid = stop_lr + (start_lr - stop_lr) * 0.5
+        self.assertTrue(np.allclose(lr.value(0), start_lr))
+        self.assertTrue(np.allclose(lr.value(8), start_lr))
+        self.assertTrue(np.allclose(lr.value(9), expected_mid))
+        self.assertTrue(np.allclose(lr.value(stop_steps), stop_lr))
+
+    def test_linear_curve(self):
+        start_lr = 1.0
+        stop_lr = 0.1
+        stop_steps = 10
+        lr = LearningRateWSD(
+            start_lr=start_lr,
+            stop_lr=stop_lr,
+            num_steps=stop_steps,
+            decay_phase_ratio=0.2,
+            decay_type="linear",
+        )
+
+        expected_mid = start_lr + (stop_lr - start_lr) * 0.5
+        self.assertTrue(np.allclose(lr.value(0), start_lr))
+        self.assertTrue(np.allclose(lr.value(8), start_lr))
+        self.assertTrue(np.allclose(lr.value(9), expected_mid))
+        self.assertTrue(np.allclose(lr.value(stop_steps), stop_lr))
 
 
 if __name__ == "__main__":

--- a/source/tests/pt/test_lr.py
+++ b/source/tests/pt/test_lr.py
@@ -9,6 +9,7 @@ tf.disable_eager_execution()
 from deepmd.pt.utils.learning_rate import (
     LearningRateCosine,
     LearningRateExp,
+    LearningRateWSD,
 )
 from deepmd.tf.utils.learning_rate import (
     LearningRateSchedule,
@@ -132,6 +133,62 @@ class TestLearningRateCosine(unittest.TestCase):
         mid_step = stop_steps // 2
         expected_mid = stop_lr + (start_lr - stop_lr) * 0.5
         self.assertTrue(np.allclose(lr.value(mid_step), expected_mid))
+
+
+class TestLearningRateWSD(unittest.TestCase):
+    def test_basic_curve(self) -> None:
+        start_lr = 1.0
+        stop_lr = 0.1
+        stop_steps = 10
+        lr = LearningRateWSD(
+            start_lr=start_lr,
+            stop_lr=stop_lr,
+            num_steps=stop_steps,
+            decay_phase_ratio=0.2,
+        )
+
+        expected_mid = 1.0 / (0.5 / stop_lr + 0.5 / start_lr)
+        self.assertTrue(np.allclose(lr.value(0), start_lr))
+        self.assertTrue(np.allclose(lr.value(8), start_lr))
+        self.assertTrue(np.allclose(lr.value(9), expected_mid))
+        self.assertTrue(np.allclose(lr.value(stop_steps), stop_lr))
+        self.assertTrue(np.allclose(lr.value(stop_steps + 5), stop_lr))
+
+    def test_cosine_curve(self) -> None:
+        start_lr = 1.0
+        stop_lr = 0.1
+        stop_steps = 10
+        lr = LearningRateWSD(
+            start_lr=start_lr,
+            stop_lr=stop_lr,
+            num_steps=stop_steps,
+            decay_phase_ratio=0.2,
+            decay_type="cosine",
+        )
+
+        expected_mid = stop_lr + (start_lr - stop_lr) * 0.5
+        self.assertTrue(np.allclose(lr.value(0), start_lr))
+        self.assertTrue(np.allclose(lr.value(8), start_lr))
+        self.assertTrue(np.allclose(lr.value(9), expected_mid))
+        self.assertTrue(np.allclose(lr.value(stop_steps), stop_lr))
+
+    def test_linear_curve(self) -> None:
+        start_lr = 1.0
+        stop_lr = 0.1
+        stop_steps = 10
+        lr = LearningRateWSD(
+            start_lr=start_lr,
+            stop_lr=stop_lr,
+            num_steps=stop_steps,
+            decay_phase_ratio=0.2,
+            decay_type="linear",
+        )
+
+        expected_mid = start_lr + (stop_lr - start_lr) * 0.5
+        self.assertTrue(np.allclose(lr.value(0), start_lr))
+        self.assertTrue(np.allclose(lr.value(8), start_lr))
+        self.assertTrue(np.allclose(lr.value(9), expected_mid))
+        self.assertTrue(np.allclose(lr.value(stop_steps), stop_lr))
 
 
 if __name__ == "__main__":

--- a/source/tests/tf/test_lr.py
+++ b/source/tests/tf/test_lr.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from deepmd.dpmodel.utils.learning_rate import (
     LearningRateExp,
+    LearningRateWSD,
 )
 from deepmd.tf.env import (
     tf,
@@ -101,6 +102,42 @@ class TestLearningRateScheduleBuild(unittest.TestCase):
         expected = lr_schedule.base_lr.value(5000)
 
         np.testing.assert_allclose(lr_value, expected, rtol=1e-10)
+
+    def test_wsd_build_and_value(self) -> None:
+        """Test TF wrapper with the WSD scheduler."""
+        lr_schedule = LearningRateSchedule(
+            {
+                "start_lr": 1e-3,
+                "stop_lr": 1e-5,
+                "type": "wsd",
+                "decay_phase_ratio": 0.1,
+            }
+        )
+        global_step = tf.constant(0, dtype=tf.int64)
+        lr_schedule.build(global_step, num_steps=10000)
+
+        self.assertIsInstance(lr_schedule.base_lr, LearningRateWSD)
+        np.testing.assert_allclose(
+            lr_schedule.value(9500), lr_schedule.base_lr.value(9500), rtol=1e-10
+        )
+
+    def test_wsd_cosine_build_and_value(self) -> None:
+        """Test TF wrapper with cosine WSD decay."""
+        lr_schedule = LearningRateSchedule(
+            {
+                "start_lr": 1e-3,
+                "stop_lr": 1e-5,
+                "type": "wsd",
+                "decay_phase_ratio": 0.1,
+                "decay_type": "cosine",
+            }
+        )
+        global_step = tf.constant(0, dtype=tf.int64)
+        lr_schedule.build(global_step, num_steps=10000)
+
+        np.testing.assert_allclose(
+            lr_schedule.value(9500), lr_schedule.base_lr.value(9500), rtol=1e-10
+        )
 
 
 if __name__ == "__main__":

--- a/source/tests/universal/dpmodel/utils/test_learning_rate.py
+++ b/source/tests/universal/dpmodel/utils/test_learning_rate.py
@@ -164,15 +164,17 @@ class TestLearningRateWSDBasic(unittest.TestCase):
             )
 
     def test_decay_phase_exceeds_post_warmup_steps(self) -> None:
-        """Test WSD rejects decay phases longer than post-warmup steps."""
-        with self.assertRaises(ValueError):
-            LearningRateWSD(
-                start_lr=1e-3,
-                stop_lr=1e-5,
-                num_steps=10,
-                warmup_steps=9,
-                decay_phase_ratio=0.2,
-            )
+        """Test WSD clamps decay_phase_steps to post-warmup steps when ratio is too large."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10,
+            warmup_steps=9,
+            decay_phase_ratio=0.2,
+        )
+        # decay_num_steps = 1, so decay_phase_steps should be clamped to 1
+        self.assertEqual(lr.decay_phase_steps, 1)
+        self.assertEqual(lr.stable_steps, 0)
 
 
 class TestLearningRateWarmup(unittest.TestCase):

--- a/source/tests/universal/dpmodel/utils/test_learning_rate.py
+++ b/source/tests/universal/dpmodel/utils/test_learning_rate.py
@@ -9,6 +9,7 @@ from deepmd.dpmodel.common import (
 from deepmd.dpmodel.utils.learning_rate import (
     LearningRateCosine,
     LearningRateExp,
+    LearningRateWSD,
 )
 
 
@@ -74,6 +75,106 @@ class TestLearningRateCosineBasic(unittest.TestCase):
         np.testing.assert_allclose(lr.stop_lr, 1e-5, rtol=1e-10)
 
 
+class TestLearningRateWSDBasic(unittest.TestCase):
+    """Test warmup-stable-decay learning rate functionality."""
+
+    def test_basic_wsd_inverse_linear(self) -> None:
+        """Test plateau and inverse-linear decay without warmup."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            decay_phase_ratio=0.1,
+        )
+        expected_mid = 1.0 / (0.5 / 1e-5 + 0.5 / 1e-3)
+
+        self.assertEqual(lr.stable_steps, 9000)
+        np.testing.assert_allclose(lr.value(0), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9000), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9500), expected_mid, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(10000), 1e-5, rtol=1e-10)
+
+    def test_basic_wsd_cosine(self) -> None:
+        """Test plateau and cosine decay without warmup."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            decay_phase_ratio=0.1,
+            decay_type="cosine",
+        )
+        expected_mid = 1e-5 + (1e-3 - 1e-5) * 0.5
+
+        self.assertEqual(lr.stable_steps, 9000)
+        np.testing.assert_allclose(lr.value(0), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9000), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9500), expected_mid, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(10000), 1e-5, rtol=1e-10)
+
+    def test_basic_wsd_linear(self) -> None:
+        """Test plateau and linear decay without warmup."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            decay_phase_ratio=0.1,
+            decay_type="linear",
+        )
+        expected_mid = 1e-3 + (1e-5 - 1e-3) * 0.5
+
+        self.assertEqual(lr.stable_steps, 9000)
+        np.testing.assert_allclose(lr.value(0), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9000), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9500), expected_mid, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(10000), 1e-5, rtol=1e-10)
+
+    def test_stop_lr_ratio(self) -> None:
+        """Test stop_lr_ratio parameter for WSD."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr_ratio=0.01,
+            num_steps=10000,
+            decay_phase_ratio=0.1,
+        )
+        np.testing.assert_allclose(lr.stop_lr, 1e-5, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(10000), 1e-5, rtol=1e-10)
+
+    def test_invalid_decay_phase_ratio(self) -> None:
+        """Test invalid WSD decay_phase_ratio values."""
+        with self.assertRaises(ValueError):
+            LearningRateWSD(
+                start_lr=1e-3,
+                stop_lr=1e-5,
+                num_steps=10000,
+                decay_phase_ratio=0.0,
+            )
+        with self.assertRaises(ValueError):
+            LearningRateWSD(
+                start_lr=1e-3,
+                stop_lr=1e-5,
+                num_steps=10000,
+                decay_phase_ratio=1.1,
+            )
+        with self.assertRaises(ValueError):
+            LearningRateWSD(
+                start_lr=1e-3,
+                stop_lr=1e-5,
+                num_steps=10000,
+                decay_type="bad_mode",
+            )
+
+    def test_decay_phase_exceeds_post_warmup_steps(self) -> None:
+        """Test WSD rejects decay phases longer than post-warmup steps."""
+        with self.assertRaises(ValueError):
+            LearningRateWSD(
+                start_lr=1e-3,
+                stop_lr=1e-5,
+                num_steps=10,
+                warmup_steps=9,
+                decay_phase_ratio=0.2,
+            )
+
+
 class TestLearningRateWarmup(unittest.TestCase):
     """Test learning rate warmup functionality."""
 
@@ -107,6 +208,41 @@ class TestLearningRateWarmup(unittest.TestCase):
         self.assertEqual(lr.decay_num_steps, 9000)
         np.testing.assert_allclose(lr.value(0), 0.0, rtol=1e-10)
         np.testing.assert_allclose(lr.value(1000), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(10000), 1e-5, rtol=1e-10)
+
+    def test_warmup_steps_wsd(self) -> None:
+        """Test warmup with default inverse-linear WSD schedule."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            warmup_steps=1000,
+            decay_phase_ratio=0.1,
+        )
+        self.assertEqual(lr.decay_num_steps, 9000)
+        self.assertEqual(lr.decay_phase_steps, 1000)
+        self.assertEqual(lr.stable_steps, 8000)
+        np.testing.assert_allclose(lr.value(0), 0.0, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(500), 0.5e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(1000), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9000), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(10000), 1e-5, rtol=1e-10)
+
+    def test_warmup_steps_wsd_linear(self) -> None:
+        """Test warmup with linear WSD decay."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            warmup_steps=1000,
+            decay_phase_ratio=0.1,
+            decay_type="linear",
+        )
+        expected_mid = 1e-3 + (1e-5 - 1e-3) * 0.5
+
+        np.testing.assert_allclose(lr.value(0), 0.0, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(1000), 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lr.value(9500), expected_mid, rtol=1e-10)
         np.testing.assert_allclose(lr.value(10000), 1e-5, rtol=1e-10)
 
     def test_warmup_ratio(self) -> None:
@@ -181,6 +317,43 @@ class TestLearningRateArrayInput(unittest.TestCase):
         np.testing.assert_allclose(lrs[1], 1e-3, rtol=1e-10)
         np.testing.assert_allclose(lrs[3], 1e-5, rtol=1e-10)
 
+    def test_array_input_wsd(self) -> None:
+        """Test inverse-linear warmup-stable-decay with array input."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            decay_phase_ratio=0.1,
+        )
+        steps = np.array([0, 9000, 9500, 10000])
+        lrs = lr.value(steps)
+        expected_mid = 1.0 / (0.5 / 1e-5 + 0.5 / 1e-3)
+
+        self.assertEqual(lrs.shape, (4,))
+        np.testing.assert_allclose(lrs[0], 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lrs[1], 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lrs[2], expected_mid, rtol=1e-10)
+        np.testing.assert_allclose(lrs[3], 1e-5, rtol=1e-10)
+
+    def test_array_input_wsd_cosine(self) -> None:
+        """Test cosine warmup-stable-decay with array input."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            decay_phase_ratio=0.1,
+            decay_type="cosine",
+        )
+        steps = np.array([0, 9000, 9500, 10000])
+        lrs = lr.value(steps)
+        expected_mid = 1e-5 + (1e-3 - 1e-5) * 0.5
+
+        self.assertEqual(lrs.shape, (4,))
+        np.testing.assert_allclose(lrs[0], 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lrs[1], 1e-3, rtol=1e-10)
+        np.testing.assert_allclose(lrs[2], expected_mid, rtol=1e-10)
+        np.testing.assert_allclose(lrs[3], 1e-5, rtol=1e-10)
+
 
 class TestLearningRateBeyondStopSteps(unittest.TestCase):
     """Test learning rate behavior beyond num_steps."""
@@ -201,5 +374,15 @@ class TestLearningRateBeyondStopSteps(unittest.TestCase):
             start_lr=1e-3,
             stop_lr=1e-5,
             num_steps=10000,
+        )
+        np.testing.assert_allclose(lr.value(20000), 1e-5, rtol=1e-10)
+
+    def test_wsd_beyond_num_steps(self) -> None:
+        """Test WSD returns stop_lr beyond decay phase."""
+        lr = LearningRateWSD(
+            start_lr=1e-3,
+            stop_lr=1e-5,
+            num_steps=10000,
+            decay_phase_ratio=0.1,
         )
         np.testing.assert_allclose(lr.value(20000), 1e-5, rtol=1e-10)


### PR DESCRIPTION
The doc will be added through PR #5276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "wsd" (warmup → stable → decay) learning-rate schedule with configurable warmup, stable duration, decay-phase ratio, and three decay modes: inverse_linear, cosine, linear. Validation prevents invalid parameter combinations and enforces sensible ranges.
  * Exposed the new schedule in the public API.

* **Tests**
  * Added comprehensive tests for decay modes, warmup/stable behavior, edge cases, array/JIT inputs, and beyond-endstep behavior.

* **Documentation**
  * Documented the new "wsd" schedule, parameters, examples, and mathematical definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->