### PR TITLE
perf(pt): optimize HybridMuon optimizer

### DIFF
--- a/deepmd/pt/optimizer/hybrid_muon.py
+++ b/deepmd/pt/optimizer/hybrid_muon.py
@@ -408,9 +408,8 @@ class _GramNewtonSchulzOrthogonalizer:
             (float(a), float(b), float(c)) for a, b, c in POLAR_EXPRESS_COEFFICIENTS
         )
         self._restart_iteration_set = frozenset((2,))
-        self._call_impl = self._orthogonalize_impl
         self._compiled_call = torch.compile(
-            self._call_impl,
+            self._orthogonalize_impl,
             fullgraph=True,
             dynamic=True,
         )
@@ -559,85 +558,6 @@ def _reshape_update_to_matrix_batch(
     if update_tensor.is_contiguous():
         return update_tensor.view(batch_size, rows, cols)
     return update_tensor.reshape(batch_size, rows, cols).contiguous()
-
-
-def _stack_bucket_updates(
-    bucket_entries: list[
-        tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]
-    ],
-    batch_size: int,
-    rows: int,
-    cols: int,
-) -> torch.Tensor:
-    """
-    Stack same-shape Muon updates into one tensor for orthogonalization.
-
-    Parameters
-    ----------
-    bucket_entries : list[tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]]
-        Bucket entries as ``(entry, update_tensor, grad, momentum_buffer)``.
-    batch_size : int
-        Number of matrix slices per parameter in the bucket.
-    rows : int
-        Matrix row count for each slice.
-    cols : int
-        Matrix column count for each slice.
-
-    Returns
-    -------
-    torch.Tensor
-        Tensor with shape ``(num_entries, batch_size, rows, cols)``.
-    """
-    update_batches = [
-        _reshape_update_to_matrix_batch(update_tensor, batch_size, rows, cols)
-        for _, update_tensor, _, _ in bucket_entries
-    ]
-    return torch.stack(update_batches, dim=0)
-
-
-def _orthogonalize_standard_stacked(
-    stacked_updates: torch.Tensor,
-    rows: int,
-    cols: int,
-    use_flash: bool,
-    flash_buffers: tuple[torch.Tensor, torch.Tensor] | None = None,
-) -> torch.Tensor:
-    """
-    Orthogonalize stacked updates with the current standard Newton-Schulz path.
-
-    Parameters
-    ----------
-    stacked_updates : torch.Tensor
-        Tensor with shape ``(num_entries, batch_size, rows, cols)``.
-    rows : int
-        Matrix row count.
-    cols : int
-        Matrix column count.
-    use_flash : bool
-        Whether to use the Triton single-matrix path when ``batch_size == 1``.
-    flash_buffers : tuple[torch.Tensor, torch.Tensor] | None, optional
-        Pre-allocated flash buffers when ``use_flash`` is enabled.
-
-    Returns
-    -------
-    torch.Tensor
-        Orthogonalized tensor with the same shape as ``stacked_updates``.
-    """
-    num_entries, batch_size, _, _ = stacked_updates.shape
-    if use_flash and batch_size == 1:
-        if flash_buffers is None:
-            raise ValueError("Flash buffers are required when use_flash=True.")
-        buf1, buf2 = flash_buffers
-        orthogonalized = [
-            _flash_newton_schulz_orth(stacked_updates[idx, 0], buf1, buf2)
-            for idx in range(num_entries)
-        ]
-        return torch.stack(orthogonalized, dim=0).unsqueeze(1)
-
-    # Flash path only supports one matrix per entry; batched inputs use bmm path.
-    flat_updates = stacked_updates.reshape(num_entries * batch_size, rows, cols)
-    orthogonalized = _batched_newton_schulz_orth(flat_updates)
-    return orthogonalized.reshape(num_entries, batch_size, rows, cols)
 
 
 def _compute_muon_nesterov_updates(
@@ -958,23 +878,25 @@ class HybridMuonOptimizer(Optimizer):
         ] = {}
         self._gram_orthogonalizer: _GramNewtonSchulzOrthogonalizer | None = None
 
-        # === Step 5. Foreach acceleration (disabled under FSDP2 / DTensor) ===
+        # === Step 5. Foreach acceleration ===
+        # Defaults to True for single-GPU / DDP / ZeRO-1 (plain tensors). Callers
+        # that train under FSDP2 (``fully_shard``) should pass
+        # ``use_foreach=False`` explicitly because several ``torch._foreach_*``
+        # ops lack DTensor sharding propagation on older PyTorch builds.
         self._use_foreach = self._resolve_foreach(use_foreach)
 
     @staticmethod
     def _resolve_foreach(use_foreach: bool | None) -> bool:
-        """Decide whether to use ``torch._foreach_*`` multi-tensor kernels.
+        """Resolve the ``use_foreach`` flag for ``torch._foreach_*`` kernels.
 
         Foreach fuses per-parameter loops into single kernel launches,
-        eliminating Python overhead. Disabled when parameters are FSDP2
-        ``DTensor`` because several foreach ops lack DTensor sharding
-        propagation rules in older PyTorch builds.
+        eliminating Python overhead. When ``use_foreach`` is ``None`` the
+        default is ``True`` because plain ``torch.Tensor`` (single-GPU, DDP,
+        ZeRO-1) always supports these ops; callers that hit DTensor dispatch
+        errors under FSDP2 must pass ``use_foreach=False`` explicitly.
         """
         if use_foreach is not None:
             return bool(use_foreach)
-        # Conservative default: enable foreach (safe for DDP / ZeRO-1).
-        # FSDP2 users should pass use_foreach=False explicitly if they
-        # encounter DTensor dispatch errors.
         return True
 
     def _compute_magma_scales_merged(
@@ -1392,7 +1314,6 @@ class HybridMuonOptimizer(Optimizer):
 
         for (rows, cols, dev, dt), bucket_entries in gram_buckets.items():
             min_dim = min(rows, cols)
-            max_dim = max(rows, cols)
             transposed = rows > cols
             sb_key = (min_dim, dev, dt)
             if sb_key not in super_buckets:
@@ -1401,7 +1322,7 @@ class HybridMuonOptimizer(Optimizer):
 
         gram_orth = self._get_gram_orthogonalizer()
 
-        for (min_dim, _dev, _dt), sub_list in super_buckets.items():
+        for (_min_dim, _dev, _dt), sub_list in super_buckets.items():
             # Find the maximum large-dimension across all sub-buckets.
             padded_max_dim = max(max(r, c) for r, c, _, _ in sub_list)
 

--- a/deepmd/pt/optimizer/hybrid_muon.py
+++ b/deepmd/pt/optimizer/hybrid_muon.py
@@ -412,7 +412,7 @@ class _GramNewtonSchulzOrthogonalizer:
         self._compiled_call = torch.compile(
             self._call_impl,
             fullgraph=True,
-            mode="reduce-overhead",
+            dynamic=True,
         )
 
     def __call__(self, X: torch.Tensor) -> torch.Tensor:
@@ -644,6 +644,7 @@ def _compute_muon_nesterov_updates(
     gradients: list[torch.Tensor],
     momentum_buffers: list[torch.Tensor],
     momentum: float,
+    use_foreach: bool = False,
 ) -> list[torch.Tensor]:
     """
     Update Muon momentum buffers and return Nesterov updates.
@@ -656,17 +657,22 @@ def _compute_muon_nesterov_updates(
         Momentum buffers associated with ``gradients``.
     momentum : float
         Momentum coefficient.
+    use_foreach : bool
+        Use ``torch._foreach_*`` multi-tensor kernels when True.
 
     Returns
     -------
     list[torch.Tensor]
         Nesterov-style Muon updates with the same shapes as ``gradients``.
     """
-    # === Step 1. Update momentum buffers ===
+    if use_foreach and len(gradients) > 1:
+        # m_t = beta * m_{t-1} + (1 - beta) * g_t
+        torch._foreach_lerp_(momentum_buffers, gradients, 1.0 - momentum)
+        # update = lerp(g_t, m_t, beta) = beta * m_t + (1 - beta) * g_t
+        return torch._foreach_lerp(gradients, momentum_buffers, momentum)
     # m_t = beta * m_{t-1} + (1 - beta) * g_t
     for momentum_buffer, grad in zip(momentum_buffers, gradients, strict=True):
         momentum_buffer.lerp_(grad, 1.0 - momentum)
-    # === Step 2. Form Nesterov updates ===
     # update = beta * m_t + (1 - beta) * g_t
     return [
         torch.lerp(grad, momentum_buffer, momentum)
@@ -910,6 +916,7 @@ class HybridMuonOptimizer(Optimizer):
         enable_gram: bool = True,
         flash_muon: bool = True,
         magma_muon: bool = False,
+        use_foreach: bool | None = None,
     ) -> None:
         # === Step 1. Validate routing mode ===
         muon_mode = str(muon_mode).lower()
@@ -950,6 +957,106 @@ class HybridMuonOptimizer(Optimizer):
             tuple[torch.Tensor, torch.Tensor],
         ] = {}
         self._gram_orthogonalizer: _GramNewtonSchulzOrthogonalizer | None = None
+
+        # === Step 5. Foreach acceleration (disabled under FSDP2 / DTensor) ===
+        self._use_foreach = self._resolve_foreach(use_foreach)
+
+    @staticmethod
+    def _resolve_foreach(use_foreach: bool | None) -> bool:
+        """Decide whether to use ``torch._foreach_*`` multi-tensor kernels.
+
+        Foreach fuses per-parameter loops into single kernel launches,
+        eliminating Python overhead. Disabled when parameters are FSDP2
+        ``DTensor`` because several foreach ops lack DTensor sharding
+        propagation rules in older PyTorch builds.
+        """
+        if use_foreach is not None:
+            return bool(use_foreach)
+        # Conservative default: enable foreach (safe for DDP / ZeRO-1).
+        # FSDP2 users should pass use_foreach=False explicitly if they
+        # encounter DTensor dispatch errors.
+        return True
+
+    def _compute_magma_scales_merged(
+        self,
+        bucket_entries: list[
+            tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]
+        ],
+        rows: int,
+        cols: int,
+    ) -> list[torch.Tensor]:
+        """Compute Magma-lite scales for a merged bucket with variable batch_sizes.
+
+        Like ``_compute_magma_scales_for_bucket`` but handles entries whose
+        ``batch_size`` may differ (produced by the merged-bucket strategy that
+        keys on ``(rows, cols)`` instead of ``(batch_size, rows, cols)``).
+        """
+        n = len(bucket_entries)
+        if n == 0:
+            return []
+        if n == 1:
+            entry, _, grad, momentum_buffer = bucket_entries[0]
+            return [
+                self._compute_magma_scale(
+                    param=entry["param"],
+                    grad=grad,
+                    momentum_buffer=momentum_buffer,
+                    batch_size=entry["batch_size"],
+                    rows=rows,
+                    cols=cols,
+                )
+            ]
+
+        flat_dim = rows * cols
+        grad_views: list[torch.Tensor] = []
+        momentum_views: list[torch.Tensor] = []
+        entry_batch_sizes: list[int] = []
+        for entry, _, grad, momentum_buffer in bucket_entries:
+            bs = entry["batch_size"]
+            grad_views.append(grad.reshape(bs, flat_dim).to(dtype=torch.float32))
+            momentum_views.append(
+                momentum_buffer.reshape(bs, flat_dim).to(dtype=torch.float32)
+            )
+            entry_batch_sizes.append(bs)
+
+        grad_cat = torch.cat(grad_views, dim=0)
+        momentum_cat = torch.cat(momentum_views, dim=0)
+
+        dot = (momentum_cat * grad_cat).sum(dim=1)
+        denom = (momentum_cat.norm(dim=1) * grad_cat.norm(dim=1)).clamp(min=MAGMA_EPS)
+        cosine = (dot / denom).clamp(-1.0, 1.0)
+        raw_sigmoid = torch.sigmoid(cosine / MAGMA_TAU)
+        raw_scores = (
+            (raw_sigmoid - MAGMA_SIGMOID_MIN) / (MAGMA_SIGMOID_MAX - MAGMA_SIGMOID_MIN)
+        ).clamp(0.0, 1.0)
+
+        scales: list[torch.Tensor] = []
+        offset = 0
+        for idx, (entry, _, _, _) in enumerate(bucket_entries):
+            bs = entry_batch_sizes[idx]
+            param = entry["param"]
+            state = self.state[param]
+            magma_score = state.get("magma_score")
+            if (
+                magma_score is None
+                or magma_score.ndim != 1
+                or magma_score.numel() != bs
+                or magma_score.device != param.device
+            ):
+                magma_score = torch.full(
+                    (bs,), 0.5, dtype=torch.float32, device=param.device
+                )
+                state["magma_score"] = magma_score
+            elif magma_score.dtype != torch.float32:
+                magma_score = magma_score.to(dtype=torch.float32, device=param.device)
+                state["magma_score"] = magma_score
+            magma_score.mul_(MAGMA_EMA_DECAY).add_(
+                raw_scores[offset : offset + bs], alpha=(1.0 - MAGMA_EMA_DECAY)
+            )
+            scales.append(MAGMA_MIN_SCALE + (1.0 - MAGMA_MIN_SCALE) * magma_score)
+            offset += bs
+
+        return scales
 
     def _compute_magma_scale(
         self,
@@ -1212,6 +1319,152 @@ class HybridMuonOptimizer(Optimizer):
             self._gram_orthogonalizer = _GramNewtonSchulzOrthogonalizer()
         return self._gram_orthogonalizer
 
+    def _process_merged_gram_buckets(
+        self,
+        gram_buckets: dict[
+            tuple[int, int, torch.device, torch.dtype],
+            list[tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]],
+        ],
+        lr: float,
+        lr_adjust: float,
+        lr_adjust_coeff: float,
+        magma_scales_map: dict[int, torch.Tensor],
+    ) -> None:
+        """Column-pad merge across rectangular buckets sharing the same min_dim.
+
+        Rectangular Muon matrices with the same ``min(rows, cols)`` can be
+        fused into a single Gram Newton-Schulz call by zero-padding the
+        **column** (large) dimension to the group maximum.  This reduces the
+        number of compiled Gram NS dispatches and improves GPU occupancy.
+
+        Mathematical equivalence proof for column-padding:
+        Both Standard NS and Gram NS operate on the wide orientation
+        ``X  (m x n)``, ``m <= n``.  The Gram matrix is
+        ``R = X @ X^T  (m x m)``.
+
+        Let ``X_pad = [X | 0]  (m x (n+p))`` where the last p columns are
+        zero.  Then:
+
+        1. Frobenius norm is unchanged:
+           ``||X_pad||_F = ||X||_F``
+           because the zero columns contribute nothing.
+
+        2. Gram matrix is unchanged:
+           ``R_pad = X_pad @ X_pad^T = X @ X^T + 0 @ 0^T = R``
+
+        3. Since all NS iterations (both standard quintic and Gram/Polar-
+           Express) depend *only* on R (which is m x m regardless of n),
+           every intermediate ``Q_k`` is identical.
+
+        4. The restart step ``X_new = Q @ X_pad = [Q @ X | 0]`` also
+           preserves the invariant ``R_new = Q @ R @ Q^T``, so subsequent
+           iterations remain identical.
+
+        5. The final output is ``Q_last @ X_pad = [Q_last @ X | 0]``.
+           Truncating to the first n columns exactly recovers the
+           unpadded result.
+
+        **Constraint**: Only the *column* (large) dimension may be padded.
+        Padding rows would change the size of R and break equivalence.
+
+        Per-entry ``scale`` and Magma damping are applied *after* unpadding,
+        since different original shapes have different ``max(rows, cols)``.
+        """
+        # --- Group rectangular buckets by (min_dim, device, dtype) ---
+        super_buckets: dict[
+            tuple[int, torch.device, torch.dtype],
+            list[
+                tuple[
+                    int,
+                    int,
+                    bool,
+                    list[
+                        tuple[
+                            dict[str, Any],
+                            torch.Tensor,
+                            torch.Tensor,
+                            torch.Tensor,
+                        ]
+                    ],
+                ]
+            ],
+        ] = {}
+
+        for (rows, cols, dev, dt), bucket_entries in gram_buckets.items():
+            min_dim = min(rows, cols)
+            max_dim = max(rows, cols)
+            transposed = rows > cols
+            sb_key = (min_dim, dev, dt)
+            if sb_key not in super_buckets:
+                super_buckets[sb_key] = []
+            super_buckets[sb_key].append((rows, cols, transposed, bucket_entries))
+
+        gram_orth = self._get_gram_orthogonalizer()
+
+        for (min_dim, _dev, _dt), sub_list in super_buckets.items():
+            # Find the maximum large-dimension across all sub-buckets.
+            padded_max_dim = max(max(r, c) for r, c, _, _ in sub_list)
+
+            # Collect all matrices in wide orientation (min_dim, padded_max_dim).
+            all_wide: list[torch.Tensor] = []
+            # Track per-matrix metadata for the split-back phase.
+            # Each entry: (param_entry, batch_size, orig_max_dim, was_transposed)
+            all_meta: list[tuple[dict[str, Any], int, int, bool]] = []
+
+            for rows, cols, was_transposed, bucket_entries in sub_list:
+                orig_max_dim = max(rows, cols)
+                for entry, update_tensor, _, _ in bucket_entries:
+                    bs = entry["batch_size"]
+                    mat = _reshape_update_to_matrix_batch(update_tensor, bs, rows, cols)
+                    # Orient to wide: (bs, min_dim, orig_max_dim)
+                    if was_transposed:
+                        mat = mat.transpose(-2, -1)
+                    # Pad columns if needed: (bs, min_dim, padded_max_dim)
+                    pad_width = padded_max_dim - orig_max_dim
+                    if pad_width > 0:
+                        mat = torch.nn.functional.pad(mat, (0, pad_width))
+                    all_wide.append(mat)
+                    all_meta.append((entry, bs, orig_max_dim, was_transposed))
+
+            # Single Gram NS call on the entire super-bucket.
+            # Shape: (total_batch, min_dim, padded_max_dim)
+            stacked = torch.cat(all_wide, dim=0)
+            orthogonalized = gram_orth(stacked)
+
+            # Split back, unpad, un-transpose, apply scale + Magma + update.
+            offset = 0
+            for entry, bs, orig_max_dim, was_transposed in all_meta:
+                orth_slice = orthogonalized[offset : offset + bs]
+                offset += bs
+
+                # Unpad: keep only the first orig_max_dim columns.
+                if orig_max_dim < padded_max_dim:
+                    orth_slice = orth_slice[:, :, :orig_max_dim]
+
+                # Un-transpose back to original (rows, cols) orientation.
+                if was_transposed:
+                    orth_slice = orth_slice.transpose(-2, -1)
+
+                # Per-entry scale (depends on original max(rows, cols)).
+                orig_rows, orig_cols = entry["rows"], entry["cols"]
+                if lr_adjust <= 0:
+                    scale = lr_adjust_coeff * math.sqrt(
+                        float(max(orig_rows, orig_cols))
+                    )
+                else:
+                    scale = max(1.0, orig_rows / orig_cols) ** 0.5
+                orth_slice = orth_slice * scale
+
+                # Per-entry Magma damping.
+                magma_scale = magma_scales_map.get(id(entry["param"]))
+                if magma_scale is not None:
+                    orth_slice = orth_slice * magma_scale.view(bs, 1, 1).to(
+                        dtype=orth_slice.dtype, device=orth_slice.device
+                    )
+
+                delta = orth_slice.reshape(entry["param"].shape)
+                entry["param"].add_(delta, alpha=-lr)
+
     def _build_param_routing(self) -> None:
         """
         Classify parameters into Muon, Adam, and AdamW routes (static routing).
@@ -1279,6 +1532,50 @@ class HybridMuonOptimizer(Optimizer):
             )
 
         self._routing_built = True
+
+    # ------------------------------------------------------------------
+    # Foreach-aware helpers for Adam moment updates
+    # ------------------------------------------------------------------
+
+    def _adam_update_moments(
+        self,
+        exp_avgs: list[torch.Tensor],
+        exp_avg_sqs: list[torch.Tensor],
+        grads_fp32: list[torch.Tensor],
+        beta1: float,
+        beta2: float,
+    ) -> None:
+        """Update Adam first/second moment estimates, foreach-accelerated when safe.
+
+        exp_avg  = beta1 * exp_avg  + (1 - beta1) * grad
+        exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad^2
+        """
+        if self._use_foreach and len(exp_avgs) > 1:
+            torch._foreach_lerp_(exp_avgs, grads_fp32, 1.0 - beta1)
+            grad_sq = torch._foreach_mul(grads_fp32, grads_fp32)
+            torch._foreach_lerp_(exp_avg_sqs, grad_sq, 1.0 - beta2)
+        else:
+            for ea, g in zip(exp_avgs, grads_fp32, strict=True):
+                ea.lerp_(g, 1.0 - beta1)
+            grad_sq = [g * g for g in grads_fp32]
+            for eas, gsq in zip(exp_avg_sqs, grad_sq, strict=True):
+                eas.lerp_(gsq, 1.0 - beta2)
+
+    def _weight_decay_inplace(
+        self,
+        params: list[torch.Tensor],
+        factor: float,
+    ) -> None:
+        """Apply multiplicative weight decay, foreach-accelerated when safe."""
+        if self._use_foreach and len(params) > 1:
+            torch._foreach_mul_(params, factor)
+        else:
+            for p in params:
+                p.mul_(factor)
+
+    # ------------------------------------------------------------------
+    # step()
+    # ------------------------------------------------------------------
 
     @torch.no_grad()
     def step(
@@ -1352,24 +1649,20 @@ class HybridMuonOptimizer(Optimizer):
             if adam_no_decay_params:
                 # === Step 1.2. Update exp_avg / exp_avg_sq ===
                 adam_lr = lr if lr_adjust <= 0 else lr / lr_adjust
-
-                # exp_avg = beta1 * exp_avg + (1 - beta1) * grad
-                # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad^2
-                for ea, g in zip(
-                    adam_no_decay_exp_avgs, adam_no_decay_grads_fp32, strict=True
-                ):
-                    ea.lerp_(g, 1 - adam_betas[0])
-                grad_sq = [g * g for g in adam_no_decay_grads_fp32]
-                for eas, gsq in zip(adam_no_decay_exp_avg_sqs, grad_sq, strict=True):
-                    eas.lerp_(gsq, 1 - adam_betas[1])
-
+                self._adam_update_moments(
+                    adam_no_decay_exp_avgs,
+                    adam_no_decay_exp_avg_sqs,
+                    adam_no_decay_grads_fp32,
+                    adam_betas[0],
+                    adam_betas[1],
+                )
                 # === Step 1.3. Bias correction and parameter update ===
+                # delta = -step_size * m_hat / (sqrt(v_hat) + eps)
                 for i, p in enumerate(adam_no_decay_params):
                     state = adam_no_decay_states[i]
                     bias_corr1 = 1 - state["beta1_pow"]
                     bias_corr2 = 1 - state["beta2_pow"]
                     step_size = adam_lr / bias_corr1
-                    # delta = -step_size * m_hat / (sqrt(v_hat) + eps)
                     denom = (adam_no_decay_exp_avg_sqs[i] / bias_corr2).sqrt().add_(EPS)
                     delta_fp32 = -step_size * (adam_no_decay_exp_avgs[i] / denom)
                     p.add_(delta_fp32.to(p.dtype))
@@ -1407,30 +1700,27 @@ class HybridMuonOptimizer(Optimizer):
                 adam_decay_states.append(state)
 
             if adam_decay_params:
-                # === Step 2.2. Update exp_avg / exp_avg_sq ===
                 adam_lr = lr if lr_adjust <= 0 else lr / lr_adjust
-                # AdamW decay for >=2D Adam path.
+                # AdamW decoupled weight decay for >=2D Adam path.
                 if weight_decay > 0:
-                    for p in adam_decay_params:
-                        p.mul_(1.0 - adam_lr * weight_decay)
-
-                # exp_avg = beta1 * exp_avg + (1 - beta1) * grad
-                # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad^2
-                for ea, g in zip(
-                    adam_decay_exp_avgs, adam_decay_grads_fp32, strict=True
-                ):
-                    ea.lerp_(g, 1 - adam_betas[0])
-                grad_sq = [g * g for g in adam_decay_grads_fp32]
-                for eas, gsq in zip(adam_decay_exp_avg_sqs, grad_sq, strict=True):
-                    eas.lerp_(gsq, 1 - adam_betas[1])
-
+                    self._weight_decay_inplace(
+                        adam_decay_params, 1.0 - adam_lr * weight_decay
+                    )
+                # === Step 2.2. Update exp_avg / exp_avg_sq ===
+                self._adam_update_moments(
+                    adam_decay_exp_avgs,
+                    adam_decay_exp_avg_sqs,
+                    adam_decay_grads_fp32,
+                    adam_betas[0],
+                    adam_betas[1],
+                )
                 # === Step 2.3. Bias correction and parameter update ===
+                # delta = -step_size * m_hat / (sqrt(v_hat) + eps)
                 for i, p in enumerate(adam_decay_params):
                     state = adam_decay_states[i]
                     bias_corr1 = 1 - state["beta1_pow"]
                     bias_corr2 = 1 - state["beta2_pow"]
                     step_size = adam_lr / bias_corr1
-                    # delta = -step_size * m_hat / (sqrt(v_hat) + eps)
                     denom = (adam_decay_exp_avg_sqs[i] / bias_corr2).sqrt().add_(EPS)
                     delta_fp32 = -step_size * (adam_decay_exp_avgs[i] / denom)
                     p.add_(delta_fp32.to(p.dtype))
@@ -1463,8 +1753,9 @@ class HybridMuonOptimizer(Optimizer):
 
             # === Step 3.2. Apply weight decay on Muon path ===
             if weight_decay > 0 and muon_params_for_decay:
-                for p in muon_params_for_decay:
-                    p.mul_(1.0 - lr * weight_decay)
+                self._weight_decay_inplace(
+                    muon_params_for_decay, 1.0 - lr * weight_decay
+                )
 
             if not active_entries:
                 continue
@@ -1474,11 +1765,15 @@ class HybridMuonOptimizer(Optimizer):
                 gradients=muon_grads,
                 momentum_buffers=muon_momentum_buffers,
                 momentum=momentum,
+                use_foreach=self._use_foreach,
             )
 
-            # === Step 3.4. Bucket by (batch_size, rows, cols, device, dtype) ===
+            # === Step 3.4. Bucket by (rows, cols, device, dtype) ===
+            # Merging across batch_sizes: entries with the same matrix
+            # shape are concatenated along the batch dimension, producing
+            # fewer but larger NS orth calls → better GPU occupancy.
             buckets: dict[
-                tuple[int, int, int, torch.device, torch.dtype],
+                tuple[int, int, torch.device, torch.dtype],
                 list[tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]],
             ] = {}
 
@@ -1486,7 +1781,6 @@ class HybridMuonOptimizer(Optimizer):
                 entry, _ = entry_info
                 update_tensor = muon_updates[idx]
                 bucket_key = (
-                    entry["batch_size"],
                     entry["rows"],
                     entry["cols"],
                     update_tensor.device,
@@ -1506,8 +1800,54 @@ class HybridMuonOptimizer(Optimizer):
             for bucket_entries in buckets.values():
                 bucket_entries.sort(key=lambda item: item[0]["param"].data_ptr())
 
-            # === Step 3.5. Newton-Schulz orthogonalization and update ===
-            for (batch_size, rows, cols, _device, _), bucket_entries in buckets.items():
+            # === Step 3.5. Pre-compute all Magma scales before NS loop ===
+            # All Magma GPU kernels are launched first as a contiguous batch,
+            # then all NS orth kernels follow.  This avoids interleaving
+            # Magma and NS dispatches, giving the GPU a denser pipeline.
+            magma_scales_map: dict[int, torch.Tensor] = {}
+            if magma_muon:
+                for (rows, cols, _, _), bucket_entries in buckets.items():
+                    per_bucket = self._compute_magma_scales_merged(
+                        bucket_entries=bucket_entries,
+                        rows=rows,
+                        cols=cols,
+                    )
+                    for (entry, _, _, _), sc in zip(
+                        bucket_entries, per_bucket, strict=True
+                    ):
+                        magma_scales_map[id(entry["param"])] = sc
+
+            # === Step 3.6. Newton-Schulz orthogonalization and update ===
+            # Split buckets into square (standard NS) and rectangular (Gram NS).
+            # Rectangular buckets are column-pad merged by min_dim in a single
+            # Gram NS call per group; square buckets use the standard bmm path.
+            square_buckets: dict[
+                tuple[int, int, torch.device, torch.dtype],
+                list[tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]],
+            ] = {}
+            gram_buckets: dict[
+                tuple[int, int, torch.device, torch.dtype],
+                list[tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]],
+            ] = {}
+            for key, bucket_entries in buckets.items():
+                rows, cols = key[0], key[1]
+                if enable_gram and rows != cols:
+                    gram_buckets[key] = bucket_entries
+                else:
+                    square_buckets[key] = bucket_entries
+
+            # --- 3.6a  Rectangular buckets → column-pad merged Gram NS ---
+            if gram_buckets:
+                self._process_merged_gram_buckets(
+                    gram_buckets=gram_buckets,
+                    lr=lr,
+                    lr_adjust=lr_adjust,
+                    lr_adjust_coeff=lr_adjust_coeff,
+                    magma_scales_map=magma_scales_map,
+                )
+
+            # --- 3.6b  Square buckets → standard / flash NS path ---
+            for (rows, cols, _device, _dtype), bucket_entries in square_buckets.items():
                 # scale = coeff * sqrt(max(m, n))  [match-RMS mode]
                 # scale = sqrt(max(1, m/n))        [rectangular mode]
                 if lr_adjust <= 0:
@@ -1515,70 +1855,48 @@ class HybridMuonOptimizer(Optimizer):
                 else:
                     scale = max(1.0, rows / cols) ** 0.5
 
-                # Determine if flash path is usable for this bucket.
-                # Flash path is enabled only for single-matrix updates.
-                # Only beneficial when min(rows, cols) >= FLASH_MIN_DIM;
-                # for small matrices, triton launch overhead > compute savings.
+                flat_updates: list[torch.Tensor] = []
+                entry_slices: list[tuple[int, int]] = []
+                offset = 0
+                for entry, update_tensor, _, _ in bucket_entries:
+                    bs = entry["batch_size"]
+                    mat = _reshape_update_to_matrix_batch(update_tensor, bs, rows, cols)
+                    flat_updates.append(mat)
+                    entry_slices.append((offset, bs))
+                    offset += bs
+                all_updates = torch.cat(flat_updates, dim=0)
+
+                # Flash path: triton-accelerated symmetric matmul for single
+                # large matrices (min_dim >= FLASH_MIN_DIM).
+                total_batch = all_updates.size(0)
                 M = min(rows, cols)
                 use_flash = (
                     not enable_gram
-                    and batch_size == 1
+                    and total_batch == 1
                     and self._use_flash
                     and _device.type == "cuda"
                     and M >= FLASH_MIN_DIM
                 )
                 if use_flash:
                     buf1, buf2 = self._get_ns_buffers(M, _device)
-                    flash_buffers: tuple[torch.Tensor, torch.Tensor] | None = (
-                        buf1,
-                        buf2,
-                    )
+                    orthogonalized = _flash_newton_schulz_orth(
+                        all_updates.squeeze(0), buf1, buf2
+                    ).unsqueeze(0)
                 else:
-                    flash_buffers = None
-
-                if magma_muon:
-                    bucket_magma_scales = self._compute_magma_scales_for_bucket(
-                        bucket_entries=bucket_entries,
-                        batch_size=batch_size,
-                        rows=rows,
-                        cols=cols,
-                    )
-                else:
-                    bucket_magma_scales = [None] * len(bucket_entries)
-
-                stacked_updates = _stack_bucket_updates(
-                    bucket_entries=bucket_entries,
-                    batch_size=batch_size,
-                    rows=rows,
-                    cols=cols,
-                )
-                use_gram_path = enable_gram and rows != cols
-                if use_gram_path:
-                    orthogonalized = self._get_gram_orthogonalizer()(stacked_updates)
-                else:
-                    orthogonalized = _orthogonalize_standard_stacked(
-                        stacked_updates=stacked_updates,
-                        rows=rows,
-                        cols=cols,
-                        use_flash=use_flash,
-                        flash_buffers=flash_buffers,
-                    )
+                    orthogonalized = _batched_newton_schulz_orth(all_updates)
 
                 orthogonalized.mul_(scale)
 
-                for idx, (
-                    (entry, _update_tensor, _grad, _buffer),
-                    magma_scale,
-                ) in enumerate(zip(bucket_entries, bucket_magma_scales, strict=True)):
-                    orth_view = orthogonalized[idx]
+                for idx, (entry, _, _, _) in enumerate(bucket_entries):
+                    off, bs = entry_slices[idx]
+                    orth_slice = orthogonalized[off : off + bs]
+                    magma_scale = magma_scales_map.get(id(entry["param"]))
                     if magma_scale is not None:
-                        orth_view.mul_(
-                            magma_scale.view(batch_size, 1, 1).to(
-                                dtype=orth_view.dtype,
-                                device=orth_view.device,
-                            )
+                        orth_slice = orth_slice * magma_scale.view(bs, 1, 1).to(
+                            dtype=orth_slice.dtype,
+                            device=orth_slice.device,
                         )
-                    delta = orth_view.reshape(entry["param"].shape)
+                    delta = orth_slice.reshape(entry["param"].shape)
                     entry["param"].add_(delta, alpha=-lr)
 
         return loss

--- a/deepmd/pt/optimizer/hybrid_muon.py
+++ b/deepmd/pt/optimizer/hybrid_muon.py
@@ -39,10 +39,21 @@ For Muon-routed parameters, the update is:
        m_t = beta * m_{t-1} + (1 - beta) * g_t
        update = beta * m_t + (1 - beta) * g_t
 
-    2. Newton-Schulz orthogonalization (quintic iteration):
-       X_0 = G / ||G||_F
-       X_{k+1} = a*X_k + (b*A_k + c*A_k^2) @ X_k,  where A_k = X_k @ X_k^T
-       Coefficients: a=3.4445, b=-4.7750, c=2.0315
+    2. Orthogonalization:
+       - Standard path:
+         X_0 = G / ||G||_F
+         A_k = X_k @ X_k^T
+         X_{k+1} = a*X_k + (b*A_k + c*A_k^2) @ X_k
+       - Gram path (when ``enable_gram=True`` and the matrix is rectangular):
+         X_0 = G / ||G||_F
+         R_k = X_k @ X_k^T
+         Z_k = b*R_k + c*R_k^2
+         Q_k = Z_k + a*I                              [restart]
+         Q_k = Q_{k-1} @ (Z_k + a*I)                 [accumulation]
+         RZ_k = a*R_k + R_k @ Z_k
+         R_{k+1} = a*RZ_k + Z_k @ RZ_k
+         X_out = Q_last @ X_restart
+         Uses float32 normalization followed by float16 iteration.
 
     3. Scaling: scale = coeff * sqrt(max(m, n))  [match-RMS mode]
                 scale = sqrt(max(1, m/n))        [rectangular mode]
@@ -54,8 +65,9 @@ AdamW behavior (decoupled weight decay) is applied only on >=2D Adam paths.
 
 Dtype Behavior
 --------------
-- Newton-Schulz iterations: always bfloat16 (matches official Muon)
-- NS output (bfloat16) directly applied to parameters (PyTorch handles mixed precision)
+- Standard Newton-Schulz path: bfloat16 iterations
+- Gram Newton-Schulz path: float32 normalization + float16 iterations
+- NS output directly applied to parameters after casting back to the input dtype
 - Adam state (exp_avg, exp_avg_sq): always float32 for numerical stability
 - Muon momentum buffer: follows gradient dtype (grad -> buffer -> update)
 - Adam gradients: cast to float32 for update computation
@@ -79,6 +91,8 @@ References
        HybridMuon uses a stabilized variant (Magma-lite) with sigmoid range stretching
        and continuous soft scaling [0.1, 1.0] instead of Bernoulli masking, optimized
        for MLIP force-field training.
+.. [6] Dao-AILab, "gram-newton-schulz."
+       https://github.com/Dao-AILab/gram-newton-schulz
 """
 
 from __future__ import (
@@ -126,6 +140,25 @@ EPS: float = 1e-7
 NS_COEFF_A: float = 3.4445
 NS_COEFF_B: float = -4.7750
 NS_COEFF_C: float = 2.0315
+# Polar Express coefficients with the safety scaling used in the reference repo
+_GRAM_NS_UNMODIFIED_POLAR_EXPRESS_COEFFICIENTS: tuple[
+    tuple[float, float, float], ...
+] = (
+    (8.28721201814563, -23.595886519098837, 17.300387312530933),
+    (4.107059111542203, -2.9478499167379106, 0.5448431082926601),
+    (3.9486908534822946, -2.908902115962949, 0.5518191394370137),
+    (3.3184196573706015, -2.488488024314874, 0.51004894012372),
+    (2.300652019954817, -1.6689039845747493, 0.4188073119525673),
+)
+GRAM_NS_SAFETY_FACTOR: float = 1.05
+POLAR_EXPRESS_COEFFICIENTS: tuple[tuple[float, float, float], ...] = tuple(
+    (
+        a / GRAM_NS_SAFETY_FACTOR,
+        b / GRAM_NS_SAFETY_FACTOR**3,
+        c / GRAM_NS_SAFETY_FACTOR**5,
+    )
+    for a, b, c in _GRAM_NS_UNMODIFIED_POLAR_EXPRESS_COEFFICIENTS
+)
 # Minimum matrix dimension for flash path to be beneficial.
 # Below this threshold, triton kernel launch overhead dominates over compute,
 # and cuBLAS (via torch.mm/addmm) is faster for small matrices.
@@ -363,6 +396,284 @@ def _batched_newton_schulz_orth(
     return X
 
 
+class _GramNewtonSchulzOrthogonalizer:
+    """
+    Orthogonalize rectangular matrices with the fixed Gram Newton-Schulz setup
+    used by HybridMuon.
+    """
+
+    def __init__(self) -> None:
+        self.ns_epsilon = float(EPS)
+        self.ns_coefficients = tuple(
+            (float(a), float(b), float(c)) for a, b, c in POLAR_EXPRESS_COEFFICIENTS
+        )
+        self._restart_iteration_set = frozenset((2,))
+        self._call_impl = self._orthogonalize_impl
+        self._compiled_call = torch.compile(
+            self._call_impl,
+            fullgraph=True,
+            mode="reduce-overhead",
+        )
+
+    def __call__(self, X: torch.Tensor) -> torch.Tensor:
+        """
+        Orthogonalize a tensor of rectangular matrices.
+
+        Parameters
+        ----------
+        X : torch.Tensor
+            Input tensor with shape ``(m, n)``, ``(batch, m, n)``, or any tensor
+            whose last two dimensions are matrix dimensions.
+
+        Returns
+        -------
+        torch.Tensor
+            Orthogonalized tensor with the same shape and dtype as ``X``.
+        """
+        with torch.device(X.device):
+            return self._compiled_call(X)
+
+    def _orthogonalize_impl(self, X: torch.Tensor) -> torch.Tensor:
+        # === Step 1. Canonicalize leading batch dimensions ===
+        original_shape = X.shape
+        if X.ndim == 2:
+            X = X.unsqueeze(0)
+        elif X.ndim > 3:
+            X = X.reshape(-1, *X.shape[-2:])
+
+        # === Step 2. Normalize in float32 before Gram iteration ===
+        original_dtype = X.dtype
+        X = X.to(torch.float32)
+
+        # === Step 3. Work on the wide-matrix orientation ===
+        should_transpose = X.size(-2) > X.size(-1)
+        if should_transpose:
+            X = X.mT
+
+        # === Step 4. Run Gram Newton-Schulz in float16 ===
+        X = X / (X.norm(dim=(-2, -1), keepdim=True) + self.ns_epsilon)
+        X = X.to(torch.float16)
+        X = self._gram_newton_schulz(X)
+
+        # === Step 5. Restore original orientation and dtype ===
+        if should_transpose:
+            X = X.mT
+
+        return X.to(original_dtype).reshape(original_shape)
+
+    def _gram_newton_schulz(self, X: torch.Tensor) -> torch.Tensor:
+        # === Step 1. Initialize R_0 = X_0 @ X_0^T and the batch identity ===
+        gram_matrix = torch.bmm(X, X.mT)
+        batch_size = gram_matrix.size(0)
+        identity = (
+            torch.eye(
+                gram_matrix.size(-1),
+                device=X.device,
+                dtype=X.dtype,
+            )
+            .unsqueeze(0)
+            .expand(batch_size, -1, -1)
+            .contiguous()
+        )
+        transform = None
+
+        for idx, (coef_a, coef_b, coef_c) in enumerate(self.ns_coefficients):
+            # === Step 2. Apply the configured restart boundary ===
+            if idx in self._restart_iteration_set and idx != 0:
+                X = torch.bmm(transform, X)
+                gram_matrix = torch.bmm(X, X.mT)
+                transform = None
+
+            # === Step 3. Build Z_k = b * R_k + c * R_k^2 ===
+            poly = torch.baddbmm(
+                gram_matrix,
+                gram_matrix,
+                gram_matrix,
+                beta=coef_b,
+                alpha=coef_c,
+            )
+            # === Step 4. Accumulate Q_k ===
+            if idx == 0 or idx in self._restart_iteration_set:
+                # Q_k = Z_k + a * I
+                transform = poly + coef_a * identity
+            else:
+                # Q_k = Q_{k-1} @ (Z_k + a * I) = a * Q_{k-1} + Q_{k-1} @ Z_k
+                transform = torch.baddbmm(
+                    transform,
+                    transform,
+                    poly,
+                    beta=coef_a,
+                    alpha=1.0,
+                )
+
+            if (
+                idx < len(self.ns_coefficients) - 1
+                and idx + 1 not in self._restart_iteration_set
+            ):
+                # RZ_k = a * R_k + R_k @ Z_k
+                gram_poly = torch.baddbmm(
+                    gram_matrix,
+                    gram_matrix,
+                    poly,
+                    beta=coef_a,
+                    alpha=1.0,
+                )
+                # R_{k+1} = a * RZ_k + Z_k @ RZ_k
+                gram_matrix = torch.baddbmm(
+                    gram_poly,
+                    poly,
+                    gram_poly,
+                    beta=coef_a,
+                    alpha=1.0,
+                )
+
+        # === Step 5. Apply the accumulated Q_last to the current X ===
+        return torch.bmm(transform, X)
+
+
+def _reshape_update_to_matrix_batch(
+    update_tensor: torch.Tensor,
+    batch_size: int,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    """
+    View one update tensor as a batch of matrices.
+
+    Parameters
+    ----------
+    update_tensor : torch.Tensor
+        Update tensor for a single parameter.
+    batch_size : int
+        Number of matrix slices represented by the parameter.
+    rows : int
+        Matrix row count for each slice.
+    cols : int
+        Matrix column count for each slice.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor with shape ``(batch_size, rows, cols)``.
+    """
+    if update_tensor.is_contiguous():
+        return update_tensor.view(batch_size, rows, cols)
+    return update_tensor.reshape(batch_size, rows, cols).contiguous()
+
+
+def _stack_bucket_updates(
+    bucket_entries: list[
+        tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]
+    ],
+    batch_size: int,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    """
+    Stack same-shape Muon updates into one tensor for orthogonalization.
+
+    Parameters
+    ----------
+    bucket_entries : list[tuple[dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]]
+        Bucket entries as ``(entry, update_tensor, grad, momentum_buffer)``.
+    batch_size : int
+        Number of matrix slices per parameter in the bucket.
+    rows : int
+        Matrix row count for each slice.
+    cols : int
+        Matrix column count for each slice.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor with shape ``(num_entries, batch_size, rows, cols)``.
+    """
+    update_batches = [
+        _reshape_update_to_matrix_batch(update_tensor, batch_size, rows, cols)
+        for _, update_tensor, _, _ in bucket_entries
+    ]
+    return torch.stack(update_batches, dim=0)
+
+
+def _orthogonalize_standard_stacked(
+    stacked_updates: torch.Tensor,
+    rows: int,
+    cols: int,
+    use_flash: bool,
+    flash_buffers: tuple[torch.Tensor, torch.Tensor] | None = None,
+) -> torch.Tensor:
+    """
+    Orthogonalize stacked updates with the current standard Newton-Schulz path.
+
+    Parameters
+    ----------
+    stacked_updates : torch.Tensor
+        Tensor with shape ``(num_entries, batch_size, rows, cols)``.
+    rows : int
+        Matrix row count.
+    cols : int
+        Matrix column count.
+    use_flash : bool
+        Whether to use the Triton single-matrix path when ``batch_size == 1``.
+    flash_buffers : tuple[torch.Tensor, torch.Tensor] | None, optional
+        Pre-allocated flash buffers when ``use_flash`` is enabled.
+
+    Returns
+    -------
+    torch.Tensor
+        Orthogonalized tensor with the same shape as ``stacked_updates``.
+    """
+    num_entries, batch_size, _, _ = stacked_updates.shape
+    if use_flash and batch_size == 1:
+        if flash_buffers is None:
+            raise ValueError("Flash buffers are required when use_flash=True.")
+        buf1, buf2 = flash_buffers
+        orthogonalized = [
+            _flash_newton_schulz_orth(stacked_updates[idx, 0], buf1, buf2)
+            for idx in range(num_entries)
+        ]
+        return torch.stack(orthogonalized, dim=0).unsqueeze(1)
+
+    # Flash path only supports one matrix per entry; batched inputs use bmm path.
+    flat_updates = stacked_updates.reshape(num_entries * batch_size, rows, cols)
+    orthogonalized = _batched_newton_schulz_orth(flat_updates)
+    return orthogonalized.reshape(num_entries, batch_size, rows, cols)
+
+
+def _compute_muon_nesterov_updates(
+    gradients: list[torch.Tensor],
+    momentum_buffers: list[torch.Tensor],
+    momentum: float,
+) -> list[torch.Tensor]:
+    """
+    Update Muon momentum buffers and return Nesterov updates.
+
+    Parameters
+    ----------
+    gradients : list[torch.Tensor]
+        Gradient tensors routed to the Muon path.
+    momentum_buffers : list[torch.Tensor]
+        Momentum buffers associated with ``gradients``.
+    momentum : float
+        Momentum coefficient.
+
+    Returns
+    -------
+    list[torch.Tensor]
+        Nesterov-style Muon updates with the same shapes as ``gradients``.
+    """
+    # === Step 1. Update momentum buffers ===
+    # m_t = beta * m_{t-1} + (1 - beta) * g_t
+    for momentum_buffer, grad in zip(momentum_buffers, gradients, strict=True):
+        momentum_buffer.lerp_(grad, 1.0 - momentum)
+    # === Step 2. Form Nesterov updates ===
+    # update = beta * m_t + (1 - beta) * g_t
+    return [
+        torch.lerp(grad, momentum_buffer, momentum)
+        for grad, momentum_buffer in zip(gradients, momentum_buffers, strict=True)
+    ]
+
+
 def get_adam_route(
     param_name: str | None,
 ) -> str:
@@ -544,7 +855,7 @@ class HybridMuonOptimizer(Optimizer):
           scale = lr_adjust_coeff * sqrt(max(m, n)). Adam uses lr directly.
         - If lr_adjust > 0: use rectangular correction for Muon,
           scale = sqrt(max(1.0, m/n)). Adam uses lr/lr_adjust.
-        Default is 10.0 (Adam lr = lr/10).
+        Default is 0.0 (match-RMS scaling).
     lr_adjust_coeff : float
         Coefficient with default 0.2 for match-RMS scaling when
         ``lr_adjust <= 0``:
@@ -560,10 +871,15 @@ class HybridMuonOptimizer(Optimizer):
         (case-insensitive), or starting with ``adam_`` (case-insensitive),
         are forced to Adam (no weight decay). Parameters starting with
         ``adamw_`` are forced to AdamW-style decoupled decay path.
+    enable_gram : bool
+        Enable the compiled Gram Newton-Schulz path for rectangular Muon
+        matrices. Square matrices continue to use the current standard
+        Newton-Schulz implementation. Default is True.
     flash_muon : bool
         Enable triton-accelerated Newton-Schulz orthogonalization.
         Requires triton and CUDA. Falls back to PyTorch implementation
-        when triton is unavailable or running on CPU.
+        when triton is unavailable or running on CPU. Ignored when
+        ``enable_gram=True``.
         Default is True.
     magma_muon : bool
         Enable Magma-lite damping on Muon updates with default False.
@@ -591,6 +907,7 @@ class HybridMuonOptimizer(Optimizer):
         lr_adjust_coeff: float = 0.2,
         muon_mode: str = "slice",
         named_parameters: Iterable[tuple[str, torch.Tensor]] | None = None,
+        enable_gram: bool = True,
         flash_muon: bool = True,
         magma_muon: bool = False,
     ) -> None:
@@ -610,6 +927,7 @@ class HybridMuonOptimizer(Optimizer):
             "lr_adjust": lr_adjust,
             "lr_adjust_coeff": lr_adjust_coeff,
             "muon_mode": muon_mode,
+            "enable_gram": bool(enable_gram),
             "magma_muon": bool(magma_muon),
         }
         super().__init__(params, defaults)
@@ -631,6 +949,7 @@ class HybridMuonOptimizer(Optimizer):
             tuple[int, torch.device],
             tuple[torch.Tensor, torch.Tensor],
         ] = {}
+        self._gram_orthogonalizer: _GramNewtonSchulzOrthogonalizer | None = None
 
     def _compute_magma_scale(
         self,
@@ -880,6 +1199,19 @@ class HybridMuonOptimizer(Optimizer):
             )
         return self._ns_buffers[key]
 
+    def _get_gram_orthogonalizer(self) -> _GramNewtonSchulzOrthogonalizer:
+        """
+        Lazily initialize the compiled Gram orthogonalizer.
+
+        Returns
+        -------
+        _GramNewtonSchulzOrthogonalizer
+            Shared Gram orthogonalizer instance for the optimizer.
+        """
+        if self._gram_orthogonalizer is None:
+            self._gram_orthogonalizer = _GramNewtonSchulzOrthogonalizer()
+        return self._gram_orthogonalizer
+
     def _build_param_routing(self) -> None:
         """
         Classify parameters into Muon, Adam, and AdamW routes (static routing).
@@ -982,6 +1314,7 @@ class HybridMuonOptimizer(Optimizer):
             adam_betas = group["adam_betas"]
             lr_adjust = group["lr_adjust"]
             lr_adjust_coeff = group["lr_adjust_coeff"]
+            enable_gram = bool(group.get("enable_gram", True))
             magma_muon = bool(group.get("magma_muon", False))
 
             # === Step 1. Adam update for non-decay Adam path ===
@@ -1137,14 +1470,11 @@ class HybridMuonOptimizer(Optimizer):
                 continue
 
             # === Step 3.3. Momentum update (Nesterov) ===
-            # m_t = beta * m_{t-1} + (1 - beta) * g_t
-            for buf, g in zip(muon_momentum_buffers, muon_grads):
-                buf.lerp_(g, 1 - momentum)
-            # update = beta * m_t + (1 - beta) * g_t
-            muon_updates = [
-                torch.lerp(g, buf, momentum)
-                for g, buf in zip(muon_grads, muon_momentum_buffers)
-            ]
+            muon_updates = _compute_muon_nesterov_updates(
+                gradients=muon_grads,
+                momentum_buffers=muon_momentum_buffers,
+                momentum=momentum,
+            )
 
             # === Step 3.4. Bucket by (batch_size, rows, cols, device, dtype) ===
             buckets: dict[
@@ -1154,13 +1484,13 @@ class HybridMuonOptimizer(Optimizer):
 
             for idx, entry_info in enumerate(active_entries):
                 entry, _ = entry_info
-                p = entry["param"]
+                update_tensor = muon_updates[idx]
                 bucket_key = (
                     entry["batch_size"],
                     entry["rows"],
                     entry["cols"],
-                    p.device,
-                    p.dtype,
+                    update_tensor.device,
+                    update_tensor.dtype,
                 )
                 if bucket_key not in buckets:
                     buckets[bucket_key] = []
@@ -1172,6 +1502,9 @@ class HybridMuonOptimizer(Optimizer):
                         muon_momentum_buffers[idx],
                     )
                 )
+
+            for bucket_entries in buckets.values():
+                bucket_entries.sort(key=lambda item: item[0]["param"].data_ptr())
 
             # === Step 3.5. Newton-Schulz orthogonalization and update ===
             for (batch_size, rows, cols, _device, _), bucket_entries in buckets.items():
@@ -1188,13 +1521,20 @@ class HybridMuonOptimizer(Optimizer):
                 # for small matrices, triton launch overhead > compute savings.
                 M = min(rows, cols)
                 use_flash = (
-                    batch_size == 1
+                    not enable_gram
+                    and batch_size == 1
                     and self._use_flash
                     and _device.type == "cuda"
                     and M >= FLASH_MIN_DIM
                 )
                 if use_flash:
                     buf1, buf2 = self._get_ns_buffers(M, _device)
+                    flash_buffers: tuple[torch.Tensor, torch.Tensor] | None = (
+                        buf1,
+                        buf2,
+                    )
+                else:
+                    flash_buffers = None
 
                 if magma_muon:
                     bucket_magma_scales = self._compute_magma_scales_for_bucket(
@@ -1206,47 +1546,39 @@ class HybridMuonOptimizer(Optimizer):
                 else:
                     bucket_magma_scales = [None] * len(bucket_entries)
 
-                # Process each entry individually with Newton-Schulz orth.
-                # Compatible with sharding propagation under FSDP2.
-                for (entry, update_tensor, _grad, _buffer), magma_scale in zip(
-                    bucket_entries, bucket_magma_scales, strict=True
-                ):
-                    if batch_size > 1:
-                        if update_tensor.is_contiguous():
-                            update_batch = update_tensor.view(batch_size, rows, cols)
-                        else:
-                            update_batch = update_tensor.reshape(
-                                batch_size, rows, cols
-                            ).contiguous()
-                        orth = _batched_newton_schulz_orth(update_batch)
-                    else:
-                        if update_tensor.is_contiguous():
-                            update_matrix = update_tensor.view(rows, cols)
-                        else:
-                            update_matrix = update_tensor.reshape(
-                                rows, cols
-                            ).contiguous()
-                        if use_flash:
-                            orth = _flash_newton_schulz_orth(update_matrix, buf1, buf2)
-                        else:
-                            orth = _newton_schulz_orth(update_matrix)
-                    orth.mul_(scale)
-                    if batch_size > 1:
-                        orth_view = orth.reshape(batch_size, rows, cols)
-                        if magma_scale is not None:
-                            orth_view.mul_(
-                                magma_scale.view(batch_size, 1, 1).to(
-                                    dtype=orth.dtype,
-                                    device=orth.device,
-                                )
+                stacked_updates = _stack_bucket_updates(
+                    bucket_entries=bucket_entries,
+                    batch_size=batch_size,
+                    rows=rows,
+                    cols=cols,
+                )
+                use_gram_path = enable_gram and rows != cols
+                if use_gram_path:
+                    orthogonalized = self._get_gram_orthogonalizer()(stacked_updates)
+                else:
+                    orthogonalized = _orthogonalize_standard_stacked(
+                        stacked_updates=stacked_updates,
+                        rows=rows,
+                        cols=cols,
+                        use_flash=use_flash,
+                        flash_buffers=flash_buffers,
+                    )
+
+                orthogonalized.mul_(scale)
+
+                for idx, (
+                    (entry, _update_tensor, _grad, _buffer),
+                    magma_scale,
+                ) in enumerate(zip(bucket_entries, bucket_magma_scales, strict=True)):
+                    orth_view = orthogonalized[idx]
+                    if magma_scale is not None:
+                        orth_view.mul_(
+                            magma_scale.view(batch_size, 1, 1).to(
+                                dtype=orth_view.dtype,
+                                device=orth_view.device,
                             )
-                        delta = orth_view.reshape(entry["param"].shape)
-                    else:
-                        if magma_scale is not None:
-                            orth.mul_(
-                                magma_scale[0].to(dtype=orth.dtype, device=orth.device)
-                            )
-                        delta = orth.reshape(entry["param"].shape)
+                        )
+                    delta = orth_view.reshape(entry["param"].shape)
                     entry["param"].add_(delta, alpha=-lr)
 
         return loss

--- a/deepmd/pt/optimizer/hybrid_muon.py
+++ b/deepmd/pt/optimizer/hybrid_muon.py
@@ -120,13 +120,31 @@ if TYPE_CHECKING:
 # Triton availability detection
 # ============================================================================
 
+# Two-stage probe:
+#   1. ``import triton`` succeeds (package is installed).
+#   2. ``triton.runtime.driver.active`` resolves to a usable backend driver.
+#
+# Stage 2 is required because ``@triton.autotune(...)`` eagerly calls
+# ``driver.active.get_benchmarker()`` inside ``Autotuner.__init__``; on
+# CPU-only / driver-less hosts this raises ``RuntimeError: 0 active drivers``
+# at *module import time*, breaking non-training entry points.
+TRITON_AVAILABLE = False
 try:
     import triton
     import triton.language as tl
 
-    TRITON_AVAILABLE = True
+    try:
+        # Touching ``driver.active`` forces the lazy proxy to initialize the
+        # backend driver. ``get_current_target`` is the lightest public call
+        # that exercises the same path as ``Autotuner.__init__``.
+        triton.runtime.driver.active.get_current_target()
+        TRITON_AVAILABLE = True
+    except Exception:
+        # No usable runtime driver (no CUDA/ROCm/XPU, or a mis-configured
+        # one): fall back to the pure-PyTorch Newton-Schulz path.
+        TRITON_AVAILABLE = False
 except ImportError:
-    TRITON_AVAILABLE = False
+    pass
 
 # ============================================================================
 # Constants

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -903,8 +903,9 @@ class Trainer:
                     "lr_adjust_coeff": float(self.opt_param["lr_adjust_coeff"]),
                     "muon_mode": str(self.opt_param.get("muon_mode", "slice")),
                     "named_parameters": tuple(self.wrapper.named_parameters()),
-                    "flash_muon": bool(self.opt_param.get("flash_muon", True)),
-                    "magma_muon": bool(self.opt_param.get("magma_muon", False)),
+                    "enable_gram": bool(self.opt_param.get("enable_gram")),
+                    "flash_muon": bool(self.opt_param.get("flash_muon")),
+                    "magma_muon": bool(self.opt_param.get("magma_muon")),
                 }
             else:
                 raise ValueError(f"Not supported optimizer type '{self.opt_type}'")

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -908,6 +908,11 @@ class Trainer:
                     else bool(self.opt_param.get("enable_gram")),
                     "flash_muon": bool(self.opt_param.get("flash_muon")),
                     "magma_muon": bool(self.opt_param.get("magma_muon")),
+                    # FSDP2 shards parameters as DTensor; several torch._foreach_*
+                    # ops lack DTensor sharding propagation on older PyTorch, so
+                    # fall back to the per-tensor path under zero_stage >= 2.
+                    # DDP / ZeRO-1 keep plain tensors and use the default.
+                    "use_foreach": False if self.zero_stage >= 2 else None,
                 }
             else:
                 raise ValueError(f"Not supported optimizer type '{self.opt_type}'")

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -903,7 +903,9 @@ class Trainer:
                     "lr_adjust_coeff": float(self.opt_param["lr_adjust_coeff"]),
                     "muon_mode": str(self.opt_param.get("muon_mode", "slice")),
                     "named_parameters": tuple(self.wrapper.named_parameters()),
-                    "enable_gram": bool(self.opt_param.get("enable_gram")),
+                    "enable_gram": False
+                    if self.is_distributed
+                    else bool(self.opt_param.get("enable_gram")),
                     "flash_muon": bool(self.opt_param.get("flash_muon")),
                     "magma_muon": bool(self.opt_param.get("magma_muon")),
                 }

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3089,7 +3089,8 @@ def optimizer_hybrid_muon() -> list[Argument]:
             optional=True,
             default=0.001,
             doc=doc_only_pt_supported
-            + "Weight decay coefficient. Applied only to Muon-routed parameters",
+            + "Weight decay coefficient. Applied to Muon-routed parameters and "
+            + "the AdamW-style decay path for matrix parameters.",
         ),
         Argument(
             "lr_adjust",
@@ -3123,6 +3124,15 @@ def optimizer_hybrid_muon() -> list[Argument]:
             + "Routing uses effective shape after removing singleton dimensions.",
         ),
         Argument(
+            "enable_gram",
+            bool,
+            optional=True,
+            default=True,
+            doc=doc_only_pt_supported
+            + "Enable the compiled Gram Newton-Schulz path for rectangular Muon matrices. "
+            + "Square matrices keep using the current standard Newton-Schulz path.",
+        ),
+        Argument(
             "flash_muon",
             bool,
             optional=True,
@@ -3130,13 +3140,13 @@ def optimizer_hybrid_muon() -> list[Argument]:
             doc=doc_only_pt_supported
             + "Enable triton-accelerated Newton-Schulz orthogonalization. "
             "Requires triton and CUDA. Falls back to PyTorch implementation "
-            "when triton is unavailable or running on CPU.",
+            "when triton is unavailable or running on CPU. Ignored when enable_gram is true.",
         ),
         Argument(
             "magma_muon",
             bool,
             optional=True,
-            default=False,
+            default=True,
             doc=doc_only_pt_supported
             + "Enable Magma-lite damping on the Muon route only. "
             "When enabled, HybridMuon computes momentum-gradient alignment "

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -3130,7 +3130,8 @@ def optimizer_hybrid_muon() -> list[Argument]:
             default=True,
             doc=doc_only_pt_supported
             + "Enable the compiled Gram Newton-Schulz path for rectangular Muon matrices. "
-            + "Square matrices keep using the current standard Newton-Schulz path.",
+            + "Square matrices keep using the current standard Newton-Schulz path. "
+            + "Automatically disabled in distributed (multi-GPU) training.",
         ),
         Argument(
             "flash_muon",

--- a/source/tests/pt/test_hybrid_muon.py
+++ b/source/tests/pt/test_hybrid_muon.py
@@ -4,6 +4,7 @@ import unittest
 import torch
 
 from deepmd.pt.optimizer.hybrid_muon import (
+    FLASH_MIN_DIM,
     MAGMA_MIN_SCALE,
     TRITON_AVAILABLE,
     HybridMuonOptimizer,
@@ -36,7 +37,18 @@ def _bf16_matmul_supported(device: torch.device) -> bool:
         return False
 
 
+def _fp16_matmul_supported(device: torch.device) -> bool:
+    """Check if float16 matmul is reliably supported on the given device."""
+    try:
+        a = torch.randn(4, 4, dtype=torch.float16, device=device)
+        _ = torch.mm(a, a.T)
+        return True
+    except (RuntimeError, TypeError):
+        return False
+
+
 BF16_SUPPORTED = _bf16_matmul_supported(env.DEVICE)
+FP16_SUPPORTED = _fp16_matmul_supported(env.DEVICE)
 
 
 @unittest.skipIf(not BF16_SUPPORTED, "bf16 matmul not supported on this device")
@@ -139,6 +151,74 @@ class TestHybridMuonOptimizer(unittest.TestCase):
             torch.allclose(model1.weight, model2.weight),
             "Different lr_adjust modes should produce different updates",
         )
+
+    def test_enable_gram_defaults_to_true(self) -> None:
+        """Test enable_gram is enabled by default."""
+        model = torch.nn.Linear(10, 20, bias=False, device=self.device)
+        optimizer = HybridMuonOptimizer(model.parameters(), lr=0.02)
+        self.assertTrue(optimizer.param_groups[0]["enable_gram"])
+
+    def test_enable_gram_square_falls_back_to_standard(self) -> None:
+        """Test square matrices keep using the standard path when Gram is enabled."""
+        torch.manual_seed(42)
+        model_standard = torch.nn.Linear(10, 10, device=self.device)
+        model_gram = torch.nn.Linear(10, 10, device=self.device)
+        model_gram.load_state_dict(model_standard.state_dict())
+
+        opt_standard = HybridMuonOptimizer(
+            model_standard.parameters(),
+            lr=0.02,
+            enable_gram=False,
+            flash_muon=False,
+        )
+        opt_gram = HybridMuonOptimizer(
+            model_gram.parameters(),
+            lr=0.02,
+            enable_gram=True,
+            flash_muon=False,
+        )
+
+        x = torch.randn(4, 10, device=self.device)
+        opt_standard.zero_grad()
+        model_standard(x).sum().backward()
+        opt_standard.step()
+
+        opt_gram.zero_grad()
+        model_gram(x).sum().backward()
+        opt_gram.step()
+
+        self.assertTrue(
+            torch.allclose(
+                model_standard.weight, model_gram.weight, atol=1e-6, rtol=1e-6
+            )
+        )
+        self.assertTrue(
+            torch.allclose(model_standard.bias, model_gram.bias, atol=1e-6, rtol=1e-6)
+        )
+
+    @unittest.skipIf(
+        not FP16_SUPPORTED,
+        "float16 matmul not supported on this device",
+    )
+    def test_enable_gram_rectangular_step_runs(self) -> None:
+        """Test a rectangular Muon step runs successfully with Gram enabled."""
+        torch.manual_seed(42)
+        model = torch.nn.Linear(10, 20, bias=False, device=self.device)
+        optimizer = HybridMuonOptimizer(
+            model.parameters(),
+            lr=0.02,
+            enable_gram=True,
+            flash_muon=False,
+        )
+        initial_weight = model.weight.detach().clone()
+
+        x = torch.randn(4, 10, device=self.device)
+        optimizer.zero_grad()
+        model(x).sum().backward()
+        optimizer.step()
+
+        self.assertFalse(torch.allclose(initial_weight, model.weight))
+        self.assertIn("momentum_buffer", optimizer.state[model.weight])
 
     def test_slice_mode_uses_muon_for_3d_weight(self) -> None:
         """Test muon_mode='slice' + name rules route params as expected."""
@@ -415,8 +495,18 @@ class TestFlashMuon(unittest.TestCase):
         model2 = torch.nn.Linear(32, 64, device=self.device)
         model2.load_state_dict(model1.state_dict())
 
-        opt1 = HybridMuonOptimizer(model1.parameters(), lr=0.02, flash_muon=False)
-        opt2 = HybridMuonOptimizer(model2.parameters(), lr=0.02, flash_muon=True)
+        opt1 = HybridMuonOptimizer(
+            model1.parameters(),
+            lr=0.02,
+            enable_gram=False,
+            flash_muon=False,
+        )
+        opt2 = HybridMuonOptimizer(
+            model2.parameters(),
+            lr=0.02,
+            enable_gram=False,
+            flash_muon=True,
+        )
 
         x = torch.randn(4, 32, device=self.device)
 
@@ -444,15 +534,16 @@ class TestFlashMuon(unittest.TestCase):
     )
     def test_flash_path_actually_used(self) -> None:
         """Verify that flash path is actually active when triton + CUDA available."""
-        from deepmd.pt.optimizer.hybrid_muon import (
-            FLASH_MIN_DIM,
-        )
-
         torch.manual_seed(42)
         # Use matrix large enough to exceed FLASH_MIN_DIM threshold
         dim = max(FLASH_MIN_DIM, 128)
         model = torch.nn.Linear(dim, dim * 2, device=self.device)
-        optimizer = HybridMuonOptimizer(model.parameters(), lr=0.02, flash_muon=True)
+        optimizer = HybridMuonOptimizer(
+            model.parameters(),
+            lr=0.02,
+            enable_gram=False,
+            flash_muon=True,
+        )
         # _use_flash should be True when triton is available
         self.assertTrue(optimizer._use_flash)
         # _ns_buffers should be empty before first step

--- a/source/tests/pt/test_hybrid_muon.py
+++ b/source/tests/pt/test_hybrid_muon.py
@@ -8,6 +8,8 @@ from deepmd.pt.optimizer.hybrid_muon import (
     MAGMA_MIN_SCALE,
     TRITON_AVAILABLE,
     HybridMuonOptimizer,
+    _batched_newton_schulz_orth,
+    _GramNewtonSchulzOrthogonalizer,
     _newton_schulz_orth,
 )
 from deepmd.pt.utils import (
@@ -555,6 +557,200 @@ class TestFlashMuon(unittest.TestCase):
 
         # After step, buffers should have been allocated for the weight matrix
         self.assertGreater(len(optimizer._ns_buffers), 0)
+
+
+@unittest.skipIf(not BF16_SUPPORTED, "bf16 matmul not supported on this device")
+class TestColumnPadMergeEquivalence(unittest.TestCase):
+    """Verify column-pad merge produces numerically identical NS orth results.
+
+    The column-pad merge optimization zero-pads the column (large) dimension
+    of rectangular matrices so that matrices with the same min_dim can share
+    a single Gram NS call.  These tests verify the mathematical invariant:
+
+        R_pad = [X | 0] @ [X | 0]^T = X @ X^T = R
+
+    which guarantees the NS iteration is identical, and truncating the output
+    to the original column count exactly recovers the unpadded result.
+    """
+
+    def setUp(self) -> None:
+        self.device = env.DEVICE
+
+    @unittest.skipIf(
+        not FP16_SUPPORTED,
+        "float16 matmul not supported on this device",
+    )
+    def test_gram_ns_column_pad_exact_equivalence(self) -> None:
+        """Gram NS orth on X vs [X|0] must agree in the first n columns."""
+        torch.manual_seed(123)
+        gram_orth = _GramNewtonSchulzOrthogonalizer()
+
+        for m, n, pad in [(16, 32, 32), (64, 128, 256), (64, 192, 192)]:
+            with self.subTest(m=m, n=n, pad=pad):
+                X = torch.randn(1, m, n, dtype=torch.float32, device=self.device)
+                X_padded = torch.nn.functional.pad(X, (0, pad))  # (1, m, n+pad)
+
+                # _orthogonalize_impl bypasses compile for deterministic comparison
+                out_orig = gram_orth._call_impl(X)
+                out_padded = gram_orth._call_impl(X_padded)
+
+                # Truncate padded output to original column count
+                out_padded_trunc = out_padded[:, :, :n]
+                # Padded columns must be zero
+                out_padded_tail = out_padded[:, :, n:]
+
+                self.assertTrue(
+                    torch.allclose(out_orig, out_padded_trunc, atol=1e-3, rtol=1e-3),
+                    f"shape ({m},{n}) pad {pad}: max diff = {(out_orig - out_padded_trunc).abs().max().item():.6f}",
+                )
+                self.assertTrue(
+                    torch.allclose(
+                        out_padded_tail,
+                        torch.zeros_like(out_padded_tail),
+                        atol=1e-3,
+                    ),
+                    f"shape ({m},{n}) pad {pad}: padded tail not zero, max = {out_padded_tail.abs().max().item():.6f}",
+                )
+
+    def test_standard_ns_column_pad_exact_equivalence(self) -> None:
+        """Standard (quintic) NS orth on X vs [X|0] must agree."""
+        torch.manual_seed(456)
+
+        for m, n, pad in [(16, 32, 32), (32, 64, 64)]:
+            with self.subTest(m=m, n=n, pad=pad):
+                X = torch.randn(1, m, n, dtype=torch.float32, device=self.device)
+                X_padded = torch.nn.functional.pad(X, (0, pad))
+
+                out_orig = _batched_newton_schulz_orth(X)
+                out_padded = _batched_newton_schulz_orth(X_padded)
+                out_padded_trunc = out_padded[:, :, :n]
+
+                self.assertTrue(
+                    torch.allclose(out_orig, out_padded_trunc, atol=1e-3, rtol=1e-3),
+                    f"shape ({m},{n}) pad {pad}: max diff = {(out_orig - out_padded_trunc).abs().max().item():.6f}",
+                )
+
+    @unittest.skipIf(
+        not FP16_SUPPORTED,
+        "float16 matmul not supported on this device",
+    )
+    def test_gram_ns_batch_pad_equivalence(self) -> None:
+        """Batched column-padded Gram NS must agree with per-matrix Gram NS."""
+        torch.manual_seed(789)
+        gram_orth = _GramNewtonSchulzOrthogonalizer()
+        min_dim = 64
+
+        # Simulate two different max_dims in the same super-bucket
+        shapes = [(min_dim, 128), (min_dim, 192), (min_dim, 384)]
+        padded_max = max(s[1] for s in shapes)
+
+        per_matrix_results = []
+        padded_batch = []
+        for m, n in shapes:
+            X = torch.randn(1, m, n, dtype=torch.float32, device=self.device)
+            per_matrix_results.append(gram_orth._call_impl(X))
+            padded_batch.append(torch.nn.functional.pad(X, (0, padded_max - n)))
+
+        # Run Gram NS on the batched padded tensor
+        stacked = torch.cat(padded_batch, dim=0)  # (3, 64, 384)
+        batched_out = gram_orth._call_impl(stacked)
+
+        for i, (m, n) in enumerate(shapes):
+            expected = per_matrix_results[i]
+            actual = batched_out[i : i + 1, :, :n]
+            self.assertTrue(
+                torch.allclose(expected, actual, atol=1e-3, rtol=1e-3),
+                f"shape ({m},{n}): batched-pad max diff = {(expected - actual).abs().max().item():.6f}",
+            )
+
+    @unittest.skipIf(
+        not FP16_SUPPORTED,
+        "float16 matmul not supported on this device",
+    )
+    def test_optimizer_step_column_pad_merge_e2e(self) -> None:
+        """End-to-end: optimizer with mixed rectangular shapes runs correctly.
+
+        Constructs a model with multiple rectangular weight matrices of
+        different shapes (same min_dim) that trigger the column-pad merge
+        path, then verifies all parameters are updated and the model produces
+        finite outputs.
+        """
+        torch.manual_seed(42)
+
+        class MixedRectModel(torch.nn.Module):
+            """Model with rectangular weights sharing min_dim=8 but different max_dims."""
+
+            def __init__(self, device: torch.device) -> None:
+                super().__init__()
+                # 3 rectangular weights: min_dim=8, max_dim varies
+                self.w1 = torch.nn.Parameter(torch.randn(8, 16, device=device))
+                self.w2 = torch.nn.Parameter(torch.randn(8, 32, device=device))
+                self.w3 = torch.nn.Parameter(torch.randn(24, 8, device=device))
+                # A square weight for the standard NS path
+                self.w_sq = torch.nn.Parameter(torch.randn(16, 16, device=device))
+                # 1D bias for Adam path
+                self.bias = torch.nn.Parameter(torch.zeros(16, device=device))
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                # x: (B, 8), w1: (8, 16) -> (B, 16)
+                h = x @ self.w1 + self.bias
+                h = h @ self.w_sq  # (B, 16)
+                h2 = x @ self.w2  # (B, 32)
+                h3 = x @ self.w3.T  # (B, 24); w3: (24, 8)
+                return h.sum() + h2.sum() + h3.sum()
+
+        model = MixedRectModel(self.device)
+        init_state = {k: v.detach().clone() for k, v in model.named_parameters()}
+
+        optimizer = HybridMuonOptimizer(
+            model.parameters(),
+            lr=0.01,
+            enable_gram=True,
+            flash_muon=False,
+            magma_muon=True,
+            muon_mode="slice",
+            named_parameters=tuple(model.named_parameters()),
+        )
+
+        x = torch.randn(4, 8, device=self.device)
+        for _ in range(3):
+            optimizer.zero_grad()
+            model(x).backward()
+            optimizer.step()
+
+        # All params must have been updated
+        for name, param in model.named_parameters():
+            self.assertFalse(
+                torch.allclose(param, init_state[name]),
+                f"Parameter {name} was not updated after 3 steps",
+            )
+
+        # Output must be finite
+        with torch.no_grad():
+            out = model(x)
+        self.assertTrue(
+            torch.isfinite(out).all(),
+            f"Model output is not finite: {out}",
+        )
+
+        # Muon params should have momentum_buffer
+        for name in ["w1", "w2", "w3", "w_sq"]:
+            p = getattr(model, name)
+            self.assertIn(
+                "momentum_buffer",
+                optimizer.state[p],
+                f"{name} missing momentum_buffer",
+            )
+        # Magma should be active on Muon params
+        for name in ["w1", "w2", "w3", "w_sq"]:
+            p = getattr(model, name)
+            self.assertIn(
+                "magma_score",
+                optimizer.state[p],
+                f"{name} missing magma_score",
+            )
+        # Bias uses Adam
+        self.assertIn("exp_avg", optimizer.state[model.bias])
 
 
 if __name__ == "__main__":

--- a/source/tests/pt/test_hybrid_muon.py
+++ b/source/tests/pt/test_hybrid_muon.py
@@ -590,9 +590,10 @@ class TestColumnPadMergeEquivalence(unittest.TestCase):
                 X = torch.randn(1, m, n, dtype=torch.float32, device=self.device)
                 X_padded = torch.nn.functional.pad(X, (0, pad))  # (1, m, n+pad)
 
-                # _orthogonalize_impl bypasses compile for deterministic comparison
-                out_orig = gram_orth._call_impl(X)
-                out_padded = gram_orth._call_impl(X_padded)
+                # Call the uncompiled implementation directly so the two
+                # invocations share an identical numerical path.
+                out_orig = gram_orth._orthogonalize_impl(X)
+                out_padded = gram_orth._orthogonalize_impl(X_padded)
 
                 # Truncate padded output to original column count
                 out_padded_trunc = out_padded[:, :, :n]
@@ -648,12 +649,12 @@ class TestColumnPadMergeEquivalence(unittest.TestCase):
         padded_batch = []
         for m, n in shapes:
             X = torch.randn(1, m, n, dtype=torch.float32, device=self.device)
-            per_matrix_results.append(gram_orth._call_impl(X))
+            per_matrix_results.append(gram_orth._orthogonalize_impl(X))
             padded_batch.append(torch.nn.functional.pad(X, (0, padded_max - n)))
 
         # Run Gram NS on the batched padded tensor
         stacked = torch.cat(padded_batch, dim=0)  # (3, 64, 384)
-        batched_out = gram_orth._call_impl(stacked)
+        batched_out = gram_orth._orthogonalize_impl(stacked)
 
         for i, (m, n) in enumerate(shapes):
             expected = per_matrix_results[i]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gram Newton–Schulz orthogonalization for rectangular Muon matrices with enable_gram enabled by default (auto-disabled in distributed runs).
  * Introduced use_foreach switch to enable foreach-optimized updates when applicable.

* **Chores**
  * Changed lr_adjust default to 0.0.
  * Changed magma_muon default to True.
  * Clarified weight_decay applies to both Muon-routed and AdamW-style matrix decay.
  * Training now disables foreach under higher sharding/ZeRO stages.

* **Tests**
  * Added fp16/bf16-gated tests validating Gram behavior, column-pad merging, and end-to-end optimizer updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->