### PR TITLE
fix(examples): use runnable local data paths in zinc_protein example

### DIFF
--- a/examples/zinc_protein/zinc_se_a_mask.json
+++ b/examples/zinc_protein/zinc_se_a_mask.json
@@ -69,14 +69,14 @@
   "training": {
     "training_data": {
       "systems": [
-        "examples/zinc_protein/train_data_dp_mask/"
+        "train_data_dp_mask/"
       ],
       "batch_size": 2,
       "_comment7": "that's all"
     },
     "validation_data": {
       "systems": [
-        "examples/zinc_protein/val_data_dp_mask/"
+        "val_data_dp_mask/"
       ],
       "batch_size": 2,
       "_comment8": "that's all"

--- a/source/tests/common/test_examples.py
+++ b/source/tests/common/test_examples.py
@@ -94,3 +94,26 @@ class TestExamples(unittest.TestCase):
                 if multi_task:
                     jdata["model"], _ = preprocess_shared_params(jdata["model"])
                 normalize(jdata, multi_task=multi_task)
+
+    def test_data_paths_exist(self) -> None:
+        """Each example's data ``systems`` must resolve relative to the example's
+        own directory, so the example is runnable from that directory.
+        """
+        for fn in input_files:
+            training = j_loader(str(fn)).get("training", {})
+            for key in ("training_data", "validation_data"):
+                data = training.get(key)
+                if not isinstance(data, dict):
+                    continue
+                systems = data.get("systems")
+                if systems is None:
+                    continue
+                if isinstance(systems, str):
+                    systems = [systems]
+                for system in systems:
+                    with self.subTest(fn=str(fn), key=key, system=system):
+                        self.assertTrue(
+                            (fn.parent / system).exists(),
+                            f"{system!r} in {fn} does not resolve relative to "
+                            f"the example directory {fn.parent}",
+                        )


### PR DESCRIPTION
## Problem

`examples/zinc_protein/zinc_se_a_mask.json` referenced its training and validation data with repo-root-relative paths (`examples/zinc_protein/train_data_dp_mask/` and `examples/zinc_protein/val_data_dp_mask/`), while the data actually lives next to the config. Every other example uses paths relative to its own directory. As a result this example only trained when launched from the repository root; run from `examples/zinc_protein`, the paths resolved to `examples/zinc_protein/examples/zinc_protein/...`, which does not exist.

## Fix

Use local `train_data_dp_mask/` and `val_data_dp_mask/` paths, matching the config-relative convention of the other examples.

## Test

`source/tests/common/test_examples.py` already loaded this config, but only ran argument-checking (`normalize`), so an unresolvable data path passed. This PR adds `test_data_paths_exist`, which asserts that every example's `training_data`/`validation_data` `systems` resolve relative to the config's own directory. Across all listed examples this fails only for the two zinc_protein paths on the current tree and passes for every other example; after the fix it passes. It permanently guards the config-relative-path convention.

## Known limitation

The new check covers the single-task `input_files` list (where this example lives); multi-task configs use a different nested data schema and are out of scope for this fix.

Fix #5694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated example data paths to use shorter, relative locations so they resolve correctly from the example directory.
  * Added a check that example input files reference existing system data paths, helping catch broken paths earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->