### PR TITLE
fix(tf): honor change-bias --numb-batch

### DIFF
--- a/deepmd/tf/entrypoints/change_bias.py
+++ b/deepmd/tf/entrypoints/change_bias.py
@@ -242,7 +242,9 @@ def _change_bias_checkpoint_file(
             log.info(f"Using bias adjustment mode: {bias_adjust_mode}")
 
             # Read current bias values from the session (after variables are restored)
-            _apply_data_based_bias(trainer, data, type_map, bias_adjust_mode)
+            _apply_data_based_bias(
+                trainer, data, type_map, bias_adjust_mode, numb_batch
+            )
 
         # Save the updated variables back to checkpoint format first
         # Create a separate directory for updated checkpoint to avoid polluting original
@@ -352,9 +354,17 @@ def _find_input_json(checkpoint_dir: Path) -> Path:
 
 
 def _apply_data_based_bias(
-    trainer: DPTrainer, data: DeepmdDataSystem, type_map: list, bias_adjust_mode: str
+    trainer: DPTrainer,
+    data: DeepmdDataSystem,
+    type_map: list,
+    bias_adjust_mode: str,
+    numb_batch: int = 0,
 ) -> None:
-    """Apply data-based bias calculation by reading current bias from session."""
+    """Apply data-based bias calculation by reading current bias from session.
+
+    ``numb_batch`` is the number of frames to use per data system when
+    estimating the bias; ``0`` means use all data.
+    """
     from deepmd.tf.env import (
         tf,
     )
@@ -393,7 +403,7 @@ def _apply_data_based_bias(
                 type_map,  # full_type_map
                 current_bias,  # Use the restored bias values
                 bias_adjust_mode=bias_adjust_mode,
-                ntest=1,
+                ntest=numb_batch,
             )
 
             # Update the bias in the session

--- a/deepmd/tf/fit/ener.py
+++ b/deepmd/tf/fit/ener.py
@@ -1040,7 +1040,8 @@ def change_energy_bias_lower(
     for sys in data.data_systems:
         test_data = sys.get_test()
         nframes = test_data["box"].shape[0]
-        numb_test = min(nframes, ntest)
+        # ntest <= 0 means using all frames in the system
+        numb_test = nframes if ntest <= 0 else min(nframes, ntest)
         if mixed_type:
             atype = test_data["type"][:numb_test].reshape([numb_test, -1])
         else:

--- a/source/tests/tf/test_change_energy_bias.py
+++ b/source/tests/tf/test_change_energy_bias.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Tests for ``change_energy_bias_lower`` frame selection (``ntest``).
+
+``change-bias --numb-batch`` is threaded through as ``ntest``; ``0`` must mean
+"use all frames per system" rather than selecting zero frames.
+"""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import (
+    Path,
+)
+
+import numpy as np
+
+from deepmd.tf.fit.ener import (
+    change_energy_bias_lower,
+)
+from deepmd.utils.data_system import (
+    DeepmdDataSystem,
+)
+
+
+class _MockDP:
+    """Minimal DeepEval stub that records how many frames it is asked to predict."""
+
+    def __init__(self, natoms: int) -> None:
+        self._natoms = natoms
+        self.frames_evaluated: list[int] = []
+
+    def get_dim_fparam(self) -> int:
+        return 0
+
+    def get_dim_aparam(self) -> int:
+        return 0
+
+    def eval(self, coord, box, atype, mixed_type=False, fparam=None, aparam=None):
+        n = coord.shape[0]
+        self.frames_evaluated.append(n)
+        return (
+            np.zeros([n, 1]),
+            np.zeros([n, self._natoms, 3]),
+            np.zeros([n, 9]),
+        )
+
+
+class TestChangeEnergyBiasNumbTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.nframes = 10
+        self.test_size = 4  # < nframes so multiple test frames are available
+        self.natoms = 3
+        self.type_map = ["O", "H"]
+        atype = np.array([0, 1, 1])
+
+        set_dir = self.tmp / "set.000"
+        set_dir.mkdir(parents=True)
+        rng = np.random.default_rng(0)
+        np.save(set_dir / "coord.npy", rng.random((self.nframes, self.natoms * 3)))
+        np.save(
+            set_dir / "box.npy",
+            np.tile((np.eye(3) * 10.0).reshape(9), (self.nframes, 1)),
+        )
+        np.save(set_dir / "energy.npy", rng.random((self.nframes, 1)))
+        (self.tmp / "type.raw").write_text("\n".join(str(t) for t in atype))
+        (self.tmp / "type_map.raw").write_text("\n".join(self.type_map))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _build_data(self) -> DeepmdDataSystem:
+        data = DeepmdDataSystem(
+            [str(self.tmp)], 1, self.test_size, 6.0, type_map=self.type_map
+        )
+        data.add("energy", 1, atomic=False, must=True, high_prec=True)
+        return data
+
+    def _frames_evaluated(self, ntest: int) -> list[int]:
+        data = self._build_data()
+        dp = _MockDP(self.natoms)
+        change_energy_bias_lower(
+            data,
+            dp,
+            self.type_map,
+            self.type_map,
+            np.zeros(len(self.type_map)),
+            bias_adjust_mode="change-by-statistic",
+            ntest=ntest,
+        )
+        return dp.frames_evaluated
+
+    def test_numb_batch_controls_frames(self) -> None:
+        # number of test frames actually available for this system
+        nframes_test = self._build_data().data_systems[0].get_test()["box"].shape[0]
+        self.assertGreater(nframes_test, 1)
+
+        # a positive ntest caps to that many frames per system
+        self.assertEqual(self._frames_evaluated(1), [1])
+        # ntest == 0 means all frames in the system
+        self.assertEqual(self._frames_evaluated(0), [nframes_test])


### PR DESCRIPTION
## Problem

`change-bias --numb-batch` is documented as the number of frames to use per data system, with `0` meaning all data. On the TensorFlow data-based path this value was ignored: `_change_bias_checkpoint_file` called `_apply_data_based_bias(...)` without `numb_batch`, and `_apply_data_based_bias` then hardcoded `ntest=1` when calling `change_energy_bias_lower`. As a result the bias was always estimated from a single frame per system regardless of `-n/--numb-batch`, and the documented `0 means all data` behavior had no effect.

## Fix

Thread `numb_batch` into `_apply_data_based_bias` and forward it to `change_energy_bias_lower` as `ntest`. In `change_energy_bias_lower`, treat `ntest <= 0` as "use all frames in the system" (`numb_test = nframes if ntest <= 0 else min(nframes, ntest)`), implementing the documented `0 means all data`. This is backward compatible: the default `ntest` is 10 and no existing caller passed a non-positive value.

## Test

There was no test covering `numb_batch` or `change_energy_bias_lower`. A new test builds a small multi-frame `DeepmdDataSystem` and a mock evaluator that records how many frames it is asked to predict, then asserts that `ntest=1` evaluates one frame per system and `ntest=0` evaluates all frames. On the current code `ntest=0` selects zero frames (raising downstream); after the fix it uses all frames.

The `numb_batch -> ntest` parameter plumbing is simple and verified by inspection; the test targets the frame-selection semantics that the fix makes controllable.

Fix #5684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bias recalculation so batch settings now use the expected number of frames.
  * When no batch limit is set, all available frames are now included instead of a smaller default subset.
* **Tests**
  * Added coverage for batch selection behavior to ensure bias updates use the correct frame counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->