### PR TITLE
perf(test): reduce redundant .pt2 compilations in GPU CI

### DIFF
--- a/source/api_cc/tests/test_deeppot_a_fparam_aparam_nframes_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_a_fparam_aparam_nframes_ptexpt.cc
@@ -148,6 +148,8 @@ class TestInferDeepPotAFparamAparamNFramesPtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_a_fparam_aparam_nframes_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_a_fparam_aparam_nframes_ptexpt.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "test_utils.h"
 
 template <class VALUETYPE>
@@ -116,13 +117,13 @@ class TestInferDeepPotAFparamAparamNFramesPtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/fparam_aparam.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 

--- a/source/api_cc/tests/test_deeppot_a_fparam_aparam_nframes_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_a_fparam_aparam_nframes_ptexpt.cc
@@ -113,13 +113,18 @@ class TestInferDeepPotAFparamAparamNFramesPtExpt : public ::testing::Test {
   std::vector<double> expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/fparam_aparam.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/fparam_aparam.pt2");
 
     natoms = expected_e.size() / nframes;
     EXPECT_EQ(nframes * natoms * 3, expected_f.size());
@@ -143,6 +148,9 @@ class TestInferDeepPotAFparamAparamNFramesPtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotAFparamAparamNFramesPtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotAFparamAparamNFramesPtExpt, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_a_fparam_aparam_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_a_fparam_aparam_ptexpt.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -76,13 +77,13 @@ class TestInferDeepPotAFParamAParamPtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/fparam_aparam.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 
@@ -336,13 +337,13 @@ class TestInferDeepPotNoDefaultFParamPtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/fparam_aparam.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
   };

--- a/source/api_cc/tests/test_deeppot_a_fparam_aparam_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_a_fparam_aparam_ptexpt.cc
@@ -73,13 +73,18 @@ class TestInferDeepPotAFParamAParamPtExpt : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/fparam_aparam.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/fparam_aparam.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -99,6 +104,9 @@ class TestInferDeepPotAFParamAParamPtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotAFParamAParamPtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotAFParamAParamPtExpt, ValueTypes);
 
@@ -325,17 +333,25 @@ TYPED_TEST(TestInferDeepPotAFParamAParamPtExpt, cpu_lmp_nlist_atomic) {
 template <class VALUETYPE>
 class TestInferDeepPotNoDefaultFParamPtExpt : public ::testing::Test {
  protected:
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/fparam_aparam.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/fparam_aparam.pt2");
   };
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotNoDefaultFParamPtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotNoDefaultFParamPtExpt, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_a_fparam_aparam_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_a_fparam_aparam_ptexpt.cc
@@ -104,6 +104,8 @@ class TestInferDeepPotAFParamAParamPtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -349,6 +351,8 @@ class TestInferDeepPotNoDefaultFParamPtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_default_fparam_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_default_fparam_ptexpt.cc
@@ -109,6 +109,8 @@ class TestInferDeepPotDefaultFParamPtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_default_fparam_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_default_fparam_ptexpt.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -81,13 +82,13 @@ class TestInferDeepPotDefaultFParamPtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/fparam_aparam_default.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 

--- a/source/api_cc/tests/test_deeppot_default_fparam_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_default_fparam_ptexpt.cc
@@ -78,13 +78,18 @@ class TestInferDeepPotDefaultFParamPtExpt : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/fparam_aparam_default.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/fparam_aparam_default.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -104,6 +109,9 @@ class TestInferDeepPotDefaultFParamPtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDefaultFParamPtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDefaultFParamPtExpt, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_dpa1_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa1_ptexpt.cc
@@ -103,6 +103,8 @@ class TestInferDeepPotDpa1PtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -257,6 +259,8 @@ class TestInferDeepPotDpa1PtExptNoPbc : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_dpa1_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa1_ptexpt.cc
@@ -72,13 +72,18 @@ class TestInferDeepPotDpa1PtExpt : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa1.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa1.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -98,6 +103,9 @@ class TestInferDeepPotDpa1PtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpa1PtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpa1PtExpt, ValueTypes);
 
@@ -218,13 +226,18 @@ class TestInferDeepPotDpa1PtExptNoPbc : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa1.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa1.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -244,6 +257,9 @@ class TestInferDeepPotDpa1PtExptNoPbc : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpa1PtExptNoPbc<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpa1PtExptNoPbc, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_dpa1_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa1_ptexpt.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -75,13 +76,13 @@ class TestInferDeepPotDpa1PtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa1.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 
@@ -229,13 +230,13 @@ class TestInferDeepPotDpa1PtExptNoPbc : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa1.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 

--- a/source/api_cc/tests/test_deeppot_dpa2_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa2_ptexpt.cc
@@ -71,13 +71,18 @@ class TestInferDeepPotDpa2PtExpt : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa2.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa2.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -97,6 +102,9 @@ class TestInferDeepPotDpa2PtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpa2PtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpa2PtExpt, ValueTypes);
 
@@ -492,13 +500,18 @@ class TestInferDeepPotDpa2PtExptNoPbc : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa2.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa2.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -518,6 +531,9 @@ class TestInferDeepPotDpa2PtExptNoPbc : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpa2PtExptNoPbc<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpa2PtExptNoPbc, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_dpa2_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa2_ptexpt.cc
@@ -102,6 +102,8 @@ class TestInferDeepPotDpa2PtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -531,6 +533,8 @@ class TestInferDeepPotDpa2PtExptNoPbc : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_dpa2_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa2_ptexpt.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -74,13 +75,13 @@ class TestInferDeepPotDpa2PtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa2.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 
@@ -503,13 +504,13 @@ class TestInferDeepPotDpa2PtExptNoPbc : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa2.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 

--- a/source/api_cc/tests/test_deeppot_dpa3_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa3_ptexpt.cc
@@ -71,13 +71,18 @@ class TestInferDeepPotDpa3PtExpt : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa3.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa3.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -97,6 +102,9 @@ class TestInferDeepPotDpa3PtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpa3PtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpa3PtExpt, ValueTypes);
 
@@ -492,13 +500,18 @@ class TestInferDeepPotDpa3PtExptNoPbc : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa3.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa3.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -518,6 +531,9 @@ class TestInferDeepPotDpa3PtExptNoPbc : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpa3PtExptNoPbc<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpa3PtExptNoPbc, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_dpa3_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa3_ptexpt.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -74,13 +75,13 @@ class TestInferDeepPotDpa3PtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa3.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 
@@ -503,13 +504,13 @@ class TestInferDeepPotDpa3PtExptNoPbc : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa3.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 

--- a/source/api_cc/tests/test_deeppot_dpa3_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa3_ptexpt.cc
@@ -102,6 +102,8 @@ class TestInferDeepPotDpa3PtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -531,6 +533,8 @@ class TestInferDeepPotDpa3PtExptNoPbc : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_dpa_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa_ptexpt.cc
@@ -70,13 +70,18 @@ class TestInferDeepPotDpaPtExpt : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa1.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa1.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -96,6 +101,9 @@ class TestInferDeepPotDpaPtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpaPtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpaPtExpt, ValueTypes);
 
@@ -482,13 +490,18 @@ class TestInferDeepPotDpaPtExptNoPbc : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_dpa1.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_dpa1.pt2");
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -508,6 +521,9 @@ class TestInferDeepPotDpaPtExptNoPbc : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotDpaPtExptNoPbc<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotDpaPtExptNoPbc, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_dpa_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa_ptexpt.cc
@@ -101,6 +101,8 @@ class TestInferDeepPotDpaPtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -521,6 +523,8 @@ class TestInferDeepPotDpaPtExptNoPbc : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_dpa_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_dpa_ptexpt.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -73,13 +74,13 @@ class TestInferDeepPotDpaPtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa1.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 
@@ -493,13 +494,13 @@ class TestInferDeepPotDpaPtExptNoPbc : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_dpa1.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 

--- a/source/api_cc/tests/test_deeppot_model_devi_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_model_devi_ptexpt.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -37,7 +38,7 @@ class TestInferDeepPotModeDeviPtExpt : public ::testing::Test {
   static deepmd::DeepPotModelDevi dp_md;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp0.init("../../tests/infer/model_devi_md0.pt2");
     dp1.init("../../tests/infer/model_devi_md1.pt2");
     dp_md.init(
@@ -47,7 +48,7 @@ class TestInferDeepPotModeDeviPtExpt : public ::testing::Test {
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
     natoms = coord.size() / 3;
@@ -431,7 +432,7 @@ class TestInferDeepPotModeDeviPtExptPrecomputed : public ::testing::Test {
   static deepmd::DeepPotModelDevi dp_md;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp0.init("../../tests/infer/model_devi_md0.pt2");
     dp1.init("../../tests/infer/model_devi_md1.pt2");
     dp_md.init(
@@ -441,7 +442,7 @@ class TestInferDeepPotModeDeviPtExptPrecomputed : public ::testing::Test {
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
     natoms = coord.size() / 3;

--- a/source/api_cc/tests/test_deeppot_model_devi_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_model_devi_ptexpt.cc
@@ -55,6 +55,12 @@ class TestInferDeepPotModeDeviPtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() {
+    dp0 = deepmd::DeepPot();
+    dp1 = deepmd::DeepPot();
+    dp_md = deepmd::DeepPotModelDevi();
+  }
 };
 
 template <class VALUETYPE>
@@ -449,6 +455,12 @@ class TestInferDeepPotModeDeviPtExptPrecomputed : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() {
+    dp0 = deepmd::DeepPot();
+    dp1 = deepmd::DeepPot();
+    dp_md = deepmd::DeepPotModelDevi();
+  }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_model_devi_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_model_devi_ptexpt.cc
@@ -32,24 +32,36 @@ class TestInferDeepPotModeDeviPtExpt : public ::testing::Test {
                                    0.25852028, 0.25852028, 0.25852028};
   int natoms;
 
-  deepmd::DeepPot dp0;
-  deepmd::DeepPot dp1;
-  deepmd::DeepPotModelDevi dp_md;
+  static deepmd::DeepPot dp0;
+  static deepmd::DeepPot dp1;
+  static deepmd::DeepPotModelDevi dp_md;
 
-  void SetUp() override {
-#ifndef BUILD_PYTORCH
-    GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
-#endif
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
     dp0.init("../../tests/infer/model_devi_md0.pt2");
     dp1.init("../../tests/infer/model_devi_md1.pt2");
     dp_md.init(
         std::vector<std::string>({"../../tests/infer/model_devi_md0.pt2",
                                   "../../tests/infer/model_devi_md1.pt2"}));
+#endif
+  }
+
+  void SetUp() override {
+#ifndef BUILD_PYTORCH
+    GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
+#endif
     natoms = coord.size() / 3;
   };
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotModeDeviPtExpt<VALUETYPE>::dp0;
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotModeDeviPtExpt<VALUETYPE>::dp1;
+template <class VALUETYPE>
+deepmd::DeepPotModelDevi TestInferDeepPotModeDeviPtExpt<VALUETYPE>::dp_md;
 
 TYPED_TEST_SUITE(TestInferDeepPotModeDeviPtExpt, ValueTypes);
 
@@ -414,24 +426,37 @@ class TestInferDeepPotModeDeviPtExptPrecomputed : public ::testing::Test {
       1.735782978938303146e-04, 2.441022592033971239e-05,
       7.333090508662540210e-05};  // max min mystd
 
-  deepmd::DeepPot dp0;
-  deepmd::DeepPot dp1;
-  deepmd::DeepPotModelDevi dp_md;
+  static deepmd::DeepPot dp0;
+  static deepmd::DeepPot dp1;
+  static deepmd::DeepPotModelDevi dp_md;
 
-  void SetUp() override {
-#ifndef BUILD_PYTORCH
-    GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
-#endif
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
     dp0.init("../../tests/infer/model_devi_md0.pt2");
     dp1.init("../../tests/infer/model_devi_md1.pt2");
     dp_md.init(
         std::vector<std::string>({"../../tests/infer/model_devi_md0.pt2",
                                   "../../tests/infer/model_devi_md1.pt2"}));
+#endif
+  }
+
+  void SetUp() override {
+#ifndef BUILD_PYTORCH
+    GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
+#endif
     natoms = coord.size() / 3;
   };
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotModeDeviPtExptPrecomputed<VALUETYPE>::dp0;
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotModeDeviPtExptPrecomputed<VALUETYPE>::dp1;
+template <class VALUETYPE>
+deepmd::DeepPotModelDevi
+    TestInferDeepPotModeDeviPtExptPrecomputed<VALUETYPE>::dp_md;
 
 TYPED_TEST_SUITE(TestInferDeepPotModeDeviPtExptPrecomputed, ValueTypes);
 

--- a/source/api_cc/tests/test_deeppot_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_ptexpt.cc
@@ -85,6 +85,8 @@ class TestInferDeepPotAPtExpt : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -489,6 +491,8 @@ class TestInferDeepPotAPtExptNoPbc : public ::testing::Test {
   };
 
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -690,6 +694,8 @@ class TestDeepPotPTExptMetadata : public ::testing::Test {
 #endif
   };
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -740,6 +746,8 @@ class TestDeepPotPTExptJsonTypes : public ::testing::Test {
 #endif
   };
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>
@@ -783,6 +791,8 @@ class TestDeepPotPTExptJsonDefaults : public ::testing::Test {
 #endif
   };
   void TearDown() override {};
+
+  static void TearDownTestSuite() { dp = deepmd::DeepPot(); }
 };
 
 template <class VALUETYPE>

--- a/source/api_cc/tests/test_deeppot_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_ptexpt.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "DeepPot.h"
+#include "DeepPotPTExpt.h"
 #include "neighbor_list.h"
 #include "test_utils.h"
 
@@ -57,13 +58,13 @@ class TestInferDeepPotAPtExpt : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_sea.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 
@@ -461,13 +462,13 @@ class TestInferDeepPotAPtExptNoPbc : public ::testing::Test {
   static deepmd::DeepPot dp;
 
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_sea.pt2");
 #endif
   }
 
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
 
@@ -636,7 +637,7 @@ TYPED_TEST(TestInferDeepPotAPtExptNoPbc, cpu_build_nlist_nframes) {
 // ========== Parser / metadata coverage tests ==========
 
 TEST(TestDeepPotPTExptParser, load_nonexistent_file) {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
   GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
   deepmd::DeepPot dp;
@@ -644,7 +645,7 @@ TEST(TestDeepPotPTExptParser, load_nonexistent_file) {
 }
 
 TEST(TestDeepPotPTExptParser, load_invalid_zip) {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
   GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
   std::string tmpfile = "test_invalid.pt2";
@@ -659,7 +660,7 @@ TEST(TestDeepPotPTExptParser, load_invalid_zip) {
 }
 
 TEST(TestDeepPotPTExptParser, load_tiny_file) {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
   GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
   std::string tmpfile = "test_tiny.pt2";
@@ -679,12 +680,12 @@ class TestDeepPotPTExptMetadata : public ::testing::Test {
  protected:
   static deepmd::DeepPot dp;
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/deeppot_sea.pt2");
 #endif
   }
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
   };
@@ -729,12 +730,12 @@ class TestDeepPotPTExptJsonTypes : public ::testing::Test {
  protected:
   static deepmd::DeepPot dp;
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/fparam_aparam.pt2");
 #endif
   }
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
   };
@@ -772,12 +773,12 @@ class TestDeepPotPTExptJsonDefaults : public ::testing::Test {
  protected:
   static deepmd::DeepPot dp;
   static void SetUpTestSuite() {
-#ifdef BUILD_PYTORCH
+#if defined(BUILD_PYTORCH) && BUILD_PT_EXPT
     dp.init("../../tests/infer/fparam_aparam_default.pt2");
 #endif
   }
   void SetUp() override {
-#ifndef BUILD_PYTORCH
+#if !defined(BUILD_PYTORCH) || !BUILD_PT_EXPT
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
   };

--- a/source/api_cc/tests/test_deeppot_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_ptexpt.cc
@@ -54,15 +54,18 @@ class TestInferDeepPotAPtExpt : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_sea.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    std::string file_name = "../../tests/infer/deeppot_sea.pt2";
-
-    dp.init(file_name);
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -82,6 +85,9 @@ class TestInferDeepPotAPtExpt : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotAPtExpt<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotAPtExpt, ValueTypes);
 
@@ -452,14 +458,18 @@ class TestInferDeepPotAPtExptNoPbc : public ::testing::Test {
   double expected_tot_e;
   std::vector<VALUETYPE> expected_tot_v;
 
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_sea.pt2");
+#endif
+  }
 
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    std::string file_name = "../../tests/infer/deeppot_sea.pt2";
-    dp.init(file_name);
 
     natoms = expected_e.size();
     EXPECT_EQ(natoms * 3, expected_f.size());
@@ -479,6 +489,9 @@ class TestInferDeepPotAPtExptNoPbc : public ::testing::Test {
 
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestInferDeepPotAPtExptNoPbc<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestInferDeepPotAPtExptNoPbc, ValueTypes);
 
@@ -664,15 +677,22 @@ TEST(TestDeepPotPTExptParser, load_tiny_file) {
 template <class VALUETYPE>
 class TestDeepPotPTExptMetadata : public ::testing::Test {
  protected:
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/deeppot_sea.pt2");
+#endif
+  }
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/deeppot_sea.pt2");
   };
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestDeepPotPTExptMetadata<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestDeepPotPTExptMetadata, ValueTypes);
 
@@ -707,15 +727,22 @@ TYPED_TEST(TestDeepPotPTExptMetadata, no_default_fparam) {
 template <class VALUETYPE>
 class TestDeepPotPTExptJsonTypes : public ::testing::Test {
  protected:
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/fparam_aparam.pt2");
+#endif
+  }
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/fparam_aparam.pt2");
   };
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestDeepPotPTExptJsonTypes<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestDeepPotPTExptJsonTypes, ValueTypes);
 
@@ -743,15 +770,22 @@ TYPED_TEST(TestDeepPotPTExptJsonTypes, float_field) {
 template <class VALUETYPE>
 class TestDeepPotPTExptJsonDefaults : public ::testing::Test {
  protected:
-  deepmd::DeepPot dp;
+  static deepmd::DeepPot dp;
+  static void SetUpTestSuite() {
+#ifdef BUILD_PYTORCH
+    dp.init("../../tests/infer/fparam_aparam_default.pt2");
+#endif
+  }
   void SetUp() override {
 #ifndef BUILD_PYTORCH
     GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
 #endif
-    dp.init("../../tests/infer/fparam_aparam_default.pt2");
   };
   void TearDown() override {};
 };
+
+template <class VALUETYPE>
+deepmd::DeepPot TestDeepPotPTExptJsonDefaults<VALUETYPE>::dp;
 
 TYPED_TEST_SUITE(TestDeepPotPTExptJsonDefaults, ValueTypes);
 

--- a/source/install/test_cc_local.sh
+++ b/source/install/test_cc_local.sh
@@ -66,12 +66,23 @@ else:
 			_GEN_ENV="LD_PRELOAD=${_LSAN_LIB} LSAN_OPTIONS=detect_leaks=0"
 		fi
 	fi
-	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_sea.py
-	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa1.py
-	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa2.py
-	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa3.py
-	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_fparam_aparam.py
-	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_model_devi.py
+	# Run gen scripts in parallel (2 groups of 3) for faster model generation.
+	# PID tracking ensures set -e still catches failures.
+	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_sea.py &
+	PID1=$!
+	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa1.py &
+	PID2=$!
+	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa2.py &
+	PID3=$!
+	wait $PID1 $PID2 $PID3
+
+	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa3.py &
+	PID4=$!
+	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_fparam_aparam.py &
+	PID5=$!
+	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_model_devi.py &
+	PID6=$!
+	wait $PID4 $PID5 $PID6
 fi
 if [ "${ENABLE_PADDLE:-TRUE}" == "TRUE" ]; then
 	PADDLE_INFERENCE_DIR=${BUILD_TMP_DIR}/paddle_inference_install_dir

--- a/source/install/test_cc_local.sh
+++ b/source/install/test_cc_local.sh
@@ -70,14 +70,16 @@ else:
 		fi
 	fi
 	# Run gen scripts in parallel (2 groups of 3) for faster model generation.
-	# PID tracking ensures set -e still catches failures.
+	# Wait on each PID separately so any failure is caught by set -e.
 	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_sea.py &
 	PID1=$!
 	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa1.py &
 	PID2=$!
 	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa2.py &
 	PID3=$!
-	wait $PID1 $PID2 $PID3
+	wait $PID1
+	wait $PID2
+	wait $PID3
 
 	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_dpa3.py &
 	PID4=$!
@@ -85,7 +87,9 @@ else:
 	PID5=$!
 	env ${_GEN_ENV} python ${INFER_SCRIPT_PATH}/gen_model_devi.py &
 	PID6=$!
-	wait $PID4 $PID5 $PID6
+	wait $PID4
+	wait $PID5
+	wait $PID6
 fi
 if [ "${ENABLE_PADDLE:-TRUE}" == "TRUE" ]; then
 	PADDLE_INFERENCE_DIR=${BUILD_TMP_DIR}/paddle_inference_install_dir

--- a/source/install/test_cc_local.sh
+++ b/source/install/test_cc_local.sh
@@ -59,6 +59,9 @@ else:
 	# runtime to be preloaded (otherwise dlopen fails).  We disable leak detection
 	# in the gen scripts to avoid false reports from torch/paddle internals.
 	INFER_SCRIPT_PATH=${SCRIPT_PATH}/../tests/infer
+	# Remove stale generated model files so they can't be accidentally reused
+	# if gen scripts change format or the code version changes.
+	rm -f ${INFER_SCRIPT_PATH}/*.pt2 ${INFER_SCRIPT_PATH}/*.pte
 	_GEN_ENV=""
 	if echo "${CXXFLAGS:-}" | grep -q fsanitize=leak; then
 		_LSAN_LIB=$(gcc -print-file-name=liblsan.so 2>/dev/null || true)

--- a/source/tests/pt_expt/model/test_model_compression.py
+++ b/source/tests/pt_expt/model/test_model_compression.py
@@ -352,20 +352,10 @@ class TestModelCompression(unittest.TestCase):
             if os.path.exists(compressed_pt2_path):
                 os.unlink(compressed_pt2_path)
 
-    def test_min_nbor_dist_roundtrip_pt2(self) -> None:
-        """Test that min_nbor_dist survives freeze → load round-trip via .pt2."""
-        md = self._make_model()
-        md.min_nbor_dist = 0.5
-
-        model_data = {"model": md.serialize(), "min_nbor_dist": 0.5}
-        with tempfile.NamedTemporaryFile(suffix=".pt2", delete=False) as f:
-            pt2_path = f.name
-        try:
-            deserialize_to_file(pt2_path, model_data)
-            loaded_data = serialize_from_file(pt2_path)
-            self.assertAlmostEqual(loaded_data["min_nbor_dist"], 0.5)
-        finally:
-            os.unlink(pt2_path)
+    # test_min_nbor_dist_roundtrip_pt2 removed: .pte and .pt2 share identical
+    # metadata storage (metadata.json in ZIP), so the .pte round-trip test
+    # (test_min_nbor_dist_roundtrip) already covers this path.  Removing saves
+    # one redundant AOTInductor compilation (~82s).
 
 
 if __name__ == "__main__":

--- a/source/tests/pt_expt/test_change_bias.py
+++ b/source/tests/pt_expt/test_change_bias.py
@@ -147,6 +147,24 @@ class TestChangeBias(unittest.TestCase):
         # Record original bias
         cls.original_bias = to_numpy(trainer.wrapper.model.get_out_bias())
 
+        # Pre-freeze shared .pte and .pt2 files so individual tests don't
+        # each pay the AOTInductor compilation cost (~82s per .pt2).
+        from deepmd.pt_expt.entrypoints.main import (
+            freeze,
+        )
+
+        cls.shared_pte = os.path.join(cls.tmpdir, "shared.pte")
+        freeze(model=cls.model_path, output=cls.shared_pte)
+        cls.shared_pt2 = os.path.join(cls.tmpdir, "shared.pt2")
+        # Clear default device: tests/pt/__init__.py may set a fake device
+        # for CPU fallback, which poisons AOTInductor compilation.
+        saved_device = torch.get_default_device()
+        torch.set_default_device(None)
+        try:
+            freeze(model=cls.model_path, output=cls.shared_pt2)
+        finally:
+            torch.set_default_device(saved_device)
+
     @classmethod
     def tearDownClass(cls) -> None:
         os.chdir(cls.old_cwd)
@@ -213,9 +231,6 @@ class TestChangeBias(unittest.TestCase):
         np.testing.assert_allclose(updated_bias, expected_bias)
 
     def test_change_bias_frozen_pte(self) -> None:
-        from deepmd.pt_expt.entrypoints.main import (
-            freeze,
-        )
         from deepmd.pt_expt.model.model import (
             BaseModel,
         )
@@ -223,19 +238,15 @@ class TestChangeBias(unittest.TestCase):
             serialize_from_file,
         )
 
-        # Freeze the checkpoint
-        pte_path = os.path.join(self.tmpdir, "frozen.pte")
-        freeze(model=self.model_path, output=pte_path)
-
-        # Get original bias
-        original_data = serialize_from_file(pte_path)
+        # Get original bias from shared frozen file
+        original_data = serialize_from_file(self.shared_pte)
         original_model = BaseModel.deserialize(original_data["model"])
         original_bias = to_numpy(original_model.get_out_bias())
 
         # Run change-bias on the frozen model
         output_pte = os.path.join(self.tmpdir, "frozen_updated.pte")
         run_dp(
-            f"dp --pt-expt change-bias {pte_path} "
+            f"dp --pt-expt change-bias {self.shared_pte} "
             f"-s {self.data_file[0]} -o {output_pte}"
         )
 
@@ -252,9 +263,6 @@ class TestChangeBias(unittest.TestCase):
 
     def test_change_bias_frozen_pt2(self) -> None:
         """Change-bias on a .pt2 frozen model."""
-        from deepmd.pt_expt.entrypoints.main import (
-            freeze,
-        )
         from deepmd.pt_expt.model.model import (
             BaseModel,
         )
@@ -262,16 +270,13 @@ class TestChangeBias(unittest.TestCase):
             serialize_from_file,
         )
 
-        pt2_path = os.path.join(self.tmpdir, "frozen.pt2")
-        freeze(model=self.model_path, output=pt2_path)
-
-        original_data = serialize_from_file(pt2_path)
+        original_data = serialize_from_file(self.shared_pt2)
         original_model = BaseModel.deserialize(original_data["model"])
         original_bias = to_numpy(original_model.get_out_bias())
 
         output_pt2 = os.path.join(self.tmpdir, "frozen_updated.pt2")
         run_dp(
-            f"dp --pt-expt change-bias {pt2_path} "
+            f"dp --pt-expt change-bias {self.shared_pt2} "
             f"-s {self.data_file[0]} -o {output_pt2}"
         )
 
@@ -286,9 +291,6 @@ class TestChangeBias(unittest.TestCase):
 
     def test_change_bias_frozen_pt2_user_defined(self) -> None:
         """Change-bias with user-defined values on a .pt2 model."""
-        from deepmd.pt_expt.entrypoints.main import (
-            freeze,
-        )
         from deepmd.pt_expt.model.model import (
             BaseModel,
         )
@@ -296,11 +298,8 @@ class TestChangeBias(unittest.TestCase):
             serialize_from_file,
         )
 
-        pt2_path = os.path.join(self.tmpdir, "frozen_ud.pt2")
-        freeze(model=self.model_path, output=pt2_path)
-
         output_pt2 = os.path.join(self.tmpdir, "frozen_ud_updated.pt2")
-        run_dp(f"dp --pt-expt change-bias {pt2_path} -b 1.0 2.0 -o {output_pt2}")
+        run_dp(f"dp --pt-expt change-bias {self.shared_pt2} -b 1.0 2.0 -o {output_pt2}")
 
         updated_data = serialize_from_file(output_pt2)
         updated_model = BaseModel.deserialize(updated_data["model"])
@@ -311,9 +310,6 @@ class TestChangeBias(unittest.TestCase):
 
     def test_change_bias_pt2_pte_consistency(self) -> None:
         """Change-bias on .pte and .pt2 should produce same bias values."""
-        from deepmd.pt_expt.entrypoints.main import (
-            freeze,
-        )
         from deepmd.pt_expt.model.model import (
             BaseModel,
         )
@@ -321,19 +317,14 @@ class TestChangeBias(unittest.TestCase):
             serialize_from_file,
         )
 
-        pte_path = os.path.join(self.tmpdir, "cons.pte")
-        pt2_path = os.path.join(self.tmpdir, "cons.pt2")
-        freeze(model=self.model_path, output=pte_path)
-        freeze(model=self.model_path, output=pt2_path)
-
         output_pte = os.path.join(self.tmpdir, "cons_updated.pte")
         output_pt2 = os.path.join(self.tmpdir, "cons_updated.pt2")
         run_dp(
-            f"dp --pt-expt change-bias {pte_path} "
+            f"dp --pt-expt change-bias {self.shared_pte} "
             f"-s {self.data_file[0]} -o {output_pte}"
         )
         run_dp(
-            f"dp --pt-expt change-bias {pt2_path} "
+            f"dp --pt-expt change-bias {self.shared_pt2} "
             f"-s {self.data_file[0]} -o {output_pt2}"
         )
 
@@ -346,26 +337,19 @@ class TestChangeBias(unittest.TestCase):
 
     def test_change_bias_pte_preserves_model_def_script(self) -> None:
         """change_bias on .pte should preserve model_def_script (training config)."""
-        from deepmd.pt_expt.entrypoints.main import (
-            freeze,
-        )
         from deepmd.pt_expt.utils.serialization import (
             serialize_from_file,
         )
 
-        # Freeze the checkpoint (embeds training config as model_def_script)
-        pte_path = os.path.join(self.tmpdir, "frozen_mds.pte")
-        freeze(model=self.model_path, output=pte_path)
-
-        # Verify training config is present
-        original_data = serialize_from_file(pte_path)
+        # Verify training config is present in shared frozen file
+        original_data = serialize_from_file(self.shared_pte)
         self.assertIn("model_def_script", original_data)
         original_mds = original_data["model_def_script"]
         self.assertIn("type_map", original_mds)  # training config has model params
 
         # Run change-bias with user-defined values
         output_pte = os.path.join(self.tmpdir, "frozen_mds_updated.pte")
-        run_dp(f"dp --pt-expt change-bias {pte_path} -b 0.1 3.2 -o {output_pte}")
+        run_dp(f"dp --pt-expt change-bias {self.shared_pte} -b 0.1 3.2 -o {output_pte}")
 
         # Verify model_def_script is preserved in the output
         updated_data = serialize_from_file(output_pte)
@@ -374,36 +358,19 @@ class TestChangeBias(unittest.TestCase):
 
     def test_change_bias_pt2_preserves_model_def_script(self) -> None:
         """change_bias on .pt2 should preserve model_def_script (training config)."""
-        from deepmd.pt_expt.entrypoints.main import (
-            freeze,
-        )
         from deepmd.pt_expt.utils.serialization import (
             serialize_from_file,
         )
 
-        # Freeze to .pt2
-        # Clear default device: tests/pt/__init__.py sets it to "cuda:9999999"
-        # for CPU fallback, which poisons AOTInductor compilation.
-        pt2_path = os.path.join(self.tmpdir, "frozen_mds.pt2")
-        torch.set_default_device(None)
-        try:
-            freeze(model=self.model_path, output=pt2_path)
-        finally:
-            torch.set_default_device("cuda:9999999")
-
-        # Verify training config is present
-        original_data = serialize_from_file(pt2_path)
+        # Verify training config is present in shared frozen file
+        original_data = serialize_from_file(self.shared_pt2)
         self.assertIn("model_def_script", original_data)
         original_mds = original_data["model_def_script"]
         self.assertIn("type_map", original_mds)  # training config has model params
 
-        # Run change-bias with user-defined values (same device workaround)
+        # Run change-bias with user-defined values
         output_pt2 = os.path.join(self.tmpdir, "frozen_mds_updated.pt2")
-        torch.set_default_device(None)
-        try:
-            run_dp(f"dp --pt-expt change-bias {pt2_path} -b 0.1 3.2 -o {output_pt2}")
-        finally:
-            torch.set_default_device("cuda:9999999")
+        run_dp(f"dp --pt-expt change-bias {self.shared_pt2} -b 0.1 3.2 -o {output_pt2}")
 
         # Verify model_def_script is preserved in the output
         updated_data = serialize_from_file(output_pt2)

--- a/source/tests/pt_expt/test_dp_freeze.py
+++ b/source/tests/pt_expt/test_dp_freeze.py
@@ -57,6 +57,13 @@ class TestDPFreezePtExpt(unittest.TestCase):
         cls.ckpt_file = os.path.join(cls.tmpdir, "model.pt")
         torch.save({"model": state_dict}, cls.ckpt_file)
 
+        # Pre-freeze shared .pte and .pt2 files so individual tests don't
+        # each pay the AOTInductor compilation cost (~82s per .pt2).
+        cls.shared_pte = os.path.join(cls.tmpdir, "shared.pte")
+        freeze(model=cls.ckpt_file, output=cls.shared_pte)
+        cls.shared_pt2 = os.path.join(cls.tmpdir, "shared.pt2")
+        freeze(model=cls.ckpt_file, output=cls.shared_pt2)
+
     @classmethod
     def tearDownClass(cls) -> None:
         shutil.rmtree(cls.tmpdir)
@@ -98,9 +105,7 @@ class TestDPFreezePtExpt(unittest.TestCase):
 
     def test_freeze_pt2(self) -> None:
         """Freeze to .pt2 (AOTInductor) and verify the file is loadable."""
-        output = os.path.join(self.tmpdir, "frozen_model.pt2")
-        freeze(model=self.ckpt_file, output=output)
-        self.assertTrue(os.path.exists(output))
+        self.assertTrue(os.path.exists(self.shared_pt2))
 
         # Verify the .pt2 can be loaded and evaluated via DeepPot
         import numpy as np
@@ -109,7 +114,7 @@ class TestDPFreezePtExpt(unittest.TestCase):
             DeepPot,
         )
 
-        dp = DeepPot(output)
+        dp = DeepPot(self.shared_pt2)
         self.assertEqual(dp.get_type_map(), ["O", "H", "B"])
         rcut = dp.get_rcut()
         self.assertGreater(rcut, 0.0)
@@ -134,11 +139,6 @@ class TestDPFreezePtExpt(unittest.TestCase):
             DeepPot,
         )
 
-        pte_path = os.path.join(self.tmpdir, "consistency.pte")
-        pt2_path = os.path.join(self.tmpdir, "consistency.pt2")
-        freeze(model=self.ckpt_file, output=pte_path)
-        freeze(model=self.ckpt_file, output=pt2_path)
-
         coord = np.array(
             [0.0, 0.0, 0.1, 1.0, 0.3, 0.2, 0.1, 1.9, 3.4],
             dtype=np.float64,
@@ -146,8 +146,8 @@ class TestDPFreezePtExpt(unittest.TestCase):
         box = np.array([5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0], dtype=np.float64)
         atype = [0, 1, 2]
 
-        dp_pte = DeepPot(pte_path)
-        dp_pt2 = DeepPot(pt2_path)
+        dp_pte = DeepPot(self.shared_pte)
+        dp_pt2 = DeepPot(self.shared_pt2)
 
         e_pte, f_pte, v_pte = dp_pte.eval(coord, box, atype)
         e_pt2, f_pt2, v_pt2 = dp_pt2.eval(coord, box, atype)
@@ -171,11 +171,6 @@ class TestDPFreezePtExpt(unittest.TestCase):
             DeepPot,
         )
 
-        pte_path = os.path.join(self.tmpdir, "nopbc_neg.pte")
-        pt2_path = os.path.join(self.tmpdir, "nopbc_neg.pt2")
-        freeze(model=self.ckpt_file, output=pte_path)
-        freeze(model=self.ckpt_file, output=pt2_path)
-
         # Coordinates with negative values — no periodic box
         coord = np.array(
             [-1.0, -2.0, 0.5, 1.0, 0.3, -0.2, 0.1, -1.9, 3.4],
@@ -183,8 +178,8 @@ class TestDPFreezePtExpt(unittest.TestCase):
         )
         atype = [0, 1, 2]
 
-        dp_pte = DeepPot(pte_path)
-        dp_pt2 = DeepPot(pt2_path)
+        dp_pte = DeepPot(self.shared_pte)
+        dp_pt2 = DeepPot(self.shared_pt2)
 
         e_pte, f_pte, v_pte = dp_pte.eval(coord, None, atype)
         e_pt2, f_pt2, v_pt2 = dp_pt2.eval(coord, None, atype)


### PR DESCRIPTION
## Summary
- **Strategy 1**: Share frozen `.pt2`/`.pte` in `setUpClass` for `test_dp_freeze.py` and `test_change_bias.py`, avoiding redundant AOTInductor compilations (~82s each)
- **Strategy 2**: Remove `test_min_nbor_dist_roundtrip_pt2` — `.pte` test already covers the same metadata round-trip path (identical `metadata.json` in ZIP)
- **Strategy 3**: Move `dp.init()` from per-test `SetUp()` to static `SetUpTestSuite()` in 9 C++ test files, loading each model once per typed test suite instead of once per test
- **Strategy 4**: Parallelize 6 gen scripts in `test_cc_local.sh` (2 groups of 3 with PID-based error propagation)
- **Cleanup**: Remove stale `.pt2`/`.pte` files before regeneration so outdated model files cannot be accidentally reused

## Benchmark (V100-SXM2-16GB, torch 2.10)

| Test | Before | After | Saving |
|------|--------|-------|--------|
| test_dp_freeze.py | 536s | 299s | 237s (44%) |
| test_change_bias.py | 495s | 460s | 35s (7%) |
| C++ PtExpt tests | 467s | 71s | 396s (85%) |
| **Total measured** | **1498s** | **830s** | **668s (11 min)** |

Strategy 4 (parallel gen scripts) saves additional build-phase time (~200s estimated).

## Test plan
- [x] `python -m pytest source/tests/pt_expt/test_dp_freeze.py -v` — 7/7 passed
- [x] `python -m pytest source/tests/pt_expt/test_change_bias.py -v` — 11/11 passed
- [x] C++ PtExpt tests (`runUnitTests_cc --gtest_filter='*PtExpt*'`) — 128/128 passed
- [ ] Full CI pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixtures now share model instances across test cases and initialize/reset them once per suite, reducing per-test overhead and adjusting skip behavior when optional backends aren’t present.
  * Python tests now reuse pre-generated frozen artifacts across tests instead of regenerating per-test.
  * Removed a redundant metadata round-trip unit test.

* **Chores**
  * Model-generation script now cleans stale artifacts and runs generation tasks in parallel to speed setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->