### PR TITLE
fix(lmp): use forward comm for PPPM DPLR AD

### DIFF
--- a/source/lmp/pppm_dplr.cpp
+++ b/source/lmp/pppm_dplr.cpp
@@ -143,7 +143,7 @@ void PPPMDPLR::compute(int eflag, int vflag) {
 
   if (differentiation_flag == 1)
 #if LAMMPS_VERSION_NUMBER >= 20221222
-    gc->reverse_comm(Grid3d::KSPACE, this, REVERSE_RHO, 1, sizeof(FFT_SCALAR),
+    gc->forward_comm(Grid3d::KSPACE, this, FORWARD_AD, 1, sizeof(FFT_SCALAR),
                      gc_buf1, gc_buf2, MPI_FFT_SCALAR);
 #elif LAMMPS_VERSION_NUMBER >= 20210831 && LAMMPS_VERSION_NUMBER < 20221222
     gc->forward_comm(GridComm::KSPACE, this, 1, sizeof(FFT_SCALAR), FORWARD_AD,


### PR DESCRIPTION
## Summary
- use forward_comm for the LAMMPS >= 20221222 PPPM DPLR analytical differentiation grid communication
- align the new Grid3d branch with the existing GridComm and forward_comm_kspace branches

## Tests
- git diff --check
- /tmp/deepmd-ruff-venv/bin/ruff check . (fails on existing UP018 findings in deepmd/tf/env.py)
- /tmp/deepmd-ruff-venv/bin/ruff format --check . (fails on existing formatting differences in deepmd/dpmodel/utils/serialization.py, deepmd/pd/utils/multi_task.py, deepmd/pt/utils/multi_task.py)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed electrostatic solver ghost-cell communication method to ensure correct field calculations during particle-mesh computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->