### PR TITLE
ci: speed up slow test workflows

### DIFF
--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -41,7 +41,10 @@ jobs:
           python-version: "3.11"
           cache: "pip"
       - uses: lukka/get-cmake@latest
-      - run: python -m pip install uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Install Python dependencies
         run: |
           source/install/uv_with_retry.sh pip install --system --group pin_tensorflow_cpu --group pin_pytorch_cpu --group pin_jax_cpu --torch-backend cpu
@@ -63,6 +66,7 @@ jobs:
           TF_INTRA_OP_PARALLELISM_THREADS: 1
           TF_INTER_OP_PARALLELISM_THREADS: 1
           CMAKE_GENERATOR: Ninja
+          CTEST_PARALLEL_LEVEL: 3
           CXXFLAGS: ${{ matrix.check_memleak && '-fsanitize=leak' || '' }}
           LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/workflows/suppr.txt
           ENABLE_TENSORFLOW: ${{ matrix.enable_tensorflow && 'TRUE' || 'FALSE' }}

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -56,7 +56,8 @@ jobs:
           DP_ENABLE_NATIVE_OPTIMIZATION: 1
           DP_ENABLE_PYTORCH: 1
       - run: dp --version
-      - run: python -m pytest source/tests
+      - name: Test Python on CUDA
+        run: python -m pytest source/tests --ignore=source/tests/pt_expt
         env:
           NUM_WORKERS: 0
           CUDA_VISIBLE_DEVICES: 0

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -26,7 +26,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - run: python -m pip install -U uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - run: |
           source/install/uv_with_retry.sh pip install --system openmpi --group pin_tensorflow_cpu --group pin_pytorch_cpu --torch-backend cpu
           export TENSORFLOW_ROOT=$(python -c 'import importlib.util,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')

--- a/source/install/test_cc_local.sh
+++ b/source/install/test_cc_local.sh
@@ -102,4 +102,4 @@ if [ "${ENABLE_PADDLE:-TRUE}" == "TRUE" ]; then
 	PADDLE_INFERENCE_DIR=${BUILD_TMP_DIR}/paddle_inference_install_dir
 	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PADDLE_INFERENCE_DIR}/third_party/install/onednn/lib:${PADDLE_INFERENCE_DIR}/third_party/install/mklml/lib
 fi
-ctest --output-on-failure
+ctest --output-on-failure --parallel "${CTEST_PARALLEL_LEVEL:-1}"


### PR DESCRIPTION
## Summary

- Cache uv installs in the slow Python and C++ test workflows with `astral-sh/setup-uv`.
- Skip `source/tests/pt_expt` in the CUDA Python job; these PyTorch export/compile tests are already covered by the CPU Python workflow and dominate Python test time.
- Allow `test_cc_local.sh` to run ctest entries in parallel when `CTEST_PARALLEL_LEVEL` is set, and enable 3-way ctest parallelism in the C++ workflow.

## Motivation

Recent CI timings show the CUDA workflow is dominated by `python -m pytest source/tests`:

- Test CUDA merge queue run `27417297979`: total CUDA job ~4h15m; Python pytest ~3h02m; C++ step ~47m; LAMMPS/i-PI ~15m.
- Test Python run `27417297836`: `source/tests/pt_expt` accounts for ~18,299s of 34,345s cumulative recorded Python 3.13 test duration.
- Test C++ run `27417297837`: TF/PT C++ matrix entries take ~47m, while the Paddle-only entries finish in ~7m.

## Validation

- `python` YAML parse for changed workflows
- `bash -n source/install/test_cc_local.sh`
- `git diff --check`
- `ruff check .`
- `ruff format --check .`
- pre-commit hooks run by `git commit` passed for changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD test infrastructure with parallel test execution for faster feedback cycles.
  * Improved dependency installation mechanism with caching support for quicker setup.
  * Refined test configuration in CUDA workflow for optimized test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->