### PR TITLE
fix(pt-expt): detach tensors before numpy serialization

### DIFF
--- a/deepmd/dpmodel/common.py
+++ b/deepmd/dpmodel/common.py
@@ -118,11 +118,16 @@ def to_numpy_array(x: Optional["Array"]) -> np.ndarray | None:
     """
     if x is None:
         return None
+    # Since pytorch/pytorch@a97dcf9, torch.asarray(..., copy=True) preserves
+    # requires_grad from tensor inputs by default.  The DLPack fallback below
+    # cannot export tensors that require gradients, so explicitly detach only
+    # for NumPy serialization.
+    if array_api_compat.is_torch_array(x) and x.requires_grad:
+        x = x.detach()
     try:
         # asarray is not within Array API standard, so may fail
         return np.asarray(x)
     except (ValueError, AttributeError, TypeError, RuntimeError):
-        # RuntimeError: handles torch tensors with requires_grad=True
         xp = array_api_compat.array_namespace(x)
         # to fix BufferError: Cannot export readonly array since signalling readonly is unsupported by DLPack.
         # Move to CPU device to ensure numpy compatibility

--- a/source/tests/consistent/test_array_api.py
+++ b/source/tests/consistent/test_array_api.py
@@ -24,6 +24,10 @@ from .common import (
 if INSTALLED_PT:
     import torch
 
+    from deepmd.pt_expt.utils.env import (
+        DEVICE,
+    )
+
 if INSTALLED_JAX:
     from deepmd.jax.env import (
         jnp,
@@ -31,6 +35,20 @@ if INSTALLED_JAX:
 
 if INSTALLED_ARRAY_API_STRICT:
     import array_api_strict as xp
+
+
+class TestArrayConversion(unittest.TestCase):
+    @unittest.skipUnless(INSTALLED_PT, "PyTorch is not installed")
+    def test_torch_parameter_requires_grad(self) -> None:
+        param = torch.nn.Parameter(
+            torch.tensor([1.0, 2.0], dtype=torch.float64, device=DEVICE)
+        )
+        self.assertTrue(param.requires_grad)
+        np.testing.assert_allclose(
+            to_numpy_array(param), np.array([1.0, 2.0], dtype=np.float64)
+        )
+        self.assertTrue(param.requires_grad)
+        self.assertEqual(param.device, DEVICE)
 
 
 class TestXpScatterSumConsistent(unittest.TestCase):


### PR DESCRIPTION
## Summary
- detach torch tensors that require gradients before exporting them through `to_numpy_array`
- document the PyTorch `torch.asarray` behavior change from pytorch/pytorch@a97dcf9
- add a regression test for serializing a trainable `torch.nn.Parameter`

## Tests
- `ruff check deepmd/dpmodel/common.py source/tests/consistent/test_array_api.py`
- `ruff format --check deepmd/dpmodel/common.py source/tests/consistent/test_array_api.py`
- `pytest source/tests/consistent/test_array_api.py::TestArrayConversion::test_torch_parameter_requires_grad -q`
- `pytest source/tests/consistent/test_array_api.py -q`
- `srun --gres=gpu:1 dp --pt-expt train input.json --skip-neighbor-stat`
- `srun --gres=gpu:1 dp --pt-expt train input.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of machine learning tensors to NumPy arrays when gradient tracking is enabled, preventing conversion failures while maintaining correct values.

* **Tests**
  * Added coverage for converting gradient-enabled PyTorch parameters, including checks for output values, dtype, and correct behavior before/after conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->