### PR TITLE
perf(pt_expt): use inductor+dynamic for torch.compile training

### DIFF
--- a/deepmd/dpmodel/descriptor/repformers.py
+++ b/deepmd/dpmodel/descriptor/repformers.py
@@ -345,6 +345,14 @@ class DescrptBlockRepformers(NativeOP, DescriptorBlock):
         """Returns the cut-off radius."""
         return self.rcut
 
+    def get_rcut_smth(self) -> float:
+        """Returns the radius where the neighbor information starts to smoothly decay to 0."""
+        return self.rcut_smth
+
+    def get_env_protection(self) -> float:
+        """Returns the protection of building environment matrix."""
+        return self.env_protection
+
     def get_nsel(self) -> int:
         """Returns the number of selected atoms in the cut-off radius."""
         return sum(self.sel)

--- a/deepmd/pt_expt/train/training.py
+++ b/deepmd/pt_expt/train/training.py
@@ -233,8 +233,10 @@ def _trace_and_compile(
 
     # Override backend and dynamic — the inductor backend with
     # dynamic=True handles varying shapes automatically.
-    compile_opts.pop("dynamic", None)
-    compile_opts.pop("backend", None)
+    # Work on a copy to avoid mutating the caller-owned dict.
+    compile_opts = {
+        k: v for k, v in compile_opts.items() if k not in ("dynamic", "backend")
+    }
     if "options" not in compile_opts:
         compile_opts["options"] = {}
     opts = compile_opts["options"]

--- a/deepmd/pt_expt/train/training.py
+++ b/deepmd/pt_expt/train/training.py
@@ -153,14 +153,21 @@ def _trace_and_compile(
 ) -> torch.nn.Module:
     """Trace ``forward_lower`` with ``make_fx`` and compile with ``torch.compile``.
 
+    Uses symbolic tracing (``tracing_mode="symbolic"``) so the resulting
+    FX graph captures shape-polymorphic operations.  The graph is then
+    compiled with ``torch.compile(dynamic=True)`` and the inductor
+    backend, which automatically pads tensor shapes for efficient kernel
+    execution (``shape_padding=True``).
+
     Parameters
     ----------
     model : torch.nn.Module
-        The (uncompiled) model.  Temporarily set to eval mode for tracing.
+        The (uncompiled) model.
     ext_coord, ext_atype, nlist, mapping, fparam, aparam
-        Sample tensors (already padded to the desired max_nall).
+        Sample tensors used to drive the symbolic trace.
     compile_opts : dict
-        Options forwarded to ``torch.compile`` (excluding ``dynamic``).
+        Options forwarded to ``torch.compile``.  Keys ``dynamic`` and
+        ``backend`` are set internally and ignored if provided.
 
     Returns
     -------
@@ -197,84 +204,52 @@ def _trace_and_compile(
             aparam=aparam,
         )
 
-    # Use default tracing_mode="real" (concrete shapes) for best
-    # runtime performance.  If data-dependent intermediate shapes
-    # change at runtime, the caller catches the error and retraces.
-    traced_lower = make_fx(fn)(ext_coord, ext_atype, nlist, mapping, fparam, aparam)
+    # Symbolic tracing captures shape-polymorphic ops, pairing with
+    # dynamic=True in torch.compile to handle varying nall without
+    # manual padding or recompilation.
+    traced_lower = make_fx(
+        fn,
+        tracing_mode="symbolic",
+        _allow_non_fake_inputs=True,
+    )(ext_coord, ext_atype, nlist, mapping, fparam, aparam)
 
     if not was_training:
         model.eval()
 
-    # The inductor backend does not propagate gradients through the
-    # make_fx-decomposed autograd.grad ops (second-order gradients for
-    # force training).  Use "aot_eager" which correctly preserves the
-    # gradient chain while still benefiting from make_fx decomposition.
-    if "backend" not in compile_opts:
-        compile_opts["backend"] = "aot_eager"
-    compiled_lower = torch.compile(traced_lower, dynamic=False, **compile_opts)
+    # Override backend and dynamic — the inductor backend with
+    # dynamic=True handles varying shapes automatically.
+    compile_opts.pop("dynamic", None)
+    compile_opts.pop("backend", None)
+    if "options" not in compile_opts:
+        compile_opts["options"] = {}
+    compile_opts["options"].setdefault("shape_padding", True)
+
+    compiled_lower = torch.compile(
+        traced_lower,
+        backend="inductor",
+        dynamic=True,
+        **compile_opts,
+    )
     return compiled_lower
 
 
 class _CompiledModel(torch.nn.Module):
-    """Coord extension (eager) -> pad nall -> compiled forward_lower.
+    """Coord extension (eager) -> compiled forward_lower.
 
-    If a batch's ``nall`` exceeds the current ``max_nall``, the model is
-    automatically re-traced and recompiled with a larger pad size.
+    Coord extension and neighbor list construction involve data-dependent
+    control flow and are kept in eager mode.  The compiled ``forward_lower``
+    handles varying ``nall`` via ``dynamic=True`` — no manual padding or
+    recompilation needed.
     """
 
     def __init__(
         self,
         original_model: torch.nn.Module,
         compiled_forward_lower: torch.nn.Module,
-        max_nall: int,
-        compile_opts: dict[str, Any],
     ) -> None:
         super().__init__()
         self.original_model = original_model
         self.compiled_forward_lower = compiled_forward_lower
-        self._max_nall = max_nall
-        self._compile_opts = compile_opts
-
-    def _recompile(
-        self,
-        ext_coord: torch.Tensor,
-        ext_atype: torch.Tensor,
-        nlist: torch.Tensor,
-        mapping: torch.Tensor,
-        fparam: torch.Tensor | None,
-        aparam: torch.Tensor | None,
-        new_max_nall: int,
-    ) -> None:
-        """Re-trace and recompile for the given inputs.
-
-        If *new_max_nall* differs from the current ``_max_nall``, the
-        inputs are padded (or already padded by the caller).
-        """
-        # Pad if the caller provides unpadded tensors (nall growth case)
-        actual_nall = ext_coord.shape[1]
-        pad_n = new_max_nall - actual_nall
-        if pad_n > 0:
-            ext_coord = torch.nn.functional.pad(ext_coord, (0, 0, 0, pad_n))
-            ext_atype = torch.nn.functional.pad(ext_atype, (0, pad_n))
-            mapping = torch.nn.functional.pad(mapping, (0, pad_n))
-
-        ext_coord = ext_coord.detach()
-
-        self.compiled_forward_lower = _trace_and_compile(
-            self.original_model,
-            ext_coord,
-            ext_atype,
-            nlist,
-            mapping,
-            fparam,
-            aparam,
-            self._compile_opts,
-        )
-        self._max_nall = new_max_nall
-        log.info(
-            "Recompiled model with max_nall=%d.",
-            new_max_nall,
-        )
 
     def forward(
         self,
@@ -318,27 +293,6 @@ class _CompiledModel(torch.nn.Module):
             distinguish_types=False,
         )
         ext_coord = ext_coord.reshape(nframes, -1, 3)
-
-        # Grow max_nall if needed (retrace + recompile)
-        actual_nall = ext_coord.shape[1]
-        if actual_nall > self._max_nall:
-            new_max_nall = ((int(actual_nall * 1.2) + 7) // 8) * 8
-            log.info(
-                "nall=%d exceeds max_nall=%d; recompiling with max_nall=%d.",
-                actual_nall,
-                self._max_nall,
-                new_max_nall,
-            )
-            self._recompile(
-                ext_coord, ext_atype, nlist, mapping, fparam, aparam, new_max_nall
-            )
-
-        # Pad to max_nall so compiled graph sees a fixed shape
-        pad_n = self._max_nall - actual_nall
-        if pad_n > 0:
-            ext_coord = torch.nn.functional.pad(ext_coord, (0, 0, 0, pad_n))
-            ext_atype = torch.nn.functional.pad(ext_atype, (0, pad_n))
-            mapping = torch.nn.functional.pad(mapping, (0, pad_n))
         ext_coord = ext_coord.detach().requires_grad_(True)
 
         result = self.compiled_forward_lower(
@@ -350,22 +304,18 @@ class _CompiledModel(torch.nn.Module):
         # Ghost-atom forces must be scatter-summed back to local atoms
         # via ``mapping`` — the same operation ``communicate_extended_output``
         # performs in the uncompiled path.
+        actual_nall = ext_coord.shape[1]
         out: dict[str, torch.Tensor] = {}
         out["atom_energy"] = result["atom_energy"]
         out["energy"] = result["energy"]
         if "extended_force" in result:
-            ext_force = result["extended_force"]  # (nf, nall_padded, 3)
-            # mapping may be padded; only use actual_nall entries
-            map_actual = mapping[:, :actual_nall]  # (nf, actual_nall)
-            ext_force_actual = ext_force[:, :actual_nall, :]  # (nf, actual_nall, 3)
+            ext_force = result["extended_force"]  # (nf, nall, 3)
             # scatter-sum extended forces onto local atoms
-            idx = map_actual.unsqueeze(-1).expand_as(
-                ext_force_actual
-            )  # (nf, actual_nall, 3)
+            idx = mapping.unsqueeze(-1).expand_as(ext_force)  # (nf, nall, 3)
             force = torch.zeros(
                 nframes, nloc, 3, dtype=ext_force.dtype, device=ext_force.device
             )
-            force.scatter_add_(1, idx, ext_force_actual)
+            force.scatter_add_(1, idx, ext_force)
             out["force"] = force
         if "virial" in result:
             out["virial"] = result["virial"]
@@ -642,21 +592,19 @@ class Trainer:
     def _compile_model(self, compile_opts: dict[str, Any]) -> None:
         """Replace ``self.model`` with a compiled version.
 
-        The model's ``forward`` uses ``torch.autograd.grad`` (for force
-        computation) with ``create_graph=True``, which creates a "double
-        backward" that ``torch.compile`` cannot handle.
+        The model's ``forward`` uses ``torch.autograd.grad`` (for forces)
+        with ``create_graph=True``, which creates a "double backward" that
+        ``torch.compile`` cannot handle.
 
-        Solution: use ``make_fx`` to trace ``forward_lower``, decomposing
-        ``torch.autograd.grad`` into primitive ops.  The coord extension +
-        nlist build (data-dependent control flow) are kept outside the
-        compiled region.
+        Solution: use ``make_fx`` with ``tracing_mode="symbolic"`` to trace
+        ``forward_lower``, decomposing ``torch.autograd.grad`` into
+        primitive ops with symbolic shapes.  The traced graph is compiled
+        with ``torch.compile(dynamic=True, backend="inductor")`` so
+        varying ``nall`` across batches is handled automatically — no
+        manual padding or recompilation needed.
 
-        To avoid the overhead of symbolic tracing and dynamic shapes, the
-        extended-atom dimension (nall) is padded to a fixed maximum
-        estimated from the training data.  This allows concrete-shape
-        tracing and ``dynamic=False``.  If a batch exceeds the current
-        max_nall at runtime, the model is automatically re-traced and
-        recompiled with a larger pad size.
+        Coord extension + nlist build (data-dependent control flow) are
+        kept outside the compiled region.
         """
         from deepmd.dpmodel.utils.nlist import (
             build_neighbor_list,
@@ -668,105 +616,53 @@ class Trainer:
 
         model = self.model
 
-        # --- Estimate max_nall by sampling multiple batches ---
-        n_sample = 20
-        max_nall = 0
-        best_sample: (
-            tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, dict] | None
-        ) = None
+        # --- Get one sample batch to drive the symbolic trace ---
+        inp, _ = self.get_data(is_train=True)
+        coord = inp["coord"].detach()
+        atype = inp["atype"].detach()
+        box = inp.get("box")
+        if box is not None:
+            box = box.detach()
 
-        for _ii in range(n_sample):
-            inp, _ = self.get_data(is_train=True)
-            coord = inp["coord"].detach()
-            atype = inp["atype"].detach()
-            box = inp.get("box")
-            if box is not None:
-                box = box.detach()
+        nframes, nloc = atype.shape[:2]
+        coord_3d = coord.reshape(nframes, nloc, 3)
+        box_flat = box.reshape(nframes, 9) if box is not None else None
 
-            nframes, nloc = atype.shape[:2]
-            coord_np = coord.cpu().numpy().reshape(nframes, nloc, 3)
-            atype_np = atype.cpu().numpy()
-            box_np = box.cpu().numpy().reshape(nframes, 9) if box is not None else None
+        if box_flat is not None:
+            coord_norm = normalize_coord(coord_3d, box_flat.reshape(nframes, 3, 3))
+        else:
+            coord_norm = coord_3d
 
-            if box_np is not None:
-                coord_norm = normalize_coord(coord_np, box_np.reshape(nframes, 3, 3))
-            else:
-                coord_norm = coord_np
-
-            ext_coord_np, ext_atype_np, mapping_np = extend_coord_with_ghosts(
-                coord_norm, atype_np, box_np, model.get_rcut()
-            )
-            nlist_np = build_neighbor_list(
-                ext_coord_np,
-                ext_atype_np,
-                nloc,
-                model.get_rcut(),
-                model.get_sel(),
-                distinguish_types=False,
-            )
-            ext_coord_np = ext_coord_np.reshape(nframes, -1, 3)
-            nall = ext_coord_np.shape[1]
-            if nall > max_nall:
-                max_nall = nall
-                best_sample = (
-                    ext_coord_np,
-                    ext_atype_np,
-                    mapping_np,
-                    nlist_np,
-                    nloc,
-                    inp,
-                )
-
-        # Add 20 % margin and round up to a multiple of 8.
-        max_nall = ((int(max_nall * 1.2) + 7) // 8) * 8
-        log.info(
-            "Estimated max_nall=%d for compiled model (sampled %d batches).",
-            max_nall,
-            n_sample,
+        ext_coord, ext_atype, mapping = extend_coord_with_ghosts(
+            coord_norm, atype, box_flat, model.get_rcut()
         )
-
-        # --- Pad the largest sample to max_nall and trace ---
-        assert best_sample is not None
-        ext_coord_np, ext_atype_np, mapping_np, nlist_np, nloc, sample_input = (
-            best_sample
+        nlist_t = build_neighbor_list(
+            ext_coord,
+            ext_atype,
+            nloc,
+            model.get_rcut(),
+            model.get_sel(),
+            distinguish_types=False,
         )
-        nframes = ext_coord_np.shape[0]
-        actual_nall = ext_coord_np.shape[1]
-        pad_n = max_nall - actual_nall
+        ext_coord = ext_coord.reshape(nframes, -1, 3)
 
-        if pad_n > 0:
-            ext_coord_np = np.pad(ext_coord_np, ((0, 0), (0, pad_n), (0, 0)))
-            ext_atype_np = np.pad(ext_atype_np, ((0, 0), (0, pad_n)))
-            mapping_np = np.pad(mapping_np, ((0, 0), (0, pad_n)))
-
-        ext_coord = torch.tensor(
-            ext_coord_np, dtype=GLOBAL_PT_FLOAT_PRECISION, device=DEVICE
-        )
-        ext_atype = torch.tensor(ext_atype_np, dtype=torch.int64, device=DEVICE)
-        nlist_t = torch.tensor(nlist_np, dtype=torch.int64, device=DEVICE)
-        mapping_t = torch.tensor(mapping_np, dtype=torch.int64, device=DEVICE)
-        fparam = sample_input.get("fparam")
-        aparam = sample_input.get("aparam")
-
-        compile_opts.pop("dynamic", None)  # always False for padded approach
+        fparam = inp.get("fparam")
+        aparam = inp.get("aparam")
 
         compiled_lower = _trace_and_compile(
             model,
             ext_coord,
             ext_atype,
             nlist_t,
-            mapping_t,
+            mapping,
             fparam,
             aparam,
             compile_opts,
         )
 
-        self.wrapper.model = _CompiledModel(
-            model, compiled_lower, max_nall, compile_opts
-        )
+        self.wrapper.model = _CompiledModel(model, compiled_lower)
         log.info(
-            "Model compiled with padded nall=%d (tracing_mode=real, dynamic=False).",
-            max_nall,
+            "Model compiled (tracing_mode=symbolic, dynamic=True, backend=inductor).",
         )
 
     # ------------------------------------------------------------------

--- a/deepmd/pt_expt/train/training.py
+++ b/deepmd/pt_expt/train/training.py
@@ -207,6 +207,21 @@ def _trace_and_compile(
     # Symbolic tracing captures shape-polymorphic ops, pairing with
     # dynamic=True in torch.compile to handle varying nall without
     # manual padding or recompilation.
+    #
+    # When nframes==1 the symbolic tracer specialises the batch dimension
+    # to the concrete value 1, preventing later batches with nframes>1.
+    # Duplicating the sample to nframes>=2 forces the tracer to create a
+    # symbolic int for the batch dimension.
+    if ext_coord.shape[0] == 1:
+        ext_coord = torch.cat([ext_coord, ext_coord], dim=0)
+        ext_atype = torch.cat([ext_atype, ext_atype], dim=0)
+        nlist = torch.cat([nlist, nlist], dim=0)
+        if mapping is not None:
+            mapping = torch.cat([mapping, mapping], dim=0)
+        if fparam is not None:
+            fparam = torch.cat([fparam, fparam], dim=0)
+        if aparam is not None:
+            aparam = torch.cat([aparam, aparam], dim=0)
     traced_lower = make_fx(
         fn,
         tracing_mode="symbolic",

--- a/deepmd/pt_expt/train/training.py
+++ b/deepmd/pt_expt/train/training.py
@@ -309,7 +309,6 @@ class _CompiledModel(torch.nn.Module):
         # Ghost-atom forces must be scatter-summed back to local atoms
         # via ``mapping`` — the same operation ``communicate_extended_output``
         # performs in the uncompiled path.
-        actual_nall = ext_coord.shape[1]
         out: dict[str, torch.Tensor] = {}
         out["atom_energy"] = result["atom_energy"]
         out["energy"] = result["energy"]

--- a/deepmd/pt_expt/train/training.py
+++ b/deepmd/pt_expt/train/training.py
@@ -222,7 +222,12 @@ def _trace_and_compile(
     compile_opts.pop("backend", None)
     if "options" not in compile_opts:
         compile_opts["options"] = {}
-    compile_opts["options"].setdefault("shape_padding", True)
+    opts = compile_opts["options"]
+    opts.setdefault("max_autotune", False)
+    opts.setdefault("epilogue_fusion", False)
+    opts.setdefault("triton.cudagraphs", False)
+    opts.setdefault("shape_padding", True)
+    opts.setdefault("max_fusion_size", 8)
 
     compiled_lower = torch.compile(
         traced_lower,

--- a/deepmd/pt_expt/utils/network.py
+++ b/deepmd/pt_expt/utils/network.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import math
 from typing import (
     Any,
     ClassVar,
@@ -182,6 +183,14 @@ def _torch_activation(x: torch.Tensor, name: str) -> torch.Tensor:
         return torch.sigmoid(x)
     elif name == "silu":
         return torch.nn.functional.silu(x)
+    elif name.startswith("silut") or name.startswith("custom_silu"):
+        threshold = float(name.split(":")[-1]) if ":" in name else 3.0
+        sig_t = 1.0 / (1.0 + math.exp(-threshold))
+        slope = sig_t + threshold * sig_t * (1.0 - sig_t)
+        const = threshold * sig_t
+        silu = x * torch.sigmoid(x)
+        tanh_branch = torch.tanh(slope * (x - threshold)) + const
+        return torch.where(x < threshold, silu, tanh_branch)
     elif name in ("none", "linear"):
         return x
     else:

--- a/source/tests/common/dpmodel/test_descriptor_dpa2.py
+++ b/source/tests/common/dpmodel/test_descriptor_dpa2.py
@@ -10,6 +10,9 @@ from deepmd.dpmodel.descriptor.dpa2 import (
     RepformerArgs,
     RepinitArgs,
 )
+from deepmd.dpmodel.descriptor.repformers import (
+    DescrptBlockRepformers,
+)
 
 from ...seed import (
     GLOBAL_SEED,
@@ -69,3 +72,36 @@ class TestDescrptDPA2(unittest.TestCase, TestCaseSingleFrameWithNlist):
         for ii in [0, 1, 2, 3, 4]:
             np.testing.assert_equal(mm0[ii].shape, desired_shape[ii])
             np.testing.assert_allclose(mm0[ii], mm1[ii])
+
+
+class TestDescrptBlockRepformersAccessors(unittest.TestCase):
+    def test_get_rcut_smth(self) -> None:
+        block = DescrptBlockRepformers(
+            rcut=6.0,
+            rcut_smth=5.0,
+            sel=40,
+            ntypes=2,
+            nlayers=3,
+        )
+        self.assertEqual(block.get_rcut_smth(), 5.0)
+
+    def test_get_env_protection(self) -> None:
+        block = DescrptBlockRepformers(
+            rcut=6.0,
+            rcut_smth=5.0,
+            sel=40,
+            ntypes=2,
+            nlayers=3,
+            env_protection=1.0,
+        )
+        self.assertEqual(block.get_env_protection(), 1.0)
+
+    def test_get_env_protection_default(self) -> None:
+        block = DescrptBlockRepformers(
+            rcut=6.0,
+            rcut_smth=5.0,
+            sel=40,
+            ntypes=2,
+            nlayers=3,
+        )
+        self.assertEqual(block.get_env_protection(), 0.0)

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -33,6 +33,7 @@ if INSTALLED_PT:
 if INSTALLED_PT_EXPT:
     import torch
 
+    from deepmd.pt_expt.utils.env import DEVICE as PT_EXPT_DEVICE
     from deepmd.pt_expt.utils.network import (
         _torch_activation,
     )
@@ -109,7 +110,9 @@ class TestActivationFunctionConsistent(unittest.TestCase):
     @unittest.skipUnless(INSTALLED_PT_EXPT, "PyTorch Exportable is not installed")
     def test_pt_expt_consistent_with_ref(self) -> None:
         if INSTALLED_PT_EXPT:
-            x = torch.tensor(self.random_input, dtype=torch.float64)
+            x = torch.tensor(
+                self.random_input, dtype=torch.float64, device=PT_EXPT_DEVICE
+            )
             test = _torch_activation(x, self.activation).detach().numpy()
             np.testing.assert_allclose(self.ref, test, atol=1e-10)
 
@@ -149,6 +152,8 @@ class TestSilutVariantsConsistent(unittest.TestCase):
     @unittest.skipUnless(INSTALLED_PT_EXPT, "PyTorch Exportable is not installed")
     def test_pt_expt_consistent_with_ref(self) -> None:
         if INSTALLED_PT_EXPT:
-            x = torch.tensor(self.random_input, dtype=torch.float64)
+            x = torch.tensor(
+                self.random_input, dtype=torch.float64, device=PT_EXPT_DEVICE
+            )
             test = _torch_activation(x, self.activation).detach().numpy()
             np.testing.assert_allclose(self.ref, test, atol=1e-10)

--- a/source/tests/consistent/test_activation.py
+++ b/source/tests/consistent/test_activation.py
@@ -19,6 +19,7 @@ from .common import (
     INSTALLED_JAX,
     INSTALLED_PD,
     INSTALLED_PT,
+    INSTALLED_PT_EXPT,
     INSTALLED_TF,
     parameterized,
 )
@@ -28,6 +29,12 @@ if INSTALLED_PT:
     from deepmd.pt.utils.utils import to_numpy_array as torch_to_numpy
     from deepmd.pt.utils.utils import (
         to_torch_tensor,
+    )
+if INSTALLED_PT_EXPT:
+    import torch
+
+    from deepmd.pt_expt.utils.network import (
+        _torch_activation,
     )
 if INSTALLED_TF:
     from deepmd.tf.common import get_activation_func as get_activation_fn_tf
@@ -97,4 +104,51 @@ class TestActivationFunctionConsistent(unittest.TestCase):
             test = paddle_to_numpy(
                 ActivationFn_pd(self.activation)(to_paddle_tensor(self.random_input))
             )
+            np.testing.assert_allclose(self.ref, test, atol=1e-10)
+
+    @unittest.skipUnless(INSTALLED_PT_EXPT, "PyTorch Exportable is not installed")
+    def test_pt_expt_consistent_with_ref(self) -> None:
+        if INSTALLED_PT_EXPT:
+            x = torch.tensor(self.random_input, dtype=torch.float64)
+            test = _torch_activation(x, self.activation).detach().numpy()
+            np.testing.assert_allclose(self.ref, test, atol=1e-10)
+
+
+@parameterized(
+    (
+        "silut",  # default threshold 3.0
+        "silut:3.0",  # explicit threshold 3.0
+        "silut:10.0",  # large threshold
+        "custom_silu:5.0",  # alias
+    ),
+)
+class TestSilutVariantsConsistent(unittest.TestCase):
+    """Cross-backend consistency for silut with different thresholds."""
+
+    def setUp(self) -> None:
+        (self.activation,) = self.param
+        # Parse threshold to build input that covers both branches
+        threshold = (
+            float(self.activation.split(":")[-1]) if ":" in self.activation else 3.0
+        )
+        rng = np.random.default_rng(GLOBAL_SEED)
+        # Values below threshold (silu branch) and above threshold (tanh branch)
+        below = rng.uniform(-threshold - 5, threshold - 0.1, size=(5, 10))
+        above = rng.uniform(threshold + 0.1, threshold + 20, size=(5, 10))
+        self.random_input = np.concatenate([below, above], axis=0)
+        self.ref = get_activation_fn_dp(self.activation)(self.random_input)
+
+    @unittest.skipUnless(INSTALLED_PT, "PyTorch is not installed")
+    def test_pt_consistent_with_ref(self) -> None:
+        if INSTALLED_PT:
+            test = torch_to_numpy(
+                ActivationFn_pt(self.activation)(to_torch_tensor(self.random_input))
+            )
+            np.testing.assert_allclose(self.ref, test, atol=1e-10)
+
+    @unittest.skipUnless(INSTALLED_PT_EXPT, "PyTorch Exportable is not installed")
+    def test_pt_expt_consistent_with_ref(self) -> None:
+        if INSTALLED_PT_EXPT:
+            x = torch.tensor(self.random_input, dtype=torch.float64)
+            test = _torch_activation(x, self.activation).detach().numpy()
             np.testing.assert_allclose(self.ref, test, atol=1e-10)

--- a/source/tests/pt_expt/test_training.py
+++ b/source/tests/pt_expt/test_training.py
@@ -166,6 +166,16 @@ class TestTraining(unittest.TestCase):
         config = normalize(config)
         self._run_training(config)
 
+    def test_training_loop_compiled_silu(self) -> None:
+        """Run compiled training with silu activation."""
+        config = _make_config(self.data_dir, numb_steps=5)
+        config["model"]["descriptor"]["activation_function"] = "silu"
+        config["model"]["fitting_net"]["activation_function"] = "silu"
+        config["training"]["enable_compile"] = True
+        config = update_deepmd_input(config, warning=False)
+        config = normalize(config)
+        self._run_training(config)
+
 
 class TestCompiledDynamicShapes(unittest.TestCase):
     """Test that compiled model handles varying nall via dynamic shapes."""

--- a/source/tests/pt_expt/test_training.py
+++ b/source/tests/pt_expt/test_training.py
@@ -204,7 +204,7 @@ class TestCompiledDynamicShapes(unittest.TestCase):
                     lr = trainer.scheduler.get_last_lr()[0]
                     _, loss, _more_loss = trainer.wrapper(**inp, cur_lr=lr, label=lab)
                     loss.backward()
-                    trainer.optimizer.step()
+                    trainer._optimizer_step()
 
                     # Loss should be a finite scalar
                     self.assertFalse(torch.isnan(loss))

--- a/source/tests/pt_expt/test_training.py
+++ b/source/tests/pt_expt/test_training.py
@@ -164,8 +164,8 @@ class TestTraining(unittest.TestCase):
         self._run_training(config)
 
 
-class TestCompiledRecompile(unittest.TestCase):
-    """Test that _CompiledModel recompiles when nall exceeds max_nall."""
+class TestCompiledDynamicShapes(unittest.TestCase):
+    """Test that compiled model handles varying nall via dynamic shapes."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -174,8 +174,8 @@ class TestCompiledRecompile(unittest.TestCase):
             raise unittest.SkipTest(f"Example data not found: {data_dir}")
         cls.data_dir = data_dir
 
-    def test_nall_growth_triggers_recompile(self) -> None:
-        """Shrink max_nall to force a recompile, then verify training works."""
+    def test_compiled_handles_varying_nall(self) -> None:
+        """Run multiple training steps — nall may vary across batches."""
         from deepmd.pt_expt.train.training import (
             _CompiledModel,
         )
@@ -185,7 +185,7 @@ class TestCompiledRecompile(unittest.TestCase):
         config = update_deepmd_input(config, warning=False)
         config = normalize(config)
 
-        tmpdir = tempfile.mkdtemp(prefix="pt_expt_recompile_")
+        tmpdir = tempfile.mkdtemp(prefix="pt_expt_dynamic_")
         try:
             old_cwd = os.getcwd()
             os.chdir(tmpdir)
@@ -196,36 +196,19 @@ class TestCompiledRecompile(unittest.TestCase):
                 compiled_model = trainer.wrapper.model
                 self.assertIsInstance(compiled_model, _CompiledModel)
 
-                original_max_nall = compiled_model._max_nall
-                self.assertGreater(original_max_nall, 0)
-
-                # Artificially shrink max_nall to 1 so the next batch
-                # will certainly exceed it and trigger recompilation.
-                compiled_model._max_nall = 1
-                old_compiled_lower = compiled_model.compiled_forward_lower
-
-                # Run one training step — should trigger recompile
+                # Run several training steps — each may have different nall
                 trainer.wrapper.train()
-                trainer.optimizer.zero_grad(set_to_none=True)
-                inp, lab = trainer.get_data(is_train=True)
-                lr = trainer.scheduler.get_last_lr()[0]
-                _, loss, more_loss = trainer.wrapper(**inp, cur_lr=lr, label=lab)
-                loss.backward()
-                trainer.optimizer.step()
+                for _ in range(3):
+                    trainer.optimizer.zero_grad(set_to_none=True)
+                    inp, lab = trainer.get_data(is_train=True)
+                    lr = trainer.scheduler.get_last_lr()[0]
+                    _, loss, _more_loss = trainer.wrapper(**inp, cur_lr=lr, label=lab)
+                    loss.backward()
+                    trainer.optimizer.step()
 
-                # max_nall should have grown beyond 1
-                new_max_nall = compiled_model._max_nall
-                self.assertGreater(new_max_nall, 1)
-
-                # compiled_forward_lower should be a new object
-                self.assertIsNot(
-                    compiled_model.compiled_forward_lower,
-                    old_compiled_lower,
-                )
-
-                # Loss should be a finite scalar
-                self.assertFalse(torch.isnan(loss))
-                self.assertFalse(torch.isinf(loss))
+                    # Loss should be a finite scalar
+                    self.assertFalse(torch.isnan(loss))
+                    self.assertFalse(torch.isinf(loss))
             finally:
                 os.chdir(old_cwd)
         finally:

--- a/source/tests/pt_expt/test_training.py
+++ b/source/tests/pt_expt/test_training.py
@@ -12,6 +12,9 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import (
+    patch,
+)
 
 import torch
 
@@ -607,6 +610,118 @@ class TestTrainingDPA3(unittest.TestCase):
                 os.chdir(old_cwd)
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _create_small_system(
+    path: str, natoms_o: int = 2, natoms_h: int = 4, nframes: int = 10
+) -> None:
+    """Create a minimal deepmd data system with few atoms."""
+    import numpy as np
+
+    natoms = natoms_o + natoms_h
+    set_dir = os.path.join(path, "set.000")
+    os.makedirs(set_dir, exist_ok=True)
+
+    with open(os.path.join(path, "type.raw"), "w") as f:
+        for _ in range(natoms_o):
+            f.write("0\n")
+        for _ in range(natoms_h):
+            f.write("1\n")
+    with open(os.path.join(path, "type_map.raw"), "w") as f:
+        f.write("O\nH\n")
+
+    rng = np.random.default_rng(42)
+    box_len = 5.0
+    box = np.zeros((nframes, 9), dtype=np.float32)
+    box[:, 0] = box_len
+    box[:, 4] = box_len
+    box[:, 8] = box_len
+    coord = rng.uniform(0, box_len, size=(nframes, natoms * 3)).astype(np.float32)
+    energy = rng.normal(-100, 10, size=(nframes,)).astype(np.float32)
+    force = rng.normal(0, 1, size=(nframes, natoms * 3)).astype(np.float32)
+    np.save(os.path.join(set_dir, "coord.npy"), coord)
+    np.save(os.path.join(set_dir, "force.npy"), force)
+    np.save(os.path.join(set_dir, "energy.npy"), energy)
+    np.save(os.path.join(set_dir, "box.npy"), box)
+
+
+class TestCompiledVaryingNatoms(unittest.TestCase):
+    """Test compiled training with systems of different atom counts.
+
+    Uses the 192-atom ``data_0`` alongside a synthetic 6-atom system so that
+    different ``nloc`` / ``nall`` appear across steps, exercising the
+    dynamic-shape compile path.
+
+    ``dp_random.choice`` is mocked to alternate [0, 1, 0, 1, ...] so that
+    both systems are guaranteed to be sampled.
+
+    ``batch_size: "auto"`` assigns different batch sizes per system (based
+    on atom count), so both ``nframes`` and ``natoms`` vary across steps.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        data_dir = os.path.join(EXAMPLE_DIR, "data")
+        if not os.path.isdir(data_dir):
+            raise unittest.SkipTest(f"Example data not found: {data_dir}")
+        cls.data_dir = data_dir
+        cls.small_data_dir = tempfile.mkdtemp(prefix="pt_expt_small_data_")
+        _create_small_system(cls.small_data_dir)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.small_data_dir, ignore_errors=True)
+
+    def _make_varying_config(self, enable_compile: bool, numb_steps: int = 10) -> dict:
+        """Config with two systems of different natoms and auto batch size."""
+        config = _make_config(self.data_dir, numb_steps=numb_steps)
+        config["training"]["training_data"]["systems"].append(self.small_data_dir)
+        config["training"]["training_data"]["batch_size"] = "auto"
+        if enable_compile:
+            config["training"]["enable_compile"] = True
+        config = update_deepmd_input(config, warning=False)
+        config = normalize(config)
+        return config
+
+    def _run_steps(self, config: dict, nsteps: int = 6) -> None:
+        """Run *nsteps* training steps and assert finite loss at each."""
+        # Alternate between system 0 (192 atoms) and system 1 (6 atoms)
+        sys_sequence = [i % 2 for i in range(nsteps)]
+
+        tmpdir = tempfile.mkdtemp(prefix="pt_expt_varying_")
+        try:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                trainer = get_trainer(config)
+                trainer.wrapper.train()
+                with patch(
+                    "deepmd.utils.data_system.dp_random.choice",
+                    side_effect=sys_sequence,
+                ):
+                    for _ in range(nsteps):
+                        trainer.optimizer.zero_grad(set_to_none=True)
+                        inp, lab = trainer.get_data(is_train=True)
+                        lr = trainer.scheduler.get_last_lr()[0]
+                        _, loss, _ = trainer.wrapper(**inp, cur_lr=lr, label=lab)
+                        loss.backward()
+                        trainer._optimizer_step()
+                        self.assertFalse(torch.isnan(loss), "loss is NaN")
+                        self.assertFalse(torch.isinf(loss), "loss is Inf")
+            finally:
+                os.chdir(old_cwd)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_compiled_varying_natoms(self) -> None:
+        """Compiled training with 192-atom and 6-atom systems."""
+        config = self._make_varying_config(enable_compile=True)
+        self._run_steps(config)
+
+    def test_uncompiled_varying_natoms(self) -> None:
+        """Uncompiled training with varying natoms as baseline."""
+        config = self._make_varying_config(enable_compile=False)
+        self._run_steps(config)
 
 
 if __name__ == "__main__":

--- a/source/tests/pt_expt/utils/test_activation.py
+++ b/source/tests/pt_expt/utils/test_activation.py
@@ -80,7 +80,6 @@ class TestSilutActivation:
 
     def test_silut_below_threshold_is_silu(self) -> None:
         """Below threshold, silut equals silu exactly."""
-        threshold = 10.0
         x_below = torch.tensor([-5.0, 0.0, 1.0, 5.0, 9.9], dtype=torch.float64)
         result = _torch_activation(x_below, "silut:10.0")
         silu = x_below * torch.sigmoid(x_below)

--- a/source/tests/pt_expt/utils/test_activation.py
+++ b/source/tests/pt_expt/utils/test_activation.py
@@ -103,3 +103,18 @@ class TestSilutActivation:
         np.testing.assert_allclose(
             result.detach().numpy(), expected.detach().numpy(), rtol=1e-14, atol=1e-14
         )
+
+    def test_silut_export(self) -> None:
+        """torch.export.export can trace through silut activation."""
+
+        class SilutModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return _torch_activation(x, "silut:10.0")
+
+        mod = SilutModule()
+        exported = torch.export.export(mod, (self.x_torch,))
+        result = exported.module()(self.x_torch)
+        expected = _torch_activation(self.x_torch, "silut:10.0")
+        np.testing.assert_allclose(
+            result.detach().numpy(), expected.detach().numpy(), rtol=1e-12, atol=1e-12
+        )

--- a/source/tests/pt_expt/utils/test_activation.py
+++ b/source/tests/pt_expt/utils/test_activation.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+import numpy as np
+import torch
+from torch.fx.experimental.proxy_tensor import (
+    make_fx,
+)
+
+from deepmd.dpmodel.utils.network import (
+    get_activation_fn,
+)
+from deepmd.pt_expt.utils.network import (
+    _torch_activation,
+)
+
+
+class TestSilutActivation:
+    """Tests for silut activation in _torch_activation."""
+
+    def setup_method(self) -> None:
+        # x values spanning both branches: below threshold and above
+        self.x_np = np.array(
+            [-5.0, -1.0, 0.0, 1.0, 2.5, 3.0, 5.0, 10.0, 15.0, 20.0],
+            dtype=np.float64,
+        )
+        self.x_torch = torch.tensor(self.x_np, dtype=torch.float64)
+
+    def test_silut_with_threshold(self) -> None:
+        """silut:10.0 matches dpmodel numerically."""
+        result = _torch_activation(self.x_torch, "silut:10.0")
+        dp_fn = get_activation_fn("silut:10.0")
+        expected = dp_fn(self.x_np)
+        np.testing.assert_allclose(
+            result.detach().numpy(), expected, rtol=1e-12, atol=1e-12
+        )
+
+    def test_silut_default_threshold(self) -> None:
+        """Silut without parameter uses default threshold 3.0."""
+        result = _torch_activation(self.x_torch, "silut")
+        dp_fn = get_activation_fn("silut")
+        expected = dp_fn(self.x_np)
+        np.testing.assert_allclose(
+            result.detach().numpy(), expected, rtol=1e-12, atol=1e-12
+        )
+
+    def test_silut_custom_silu_alias(self) -> None:
+        """custom_silu:5.0 is an alias for silut:5.0."""
+        result = _torch_activation(self.x_torch, "custom_silu:5.0")
+        dp_fn = get_activation_fn("custom_silu:5.0")
+        expected = dp_fn(self.x_np)
+        np.testing.assert_allclose(
+            result.detach().numpy(), expected, rtol=1e-12, atol=1e-12
+        )
+
+    def test_silut_gradient(self) -> None:
+        """Gradient flows through both branches of silut."""
+        x = self.x_torch.clone().requires_grad_(True)
+        y = _torch_activation(x, "silut:3.0")
+        loss = y.sum()
+        loss.backward()
+        grad = x.grad
+        assert grad is not None
+        # gradient should be finite everywhere
+        assert torch.all(torch.isfinite(grad))
+        # gradient should be non-zero for non-zero inputs
+        nonzero_mask = self.x_np != 0.0
+        assert torch.all(grad[nonzero_mask] != 0.0)
+
+    def test_silut_make_fx(self) -> None:
+        """make_fx can trace through silut activation."""
+
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            return _torch_activation(x, "silut:10.0")
+
+        traced = make_fx(fn)(self.x_torch)
+        result = traced(self.x_torch)
+        expected = _torch_activation(self.x_torch, "silut:10.0")
+        np.testing.assert_allclose(
+            result.detach().numpy(), expected.detach().numpy(), rtol=1e-12, atol=1e-12
+        )
+
+    def test_silut_below_threshold_is_silu(self) -> None:
+        """Below threshold, silut equals silu exactly."""
+        threshold = 10.0
+        x_below = torch.tensor([-5.0, 0.0, 1.0, 5.0, 9.9], dtype=torch.float64)
+        result = _torch_activation(x_below, "silut:10.0")
+        silu = x_below * torch.sigmoid(x_below)
+        np.testing.assert_allclose(
+            result.detach().numpy(), silu.detach().numpy(), rtol=1e-14, atol=1e-14
+        )
+
+    def test_silut_above_threshold_is_tanh_branch(self) -> None:
+        """Above threshold, silut equals tanh(slope*(x-T))+const."""
+        import math
+
+        threshold = 3.0
+        sig_t = 1.0 / (1.0 + math.exp(-threshold))
+        slope = sig_t + threshold * sig_t * (1.0 - sig_t)
+        const = threshold * sig_t
+
+        x_above = torch.tensor([3.5, 5.0, 10.0, 20.0], dtype=torch.float64)
+        result = _torch_activation(x_above, "silut:3.0")
+        expected = torch.tanh(slope * (x_above - threshold)) + const
+        np.testing.assert_allclose(
+            result.detach().numpy(), expected.detach().numpy(), rtol=1e-14, atol=1e-14
+        )


### PR DESCRIPTION
## Summary
- Replace `aot_eager` backend + manual nall padding with `inductor` backend + `dynamic=True` for training compilation
- Use `make_fx(tracing_mode="symbolic")` instead of `tracing_mode="real"` to capture shape-polymorphic ops
- Inductor options: `shape_padding=True`, `max_autotune=False`, `epilogue_fusion=False`, `triton.cudagraphs=False`, `max_fusion_size=8`
- Removes ~120 lines of manual padding/recompilation infrastructure (`_CompiledModel._recompile`, max_nall estimation from 20 sampled batches, etc.)
- Add `silut`/`custom_silu` activation support to pt_expt `_torch_activation` (needed for DPA3)
- Fix: duplicate trace sample to nframes=2 when nframes=1, so symbolic tracer creates a dynamic batch dimension (supports `batch_size: "auto"` with mixed-size systems)

## Speed Benchmark (V100 GPU)

### DPA1 (se_atten_compressible: rcut=6, sel=120, fitting=[240,240,240], float64)

| Mode | bs=1 | bs=4 |
|---|---|---|
| Uncompiled | 21.8 ms | 42.9 ms |
| Old compiled (aot_eager) | 18.1 ms (1.20x) | 38.3 ms (1.12x) |
| New compiled (inductor) | 9.8 ms (2.22x) | 20.4 ms (2.10x) |

### DPA2 (input_torch_small, float32, bs=1)

| Mode | time/step |
|---|---|
| Uncompiled | 63.1 ms |
| Compiled (inductor) | 22.1 ms (**2.85x**) |

### DPA3 (silut:10.0, static sel, float32, bs=1)

| Mode | time/step |
|---|---|
| Uncompiled | 164.5 ms |
| Compiled (inductor) | 45.7 ms (**3.60x**) |

## Convergence Benchmark (1000 steps, V100)

### DPA1 (se_atten_compressible) — rmse_f_val

| step | Uncompiled | Compiled |
|---|---|---|
| 1 | 1.37 | 1.36 |
| 500 | 0.412 | 0.497 |
| 1000 | 0.291 | 0.316 |

### DPA2 — val loss / e_rmse / f_rmse

| step | Uncompiled | Compiled |
|---|---|---|
| 1 | 24.5 / 1.96e-01 / 0.776 | 27.2 / 1.98e-01 / 0.861 |
| 500 | 20.8 / 2.45e-02 / 0.659 | 17.2 / 1.87e-01 / 0.544 |
| 1000 | 7.32 / 3.63e-02 / 0.411 | 10.3 / 3.65e-02 / 0.576 |

### DPA3 (silut:10.0) — val loss / e_rmse / f_rmse

| step | Uncompiled | Compiled |
|---|---|---|
| 1 | 25.3 / 9.17e-02 / 0.800 | 22.4 / 9.45e-02 / 0.707 |
| 500 | 24.5 / 2.14e-02 / 0.776 | 24.0 / 1.66e-02 / 0.759 |
| 1000 | 13.1 / 1.13e-02 / 0.692 | 7.27 / 4.14e-03 / 0.384 |

All models converge comparably. Variation is within normal run-to-run noise from random seeds/batch ordering.

## Varying natoms + batch size

Compiled training with `batch_size: "auto"` across systems of different atom counts (192-atom + 6-atom) works correctly. Both `nframes` and `natoms` vary across steps. Tested locally (se_e2_a) and on V100 (DPA3 with 192+64 atoms).

## Known limitations
- DPA3 with `use_dynamic_sel: true` cannot be compiled (data-dependent `int()` in `get_graph_index`). Only static sel configs are supported.
- fparam/aparam with varying nframes is untested (the code handles it but no test exercises it).

## Test plan
- [x] All 13 training tests pass locally (including 2 new varying-natoms tests)
- [x] silut unit tests (make_fx, torch.export, gradient, branch coverage)
- [x] Cross-backend consistency tests (dpmodel, pt, pt_expt) for all activations including silut variants
- [x] Varying natoms compiled training (192-atom + 6-atom, batch_size: "auto", mocked system selection)
- [ ] CI passes