### PR TITLE
fix(dev): fix devcontainer LAMMPS pytest wrapper paths

### DIFF
--- a/.devcontainer/gdb_pytest_lmp
+++ b/.devcontainer/gdb_pytest_lmp
@@ -1,5 +1,5 @@
 #!/bin/bash
-SCRIPT_PATH=$(dirname $(realpath -s $0))/../..
+SCRIPT_PATH=$(dirname $(realpath -s $0))
 
 export CMAKE_PREFIX_PATH=${SCRIPT_PATH}/../libtorch
 TENSORFLOW_ROOT=$(python -c 'import importlib.util,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')

--- a/.devcontainer/pytest_lmp
+++ b/.devcontainer/pytest_lmp
@@ -1,5 +1,5 @@
 #!/bin/bash
-SCRIPT_PATH=$(dirname $(realpath -s $0))/../..
+SCRIPT_PATH=$(dirname $(realpath -s $0))
 
 export CMAKE_PREFIX_PATH=${SCRIPT_PATH}/../libtorch
 TENSORFLOW_ROOT=$(python -c 'import importlib.util,pathlib;print(pathlib.Path(importlib.util.find_spec("tensorflow").origin).parent)')


### PR DESCRIPTION
## Problem

The devcontainer LAMMPS pytest wrappers compute `SCRIPT_PATH` two directories above the wrapper script (`SCRIPT_PATH=$(dirname $(realpath -s $0))/../..`), while `.devcontainer/lmp`/`gdb_lmp` and all the devcontainer build scripts use the `.devcontainer` directory itself (`SCRIPT_PATH=$(dirname $(realpath -s $0))`). All wrappers then derive `${SCRIPT_PATH}/../libtorch`, `${SCRIPT_PATH}/../dp/lib` and `${SCRIPT_PATH}/../.venv`. The build scripts install `libtorch`, `dp`, and `.venv` at the repository root (`download_libtorch.sh` unzips into `${SCRIPT_PATH}/..`, `build_cxx.sh` installs to `${SCRIPT_PATH}/../dp/`, `build_py.sh` runs `uv sync` from `${SCRIPT_PATH}/..`). So the pytest wrappers' extra `/../..` resolves those paths two directory levels too high — pointing `LAMMPS_PLUGIN_PATH`/`LD_LIBRARY_PATH` outside the checkout.

## Fix

Drop the `/../..` from `.devcontainer/pytest_lmp` and `.devcontainer/gdb_pytest_lmp` so all four wrappers share the same base and resolve to the repository root, consistent with the build scripts.

## Scope / impact

These wrappers are interactive developer convenience scripts inside the devcontainer; CI does not invoke them (LAMMPS tests in CI set their own plugin and library paths). The bug therefore only affected a developer manually running `.devcontainer/pytest_lmp` to debug LAMMPS tests, where the deepmd LAMMPS plugin would fail to load. There is nothing to unit-test here; the fix is verified by inspection — all four wrappers now use an identical `SCRIPT_PATH` base and identical `${SCRIPT_PATH}/../…` derivations.

Fix #5691