### PR TITLE
CI: Update OS version in Read the Docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-26.04
   tools:
     python: "3.11"
   jobs:


### PR DESCRIPTION
https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build environment to use a newer OS image, maintaining compatibility with existing Python toolchain and build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->