### PR TITLE
build(ci): ensure C++ toolchain before pytest

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -26,6 +26,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+      - name: Ensure a working C++ toolchain (torch inductor needs it)
+        # Hosted-runner VMs occasionally boot with a broken gcc where the g++
+        # driver is present but cc1plus is missing, which makes torch inductor's
+        # C++ JIT compilation fail deep inside the tests with an opaque
+        # "g++: cannot execute 'cc1plus'" error. Reinstall the compiler and
+        # fail fast here with a clear message if it is still broken.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --reinstall build-essential
+          echo 'int main(){}' | g++ -x c++ - -o /tmp/cctest && echo "g++/cc1plus OK"
       - run: python -m pip install -U uv
       - run: |
           source/install/uv_with_retry.sh pip install --system openmpi --group pin_tensorflow_cpu --group pin_pytorch_cpu --torch-backend cpu


### PR DESCRIPTION
## Summary

The `Test Python` job (`.github/workflows/test_python.yml`) does `checkout → setup-python → pip install → pytest` and never verifies the C++ compiler, yet torch inductor shells out to the system `g++` to JIT-compile C++ kernels at test time (e.g. the `_CompiledModel` / `torch.compile` tests).

When a GitHub-hosted runner VM occasionally boots with a broken gcc — the `g++` driver present but its backend `cc1plus` missing — this surfaces as an opaque failure deep inside the suite:

```
torch._inductor.exc.InductorError: CppCompileError: C++ compile error
g++: fatal error: cannot execute 'cc1plus': execvp: No such file or directory
```

This was observed once on an unrelated docs-only PR. The re-run on a **fresh VM with identical code passed**, confirming it is a transient per-VM toolchain corruption, not a code defect — and a survey of other recent `Test Python` failures showed all of them were genuine code/test failures, none with this `cc1plus` signature.

## Change

Add a step right after `setup-python` that:
- reinstalls `build-essential` (re-laying down `gcc`, which ships `cc1plus`), self-healing a corrupted VM, and
- verifies a trivial C++ compile, so if the toolchain is still broken the job fails immediately with a clear message instead of 40 minutes into pytest.

## Notes / known limitations

- This makes the flake self-correct without a manual job re-run. It does not eliminate the underlying hosted-runner image variability; pinning to a container image would be the fully-deterministic alternative but is a larger change.
- `pytest-rerunfailures` would not help here: retrying the same test on the same VM hits the same missing `cc1plus`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow to enhance build validation during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->