### PR TITLE
build: move vesin[torch] to the torch extra (fix conda-forge)

### DIFF
--- a/backend/find_pytorch.py
+++ b/backend/find_pytorch.py
@@ -137,6 +137,11 @@ def get_pt_requirement(pt_version: str = "") -> dict:
             # https://github.com/pytorch/pytorch/commit/7e0c26d4d80d6602aed95cb680dfc09c9ce533bc
             else "torch>=2.1.0",
             "e3nn>=0.5.9",
+            # O(N) cell-list neighbor list for fast Python/ASE inference; the
+            # torch bindings (vesin-torch) ship only as a PyPI extra, so keep it
+            # under the torch extra rather than the core deps (conda-forge has
+            # vesin but not vesin-torch).
+            "vesin[torch]",
             *mpi_requirement,
             *cibw_requirement,
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,6 @@ dependencies = [
     'array-api-compat',
     'lmdb',
     'msgpack',
-    # O(N) cell-list neighbor list (vesin.torch) for fast Python/ASE inference
-    'vesin[torch]',
 ]
 requires-python = ">=3.10"
 keywords = ["deepmd"]


### PR DESCRIPTION
## Summary

`vesin`'s torch bindings ship as a separate PyPI package (`vesin-torch`, pulled in by the `vesin[torch]` extra). **conda-forge packages `vesin` but not `vesin-torch`**, so listing `vesin[torch]` in the **core** `dependencies` (added in #5491) breaks the conda-forge build of the base `deepmd-kit` package.

This moves `vesin[torch]` out of the core dependencies and into the **`torch` optional-dependency extra** (`backend/find_pytorch.get_pt_requirement`), so only `deepmd-kit[torch]` (pip) pulls it. The neighbor-list runtime already guards usage via `is_vesin_torch_available()`, and `nlist_backend="auto"` falls back to the native builder when vesin is absent, so this is behavior-preserving for installs that don't ship the torch extra.

## Changes

- `pyproject.toml`: drop `vesin[torch]` from core `dependencies`.
- `backend/find_pytorch.py`: add `vesin[torch]` to the `torch` extra.

## Known limitations

- No automated test covers the build-backend's generated extras; the change is verified by inspection (the `pip install deepmd-kit[torch]` resolution and the conda-forge recipe build are not exercised in CI here).
- When torch is not requested, the `torch` extra is empty and vesin is not installed (intended).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency configuration for improved package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->