### PR TITLE
docs: fix stale documentation links and placeholders

### DIFF
--- a/doc/freeze/freeze.md
+++ b/doc/freeze/freeze.md
@@ -41,7 +41,7 @@ $ dp --pd freeze -o model
 
 in the folder where the model is trained. The output model is called `model.json` and `model.pdiparams`.
 
-In [multi-task mode](../train/multi-task-training-pd.md), you need to choose one available heads (e.g. `CHOSEN_BRANCH`) by `--head`
+In [multi-task mode](../train/multi-task-training.md), you need to choose one available heads (e.g. `CHOSEN_BRANCH`) by `--head`
 to specify which model branch you want to freeze:
 
 ```bash

--- a/doc/model/train-se-a-mask.md
+++ b/doc/model/train-se-a-mask.md
@@ -68,7 +68,7 @@ To make the `aparam.npy` used for descriptor `se_a_mask`, two variables in `fitt
 - {ref}`use_aparam_as_mask <model[standard]/fitting_net[ener]/use_aparam_as_mask>` is set to `true` to use the `aparam.npy` as the mask of the atoms in the descriptor `se_a_mask`.
 
 Finally, to make a reasonable fitting task with `se_a_mask` descriptor for DP/MM simulations, the loss function with `se_a_mask` is designed to include the atomic forces difference in specific atoms of the input particles only.
-More details about the selection of the specific atoms can be found in paper \[DP/MM\](left to be filled).
+More details about the selection of the specific atoms can be found in the DP/MM paper.
 Thus, `atom_pref.npy` ( [ nframes * natoms ] ) is required as the indicator of the specific atoms in the input particles.
 And the `loss` section in the training input script should be set as follows.
 


### PR DESCRIPTION
## Problem

Two documentation references were stale:

- `doc/freeze/freeze.md` linked the Paddle multi-task freezing text to `../train/multi-task-training-pd.md`, which does not exist in the checkout (only `../train/multi-task-training.md` is present). The PyTorch section of the same file already links to `../train/multi-task-training`.
- `doc/model/train-se-a-mask.md` contained an unfinished placeholder link, `[DP/MM](left to be filled)`.

## Fix

- Point the Paddle multi-task link at the existing `../train/multi-task-training.md`.
- Drop the `[DP/MM](left to be filled)` placeholder markup, since no citation target is available, leaving plain text.

## Note on the third item

The original issue also flagged `doc/getting-started/install.md` linking to `install-from-source.md`. That one is not a bug: `doc/getting-started/install.md` is a symlink to `../install/easy-install.md`, and the `[build from source](install-from-source.md)` link is correct relative to that file's real location under `doc/install/`, where `install-from-source.md` exists. It is left unchanged.

## Test

These are documentation link fixes. There is no docs linkcheck in CI, and Sphinx/MyST do not fail the build on broken relative Markdown links, which is why these went unnoticed. A linkcheck is intentionally not added here: the docs use MyST extensionless cross-references (e.g. the sibling `../train/multi-task-training` link in the same file), so a naive relative-file-existence validator would produce false positives; a robust linkcheck is a separate infrastructure change out of scope for this fix. The fix is verified by confirming the corrected link target exists and the placeholder is removed.

Fix #5695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a training guide link for multi-task mode so it points to the current documentation page.
  * Improved explanatory text in the `se_a_mask` guide with a clearer reference to the relevant DP/MM paper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->