### PR TITLE
fix(pt): Treat cuBLAS allocation failures as PyTorch OOM during auto bs

### DIFF
--- a/deepmd/pt/utils/auto_batch_size.py
+++ b/deepmd/pt/utils/auto_batch_size.py
@@ -78,6 +78,7 @@ class AutoBatchSize(AutoBatchSizeBase):
             "CUDA out of memory.",
             "CUDA driver error: out of memory",
             "CUDA error: out of memory",
+            "CUBLAS_STATUS_ALLOC_FAILED",
             "cusolver error: CUSOLVER_STATUS_INTERNAL_ERROR",
         )
         if any(m in msg for msg in msgs for m in plain_oom_markers):

--- a/source/tests/pt/test_auto_batch_size.py
+++ b/source/tests/pt/test_auto_batch_size.py
@@ -22,6 +22,20 @@ class TestAutoBatchSize(unittest.TestCase):
         empty_cache.assert_called_once()
 
     @mock.patch("deepmd.pt.utils.auto_batch_size.torch.cuda.empty_cache")
+    def test_is_oom_error_cublas_alloc_failed(self, empty_cache) -> None:
+        auto_batch_size = AutoBatchSize(256, 2.0)
+
+        self.assertTrue(
+            auto_batch_size.is_oom_error(
+                RuntimeError(
+                    "CUDA error: CUBLAS_STATUS_ALLOC_FAILED when calling "
+                    "`cublasCreate(handle)`"
+                )
+            )
+        )
+        empty_cache.assert_called_once()
+
+    @mock.patch("deepmd.pt.utils.auto_batch_size.torch.cuda.empty_cache")
     def test_is_oom_error_empty_runtime_error_from_cuda_oom(self, empty_cache) -> None:
         auto_batch_size = AutoBatchSize(256, 2.0)
         cause = RuntimeError("CUDA driver error: out of memory")


### PR DESCRIPTION
Treat cuBLAS allocation failures as PyTorch OOM during auto batch sizing

PyTorch inference can raise  after an oversized
batch attempt, especially during . Previously this was treated as a generic RuntimeError, so  stopped after the first batch size reduction instead of continuing to shrink the inference batch.

Add this cuBLAS allocation failure to the PyTorch auto-batch OOM markers and cover it with a unit test, allowing  to continue retrying with smaller batch sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU memory error detection to properly recognize and handle CUDA allocation failures, enabling automatic memory recovery and improving reliability during compute-intensive operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/deepmd-kit/pull/5440)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->