### PR TITLE
test(universal): replace Cartesian product with curated matrices for descriptor test

### DIFF
--- a/source/tests/universal/dpmodel/atomc_model/test_atomic_model.py
+++ b/source/tests/universal/dpmodel/atomc_model/test_atomic_model.py
@@ -41,18 +41,18 @@ from ...common.cases.atomic_model.atomic_model import (
 )
 from ...dpmodel.descriptor.test_descriptor import (
     DescriptorParamDPA1,
-    DescriptorParamDPA1List,
+    DescriptorParamDPA1EnergyModelList,
     DescriptorParamDPA2,
-    DescriptorParamDPA2List,
+    DescriptorParamDPA2EnergyModelList,
     DescriptorParamHybrid,
     DescriptorParamHybridMixed,
     DescriptorParamHybridMixedTTebd,
     DescriptorParamSeA,
-    DescriptorParamSeAList,
+    DescriptorParamSeAEnergyModelList,
     DescriptorParamSeR,
-    DescriptorParamSeRList,
+    DescriptorParamSeREnergyModelList,
     DescriptorParamSeT,
-    DescriptorParamSeTList,
+    DescriptorParamSeTEnergyModelList,
 )
 from ...dpmodel.model.test_model import (
     skip_model_tests,
@@ -81,29 +81,64 @@ def make_sel_type_from_atom_exclude_types(type_map, atom_exclude_types):
     return sel_type.tolist()
 
 
+ENERGY_DESCRIPTOR_PARAMS = (
+    *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAEnergyModelList],
+    *[(param_func, DescrptSeR) for param_func in DescriptorParamSeREnergyModelList],
+    *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTEnergyModelList],
+    *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1EnergyModelList],
+    *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2EnergyModelList],
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamSeR, DescrptSeR),
+    (DescriptorParamSeT, DescrptSeT),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
+DEFAULT_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_VEC_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
+DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_VEC_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+)
+
+DEFAULT_DPA12_DESCRIPTOR_PARAMS = (
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
+DEFAULT_DPA12_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_DPA12_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        ENERGY_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
         ([], [0]),  # atom_exclude_types
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -158,27 +193,12 @@ class TestEnergyAtomicModelDP(unittest.TestCase, EnerAtomicModelTest, DPTestCase
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamDos, DOSFittingNet),),  # fitting_class_param & class
         ([], [0]),  # atom_exclude_types
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, DOSFittingNet) for param_func in FittingParamDosList],
         ),  # fitting_class_param & class
@@ -233,22 +253,12 @@ class TestDosAtomicModelDP(unittest.TestCase, DosAtomicModelTest, DPTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamDipole, DipoleFitting),),  # fitting_class_param & class
         ([], [0]),  # atom_exclude_types
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, DipoleFitting) for param_func in FittingParamDipoleList],
         ),  # fitting_class_param & class
@@ -304,22 +314,12 @@ class TestDipoleAtomicModelDP(unittest.TestCase, DipoleAtomicModelTest, DPTestCa
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamPolar, PolarFitting),),  # fitting_class_param & class
         ([], [0]),  # atom_exclude_types
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, PolarFitting) for param_func in FittingParamPolarList],
         ),  # fitting_class_param & class
@@ -375,19 +375,11 @@ class TestPolarAtomicModelDP(unittest.TestCase, PolarAtomicModelTest, DPTestCase
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA12_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA12_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -449,9 +441,7 @@ class TestZBLAtomicModelDP(unittest.TestCase, ZBLAtomicModelTest, DPTestCase):
 @parameterized(
     des_parameterized=(
         (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
+            *DEFAULT_VEC_DESCRIPTOR_PARAMS,
             (DescriptorParamHybridMixed, DescrptHybrid),
             (DescriptorParamHybridMixedTTebd, DescrptHybrid),
         ),  # descrpt_class_param & class
@@ -459,11 +449,7 @@ class TestZBLAtomicModelDP(unittest.TestCase, ZBLAtomicModelTest, DPTestCase):
         ([], [0]),  # atom_exclude_types
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[
                 (param_func, PropertyFittingNet)

--- a/source/tests/universal/dpmodel/descriptor/test_descriptor.py
+++ b/source/tests/universal/dpmodel/descriptor/test_descriptor.py
@@ -573,19 +573,6 @@ DescriptorParamDPA3List = parameterize_func(
 )
 
 
-def DescriptorParamDPA3DefaultChgSpin(ntypes, rcut, rcut_smth, sel, type_map, **kwargs):
-    return DescriptorParamDPA3(
-        ntypes,
-        rcut,
-        rcut_smth,
-        sel,
-        type_map,
-        **kwargs,
-        add_chg_spin_ebd=True,
-        default_chg_spin=[5.0, 1.0],
-    )
-
-
 # to get name for the default function
 DescriptorParamDPA3 = DescriptorParamDPA3List[0]
 
@@ -814,10 +801,18 @@ DescriptorParamDPA3EnergyModelList = (
     _descriptor_param_variant(
         DescriptorParamDPA3, "DescriptorParamDPA3_no_loc_mapping", use_loc_mapping=False
     ),
+    _descriptor_param_variant(
+        DescriptorParamDPA3,
+        "DescriptorParamDPA3_default_chg_spin",
+        add_chg_spin_ebd=True,
+        default_chg_spin=[5.0, 1.0],
+    ),
     # Mixed high-risk combination.
     _descriptor_param_variant(
         DescriptorParamDPA3,
         "DescriptorParamDPA3_mixed_high_risk",
+        add_chg_spin_ebd=True,
+        default_chg_spin=[5.0, 1.0],
         exclude_types=[[0, 1]],
         optim_update=False,
         edge_init_use_dist=False,

--- a/source/tests/universal/dpmodel/descriptor/test_descriptor.py
+++ b/source/tests/universal/dpmodel/descriptor/test_descriptor.py
@@ -3,6 +3,9 @@ import unittest
 from collections import (
     OrderedDict,
 )
+from typing import (
+    Any,
+)
 
 from deepmd.dpmodel.descriptor import (
     DescrptDPA1,
@@ -585,6 +588,245 @@ def DescriptorParamDPA3DefaultChgSpin(ntypes, rcut, rcut_smth, sel, type_map, **
 
 # to get name for the default function
 DescriptorParamDPA3 = DescriptorParamDPA3List[0]
+
+
+def _descriptor_param_variant(param_func, name: str, **fixed_kwargs: Any):
+    def wrapper(*args, **kwargs):
+        return param_func(*args, **{**fixed_kwargs, **kwargs})
+
+    wrapper.__name__ = name
+    wrapper.__qualname__ = name
+    return wrapper
+
+
+# Curated descriptor variants for model/atomic-model integration tests. The
+# descriptor tests above still cover the full parameter matrices; model-level
+# tests only need representative toggles to avoid a Cartesian-product blow-up.
+DescriptorParamSeAEnergyModelList = (
+    # Baseline coverage.
+    DescriptorParamSeA,
+    # Single-option descriptor toggles.
+    _descriptor_param_variant(
+        DescriptorParamSeA, "DescriptorParamSeA_resnet_dt", resnet_dt=True
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeA, "DescriptorParamSeA_type_two_sides", type_one_side=False
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeA, "DescriptorParamSeA_exclude_types", exclude_types=[[0, 1]]
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeA, "DescriptorParamSeA_env_protection", env_protection=1e-2
+    ),
+    # Mixed high-risk combination.
+    _descriptor_param_variant(
+        DescriptorParamSeA,
+        "DescriptorParamSeA_mixed_high_risk",
+        resnet_dt=True,
+        type_one_side=False,
+        exclude_types=[[0, 1]],
+        env_protection=1e-2,
+    ),
+)
+
+DescriptorParamSeREnergyModelList = (
+    # Baseline coverage.
+    DescriptorParamSeR,
+    # Single-option descriptor toggles.
+    _descriptor_param_variant(
+        DescriptorParamSeR, "DescriptorParamSeR_resnet_dt", resnet_dt=True
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeR, "DescriptorParamSeR_exclude_types", exclude_types=[[0, 1]]
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeR, "DescriptorParamSeR_env_protection", env_protection=1e-8
+    ),
+    # Mixed high-risk combination.
+    _descriptor_param_variant(
+        DescriptorParamSeR,
+        "DescriptorParamSeR_mixed_high_risk",
+        resnet_dt=True,
+        exclude_types=[[0, 1]],
+        env_protection=1e-8,
+    ),
+)
+
+DescriptorParamSeTEnergyModelList = (
+    # Baseline coverage.
+    DescriptorParamSeT,
+    # Single-option descriptor toggles.
+    _descriptor_param_variant(
+        DescriptorParamSeT, "DescriptorParamSeT_resnet_dt", resnet_dt=True
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeT, "DescriptorParamSeT_exclude_types", exclude_types=[[0, 1]]
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeT, "DescriptorParamSeT_env_protection", env_protection=1e-8
+    ),
+    # Mixed high-risk combination.
+    _descriptor_param_variant(
+        DescriptorParamSeT,
+        "DescriptorParamSeT_mixed_high_risk",
+        resnet_dt=True,
+        exclude_types=[[0, 1]],
+        env_protection=1e-8,
+    ),
+)
+
+DescriptorParamSeTTebdEnergyModelList = (
+    # Baseline coverage.
+    DescriptorParamSeTTebd,
+    # Single-option descriptor toggles.
+    _descriptor_param_variant(
+        DescriptorParamSeTTebd,
+        "DescriptorParamSeTTebd_strip",
+        tebd_input_mode="strip",
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeTTebd,
+        "DescriptorParamSeTTebd_exclude_types",
+        exclude_types=[[0, 1]],
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeTTebd, "DescriptorParamSeTTebd_no_smooth", smooth=False
+    ),
+    _descriptor_param_variant(
+        DescriptorParamSeTTebd,
+        "DescriptorParamSeTTebd_econf",
+        use_econf_tebd=True,
+    ),
+    # Mixed high-risk combination.
+    _descriptor_param_variant(
+        DescriptorParamSeTTebd,
+        "DescriptorParamSeTTebd_mixed_high_risk",
+        tebd_input_mode="strip",
+        exclude_types=[[0, 1]],
+        smooth=False,
+        use_econf_tebd=True,
+    ),
+)
+
+DescriptorParamDPA1EnergyModelList = (
+    # Baseline coverage.
+    DescriptorParamDPA1,
+    # Single-option descriptor toggles.
+    _descriptor_param_variant(
+        DescriptorParamDPA1, "DescriptorParamDPA1_strip", tebd_input_mode="strip"
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA1, "DescriptorParamDPA1_no_attention", attn_layer=0
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA1, "DescriptorParamDPA1_exclude_types", exclude_types=[[0, 1]]
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA1, "DescriptorParamDPA1_temperature", temperature=1.0
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA1,
+        "DescriptorParamDPA1_no_smooth_type_embedding",
+        smooth_type_embedding=False,
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA1, "DescriptorParamDPA1_econf", use_econf_tebd=True
+    ),
+    # Mixed high-risk combination.
+    _descriptor_param_variant(
+        DescriptorParamDPA1,
+        "DescriptorParamDPA1_mixed_high_risk",
+        tebd_input_mode="strip",
+        exclude_types=[[0, 1]],
+        temperature=1.0,
+        smooth_type_embedding=False,
+        use_econf_tebd=True,
+    ),
+)
+
+DescriptorParamDPA2EnergyModelList = (
+    # Baseline coverage.
+    DescriptorParamDPA2,
+    # Single-option descriptor toggles.
+    _descriptor_param_variant(
+        DescriptorParamDPA2,
+        "DescriptorParamDPA2_repinit_strip",
+        repinit_tebd_input_mode="strip",
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA2,
+        "DescriptorParamDPA2_no_three_body",
+        repinit_use_three_body=False,
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA2,
+        "DescriptorParamDPA2_residual_update",
+        repformer_update_style="res_residual",
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA2, "DescriptorParamDPA2_no_smooth", smooth=False
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA2, "DescriptorParamDPA2_exclude_types", exclude_types=[[0, 1]]
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA2,
+        "DescriptorParamDPA2_no_repinit_tebd_out",
+        add_tebd_to_repinit_out=False,
+    ),
+    # Mixed high-risk combination.
+    _descriptor_param_variant(
+        DescriptorParamDPA2,
+        "DescriptorParamDPA2_mixed_high_risk",
+        repinit_tebd_input_mode="strip",
+        repinit_use_three_body=False,
+        repformer_update_style="res_residual",
+        smooth=False,
+        exclude_types=[[0, 1]],
+        add_tebd_to_repinit_out=False,
+    ),
+)
+
+DescriptorParamDPA3EnergyModelList = (
+    # Baseline coverage.
+    DescriptorParamDPA3,
+    # Single-option descriptor toggles.
+    _descriptor_param_variant(
+        DescriptorParamDPA3, "DescriptorParamDPA3_exclude_types", exclude_types=[[0, 1]]
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA3, "DescriptorParamDPA3_no_optim_update", optim_update=False
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA3,
+        "DescriptorParamDPA3_no_dist_edge_init",
+        edge_init_use_dist=False,
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA3, "DescriptorParamDPA3_no_exp_switch", use_exp_switch=False
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA3, "DescriptorParamDPA3_static_sel", use_dynamic_sel=False
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA3, "DescriptorParamDPA3_env_protection", env_protection=1e-8
+    ),
+    _descriptor_param_variant(
+        DescriptorParamDPA3, "DescriptorParamDPA3_no_loc_mapping", use_loc_mapping=False
+    ),
+    # Mixed high-risk combination.
+    _descriptor_param_variant(
+        DescriptorParamDPA3,
+        "DescriptorParamDPA3_mixed_high_risk",
+        exclude_types=[[0, 1]],
+        optim_update=False,
+        edge_init_use_dist=False,
+        use_exp_switch=False,
+        use_dynamic_sel=False,
+        env_protection=1e-8,
+        use_loc_mapping=False,
+    ),
+)
 
 
 def DescriptorParamHybrid(ntypes, rcut, rcut_smth, sel, type_map, **kwargs):

--- a/source/tests/universal/dpmodel/descriptor/test_descriptor.py
+++ b/source/tests/universal/dpmodel/descriptor/test_descriptor.py
@@ -579,7 +579,7 @@ DescriptorParamDPA3 = DescriptorParamDPA3List[0]
 
 def _descriptor_param_variant(param_func, name: str, **fixed_kwargs: Any):
     def wrapper(*args, **kwargs):
-        return param_func(*args, **{**fixed_kwargs, **kwargs})
+        return param_func(*args, **{**kwargs, **fixed_kwargs})
 
     wrapper.__name__ = name
     wrapper.__qualname__ = name

--- a/source/tests/universal/dpmodel/descriptor/test_descriptor.py
+++ b/source/tests/universal/dpmodel/descriptor/test_descriptor.py
@@ -703,7 +703,7 @@ DescriptorParamDPA1EnergyModelList = (
         DescriptorParamDPA1, "DescriptorParamDPA1_strip", tebd_input_mode="strip"
     ),
     _descriptor_param_variant(
-        DescriptorParamDPA1, "DescriptorParamDPA1_no_attention", attn_layer=0
+        DescriptorParamDPA1, "DescriptorParamDPA1_with_attention", attn_layer=2
     ),
     _descriptor_param_variant(
         DescriptorParamDPA1, "DescriptorParamDPA1_exclude_types", exclude_types=[[0, 1]]
@@ -724,6 +724,7 @@ DescriptorParamDPA1EnergyModelList = (
         DescriptorParamDPA1,
         "DescriptorParamDPA1_mixed_high_risk",
         tebd_input_mode="strip",
+        attn_layer=2,
         exclude_types=[[0, 1]],
         temperature=1.0,
         smooth_type_embedding=False,

--- a/source/tests/universal/dpmodel/model/test_model.py
+++ b/source/tests/universal/dpmodel/model/test_model.py
@@ -38,22 +38,22 @@ from ..backend import (
 )
 from ..descriptor.test_descriptor import (
     DescriptorParamDPA1,
-    DescriptorParamDPA1List,
+    DescriptorParamDPA1EnergyModelList,
     DescriptorParamDPA2,
-    DescriptorParamDPA2List,
+    DescriptorParamDPA2EnergyModelList,
     DescriptorParamDPA3,
-    DescriptorParamDPA3List,
+    DescriptorParamDPA3EnergyModelList,
     DescriptorParamHybrid,
     DescriptorParamHybridMixed,
     DescriptorParamHybridMixedTTebd,
     DescriptorParamSeA,
-    DescriptorParamSeAList,
+    DescriptorParamSeAEnergyModelList,
     DescriptorParamSeR,
-    DescriptorParamSeRList,
+    DescriptorParamSeREnergyModelList,
     DescriptorParamSeT,
-    DescriptorParamSeTList,
+    DescriptorParamSeTEnergyModelList,
     DescriptorParamSeTTebd,
-    DescriptorParamSeTTebdList,
+    DescriptorParamSeTTebdEnergyModelList,
 )
 from ..fitting.test_fitting import (
     FittingParamEnergy,
@@ -89,35 +89,47 @@ def skip_model_tests(test_obj):
     return False, None
 
 
+ENERGY_DESCRIPTOR_PARAMS = (
+    *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAEnergyModelList],
+    *[(param_func, DescrptSeR) for param_func in DescriptorParamSeREnergyModelList],
+    *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTEnergyModelList],
+    *[
+        (param_func, DescrptSeTTebd)
+        for param_func in DescriptorParamSeTTebdEnergyModelList
+    ],
+    *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1EnergyModelList],
+    *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2EnergyModelList],
+    *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3EnergyModelList],
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamSeR, DescrptSeR),
+    (DescriptorParamSeT, DescrptSeT),
+    (DescriptorParamSeTTebd, DescrptSeTTebd),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+    (DescriptorParamDPA3, DescrptDPA3),
+)
+
+SPIN_DESCRIPTOR_PARAMS = (
+    *DEFAULT_DESCRIPTOR_PARAMS,
+    # unsupported for SpinModel to hybrid both mixed_types and no-mixed_types descriptor
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[
-                (param_func, DescrptSeTTebd)
-                for param_func in DescriptorParamSeTTebdList
-            ],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        ENERGY_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamSeTTebd, DescrptSeTTebd),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -179,34 +191,11 @@ class TestEnergyModelDP(unittest.TestCase, EnerModelTest, DPTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[
-                (param_func, DescrptSeTTebd)
-                for param_func in DescriptorParamSeTTebdList
-            ],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            # (DescriptorParamHybrid, DescrptHybrid),
-            # unsupported for SpinModel to hybrid both mixed_types and no-mixed_types descriptor
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        SPIN_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamSeTTebd, DescrptSeTTebd),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class

--- a/source/tests/universal/pt/atomc_model/test_atomic_model.py
+++ b/source/tests/universal/pt/atomc_model/test_atomic_model.py
@@ -35,18 +35,18 @@ from ...common.cases.atomic_model.atomic_model import (
 )
 from ...dpmodel.descriptor.test_descriptor import (
     DescriptorParamDPA1,
-    DescriptorParamDPA1List,
+    DescriptorParamDPA1EnergyModelList,
     DescriptorParamDPA2,
-    DescriptorParamDPA2List,
+    DescriptorParamDPA2EnergyModelList,
     DescriptorParamHybrid,
     DescriptorParamHybridMixed,
     DescriptorParamHybridMixedTTebd,
     DescriptorParamSeA,
-    DescriptorParamSeAList,
+    DescriptorParamSeAEnergyModelList,
     DescriptorParamSeR,
-    DescriptorParamSeRList,
+    DescriptorParamSeREnergyModelList,
     DescriptorParamSeT,
-    DescriptorParamSeTList,
+    DescriptorParamSeTEnergyModelList,
 )
 from ...dpmodel.fitting.test_fitting import (
     FittingParamDipole,
@@ -67,29 +67,63 @@ from ..backend import (
     PTTestCase,
 )
 
+ENERGY_DESCRIPTOR_PARAMS = (
+    *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAEnergyModelList],
+    *[(param_func, DescrptSeR) for param_func in DescriptorParamSeREnergyModelList],
+    *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTEnergyModelList],
+    *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1EnergyModelList],
+    *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2EnergyModelList],
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamSeR, DescrptSeR),
+    (DescriptorParamSeT, DescrptSeT),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
+DEFAULT_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_VEC_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
+DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_VEC_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+)
+
+DEFAULT_DPA12_DESCRIPTOR_PARAMS = (
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
+DEFAULT_DPA12_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_DPA12_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        ENERGY_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -140,26 +174,11 @@ class TestEnergyAtomicModelPT(unittest.TestCase, EnerAtomicModelTest, PTTestCase
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamDos, DOSFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, DOSFittingNet) for param_func in FittingParamDosList],
         ),  # fitting_class_param & class
@@ -210,21 +229,11 @@ class TestDosAtomicModelPT(unittest.TestCase, DosAtomicModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamDipole, DipoleFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, DipoleFittingNet) for param_func in FittingParamDipoleList],
         ),  # fitting_class_param & class
@@ -276,21 +285,11 @@ class TestDipoleAtomicModelPT(unittest.TestCase, DipoleAtomicModelTest, PTTestCa
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamPolar, PolarFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, PolarFittingNet) for param_func in FittingParamPolarList],
         ),  # fitting_class_param & class
@@ -342,19 +341,11 @@ class TestPolarAtomicModelPT(unittest.TestCase, PolarAtomicModelTest, PTTestCase
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA12_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA12_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -418,21 +409,11 @@ class TestZBLAtomicModelPT(unittest.TestCase, ZBLAtomicModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamProperty, PropertyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[
                 (param_func, PropertyFittingNet)

--- a/source/tests/universal/pt/model/test_model.py
+++ b/source/tests/universal/pt/model/test_model.py
@@ -53,22 +53,22 @@ from ...common.cases.model.model import (
 )
 from ...dpmodel.descriptor.test_descriptor import (
     DescriptorParamDPA1,
-    DescriptorParamDPA1List,
+    DescriptorParamDPA1EnergyModelList,
     DescriptorParamDPA2,
-    DescriptorParamDPA2List,
+    DescriptorParamDPA2EnergyModelList,
     DescriptorParamDPA3,
-    DescriptorParamDPA3List,
+    DescriptorParamDPA3EnergyModelList,
     DescriptorParamHybrid,
     DescriptorParamHybridMixed,
     DescriptorParamHybridMixedTTebd,
     DescriptorParamSeA,
-    DescriptorParamSeAList,
+    DescriptorParamSeAEnergyModelList,
     DescriptorParamSeR,
-    DescriptorParamSeRList,
+    DescriptorParamSeREnergyModelList,
     DescriptorParamSeT,
-    DescriptorParamSeTList,
+    DescriptorParamSeTEnergyModelList,
     DescriptorParamSeTTebd,
-    DescriptorParamSeTTebdList,
+    DescriptorParamSeTTebdEnergyModelList,
 )
 from ...dpmodel.fitting.test_fitting import (
     FittingParamDipole,
@@ -108,36 +108,95 @@ defalut_fit_param = [
     FittingParamProperty,
 ]
 
+ENERGY_DESCRIPTOR_PARAMS = (
+    *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAEnergyModelList],
+    *[(param_func, DescrptSeR) for param_func in DescriptorParamSeREnergyModelList],
+    *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTEnergyModelList],
+    *[
+        (param_func, DescrptSeTTebd)
+        for param_func in DescriptorParamSeTTebdEnergyModelList
+    ],
+    *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1EnergyModelList],
+    *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2EnergyModelList],
+    *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3EnergyModelList],
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamSeR, DescrptSeR),
+    (DescriptorParamSeT, DescrptSeT),
+    (DescriptorParamSeTTebd, DescrptSeTTebd),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+    (DescriptorParamDPA3, DescrptDPA3),
+)
+
+DEFAULT_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_DPA_DESCRIPTOR_PARAMS = (
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+    (DescriptorParamDPA3, DescrptDPA3),
+)
+
+DEFAULT_DPA_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_DPA_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_DPA12_DESCRIPTOR_PARAMS = (
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
+DEFAULT_DPA12_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_DPA12_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
+DEFAULT_VEC_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+    (DescriptorParamDPA3, DescrptDPA3),
+)
+
+DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID = (
+    *DEFAULT_VEC_DESCRIPTOR_PARAMS,
+    (DescriptorParamHybrid, DescrptHybrid),
+    (DescriptorParamHybridMixed, DescrptHybrid),
+)
+
+DEFAULT_SPIN_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamSeR, DescrptSeR),
+    (DescriptorParamSeT, DescrptSeT),
+    (DescriptorParamSeTTebd, DescrptSeTTebd),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+    # unsupported for SpinModel to hybrid both mixed_types and no-mixed_types descriptor
+    (DescriptorParamHybridMixed, DescrptHybrid),
+    (DescriptorParamHybridMixedTTebd, DescrptHybrid),
+)
+
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[
-                (param_func, DescrptSeTTebd)
-                for param_func in DescriptorParamSeTTebdList
-            ],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        ENERGY_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamSeTTebd, DescrptSeTTebd),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -218,33 +277,11 @@ class TestEnergyModelPT(unittest.TestCase, EnerModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[
-                (param_func, DescrptSeTTebd)
-                for param_func in DescriptorParamSeTTebdList
-            ],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamDos, DOSFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamSeTTebd, DescrptSeTTebd),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, DOSFittingNet) for param_func in FittingParamDosList],
         ),  # fitting_class_param & class
@@ -326,23 +363,11 @@ class TestDosModelPT(unittest.TestCase, DosModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamDipole, DipoleFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, DipoleFittingNet) for param_func in FittingParamDipoleList],
         ),  # fitting_class_param & class
@@ -425,23 +450,11 @@ class TestDipoleModelPT(unittest.TestCase, DipoleModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamPolar, PolarFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, PolarFittingNet) for param_func in FittingParamPolarList],
         ),  # fitting_class_param & class
@@ -520,19 +533,11 @@ class TestPolarModelPT(unittest.TestCase, PolarModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA12_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA12_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -623,32 +628,11 @@ class TestZBLModelPT(unittest.TestCase, ZBLModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptSeR) for param_func in DescriptorParamSeRList],
-            *[(param_func, DescrptSeT) for param_func in DescriptorParamSeTList],
-            *[
-                (param_func, DescrptSeTTebd)
-                for param_func in DescriptorParamSeTTebdList
-            ],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            # (DescriptorParamHybrid, DescrptHybrid),
-            # unsupported for SpinModel to hybrid both mixed_types and no-mixed_types descriptor
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_SPIN_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamSeR, DescrptSeR),
-            (DescriptorParamSeT, DescrptSeT),
-            (DescriptorParamSeTTebd, DescrptSeTTebd),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-        ),  # descrpt_class_param & class
+        DEFAULT_SPIN_DESCRIPTOR_PARAMS[:6],  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class
@@ -754,23 +738,11 @@ class TestSpinEnergyModelDP(unittest.TestCase, SpinEnerModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptSeA) for param_func in DescriptorParamSeAList],
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            (DescriptorParamHybrid, DescrptHybrid),
-            (DescriptorParamHybridMixed, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamProperty, PropertyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamSeA, DescrptSeA),
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_VEC_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[
                 (param_func, PropertyFittingNet)
@@ -852,21 +824,11 @@ class TestPropertyModelPT(unittest.TestCase, PropertyModelTest, PTTestCase):
 
 @parameterized(
     des_parameterized=(
-        (
-            *[(param_func, DescrptDPA1) for param_func in DescriptorParamDPA1List],
-            *[(param_func, DescrptDPA2) for param_func in DescriptorParamDPA2List],
-            *[(param_func, DescrptDPA3) for param_func in DescriptorParamDPA3List],
-            (DescriptorParamHybridMixed, DescrptHybrid),
-            (DescriptorParamHybridMixedTTebd, DescrptHybrid),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA_DESCRIPTOR_PARAMS_WITH_HYBRID,  # descrpt_class_param & class
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        (
-            (DescriptorParamDPA1, DescrptDPA1),
-            (DescriptorParamDPA2, DescrptDPA2),
-            (DescriptorParamDPA3, DescrptDPA3),
-        ),  # descrpt_class_param & class
+        DEFAULT_DPA_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class

--- a/source/tests/universal/pt/model/test_model.py
+++ b/source/tests/universal/pt/model/test_model.py
@@ -189,6 +189,15 @@ DEFAULT_SPIN_DESCRIPTOR_PARAMS = (
     (DescriptorParamHybridMixedTTebd, DescrptHybrid),
 )
 
+DEFAULT_SPIN_FIT_DESCRIPTOR_PARAMS = (
+    (DescriptorParamSeA, DescrptSeA),
+    (DescriptorParamSeR, DescrptSeR),
+    (DescriptorParamSeT, DescrptSeT),
+    (DescriptorParamSeTTebd, DescrptSeTTebd),
+    (DescriptorParamDPA1, DescrptDPA1),
+    (DescriptorParamDPA2, DescrptDPA2),
+)
+
 
 @parameterized(
     des_parameterized=(
@@ -632,7 +641,7 @@ class TestZBLModelPT(unittest.TestCase, ZBLModelTest, PTTestCase):
         ((FittingParamEnergy, EnergyFittingNet),),  # fitting_class_param & class
     ),
     fit_parameterized=(
-        DEFAULT_SPIN_DESCRIPTOR_PARAMS[:6],  # descrpt_class_param & class
+        DEFAULT_SPIN_FIT_DESCRIPTOR_PARAMS,  # descrpt_class_param & class
         (
             *[(param_func, EnergyFittingNet) for param_func in FittingParamEnergyList],
         ),  # fitting_class_param & class


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized descriptor parameter combinations into shared, reusable constants used across atomic/PT and model test suites to reduce repetition.
  * Added curated energy-model-specific parameter variants and a small helper to create fixed-argument variants for integration tests.
  * Removed an outdated descriptor helper and updated parameterized tests to consume the new centralized parameter collections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/deepmd-kit/pull/5459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->