### PR TITLE
fix(pt): HybridMuon ZeRO checkpoint slowdown

### DIFF
--- a/deepmd/pt/optimizer/hybrid_muon.py
+++ b/deepmd/pt/optimizer/hybrid_muon.py
@@ -958,8 +958,7 @@ class HybridMuonOptimizer(Optimizer):
         # === Step 3. Build parameter id -> name mapping ===
         self._param_name_map: dict[int, str] = {}
         if named_parameters is not None:
-            for name, param in named_parameters:
-                self._param_name_map[id(param)] = str(name)
+            self.set_param_names(named_parameters)
 
         # Static parameter routing: built once on first step() call.
         self._routing_built = False
@@ -980,6 +979,22 @@ class HybridMuonOptimizer(Optimizer):
         # ``use_foreach=False`` explicitly because several ``torch._foreach_*``
         # ops lack DTensor sharding propagation on older PyTorch builds.
         self._use_foreach = self._resolve_foreach(use_foreach)
+
+    def set_param_names(
+        self, named_parameters: Iterable[tuple[str, torch.Tensor]]
+    ) -> None:
+        """
+        Set runtime-only parameter names used for name-based routing.
+
+        The mapping intentionally stays outside optimizer defaults and
+        ``param_groups`` so optimizer checkpoints do not persist full
+        ``(name, Parameter)`` tuples. Under ZeRO-1 this avoids gathering a
+        duplicate model-sized object graph during ``consolidate_state_dict``.
+        """
+        self._param_name_map = {
+            id(param): str(name) for name, param in named_parameters
+        }
+        self._routing_built = False
 
     @staticmethod
     def _resolve_foreach(use_foreach: bool | None) -> bool:

--- a/deepmd/pt/train/training.py
+++ b/deepmd/pt/train/training.py
@@ -1015,6 +1015,7 @@ class Trainer:
                 float(self.opt_param["adam_beta2"]),
             )
             weight_decay = float(self.opt_param["weight_decay"])
+            runtime_named_parameters = tuple(self.wrapper.named_parameters())
 
             if self.opt_type in ("Adam", "AdamW"):
                 cls = torch.optim.Adam if self.opt_type == "Adam" else torch.optim.AdamW
@@ -1035,7 +1036,6 @@ class Trainer:
                     "lr_adjust": float(self.opt_param["lr_adjust"]),
                     "lr_adjust_coeff": float(self.opt_param["lr_adjust_coeff"]),
                     "muon_mode": str(self.opt_param.get("muon_mode", "slice")),
-                    "named_parameters": tuple(self.wrapper.named_parameters()),
                     "enable_gram": bool(self.opt_param.get("enable_gram")),
                     "flash_muon": bool(self.opt_param.get("flash_muon")),
                     "magma_muon": bool(self.opt_param.get("magma_muon")),
@@ -1054,6 +1054,11 @@ class Trainer:
                 weight_decay=weight_decay,
                 **extra,
             )
+            if self.opt_type == "HybridMuon":
+                target_optimizer = (
+                    self.optimizer.optim if self.zero_stage == 1 else self.optimizer
+                )
+                target_optimizer.set_param_names(runtime_named_parameters)
             self._load_optimizer_state(optimizer_state_dict)
             self.scheduler = self._create_lr_scheduler(
                 self.optimizer,


### PR DESCRIPTION
## Summary
- Keep HybridMuon name-based routing metadata out of optimizer `param_groups`.
- Inject runtime parameter names after optimizer construction, including the ZeRO-1 inner optimizer path.
- Prevent `ZeroRedundancyOptimizer.consolidate_state_dict()` from gathering a duplicate model-sized `named_parameters` object graph.

## Test plan
- Ran 2-GPU ZeRO-1 short DPA4/SeZM training with `HybridMuon`.
- Verified checkpoint save time dropped from ~8.5s to ~3.0s in the short test.
- Verified generated checkpoints no longer contain `optimizer.param_groups[0]["named_parameters"]`.
- Verified restart from the patched checkpoint continues training and saves a valid checkpoint.
- Checked linter diagnostics for modified files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured parameter name registration in the HybridMuon optimizer for improved flexibility during training setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->