### PR TITLE
feat(pt/ptexpt): Filter LAMMPS neighbor lists by model cutoff

### DIFF
--- a/source/api_cc/include/common.h
+++ b/source/api_cc/include/common.h
@@ -43,6 +43,18 @@ struct NeighborListData {
   void shuffle(const std::vector<int>& fwd_map);
   void shuffle(const deepmd::AtomMap& map);
   void shuffle_exclude_empty(const std::vector<int>& fwd_map);
+  /**
+   * @brief Remove neighbor entries whose geometric distance exceeds cutoff.
+   * @param[in] coord Coordinates of the extended atoms, shaped as nall x 3.
+   * @param[in] cutoff Model cutoff distance in the same unit as coord.
+   *
+   * The neighbor rows may be backed by a LAMMPS skin list.  The model lower
+   * interface consumes a cutoff neighbor list, so this method trims the copied
+   * list after atom remapping and before dense tensor padding.
+   */
+  template <typename VALUETYPE>
+  void filter_by_distance(const std::vector<VALUETYPE>& coord,
+                          const VALUETYPE cutoff);
   void make_inlist(InputNlist& inlist);
   void padding();
 };

--- a/source/api_cc/src/DeepPotPT.cc
+++ b/source/api_cc/src/DeepPotPT.cc
@@ -201,6 +201,7 @@ void DeepPotPT::compute(ENERGYVTYPE& ener,
   if (ago == 0) {
     nlist_data.copy_from_nlist(lmp_list, nall - nghost);
     nlist_data.shuffle_exclude_empty(fwd_map);
+    nlist_data.filter_by_distance(dcoord, static_cast<VALUETYPE>(rcut));
     nlist_data.padding();
     if (do_message_passing) {
       if (has_null_atoms) {

--- a/source/api_cc/src/DeepPotPTExpt.cc
+++ b/source/api_cc/src/DeepPotPTExpt.cc
@@ -437,6 +437,7 @@ void DeepPotPTExpt::compute(ENERGYVTYPE& ener,
   if (ago == 0) {
     nlist_data.copy_from_nlist(lmp_list, nall - nghost);
     nlist_data.shuffle_exclude_empty(fwd_map);
+    nlist_data.filter_by_distance(dcoord, static_cast<VALUETYPE>(rcut));
     nlist_data.padding();
 
     // Rebuild mapping tensor

--- a/source/api_cc/src/DeepSpinPT.cc
+++ b/source/api_cc/src/DeepSpinPT.cc
@@ -170,6 +170,7 @@ void DeepSpinPT::compute(ENERGYVTYPE& ener,
   if (ago == 0) {
     nlist_data.copy_from_nlist(lmp_list, nall - nghost);
     nlist_data.shuffle_exclude_empty(fwd_map);
+    nlist_data.filter_by_distance(dcoord, static_cast<VALUETYPE>(rcut));
     nlist_data.padding();
     if (do_message_passing) {
       if (has_null_atoms) {

--- a/source/api_cc/src/DeepSpinPTExpt.cc
+++ b/source/api_cc/src/DeepSpinPTExpt.cc
@@ -482,6 +482,7 @@ void DeepSpinPTExpt::compute(ENERGYVTYPE& ener,
   if (ago == 0) {
     nlist_data.copy_from_nlist(lmp_list, nall - nghost);
     nlist_data.shuffle_exclude_empty(fwd_map);
+    nlist_data.filter_by_distance(dcoord, static_cast<VALUETYPE>(rcut));
     nlist_data.padding();
 
     // Rebuild mapping tensor.  Phantom slots (when phantom_n > 0) get

--- a/source/api_cc/src/DeepTensorPT.cc
+++ b/source/api_cc/src/DeepTensorPT.cc
@@ -314,6 +314,7 @@ void DeepTensorPT::compute(std::vector<VALUETYPE>& global_tensor,
   // Process neighbor list following DeepPotPT pattern
   nlist_data.copy_from_nlist(lmp_list, nall - nghost);
   nlist_data.shuffle_exclude_empty(fwd_map);
+  nlist_data.filter_by_distance(dcoord, static_cast<VALUETYPE>(rcut));
   nlist_data.padding();
 
   at::Tensor firstneigh = createNlistTensor(nlist_data.jlist);

--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -344,6 +344,47 @@ void deepmd::NeighborListData::shuffle_exclude_empty(
   ilist = new_ilist;
   jlist = new_jlist;
 }
+
+template <typename VALUETYPE>
+void deepmd::NeighborListData::filter_by_distance(
+    const std::vector<VALUETYPE>& coord, const VALUETYPE cutoff) {
+  const size_t nall = coord.size() / 3;
+  const VALUETYPE cutoff_sq = cutoff * cutoff;
+  for (size_t ii = 0; ii < jlist.size(); ++ii) {
+    const int center = ilist[ii];
+    auto& row = jlist[ii];
+    if (center < 0 || static_cast<size_t>(center) >= nall) {
+      row.clear();
+      continue;
+    }
+
+    size_t write_pos = 0;
+    const size_t center_offset = static_cast<size_t>(center) * 3;
+    for (const int neighbor : row) {
+      if (neighbor < 0 || static_cast<size_t>(neighbor) >= nall) {
+        continue;
+      }
+      const size_t neighbor_offset = static_cast<size_t>(neighbor) * 3;
+      const VALUETYPE dx = coord[neighbor_offset] - coord[center_offset];
+      const VALUETYPE dy =
+          coord[neighbor_offset + 1] - coord[center_offset + 1];
+      const VALUETYPE dz =
+          coord[neighbor_offset + 2] - coord[center_offset + 2];
+      const VALUETYPE rr = dx * dx + dy * dy + dz * dz;
+      if (rr <= cutoff_sq) {
+        row[write_pos++] = neighbor;
+      }
+    }
+    row.resize(write_pos);
+  }
+}
+
+template void deepmd::NeighborListData::filter_by_distance<double>(
+    const std::vector<double>& coord, const double cutoff);
+
+template void deepmd::NeighborListData::filter_by_distance<float>(
+    const std::vector<float>& coord, const float cutoff);
+
 void deepmd::NeighborListData::padding() {
   size_t max_length = 0;
   for (const auto& row : jlist) {

--- a/source/api_cc/tests/test_deeppot_pt.cc
+++ b/source/api_cc/tests/test_deeppot_pt.cc
@@ -404,6 +404,88 @@ TYPED_TEST(TestInferDeepPotAPt, cpu_lmp_nlist_2rc) {
   }
 }
 
+TYPED_TEST(TestInferDeepPotAPt, cpu_lmp_nlist_skin_below_model_width) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  int& natoms = this->natoms;
+  double& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+  int nloc = coord.size() / 3;
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;
+  std::vector<std::vector<int> > nlist_wide;
+  _build_nlist<VALUETYPE>(nlist_wide, coord_cpy, atype_cpy, mapping, coord,
+                          atype, box, rc * 2);
+
+  const double rc2 = static_cast<double>(rc) * static_cast<double>(rc);
+  bool has_skin_neighbor = false;
+  std::vector<std::vector<int> > nlist_skin(nlist_wide.size());
+  for (size_t ii = 0; ii < nlist_wide.size(); ++ii) {
+    bool added_skin_neighbor = false;
+    for (const int jj : nlist_wide[ii]) {
+      const double dx = static_cast<double>(coord_cpy[jj * 3]) -
+                        static_cast<double>(coord_cpy[ii * 3]);
+      const double dy = static_cast<double>(coord_cpy[jj * 3 + 1]) -
+                        static_cast<double>(coord_cpy[ii * 3 + 1]);
+      const double dz = static_cast<double>(coord_cpy[jj * 3 + 2]) -
+                        static_cast<double>(coord_cpy[ii * 3 + 2]);
+      const double rr = dx * dx + dy * dy + dz * dz;
+      if (rr <= rc2) {
+        nlist_skin[ii].push_back(jj);
+      } else if (!added_skin_neighbor) {
+        nlist_skin[ii].push_back(jj);
+        added_skin_neighbor = true;
+        has_skin_neighbor = true;
+      }
+    }
+  }
+  ASSERT_TRUE(has_skin_neighbor);
+
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_skin);
+
+  double ener;
+  std::vector<VALUETYPE> force_(nall * 3, 0.0), virial(9, 0.0);
+  dp.compute(ener, force_, virial, coord_cpy, atype_cpy, box, nall - nloc,
+             inlist, 0);
+  std::vector<VALUETYPE> force;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(force.size(), natoms * 3);
+  EXPECT_EQ(virial.size(), 9);
+
+  EXPECT_LT(fabs(ener - expected_tot_e), EPSILON);
+  for (int ii = 0; ii < natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+
+  ener = 0.;
+  std::fill(force_.begin(), force_.end(), 0.0);
+  std::fill(virial.begin(), virial.end(), 0.0);
+  dp.compute(ener, force_, virial, coord_cpy, atype_cpy, box, nall - nloc,
+             inlist, 1);
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_LT(fabs(ener - expected_tot_e), EPSILON);
+  for (int ii = 0; ii < natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
 TYPED_TEST(TestInferDeepPotAPt, cpu_lmp_nlist_type_sel) {
   using VALUETYPE = TypeParam;
   std::vector<VALUETYPE>& coord = this->coord;

--- a/source/api_cc/tests/test_deeppot_ptexpt.cc
+++ b/source/api_cc/tests/test_deeppot_ptexpt.cc
@@ -388,6 +388,73 @@ TYPED_TEST(TestInferDeepPotAPtExpt, cpu_lmp_nlist_2rc) {
   }
 }
 
+TYPED_TEST(TestInferDeepPotAPtExpt, cpu_lmp_nlist_skin_below_model_width) {
+  using VALUETYPE = TypeParam;
+  std::vector<VALUETYPE>& coord = this->coord;
+  std::vector<int>& atype = this->atype;
+  std::vector<VALUETYPE>& box = this->box;
+  std::vector<VALUETYPE>& expected_f = this->expected_f;
+  int& natoms = this->natoms;
+  double& expected_tot_e = this->expected_tot_e;
+  std::vector<VALUETYPE>& expected_tot_v = this->expected_tot_v;
+  deepmd::DeepPot& dp = this->dp;
+  float rc = dp.cutoff();
+  int nloc = coord.size() / 3;
+  std::vector<VALUETYPE> coord_cpy;
+  std::vector<int> atype_cpy, mapping;
+  std::vector<std::vector<int> > nlist_wide;
+  _build_nlist<VALUETYPE>(nlist_wide, coord_cpy, atype_cpy, mapping, coord,
+                          atype, box, rc * 2);
+
+  const double rc2 = static_cast<double>(rc) * static_cast<double>(rc);
+  bool has_skin_neighbor = false;
+  std::vector<std::vector<int> > nlist_skin(nlist_wide.size());
+  for (size_t ii = 0; ii < nlist_wide.size(); ++ii) {
+    bool added_skin_neighbor = false;
+    for (const int jj : nlist_wide[ii]) {
+      const double dx = static_cast<double>(coord_cpy[jj * 3]) -
+                        static_cast<double>(coord_cpy[ii * 3]);
+      const double dy = static_cast<double>(coord_cpy[jj * 3 + 1]) -
+                        static_cast<double>(coord_cpy[ii * 3 + 1]);
+      const double dz = static_cast<double>(coord_cpy[jj * 3 + 2]) -
+                        static_cast<double>(coord_cpy[ii * 3 + 2]);
+      const double rr = dx * dx + dy * dy + dz * dz;
+      if (rr <= rc2) {
+        nlist_skin[ii].push_back(jj);
+      } else if (!added_skin_neighbor) {
+        nlist_skin[ii].push_back(jj);
+        added_skin_neighbor = true;
+        has_skin_neighbor = true;
+      }
+    }
+  }
+  ASSERT_TRUE(has_skin_neighbor);
+
+  int nall = coord_cpy.size() / 3;
+  std::vector<int> ilist(nloc), numneigh(nloc);
+  std::vector<int*> firstneigh(nloc);
+  deepmd::InputNlist inlist(nloc, &ilist[0], &numneigh[0], &firstneigh[0]);
+  convert_nlist(inlist, nlist_skin);
+
+  double ener;
+  std::vector<VALUETYPE> force_(nall * 3, 0.0), virial(9, 0.0);
+  dp.compute(ener, force_, virial, coord_cpy, atype_cpy, box, nall - nloc,
+             inlist, 0);
+  std::vector<VALUETYPE> force;
+  _fold_back<VALUETYPE>(force, force_, mapping, nloc, nall, 3);
+
+  EXPECT_EQ(force.size(), natoms * 3);
+  EXPECT_EQ(virial.size(), 9);
+
+  EXPECT_LT(fabs(ener - expected_tot_e), EPSILON);
+  for (int ii = 0; ii < natoms * 3; ++ii) {
+    EXPECT_LT(fabs(force[ii] - expected_f[ii]), EPSILON);
+  }
+  for (int ii = 0; ii < 3 * 3; ++ii) {
+    EXPECT_LT(fabs(virial[ii] - expected_tot_v[ii]), EPSILON);
+  }
+}
+
 TYPED_TEST(TestInferDeepPotAPtExpt, cpu_lmp_nlist_oversized) {
   using VALUETYPE = TypeParam;
   std::vector<VALUETYPE>& coord = this->coord;

--- a/source/api_cc/tests/test_neighbor_list_data.cc
+++ b/source/api_cc/tests/test_neighbor_list_data.cc
@@ -136,4 +136,39 @@ TEST(TestNeighborListData, RoundTripWithEmptyRows) {
   EXPECT_EQ(out.numneigh[3], 1);
 }
 
+TEST(TestNeighborListData, FilterByDistanceUsesIlistCenters) {
+  NeighborListData data;
+  data.ilist = {3, 0, 1};
+  data.jlist = {{0, 2, 4}, {1, 2, -1}, {3, 4}};
+  const std::vector<double> coord = {
+      0.0,  0.0, 0.0,  // atom 0
+      2.0,  0.0, 0.0,  // atom 1
+      7.0,  0.0, 0.0,  // atom 2
+      1.0,  0.0, 0.0,  // atom 3
+      10.0, 0.0, 0.0,  // atom 4
+  };
+
+  data.filter_by_distance(coord, 5.0);
+
+  ASSERT_EQ(data.jlist.size(), 3);
+  EXPECT_EQ(data.jlist[0], (std::vector<int>{0}));
+  EXPECT_EQ(data.jlist[1], (std::vector<int>{1}));
+  EXPECT_EQ(data.jlist[2], (std::vector<int>{3}));
+}
+
+TEST(TestNeighborListData, FilterByDistanceClearsInvalidCenterRows) {
+  NeighborListData data;
+  data.ilist = {0, 5};
+  data.jlist = {{1}, {0, 1}};
+  const std::vector<float> coord = {
+      0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
+  };
+
+  data.filter_by_distance(coord, 2.0f);
+
+  ASSERT_EQ(data.jlist.size(), 2);
+  EXPECT_EQ(data.jlist[0], (std::vector<int>{1}));
+  EXPECT_TRUE(data.jlist[1].empty());
+}
+
 }  // namespace deepmd


### PR DESCRIPTION
## Summary
- Trim LAMMPS-provided neighbor lists to the model cutoff before building PyTorch/PTExpt lower-interface tensors.
- Share the cutoff filtering logic through `NeighborListData` and apply it to PT, PTExpt, spin, and tensor C++ inference paths.
- Add regression coverage for skin-list neighbors that stay within the model nlist width but lie outside `rcut`.

## Test plan
- `ninja -C /tmp/deepmd-kit-api-cc-test runUnitTests_cc`
- `runUnitTests_cc --gtest_filter='TestNeighborListData.FilterByDistance*:TestInferDeepPotAPt/*cpu_lmp_nlist_skin_below_model_width*'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added neighbor list distance-based filtering that removes neighbors beyond a specified cutoff distance before tensor padding in model computation.

* **Tests**
  * Added tests verifying neighbor list filtering behavior with LAMMPS-style neighbor list inputs across multiple model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->