### PR TITLE
fix(tf): keep linear-model loss configs after frozen components

### DIFF
--- a/deepmd/tf/model/linear.py
+++ b/deepmd/tf/model/linear.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import copy
 import operator
 from enum import (
     Enum,
@@ -77,11 +78,14 @@ class LinearModel(Model):
 
     def get_loss(self, loss: dict, lr: LearningRateExp) -> Loss | dict | None:
         """Get the loss function(s)."""
-        # the first model that is not None, or None if all models are None
+        # Return the first submodel loss that is not None, or None if all
+        # submodels are non-trainable. Each submodel must receive the original
+        # loss config: frozen/table submodels return None, so consuming the
+        # return value would pass None to a later trainable submodel.
         for model in self.models:
-            loss = model.get_loss(loss, lr)
-            if loss is not None:
-                return loss
+            submodel_loss = model.get_loss(copy.deepcopy(loss), lr)
+            if submodel_loss is not None:
+                return submodel_loss
         return None
 
     def get_rcut(self) -> float:

--- a/source/tests/tf/test_linear_model.py
+++ b/source/tests/tf/test_linear_model.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
+import unittest
 
 import numpy as np
 
@@ -121,3 +122,37 @@ class TestLinearModel(tf.test.TestCase):
         for pb in self.graph_dirs:
             os.remove(pb)
         del_data()
+
+
+class TestLinearModelGetLoss(unittest.TestCase):
+    """A non-trainable submodel (frozen/pairtab) returns ``None`` from
+    ``get_loss``; a later trainable submodel must still receive the original
+    loss configuration rather than that ``None``.
+    """
+
+    def test_get_loss_skips_none_returning_submodels(self) -> None:
+        class _NoneLossModel:
+            """Mimics frozen/pairtab submodels, which own no trainable loss."""
+
+            def get_loss(self, loss, lr):
+                return None
+
+        class _EnerLossModel:
+            """Mimics a trainable ener submodel: dereferences loss as a dict
+            (as EnerFitting.get_loss does via ``loss.pop``).
+            """
+
+            def get_loss(self, loss, lr):
+                loss.pop("type", "ener")
+                return "ener-loss"
+
+        # bypass the heavy __init__; get_loss only touches self.models
+        model = object.__new__(LinearEnergyModel)
+        model.models = [_NoneLossModel(), _EnerLossModel()]
+
+        loss_config = {"type": "ener", "start_pref_e": 1.0}
+        result = model.get_loss(loss_config, lr=None)
+
+        self.assertEqual(result, "ener-loss")
+        # the original config must be preserved for other consumers
+        self.assertEqual(loss_config, {"type": "ener", "start_pref_e": 1.0})


### PR DESCRIPTION
## Problem

`LinearModel.get_loss()` reassigned its `loss` argument to each submodel's returned value:

```python
for model in self.models:
    loss = model.get_loss(loss, lr)
    if loss is not None:
        return loss
```

Frozen and pairtab submodels return `None` from `get_loss()` because they own no trainable loss. When such a non-trainable submodel is ordered before a trainable energy submodel, the trainable submodel is then called with `loss=None`, and `EnerFitting.get_loss()` dereferences it as a dict via `loss.pop("type", ...)`, raising `AttributeError: 'NoneType' object has no attribute 'pop'` during trainer construction — even though the original loss config could have been used.

## Fix

Iterate with a separate variable and pass a `copy.deepcopy(loss)` of the original loss configuration to each submodel, returning the first non-`None` result. This keeps the caller's loss config intact for the trainable submodel regardless of submodel ordering, and avoids mutating the shared config (`EnerFitting.get_loss` pops keys from it).

## Test

`source/tests/tf/test_linear_model.py` covered a linear model whose submodels never hit this ordering, so the crash path was unexercised. A new lightweight `TestLinearModelGetLoss` constructs a `LinearEnergyModel` with a `None`-returning submodel (mimicking frozen/pairtab) ordered before a trainable submodel (mimicking `EnerFitting.get_loss`'s `loss.pop`), and asserts `get_loss` returns the trainable loss and leaves the original config unmutated. On the current code it fails with the `NoneType ... pop` error; after the fix it passes.

Fix #5682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves the original loss configuration when evaluating multiple submodels.
  * Ensures a non-trainable submodel returning no loss does not affect later trainable submodels.

* **Tests**
  * Added coverage for loss handling across submodels, including unchanged input configuration and correct fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->