### PR TITLE
test(pt-expt): add .pte and .pt2 tests for dp convert-backend

### DIFF
--- a/source/tests/infer/fparam_aparam-testcase.yaml
+++ b/source/tests/infer/fparam_aparam-testcase.yaml
@@ -26,7 +26,7 @@ model_def_script:
         "set_davg_zero": False,
         "trainable": True,
         "type": "se_e2_a",
-        "type_one_side": False,
+        "type_one_side": True,
       },
     "fitting_net":
       {

--- a/source/tests/infer/fparam_aparam.yaml
+++ b/source/tests/infer/fparam_aparam.yaml
@@ -526,7 +526,7 @@ model:
     embeddings:
       "@class": NetworkCollection
       "@version": 1
-      ndim: 2
+      ndim: 1
       network_type: embedding_network
       networks:
         - "@class": EmbeddingNetwork
@@ -916,7 +916,7 @@ model:
     type: se_e2_a
     type_map: &id001
       - O
-    type_one_side: false
+    type_one_side: true
   fitting:
     "@class": Fitting
     "@variables":
@@ -2012,7 +2012,7 @@ model_def_script:
     set_davg_zero: false
     trainable: true
     type: se_e2_a
-    type_one_side: false
+    type_one_side: true
   fitting_net:
     activation_function: tanh
     atom_ener: *id004

--- a/source/tests/infer/fparam_aparam_default.yaml
+++ b/source/tests/infer/fparam_aparam_default.yaml
@@ -526,7 +526,7 @@ model:
     embeddings:
       "@class": NetworkCollection
       "@version": 1
-      ndim: 2
+      ndim: 1
       network_type: embedding_network
       networks:
         - "@class": EmbeddingNetwork
@@ -916,7 +916,7 @@ model:
     type: se_e2_a
     type_map: &id001
       - O
-    type_one_side: false
+    type_one_side: true
   fitting:
     "@class": Fitting
     "@variables":
@@ -2021,7 +2021,7 @@ model_def_script:
     set_davg_zero: false
     trainable: true
     type: se_e2_a
-    type_one_side: false
+    type_one_side: true
   fitting_net:
     activation_function: tanh
     atom_ener: *id004

--- a/source/tests/infer/test_models.py
+++ b/source/tests/infer/test_models.py
@@ -48,7 +48,19 @@ class TestDeepPot(unittest.TestCase):
                 "se_e2_r type_one_side is not supported for PyTorch models"
             )
         cls.case = get_cases()[key]
-        cls.model_name = cls.case.get_model(extension)
+        if extension == ".pt2":
+            import torch
+
+            # Clear default device: tests/pt/__init__.py may set a fake
+            # device for CPU fallback, which poisons AOTInductor compilation.
+            saved_device = torch.get_default_device()
+            torch.set_default_device(None)
+            try:
+                cls.model_name = cls.case.get_model(extension)
+            finally:
+                torch.set_default_device(saved_device)
+        else:
+            cls.model_name = cls.case.get_model(extension)
         cls.dp = DeepEval(cls.model_name)
 
     @classmethod

--- a/source/tests/infer/test_models.py
+++ b/source/tests/infer/test_models.py
@@ -13,6 +13,7 @@ from deepmd.infer.deep_pot import (
 )
 
 from ..consistent.common import (
+    INSTALLED_PT_EXPT,
     parameterized,
 )
 from .case import (
@@ -28,7 +29,7 @@ default_places = 7
         "se_e2_r",
         "fparam_aparam",
     ),  # key
-    (".pb", ".pth"),  # model extension
+    (".pb", ".pth", ".pte", ".pt2"),  # model extension
 )
 class TestDeepPot(unittest.TestCase):
     # moved from tests/tf/test_deeppot_a.py
@@ -36,6 +37,16 @@ class TestDeepPot(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         key, extension = cls.param
+        if extension in (".pte", ".pt2") and not INSTALLED_PT_EXPT:
+            raise unittest.SkipTest("pt_expt backend not installed")
+        if key in ("se_e2_a", "se_e2_r") and extension in (".pte", ".pt2"):
+            raise unittest.SkipTest(
+                "type_one_side=False is not supported for pt_expt export"
+            )
+        if key == "se_e2_r" and extension == ".pth":
+            raise unittest.SkipTest(
+                "se_e2_r type_one_side is not supported for PyTorch models"
+            )
         cls.case = get_cases()[key]
         cls.model_name = cls.case.get_model(extension)
         cls.dp = DeepEval(cls.model_name)
@@ -43,13 +54,6 @@ class TestDeepPot(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         cls.dp = None
-
-    def setUp(self) -> None:
-        key, extension = self.param
-        if key == "se_e2_r" and extension == ".pth":
-            self.skipTest(
-                reason="se_e2_r type_one_side is not supported for PyTorch models"
-            )
 
     def test_attrs(self) -> None:
         assert isinstance(self.dp, DeepPot)
@@ -153,6 +157,8 @@ class TestDeepPot(unittest.TestCase):
 
     def test_descriptor(self) -> None:
         _, extension = self.param
+        if extension in (".pte", ".pt2"):
+            self.skipTest("eval_descriptor not supported for pt_expt models")
         for ii, result in enumerate(self.case.results):
             if result.descriptor is None:
                 continue
@@ -166,8 +172,8 @@ class TestDeepPot(unittest.TestCase):
 
     def test_fitting_last_layer(self) -> None:
         _, extension = self.param
-        if extension == ".pb":
-            self.skipTest("fitting_last_layer not supported for TensorFlow models")
+        if extension in (".pb", ".pte", ".pt2"):
+            self.skipTest("fitting_last_layer not supported for this backend")
         for ii, result in enumerate(self.case.results):
             if result.fit_ll is None:
                 continue


### PR DESCRIPTION
## Summary
- Add `.pte` and `.pt2` to parameterized extensions in `test_models.py` to verify `convert-backend` works for the pt_expt exportable formats
- Switch `fparam_aparam` model (1 atom type) from `type_one_side=False` to `True` (with `ndim` 2→1), which is equivalent for single-type models but enables pt_expt export
- Skip `se_e2_a`/`se_e2_r` for `.pte`/`.pt2` — `type_one_side=False` with multiple types triggers `GuardOnDataDependentSymNode` in `make_fx` (data-dependent indexing in `NetworkCollection(ndim=2)`)
- Skip `test_descriptor` and `test_fitting_last_layer` for `.pte`/`.pt2` (not implemented in pt_expt `DeepEval`)

## Test plan
- [x] `python -m pytest source/tests/infer/test_models.py -v` — 55 passed, 67 skipped
- [x] `python -m pytest source/tests/infer/test_models.py -v -k "pte or pt2"` — 12 passed (fparam_aparam), rest skipped
- [x] Existing `.pb`/`.pth` tests unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test case configurations with adjusted model descriptor and embedding parameters
  * Extended test suite parameterization to support additional model file formats (.pte, .pt2)
  * Reorganized model compatibility skip conditions for improved test structure and maintainability
  * Added special handling when loading certain model formats to ensure stable device behavior during tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->