### PR TITLE
fix(tf): accept standard checkpoint inputs in change-bias

### DIFF
--- a/deepmd/tf/entrypoints/change_bias.py
+++ b/deepmd/tf/entrypoints/change_bias.py
@@ -126,6 +126,23 @@ def change_bias(
             log_level,
         )
     else:
+        # Checkpoint directory, or a checkpoint prefix such as "model.ckpt-1000"
+        # that carries no recognized suffix. Route these to the checkpoint
+        # handler when a TensorFlow "checkpoint" state file is present.
+        input_path = Path(INPUT)
+        checkpoint_dir = input_path if input_path.is_dir() else input_path.parent
+        if (checkpoint_dir / "checkpoint").is_file():
+            return _change_bias_checkpoint_file(
+                INPUT,
+                mode,
+                bias_value,
+                datafile,
+                system,
+                numb_batch,
+                model_branch,
+                output,
+                log_level,
+            )
         raise RuntimeError(
             "The model provided must be a checkpoint file or frozen model file (.pb)"
         )
@@ -147,7 +164,9 @@ def _change_bias_checkpoint_file(
     tf.reset_default_graph()
 
     checkpoint_path = Path(checkpoint_prefix)
-    checkpoint_dir = checkpoint_path.parent
+    checkpoint_dir = (
+        checkpoint_path if checkpoint_path.is_dir() else checkpoint_path.parent
+    )
 
     # Check for valid checkpoint and find the actual checkpoint path
     checkpoint_state_file = checkpoint_dir / "checkpoint"

--- a/source/tests/tf/test_change_bias.py
+++ b/source/tests/tf/test_change_bias.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+import importlib
 import json
 import os
 import shutil
@@ -7,10 +8,18 @@ import unittest
 from pathlib import (
     Path,
 )
+from unittest import (
+    mock,
+)
 
 from deepmd.tf.entrypoints.change_bias import (
     change_bias,
 )
+
+# the ``entrypoints`` package re-exports the ``change_bias`` function, which
+# shadows the submodule under attribute access; fetch the real module so its
+# private helpers can be patched.
+change_bias_module = importlib.import_module("deepmd.tf.entrypoints.change_bias")
 from deepmd.tf.train.run_options import (
     RunOptions,
 )
@@ -111,6 +120,38 @@ class TestChangeBias(unittest.TestCase):
             )
 
         self.assertIn("No valid checkpoint found", str(cm.exception))
+
+    def test_change_bias_accepts_checkpoint_prefix_with_step(self):
+        """A checkpoint prefix such as ``model.ckpt-1000`` carries no recognized
+        suffix, but must be routed to the checkpoint handler when a TensorFlow
+        ``checkpoint`` state file sits beside it.
+        """
+        ckpt_dir = self.temp_path / "ckpt_prefix"
+        ckpt_dir.mkdir()
+        (ckpt_dir / "checkpoint").write_text('model_checkpoint_path: "model.ckpt-1000"')
+        prefix = ckpt_dir / "model.ckpt-1000"
+
+        with mock.patch.object(
+            change_bias_module, "_change_bias_checkpoint_file"
+        ) as mocked:
+            change_bias(INPUT=str(prefix), mode="change", system=".")
+        mocked.assert_called_once()
+        self.assertEqual(mocked.call_args.args[0], str(prefix))
+
+    def test_change_bias_accepts_checkpoint_directory(self):
+        """A checkpoint directory (no suffix) containing a ``checkpoint`` state
+        file must be routed to the checkpoint handler, not rejected.
+        """
+        ckpt_dir = self.temp_path / "ckpt_dir"
+        ckpt_dir.mkdir()
+        (ckpt_dir / "checkpoint").write_text('model_checkpoint_path: "model.ckpt-1000"')
+
+        with mock.patch.object(
+            change_bias_module, "_change_bias_checkpoint_file"
+        ) as mocked:
+            change_bias(INPUT=str(ckpt_dir), mode="change", system=".")
+        mocked.assert_called_once()
+        self.assertEqual(mocked.call_args.args[0], str(ckpt_dir))
 
     def test_change_bias_user_defined_requires_real_model(self):
         """Test that user-defined bias requires a real model with proper structure."""


### PR DESCRIPTION
## Problem

The TensorFlow `change-bias` dispatcher only accepts inputs ending in `.pb`, `.pbtxt`, `.ckpt`, `.meta`, `.data`, or `.index`, and rejects everything else with `RuntimeError("The model provided must be a checkpoint file or frozen model file (.pb)")`.

However, the CLI examples and the frozen-model fallback message recommend passing a checkpoint directory, and real TensorFlow checkpoint prefixes commonly look like `model.ckpt-1000`. A checkpoint directory has no recognized suffix, and a `model.ckpt-1000` prefix ends in `-1000`, so both are rejected before `_change_bias_checkpoint_file()` — which already resolves the checkpoint via the `checkpoint` state file — can run.

## Fix

Route suffix-less inputs to the checkpoint handler when a TensorFlow `checkpoint` state file is present in the effective directory (the input itself if it is a directory, otherwise its parent). Inputs without such a state file still raise the original error. `_change_bias_checkpoint_file()` now also resolves `checkpoint_dir` correctly when the input is a directory.

## Test

`source/tests/tf/test_change_bias.py` previously exercised only `.pb`, `.ckpt`, and bad-suffix inputs, never a bare directory or a `ckpt-<step>` prefix. Two new tests mock `_change_bias_checkpoint_file` and assert it is invoked for a `model.ckpt-1000` prefix and for a checkpoint directory that contain a `checkpoint` state file. On the current dispatcher both raise the "checkpoint file or frozen model file" RuntimeError before reaching the handler; after the fix both route correctly. The existing rejection tests (e.g. a `model.xyz` file with no checkpoint state file) still raise.

Fix #5683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of checkpoint inputs so bias changes now work reliably for both checkpoint file prefixes and checkpoint directories.
  * Unrecognized input paths are now treated as checkpoint-based inputs only when a valid checkpoint state is present, reducing incorrect routing.

* **Tests**
  * Added coverage for checkpoint prefix and directory cases to verify the correct bias-change path is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->