### PR TITLE
fix(gpu): avoid neighbor-list prefix scan deadlock

### DIFF
--- a/source/lib/src/gpu/neighbor_list.cu
+++ b/source/lib/src/gpu/neighbor_list.cu
@@ -43,11 +43,14 @@ __global__ void parallel_prefix_scan(int* numneigh,
   // Initialize running total
   parallel_prefix_scan_op prefix_op(0);
 
-  // Have the block iterate over segments of items
-  for (int ii = threadIdx.x; ii < nall; ii += THREADS_PER_BLOCK) {
+  // Have the full block iterate over segments of items. BlockScan and
+  // __syncthreads are block-wide collectives, so every thread in the block
+  // must enter every iteration, including the partially-filled tail segment.
+  for (int base = 0; base < nall; base += THREADS_PER_BLOCK) {
+    int ii = base + threadIdx.x;
     int block_offset = blockIdx.x * mem_size;
     // Load a segment of consecutive items that are blocked across threads
-    int i_data = temp_nlist[block_offset + ii];
+    int i_data = ii < nall ? temp_nlist[block_offset + ii] : -1;
     int o_data = i_data == -1 ? 0 : 1;
 
     // Collectively compute the block-wide exclusive prefix sum
@@ -55,7 +58,7 @@ __global__ void parallel_prefix_scan(int* numneigh,
 
     __syncthreads();
     // Store scanned items to output segment
-    if (i_data != -1) {
+    if (ii < nall && i_data != -1) {
       nei_order[block_offset + ii] = o_data;
     }
     // Store numneigh into the output array

--- a/source/lib/tests/test_neighbor_list.cc
+++ b/source/lib/tests/test_neighbor_list.cc
@@ -229,4 +229,52 @@ TEST_F(TestNeighborList, gpu_lessmem) {
   deepmd::delete_device_memory(c_cpy_dev);
 }
 
+TEST(TestNeighborListStandalone, gpu_tail_segment_prefix_scan) {
+  const int nloc = 2;
+  const int nall = TPB + 68;
+  const int mem_size = nall;
+  const double rc = 1.0;
+
+  std::vector<double> coord(nall * 3, 0.0);
+  for (int ii = 0; ii < nall; ++ii) {
+    coord[ii * 3] = ii * 10.0;
+  }
+
+  int *nlist_data_dev = NULL, *jlist_dev = NULL, *ilist_dev = NULL,
+      *numneigh_dev = NULL;
+  int** firstneigh_dev = NULL;
+  std::vector<int*> temp_firstneigh(nloc);
+  double* coord_dev = NULL;
+
+  deepmd::malloc_device_memory(nlist_data_dev, 2 * nloc * mem_size);
+  deepmd::malloc_device_memory(jlist_dev, nloc * mem_size);
+  deepmd::malloc_device_memory(ilist_dev, nloc);
+  deepmd::malloc_device_memory(numneigh_dev, nloc);
+  for (int ii = 0; ii < nloc; ++ii) {
+    temp_firstneigh[ii] = jlist_dev + ii * mem_size;
+  }
+  deepmd::malloc_device_memory_sync(firstneigh_dev, temp_firstneigh);
+  deepmd::malloc_device_memory_sync(coord_dev, coord);
+  deepmd::InputNlist nlist_dev(nloc, ilist_dev, numneigh_dev, firstneigh_dev);
+
+  int max_list_size = -1;
+  int ret = deepmd::build_nlist_gpu(nlist_dev, &max_list_size, nlist_data_dev,
+                                    coord_dev, nloc, nall, mem_size, rc);
+
+  EXPECT_EQ(ret, 0);
+  EXPECT_EQ(max_list_size, 0);
+  std::vector<int> numneigh(nloc, -1);
+  deepmd::memcpy_device_to_host(numneigh_dev, numneigh.data(), nloc);
+  for (int ii = 0; ii < nloc; ++ii) {
+    EXPECT_EQ(numneigh[ii], 0);
+  }
+
+  deepmd::delete_device_memory(nlist_data_dev);
+  deepmd::delete_device_memory(jlist_dev);
+  deepmd::delete_device_memory(ilist_dev);
+  deepmd::delete_device_memory(numneigh_dev);
+  deepmd::delete_device_memory(firstneigh_dev);
+  deepmd::delete_device_memory(coord_dev);
+}
+
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
Fixes #5117.

The CUDA neighbor-list prefix scan used `threadIdx.x` as the loop induction variable around `cub::BlockScan` and `__syncthreads()`. When `nall` is not a multiple of the block size, only the threads covered by the tail segment enter the final iteration, so the block-wide collective diverges and the GPU op can hang.

This changes the loop to iterate by segment base so every thread in the block participates in every `BlockScan`/`__syncthreads()` iteration. Threads outside the tail segment load a sentinel and skip output writes.

A CUDA regression test covers the tail segment case with `nall = TPB + 68`, which matches the divergent pattern observed in #5117.

Validation:
- Built current master plus this patch from source with CUDA 12.9, TensorFlow 2.19.1, and `CMAKE_CUDA_ARCHITECTURES=120`.
- Confirmed the test runtime loaded the freshly built `libdeepmd.so`, `libdeepmd_op.so`, `libdeepmd_op_cuda.so`, `libdeepmd_dyn_cudart.so`, and `libop_grads.so`.
- Re-ran the issue input on RTX 5090 with `srun --gres=gpu:1 dp --tf train input.json`; training passed the previous `data stating...` hang point and completed `stop_batch = 2000` with exit code 0.
- `git diff --check` passed.
- pre-commit hooks for the committed C++ files passed, including `clang-format`.

Notes:
- `ruff check` on git-tracked Python files passed. `ruff format --check` reports an existing unrelated format issue in `source/3rdparty/implib/implib-gen.py`; this PR only changes C++/CUDA files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU neighbor list computation to correctly handle edge cases in segment processing, ensuring accurate results across all particle configurations.

* **Tests**
  * Added GPU test to verify neighbor list computation correctness in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->