### PR TITLE
fix(pt): typo in epoch training

### DIFF
--- a/deepmd/pd/train/training.py
+++ b/deepmd/pd/train/training.py
@@ -141,7 +141,7 @@ class Trainer:
 
         # Iteration config
         self.num_steps = training_params.get("numb_steps")
-        self.num_epoch = training_params.get("num_epoch")
+        self.num_epoch = training_params.get("numb_epoch")
         self.num_epoch_dict = training_params.get("num_epoch_dict")
         self.acc_freq: int = training_params.get(
             "acc_freq", 1

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -164,7 +164,7 @@ class Trainer:
 
         # Iteration config
         self.num_steps = training_params.get("numb_steps")
-        self.num_epoch = training_params.get("num_epoch")
+        self.num_epoch = training_params.get("numb_epoch")
         self.num_epoch_dict = training_params.get("num_epoch_dict")
         self.disp_file = training_params.get("disp_file", "lcurve.out")
         self.disp_freq = training_params.get("disp_freq", 1000)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration lookup for the epoch count so training now reads and respects the configured number of epochs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->