### PR TITLE
fix(jax): restore batched neighbor statistics

### DIFF
--- a/deepmd/jax/entrypoints/train.py
+++ b/deepmd/jax/entrypoints/train.py
@@ -18,8 +18,14 @@ from deepmd.jax.env import (
     jax,
     jax_export,
 )
+from deepmd.jax.model.base_model import (
+    BaseModel,
+)
 from deepmd.jax.train.trainer import (
     DPTrainer,
+)
+from deepmd.jax.utils.update_sel import (
+    use_jax_update_sel,
 )
 from deepmd.utils import random as dp_random
 from deepmd.utils.argcheck import (
@@ -138,8 +144,9 @@ def train(
     jdata = update_deepmd_input(jdata, warning=True, dump="input_v2_compat.json")
 
     jdata = normalize(jdata)
+    min_nbor_dist = None
     if not skip_neighbor_stat:
-        jdata = update_sel(jdata)
+        jdata, min_nbor_dist = update_sel(jdata)
 
     with open(output, "w") as fp:
         json.dump(jdata, fp, indent=4)
@@ -155,6 +162,8 @@ def train(
         init_model=init_model,
         restart=restart,
     )
+    if min_nbor_dist is not None:
+        model.model.min_nbor_dist = min_nbor_dist
     rcut = model.model.get_rcut()
     type_map = model.model.get_type_map()
     if len(type_map) == 0:
@@ -193,11 +202,21 @@ def train(
     log.info(f"wall time: {(end_time - start_time):.3f} s")
 
 
-def update_sel(jdata: dict) -> dict:
+def update_sel(jdata: dict) -> tuple[dict, float | None]:
     """Update descriptor selections from neighbor statistics when available."""
     log.info(
-        "Skip neighbor statistics update for JAX training; "
-        "BaseModel.update_sel currently needs more memory than expected."
+        "Calculate neighbor statistics... (add --skip-neighbor-stat to skip this step)"
     )
-    # TODO: Restore BaseModel.update_sel once the JAX data path avoids OOM.
-    return jdata.copy()
+    jdata_cpy = jdata.copy()
+    type_map = jdata["model"].get("type_map")
+    train_data = get_data(
+        jdata["training"]["training_data"],
+        0,  # not used
+        type_map,
+        None,  # not used
+    )
+    with use_jax_update_sel():
+        jdata_cpy["model"], min_nbor_dist = BaseModel.update_sel(
+            train_data, type_map, jdata["model"]
+        )
+    return jdata_cpy, min_nbor_dist

--- a/deepmd/jax/utils/update_sel.py
+++ b/deepmd/jax/utils/update_sel.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+from collections.abc import (
+    Iterator,
+)
+from contextlib import (
+    contextmanager,
+)
+from typing import (
+    Any,
+)
+
+from deepmd.jax.utils.neighbor_stat import (
+    NeighborStat,
+)
+from deepmd.utils.update_sel import (
+    BaseUpdateSel,
+)
+
+
+class UpdateSel(BaseUpdateSel):
+    @property
+    def neighbor_stat(self) -> type[NeighborStat]:
+        return NeighborStat
+
+
+_MISSING = object()
+
+
+def _get_update_sel_descriptors() -> tuple[type[Any], ...]:
+    import deepmd.dpmodel.descriptor as _dpmodel_descriptor  # noqa: F401
+    from deepmd.dpmodel.descriptor.base_descriptor import (
+        BaseDescriptor,
+    )
+
+    return tuple(
+        {
+            descriptor_cls
+            for descriptor_cls in BaseDescriptor.get_plugins().values()
+            if hasattr(descriptor_cls, "_update_sel_cls")
+        }
+    )
+
+
+@contextmanager
+def use_jax_update_sel() -> Iterator[None]:
+    """Use JAX neighbor statistics in dpmodel descriptor update_sel methods."""
+    descriptor_classes = _get_update_sel_descriptors()
+    saved_update_sel = {
+        descriptor_cls: descriptor_cls.__dict__.get("_update_sel_cls", _MISSING)
+        for descriptor_cls in descriptor_classes
+    }
+    try:
+        for descriptor_cls in descriptor_classes:
+            descriptor_cls._update_sel_cls = UpdateSel
+        yield
+    finally:
+        for descriptor_cls, update_sel_cls in saved_update_sel.items():
+            if update_sel_cls is _MISSING:
+                del descriptor_cls._update_sel_cls
+            else:
+                descriptor_cls._update_sel_cls = update_sel_cls

--- a/source/tests/jax/test_training.py
+++ b/source/tests/jax/test_training.py
@@ -24,6 +24,9 @@ from deepmd.jax.entrypoints.freeze import (
 from deepmd.jax.entrypoints.main import (
     main,
 )
+from deepmd.jax.entrypoints.train import (
+    update_sel,
+)
 from deepmd.utils.compat import (
     convert_optimizer_v31_to_v32,
 )
@@ -136,6 +139,30 @@ class TestJAXTraining(unittest.TestCase):
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn(1, _lcurve_steps(self.work_dir / "lcurve.out"))
+
+    @patch("deepmd.jax.entrypoints.train.get_data")
+    @patch("deepmd.jax.utils.update_sel.UpdateSel.get_nbor_stat")
+    def test_update_sel_uses_jax_neighbor_stat(self, get_nbor_stat, get_data) -> None:
+        """JAX update_sel should calculate neighbor statistics instead of skipping."""
+        get_nbor_stat.return_value = 0.5, [10, 20]
+        jdata = {
+            "model": {
+                "type_map": ["O", "H"],
+                "descriptor": {
+                    "type": "se_e2_a",
+                    "rcut": 6.0,
+                    "sel": "auto",
+                },
+            },
+            "training": {"training_data": {}},
+        }
+
+        updated, min_nbor_dist = update_sel(jdata)
+
+        self.assertEqual(updated["model"]["descriptor"]["sel"], [12, 24])
+        self.assertEqual(min_nbor_dist, 0.5)
+        get_data.assert_called_once_with({}, 0, ["O", "H"], None)
+        get_nbor_stat.assert_called_once()
 
     @patch("deepmd.jax.entrypoints.freeze.deserialize_to_file")
     @patch("deepmd.jax.entrypoints.freeze.serialize_from_file")


### PR DESCRIPTION
## Summary
- restore JAX training neighbor statistics instead of silently skipping update_sel
- route descriptor update_sel through the JAX NeighborStat implementation with AutoBatchSize
- persist min_nbor_dist on the JAX model and add a regression test for sel=auto

## Tests
- ruff check .
- pytest source/tests/jax/test_training.py -v
- timeout 180 srun --gres=gpu:1 pytest source/tests/jax/test_training.py::TestJAXTraining::test_train_entrypoint_runs_one_step_from_scratch -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * JAX training now automatically computes neighbor statistics during training to optimize model parameters
  * Minimum neighbor distance is automatically determined and configured on the model during training
  * Optional setting available to skip neighbor statistics computation if preferred

<!-- end of auto-generated comment: release notes by coderabbit.ai -->