### PR TITLE
fix(test): unpack charge_spin in test_pt2_dual_artifact_for_gnn

### DIFF
--- a/source/tests/pt_expt/model/test_export_with_comm.py
+++ b/source/tests/pt_expt/model/test_export_with_comm.py
@@ -155,12 +155,14 @@ def test_pt2_dual_artifact_for_gnn(tmp_path) -> None:
     # 3. Run both artifacts with nframes=1 (matches what the with-comm
     # artifact requires; LAMMPS always passes one frame anyway).
     sample = _make_sample_inputs(model, nframes=1, has_spin=False)
-    ext_coord, ext_atype, nlist_t, mapping_t, fparam, aparam = sample
+    ext_coord, ext_atype, nlist_t, mapping_t, fparam, aparam, charge_spin = sample
     nloc = nlist_t.shape[1]
     nall = ext_atype.shape[1]
     nghost = nall - nloc
 
-    out_regular = regular(ext_coord, ext_atype, nlist_t, mapping_t, fparam, aparam)
+    out_regular = regular(
+        ext_coord, ext_atype, nlist_t, mapping_t, fparam, aparam, charge_spin
+    )
 
     # 4. Build runtime comm tensors mirroring the mapping (single-rank
     # self-send: ghost slot ii receives node[mapping[ii]], identical to
@@ -181,6 +183,7 @@ def test_pt2_dual_artifact_for_gnn(tmp_path) -> None:
         mapping_t,
         fparam,
         aparam,
+        charge_spin,
         *comm_inputs,
     )
 


### PR DESCRIPTION
#5431 extended `_make_sample_inputs` to return a 7th tensor (`charge_spin`) and updated the exported-artifact signatures accordingly, but missed `test_pt2_dual_artifact_for_gnn`: the test is decorated with `skipif(CI == "true")` (AOTInductor compile too slow for CI), so the breakage was invisible to CI and only surfaces on a local full run — `ValueError: too many values to unpack (expected 6)`.

Fix: unpack the 7th value and pass `charge_spin` to both the regular and with-comm artifacts (it sits between `aparam` and the comm tensors in the exported signature).

Verified locally: `source/tests/pt_expt/model/test_export_with_comm.py` — 4 passed.

Known limitation: this test remains CI-skipped by design, so future signature changes can silently break it again; running it locally before release is the only guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases to align with modified artifact interface signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->