### PR TITLE
Fix #5360: Deprecate the GROMACS patch

### DIFF
--- a/source/gmx/CMakeLists.txt
+++ b/source/gmx/CMakeLists.txt
@@ -1,3 +1,7 @@
+message(
+  DEPRECATION
+  "The GROMACS plugin is deprecated and will be removed in a future version. "
+  "See https://arxiv.org/abs/2602.02234 for a third-party alternative.")
 message(STATUS "Build GROMACS plugin")
 
 file(GLOB PATCH_VERSIONS patches/*)

--- a/source/gmx/CMakeLists.txt
+++ b/source/gmx/CMakeLists.txt
@@ -1,7 +1,7 @@
 message(
   DEPRECATION
-  "The GROMACS plugin is deprecated and will be removed in a future version. "
-  "See https://arxiv.org/abs/2602.02234 for a third-party alternative.")
+    "The GROMACS plugin is deprecated and will be removed in a future version. "
+    "See https://arxiv.org/abs/2602.02234 for a third-party alternative.")
 message(STATUS "Build GROMACS plugin")
 
 file(GLOB PATCH_VERSIONS patches/*)

--- a/source/gmx/dp_gmx_patch
+++ b/source/gmx/dp_gmx_patch
@@ -1,4 +1,6 @@
 #!/bin/bash
+echo "WARNING: The GROMACS patch in deepmd-kit is deprecated and will be removed in a future version." >&2
+echo "WARNING: See https://arxiv.org/abs/2602.02234 for a third-party alternative." >&2
 DEEPMD_PATCH_SCRIPT_DIR=$(dirname $(readlink -f "$0"))
 DEEPMD_PATCH_ROOT=${DEEPMD_PATCH_SCRIPT_DIR}/../share/deepmd_gromacs_patches
 VERSION="NULL"


### PR DESCRIPTION
Closes #5360

Adds CMake deprecation warnings and runtime shell warnings to the GROMACS plugin build and patch script.

## Changes

- **`source/gmx/CMakeLists.txt`**: Prepends a `message(DEPRECATION ...)` call before the existing `message(STATUS "Build GROMACS plugin")` line, emitting a deprecation warning at CMake configure time that references the third-party alternative at https://arxiv.org/abs/2602.02234.
- **`source/gmx/dp_gmx_patch`**: Adds two `echo ... >&2` lines at the top of the script, printing deprecation warnings to stderr before any patch logic executes.

## Motivation

The GROMACS patch has not been updated in 5 years and has no active maintainers or contributors in the deepmd-kit project. Rather than silently continuing to ship stale, unsupported code, these warnings surface the deprecation to users at the two natural entry points: CMake configuration (when building the plugin) and script invocation (when applying the patch). A maintained third-party implementation (https://arxiv.org/abs/2602.02234) exists and is referenced in both warning messages.

## Testing

- **CMake**: Running `cmake` on a build that enables the GROMACS plugin now prints a `DEPRECATION` diagnostic; with default CMake settings this is visible in configure output and can be promoted to an error via `-Werror=dev`.
- **Shell script**: Invoking `dp_gmx_patch` now immediately prints both `WARNING:` lines to stderr before proceeding, verifiable with `./dp_gmx_patch 2>&1 | head -2`.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deprecation warnings for the GROMACS plugin and patch, informing users that these components will be removed in a future release with references to third-party alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->