### PR TITLE
fix(pt): use strict=False when loading .pt checkpoints for inference

### DIFF
--- a/deepmd/pt/infer/deep_eval.py
+++ b/deepmd/pt/infer/deep_eval.py
@@ -170,7 +170,18 @@ class DeepEval(DeepEvalBackend):
             if not self.input_param.get("hessian_mode") and not no_jit:
                 model = torch.jit.script(model)
             self.dp = ModelWrapper(model)
-            self.dp.load_state_dict(state_dict)
+            missing, unexpected = self.dp.load_state_dict(state_dict, strict=False)
+            if missing:
+                log.warning(
+                    "Checkpoint loaded with missing keys (likely from an older "
+                    "version): %s",
+                    missing,
+                )
+            if unexpected:
+                log.warning(
+                    "Checkpoint loaded with unexpected keys: %s",
+                    unexpected,
+                )
         elif str(self.model_path).endswith(".pth"):
             extra_files = {"data_modifier.pth": ""}
             model = torch.jit.load(


### PR DESCRIPTION
## Summary

- Use `strict=False` in `load_state_dict` when loading `.pt` checkpoints in the `no_jit=True` inference path
- Log warnings for missing/unexpected keys instead of crashing

## Root cause

PR #5323 and #5057 added new buffers/parameters to `DescrptBlockSeAtten.__init__`:
- `type_embd_data` (buffer, for type embedding compression)
- `compress_info` (ParameterList, for geometric compression)
- `compress_data` (ParameterList, for geometric compression)

These are initialized to zero-size tensors (uncompressed state). Old checkpoints saved before these PRs don't contain these keys, so `load_state_dict(strict=True)` raises `RuntimeError: Missing key(s)`.

## Fix

Use `strict=False` with warning logs, matching the pattern already used in `training.py:740`. The zero-initialized defaults correctly represent uncompressed state.

## Test plan

- [x] Pre-existing tests pass (no behavioral change for new checkpoints)
- [x] Fixes loading of old DPA-2 checkpoints (`dpa-2.4-7M.pt`) with `no_jit=True`

Reported by @njzjz .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint loading compatibility to support models with missing or unexpected parameters, with detailed warning messages logged for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->