### PR TITLE
fix(pt_expt): respect model default_fparam in data requirement

### DIFF
--- a/deepmd/pt_expt/train/training.py
+++ b/deepmd/pt_expt/train/training.py
@@ -119,13 +119,17 @@ def get_loss(
 def get_additional_data_requirement(_model: Any) -> list[DataRequirementItem]:
     additional_data_requirement: list[DataRequirementItem] = []
     if _model.get_dim_fparam() > 0:
+        has_default_fparam = _model.has_default_fparam()
+        fparam_default = (
+            np.asarray(_model.get_default_fparam()) if has_default_fparam else 0.0
+        )
         additional_data_requirement.append(
             DataRequirementItem(
                 "fparam",
                 _model.get_dim_fparam(),
                 atomic=False,
-                must=False,
-                default=0.0,
+                must=not has_default_fparam,
+                default=fparam_default,
             )
         )
     if _model.get_dim_aparam() > 0:

--- a/source/tests/pt_expt/test_training.py
+++ b/source/tests/pt_expt/test_training.py
@@ -545,6 +545,74 @@ class TestGetData(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+class TestAdditionalDataRequirement(unittest.TestCase):
+    """Cover both branches of fparam handling in get_additional_data_requirement.
+
+    Regression guard for the bug where pt_expt hard-coded ``default=0.0`` for
+    fparam, ignoring the model's ``default_fparam``.  When the dataset has no
+    ``fparam.npy``, that caused the data system to feed zeros to the fitting
+    net while pt fed the model default — producing a constant DC offset
+    (e.g. ``[0, -100]`` after fparam normalisation) that slowed training.
+    """
+
+    def test_has_default_fparam(self) -> None:
+        """has_default_fparam==True: must=False and default broadcasts the model value."""
+        from deepmd.pt_expt.train.training import (
+            get_additional_data_requirement,
+        )
+
+        class _M:
+            def get_dim_fparam(self) -> int:
+                return 2
+
+            def get_dim_aparam(self) -> int:
+                return 0
+
+            def has_default_fparam(self) -> bool:
+                return True
+
+            def get_default_fparam(self) -> list[float]:
+                return [0.0, 1.0]
+
+        reqs = get_additional_data_requirement(_M())
+        self.assertEqual(len(reqs), 1)
+        fparam_req = reqs[0]
+        self.assertEqual(fparam_req.key, "fparam")
+        self.assertEqual(fparam_req.ndof, 2)
+        self.assertFalse(fparam_req.must)
+        # default is the model's default_fparam, not 0.0
+        self.assertNotIsInstance(fparam_req.default, float)
+        import numpy as np
+
+        np.testing.assert_array_equal(np.asarray(fparam_req.default), [0.0, 1.0])
+
+    def test_no_default_fparam(self) -> None:
+        """has_default_fparam==False: must=True (data file must exist) and default=0.0."""
+        from deepmd.pt_expt.train.training import (
+            get_additional_data_requirement,
+        )
+
+        class _M:
+            def get_dim_fparam(self) -> int:
+                return 2
+
+            def get_dim_aparam(self) -> int:
+                return 0
+
+            def has_default_fparam(self) -> bool:
+                return False
+
+            def get_default_fparam(self) -> None:
+                return None
+
+        reqs = get_additional_data_requirement(_M())
+        self.assertEqual(len(reqs), 1)
+        fparam_req = reqs[0]
+        self.assertEqual(fparam_req.key, "fparam")
+        self.assertTrue(fparam_req.must)
+        self.assertEqual(fparam_req.default, 0.0)
+
+
 class TestRestart(unittest.TestCase):
     """Test restart and init_model resume paths."""
 


### PR DESCRIPTION
## Summary

- `pt_expt`'s `get_additional_data_requirement` hard-coded `default=0.0` for the `fparam` data item, ignoring the model's `default_fparam`. For datasets without `fparam.npy`, the data system fed zeros to the fitting net while `pt` correctly fed the model's default — after fparam normalisation a constant DC offset (e.g. `[0, -100]` when stats are `avg=[0,1]`, `inv_std=[100,100]`) was injected on every step, slowing multi-task training convergence vs the `pt` baseline.
- Mirror `pt`'s logic (`deepmd/pt/train/training.py:1762-1779`): pull `default_fparam` from the model and set `must=not has_default_fparam`. The fparam-present path is unchanged (`find_fparam=1.0` → the default value is unused).
- Add a focused unit test that covers both branches (`has_default_fparam` true / false) per the project's UT-coverage rule.

## Test plan

- [x] `pytest source/tests/pt_expt/test_training.py::TestAdditionalDataRequirement -v` — both new branches pass.
- [x] `pytest source/tests/pt_expt/test_training.py::TestTraining -v` — 4 existing training-loop tests still pass.
- [x] `pytest source/tests/pt_expt/test_training.py::TestCompiledVaryingNframesWithParams -v` — fparam-present compile path with `numb_fparam=2` still passes.
- [ ] End-to-end multi-task convergence comparison (pt vs pt_expt) on the user's reported script — requires Electrolyte data not available in this environment; intent is verified analytically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved force parameter handling: the system now properly respects model-provided default values when determining whether force parameters are required during training.

* **Tests**
  * Added comprehensive test coverage for force parameter requirement logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->