### PR TITLE
fix(pt_expt): let deepmd.pt import errors propagate in comm op check

### DIFF
--- a/deepmd/pt_expt/utils/comm.py
+++ b/deepmd/pt_expt/utils/comm.py
@@ -50,28 +50,36 @@ def _check_underlying_ops_loaded() -> None:
     like DDP-spawned subprocesses that re-import modules from scratch
     and never see the test conftest's ``import deepmd.pt``.
     """
-    if not (
-        hasattr(torch.ops, "deepmd_export")
-        and hasattr(torch.ops.deepmd_export, "border_op")
-        and hasattr(torch.ops.deepmd_export, "border_op_backward")
-    ):
-        # Triggers cxx_op.py which torch.ops.load_library's the .so.
-        # Let import errors propagate — ABI / torch-version mismatches
-        # against libdeepmd_op_pt.so surface here with diagnostic detail
-        # (e.g. ``undefined symbol``) that the generic RuntimeError below
-        # would otherwise hide.
-        import deepmd.pt  # noqa: F401
 
-    if not (
-        hasattr(torch.ops, "deepmd_export")
-        and hasattr(torch.ops.deepmd_export, "border_op")
-        and hasattr(torch.ops.deepmd_export, "border_op_backward")
-    ):
+    def _ops_registered() -> bool:
+        return (
+            hasattr(torch.ops, "deepmd_export")
+            and hasattr(torch.ops.deepmd_export, "border_op")
+            and hasattr(torch.ops.deepmd_export, "border_op_backward")
+        )
+
+    import_err: Exception | None = None
+    if not _ops_registered():
+        # Triggers cxx_op.py which torch.ops.load_library's the .so.
+        try:
+            import deepmd.pt  # noqa: F401
+        except Exception as exc:
+            # ``deepmd/pt/__init__.py`` loads ``cxx_op`` (which registers
+            # the ops) before running ``load_entry_point("deepmd.pt")``.
+            # A broken third-party entry point can make the import raise
+            # *after* the ops were already registered, so only re-raise
+            # when the registration is still missing — that branch is the
+            # one where the error (typically an ``undefined symbol`` ABI
+            # mismatch against libdeepmd_op_pt.so) carries the diagnostic
+            # detail that the generic RuntimeError below would hide.
+            import_err = exc
+
+    if not _ops_registered():
         raise RuntimeError(
             "torch.ops.deepmd_export.{border_op,border_op_backward} "
             "are not registered. Build libdeepmd_op_pt.so and ensure "
             "deepmd.pt is importable before this module."
-        )
+        ) from import_err
 
 
 _check_underlying_ops_loaded()

--- a/deepmd/pt_expt/utils/comm.py
+++ b/deepmd/pt_expt/utils/comm.py
@@ -75,11 +75,18 @@ def _check_underlying_ops_loaded() -> None:
             import_err = exc
 
     if not _ops_registered():
+        if import_err is not None:
+            # Surface the raw import error (typically ``ImportError`` with
+            # ``undefined symbol`` ABI detail) instead of burying it in a
+            # generic message — that detail is what tells the user the
+            # mismatch is between libdeepmd_op_pt.so and the runtime torch,
+            # not a missing build.
+            raise import_err
         raise RuntimeError(
             "torch.ops.deepmd_export.{border_op,border_op_backward} "
             "are not registered. Build libdeepmd_op_pt.so and ensure "
             "deepmd.pt is importable before this module."
-        ) from import_err
+        )
 
 
 _check_underlying_ops_loaded()

--- a/deepmd/pt_expt/utils/comm.py
+++ b/deepmd/pt_expt/utils/comm.py
@@ -56,13 +56,11 @@ def _check_underlying_ops_loaded() -> None:
         and hasattr(torch.ops.deepmd_export, "border_op_backward")
     ):
         # Triggers cxx_op.py which torch.ops.load_library's the .so.
-        try:
-            import deepmd.pt  # noqa: F401
-        except Exception:
-            # If deepmd.pt itself fails to import, fall through to the
-            # explicit RuntimeError below — clearer than re-raising a
-            # potentially-unrelated import error.
-            pass
+        # Let import errors propagate — ABI / torch-version mismatches
+        # against libdeepmd_op_pt.so surface here with diagnostic detail
+        # (e.g. ``undefined symbol``) that the generic RuntimeError below
+        # would otherwise hide.
+        import deepmd.pt  # noqa: F401
 
     if not (
         hasattr(torch.ops, "deepmd_export")


### PR DESCRIPTION
## Summary

`_check_underlying_ops_loaded()` in `deepmd/pt_expt/utils/comm.py` wraps `import deepmd.pt` in a blanket `except Exception: pass`, then falls through to a generic `RuntimeError` telling the user to build `libdeepmd_op_pt.so`.

The problem: when the .so *is* built but loaded against a mismatched torch version, `import deepmd.pt` raises an `ImportError` with diagnostic detail (e.g. `undefined symbol: ...`) — exactly the message the user needs. The current code hides it and tells them to rebuild a library that's already built.

This PR removes the `try/except` and lets the import error propagate. The downstream `RuntimeError` still fires for the case where the import succeeds but the ops still aren't registered.

## Trade-off

External callers that previously caught `RuntimeError` from `comm.py` import will now see the raw `ImportError` for the .so-mismatch case. No in-tree caller does this. The diagnostic gain outweighs the contract change.

## Test plan

- [x] Existing pt_expt tests (every consumer imports `comm.py`) — happy path unchanged
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization error reporting: when native registrations fail to load, the underlying import/ABI error is now preserved and surfaced instead of being masked by a generic message, making root causes clearer for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/deepmd-kit/pull/5474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->