### PR TITLE
fix(jax): reuse atomic forward outputs in force path

### DIFF
--- a/deepmd/jax/model/base_model.py
+++ b/deepmd/jax/model/base_model.py
@@ -30,20 +30,86 @@ def forward_common_atomic(
     charge_spin: jnp.ndarray | None = None,
 ) -> dict[str, jnp.ndarray]:
     del comm_dict  # JAX path has no MPI ghost exchange
-    atomic_ret = self.atomic_model.forward_common_atomic(
-        extended_coord,
-        extended_atype,
-        nlist,
-        mapping=mapping,
-        fparam=fparam,
-        aparam=aparam,
-        charge_spin=charge_spin,
-    )
+    atomic_ret = None
     atomic_output_def = self.atomic_output_def()
     model_predict = {}
-    for kk, vv in atomic_ret.items():
-        model_predict[kk] = vv
+
+    def get_atomic_ret() -> dict[str, jnp.ndarray]:
+        # Some outputs, such as masks, are not differentiated. Compute the
+        # primal atomic outputs lazily so force paths can obtain them from
+        # jacrev(has_aux=True) instead of paying for a separate forward pass.
+        nonlocal atomic_ret
+        if atomic_ret is None:
+            atomic_ret = self.atomic_model.forward_common_atomic(
+                extended_coord,
+                extended_atype,
+                nlist,
+                mapping=mapping,
+                fparam=fparam,
+                aparam=aparam,
+                charge_spin=charge_spin,
+            )
+        return atomic_ret
+
+    for kk in atomic_output_def.keys():
         vdef = atomic_output_def[kk]
+        vv = None
+        ff = None
+        if vdef.reducible and vdef.r_differentiable:
+
+            def eval_output(
+                cc_ext: jnp.ndarray,
+                extended_atype: jnp.ndarray,
+                nlist: jnp.ndarray,
+                mapping: jnp.ndarray | None,
+                fparam: jnp.ndarray | None,
+                aparam: jnp.ndarray | None,
+                charge_spin_: jnp.ndarray | None,
+                *,
+                _kk: str = kk,
+                _atom_axis: int = -(len(vdef.shape) + 1),
+            ) -> tuple[jnp.ndarray, dict[str, jnp.ndarray]]:
+                atomic_ret_ = self.atomic_model.forward_common_atomic(
+                    cc_ext[None, ...],
+                    extended_atype[None, ...],
+                    nlist[None, ...],
+                    mapping=mapping[None, ...] if mapping is not None else None,
+                    fparam=fparam[None, ...] if fparam is not None else None,
+                    aparam=aparam[None, ...] if aparam is not None else None,
+                    charge_spin=charge_spin_[None, ...]
+                    if charge_spin_ is not None
+                    else None,
+                )
+                output = jnp.sum(atomic_ret_[_kk][0], axis=_atom_axis)
+                # This function is vmapped over frames; strip the leading
+                # singleton frame dimension so the aux tree has the same
+                # batched shape as a direct forward_common_atomic call.
+                return output, {kk_: vv_[0] for kk_, vv_ in atomic_ret_.items()}
+
+            # Compute the coordinate Jacobian and the primal atomic outputs in
+            # one transformed forward. Without has_aux, the code would need a
+            # separate forward_common_atomic call before/after jacrev just to
+            # populate atom_energy, masks, and reduced outputs.
+            # extended_coord: [nf, nall, 3]
+            # ff: [nf, *def, nall, 3]
+            ff, aux_atomic_ret = jax.vmap(
+                jax.jacrev(eval_output, argnums=0, has_aux=True)
+            )(
+                extended_coord,
+                extended_atype,
+                nlist,
+                mapping,
+                fparam,
+                aparam,
+                charge_spin,
+            )
+            ff = -ff
+            if atomic_ret is None:
+                atomic_ret = aux_atomic_ret
+            vv = atomic_ret[kk]
+        else:
+            vv = get_atomic_ret()[kk]
+        model_predict[kk] = vv
         shap = vdef.shape
         atom_axis = -(len(shap) + 1)
         if vdef.reducible:
@@ -60,53 +126,11 @@ def forward_common_atomic(
                 model_predict[kk_redu] = jnp.sum(vv, axis=atom_axis)
             kk_derv_r, kk_derv_c = get_deriv_name(kk)
             if vdef.r_differentiable:
-
-                def eval_output(
-                    cc_ext: jnp.ndarray,
-                    extended_atype: jnp.ndarray,
-                    nlist: jnp.ndarray,
-                    mapping: jnp.ndarray | None,
-                    fparam: jnp.ndarray | None,
-                    aparam: jnp.ndarray | None,
-                    charge_spin_: jnp.ndarray | None,
-                    *,
-                    _kk: str = kk,
-                    _atom_axis: int = atom_axis,
-                ) -> jnp.ndarray:
-                    atomic_ret = self.atomic_model.forward_common_atomic(
-                        cc_ext[None, ...],
-                        extended_atype[None, ...],
-                        nlist[None, ...],
-                        mapping=mapping[None, ...] if mapping is not None else None,
-                        fparam=fparam[None, ...] if fparam is not None else None,
-                        aparam=aparam[None, ...] if aparam is not None else None,
-                        charge_spin=charge_spin_[None, ...]
-                        if charge_spin_ is not None
-                        else None,
-                    )
-                    return jnp.sum(atomic_ret[_kk][0], axis=_atom_axis)
-
-                # extended_coord: [nf, nall, 3]
-                # ff: [nf, *def, nall, 3]
-                ff = -jax.vmap(jax.jacrev(eval_output, argnums=0))(
-                    extended_coord,
-                    extended_atype,
-                    nlist,
-                    mapping,
-                    fparam,
-                    aparam,
-                    charge_spin,
-                )
-                # extended_force: [nf, nall, *def, 3]
-                def_ndim = len(vdef.shape)
-                extended_force = jnp.transpose(
-                    ff, [0, def_ndim + 1, *range(1, def_ndim + 1), def_ndim + 2]
-                )
-
-                model_predict[kk_derv_r] = extended_force
                 if vdef.r_hessian:
                     # [nf, *def, nall, 3, nall, 3]
-                    hessian = jax.vmap(jax.hessian(eval_output, argnums=0))(
+                    hessian, _ = jax.vmap(
+                        jax.hessian(eval_output, argnums=0, has_aux=True)
+                    )(
                         extended_coord,
                         extended_atype,
                         nlist,
@@ -117,6 +141,13 @@ def forward_common_atomic(
                     )
                     kk_hessian = get_hessian_name(kk)
                     model_predict[kk_hessian] = hessian
+                # extended_force: [nf, nall, *def, 3]
+                def_ndim = len(vdef.shape)
+                extended_force = jnp.transpose(
+                    ff, [0, def_ndim + 1, *range(1, def_ndim + 1), def_ndim + 2]
+                )
+
+                model_predict[kk_derv_r] = extended_force
             if vdef.c_differentiable:
                 assert vdef.r_differentiable
                 # avr: [nf, *def, nall, 3, 3]
@@ -140,6 +171,10 @@ def forward_common_atomic(
                         _kk: str = kk,
                         _atom_axis: int = atom_axis - 1,
                     ) -> jnp.ndarray:
+                        # This derivative is for the coordinate-weighted atomic
+                        # virial correction, so it must run its own transformed
+                        # forward; reusing the cached primal atomic_ret would
+                        # stop the required derivative through atomic_ret[_kk].
                         # atomic_ret[_kk]: [nf, nloc, *def]
                         atomic_ret = self.atomic_model.forward_common_atomic(
                             cc_ext[None, ...],


### PR DESCRIPTION
## Summary

- Lazily materialize JAX atomic outputs in `forward_common_atomic`.
- Use `jax.jacrev(..., has_aux=True)` for reducible coordinate-differentiable outputs so the force path can reuse the transformed forward's primal atomic outputs instead of running a separate atomic forward.
- Keep the coordinate-weighted atomic virial correction as a separate transformed forward because that derivative must still flow through `atomic_ret[kk]`.
- Use `jax.hessian(..., has_aux=True)` for the hessian branch and discard the auxiliary atomic outputs there.

Requesting review from @wanghan-iapcm.

## Benchmark

Command:

```bash
srun --gres=gpu:1 env PYTHONPATH=<baseline-or-this-worktree>:$PYTHONPATH \
  dp --jax train input.json --skip-neighbor-stat -o out.json
```

Setup:

- Input derived from `examples/water/se_e2_a/input.json`
- Absolute water data paths, `numb_steps=1000`, `disp_freq=250`, `save_freq=1000000`
- JAX 0.8.0
- GPU: NVIDIA GeForce RTX 5090
- Baseline: `58bef11c9`
- This PR: `e60455b57`

`Batch` wall times below are the training-reported interval wall times.

| Version | Batch 1 | Batch 250 | Batch 500 | Batch 750 | Batch 1000 | Training wall time | `/usr/bin/time real` |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline | 12.52 s | 21.71 s | 14.05 s | 14.13 s | 14.29 s | 92.208 s | 96.01 s |
| This PR | 10.25 s | 15.48 s | 10.18 s | 10.11 s | 10.11 s | 70.924 s | 74.47 s |

Speedup:

- Steady-state average over the last three 250-step intervals: `14.1567 s -> 10.1333 s`, about `1.40x` faster, `28.4%` less time.
- End-to-end training wall time: `92.208 s -> 70.924 s`, about `1.30x` faster, `23.1%` less time.
- `/usr/bin/time real`: `96.01 s -> 74.47 s`, about `1.29x` faster, `22.4%` less time.

The printed `lcurve.out` rows matched exactly between baseline and this PR at steps 1, 250, 500, 750, and 1000.

## Tests

```bash
ruff format deepmd/jax/model/base_model.py
ruff check deepmd/jax/model/base_model.py
pytest source/tests/jax/test_dp_hessian_model.py -q
pytest source/tests/consistent/descriptor/test_se_e2_a.py -q -k test_jax_self_consistent
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinate-derivative handling for model outputs, which should make force and higher-order derivative calculations more reliable.
  * Reduced unnecessary recomputation during prediction, helping derived results compute more efficiently and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->