### PR TITLE
docs(examples): build and document graph.pb generation in infer_water

### DIFF
--- a/examples/infer_water/CMakeLists.txt
+++ b/examples/infer_water/CMakeLists.txt
@@ -4,6 +4,11 @@ project(infer_water)
 # find DeePMD-kit
 find_package(DeePMD REQUIRED)
 
+# helper that generates graph.pb from the bundled test model
+add_executable(convert_model convert_model.c)
+# link DeePMD-kit C API
+target_link_libraries(convert_model PRIVATE DeePMD::deepmd_c)
+
 # C++ example
 add_executable(infer_water_cc infer_water.cpp)
 # link DeePMD-kit C++ API

--- a/examples/infer_water/README.md
+++ b/examples/infer_water/README.md
@@ -8,3 +8,26 @@ Build the project using
 cmake -DCMAKE_PREFIX_PATH=$deepmd_root .
 make
 ```
+
+Building only compiles the executables; it does not create the model file.
+The inference programs load a frozen model `graph.pb` from the current
+directory, so generate it first by running the `convert_model` helper, which
+converts the bundled test model `../../source/tests/infer/deeppot.pbtxt` into
+`graph.pb`:
+
+```sh
+./convert_model
+```
+
+Run `convert_model` from this directory so the relative path to the bundled
+model resolves. It requires `$deepmd_root` to be built with the TensorFlow
+backend, because `graph.pb` is a TensorFlow frozen model.
+
+Then run any of the inference examples:
+
+```sh
+./infer_water_cc
+./infer_water_c
+./infer_water_hpp
+./infer_water_nlist
+```


### PR DESCRIPTION
## Problem

The `examples/infer_water` README tells users to run `cmake` and `make`, but the resulting inference binaries (`infer_water_cc`, `infer_water_c`, `infer_water_hpp`, `infer_water_nlist`) load a frozen model `graph.pb` from the current directory. `graph.pb` is gitignored and never generated, and the `convert_model.c` helper that creates it is neither built by `CMakeLists.txt` nor mentioned in the README. Following the documented steps therefore produces binaries that fail at runtime.

## Fix

Add `convert_model` as a CMake target (it uses only `DP_ConvertPbtxtToPb` from `deepmd/c_api.h`, so it links `DeePMD::deepmd_c` like the other C examples) and document the full sequence in the README: build, run `./convert_model` to generate `graph.pb` from the bundled test model `source/tests/infer/deeppot.pbtxt`, then run the inference examples. The README makes explicit that `make` only compiles the executables and does not create the model file, and that `convert_model` must be run from the example directory (so the relative path to the bundled model resolves) with a TensorFlow-enabled build (since `graph.pb` is a TensorFlow frozen model).

## Test

This is a build/documentation example that is not part of the unit-test suite; a meaningful test would require building the example project against an installed TensorFlow-enabled DeePMD-kit and running the binaries, which is outside the unit scope. The fix is verified by inspection: `convert_model.c` includes only `deepmd/c_api.h`, `DP_ConvertPbtxtToPb` is a real C-API function, and the bundled `deeppot.pbtxt` fixture exists and resolves relative to the example directory.

Fix #5693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new helper build target for converting a model file in the water inference example.
  * Expanded the example documentation with step-by-step build and inference guidance.

* **Documentation**
  * Clarified that building the example only compiles executables and does not generate the model file.
  * Added instructions for creating the required `graph.pb` file and running the available inference binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->