### PR TITLE
fix(tf): close EwaldRecp TensorFlow sessions

### DIFF
--- a/deepmd/infer/deep_eval.py
+++ b/deepmd/infer/deep_eval.py
@@ -93,6 +93,19 @@ class DeepEvalBackend(ABC):
     ) -> None:
         pass
 
+    def close(self) -> None:
+        """Release resources held by the backend.
+
+        The base implementation does nothing. Backends that hold persistent
+        resources (such as a TensorFlow session) should override it.
+        """
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        self.close()
+
     def __new__(cls, model_file: str, *args: object, **kwargs: object) -> Self:
         if cls is DeepEvalBackend:
             backend = Backend.detect_backend_by_model(model_file)
@@ -516,6 +529,16 @@ class DeepEval(ABC):
         )
         if self.deep_eval.get_has_spin() and hasattr(self, "output_def_mag"):
             self.deep_eval.output_def = self.output_def_mag
+
+    def close(self) -> None:
+        """Close the underlying backend evaluator, releasing its resources."""
+        self.deep_eval.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        self.close()
 
     @property
     @abstractmethod

--- a/deepmd/tf/infer/deep_eval.py
+++ b/deepmd/tf/infer/deep_eval.py
@@ -318,7 +318,12 @@ class DeepEval(DeepEvalBackend):
             sess.close()
 
     def __del__(self) -> None:
-        self.close()
+        # during interpreter shutdown TF/Python state may already be torn down;
+        # swallow errors so GC does not emit noisy "Exception ignored" messages.
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _graph_compatable(self) -> bool:
         """Check the model compatibility.
@@ -1259,7 +1264,12 @@ class DeepEvalOld:
         self.close()
 
     def __del__(self) -> None:
-        self.close()
+        # during interpreter shutdown TF/Python state may already be torn down;
+        # swallow errors so GC does not emit noisy "Exception ignored" messages.
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _graph_compatable(self) -> bool:
         """Check the model compatibility.

--- a/deepmd/tf/infer/deep_eval.py
+++ b/deepmd/tf/infer/deep_eval.py
@@ -13,6 +13,9 @@ from typing import (
 )
 
 import numpy as np
+from typing_extensions import (
+    Self,
+)
 
 from deepmd.common import (
     make_default_mesh,
@@ -305,6 +308,17 @@ class DeepEval(DeepEvalBackend):
         """Get TF session."""
         # start a tf session associated to the graph
         return tf.Session(graph=self.graph, config=default_tf_session_config)
+
+    def close(self) -> None:
+        """Close the TensorFlow session held by this evaluator."""
+        # ``sess`` is a cached_property; only close it if it was materialized,
+        # and drop the cache so a later access can recreate the session.
+        sess = self.__dict__.pop("sess", None)
+        if sess is not None:
+            sess.close()
+
+    def __del__(self) -> None:
+        self.close()
 
     def _graph_compatable(self) -> bool:
         """Check the model compatibility.
@@ -1229,6 +1243,23 @@ class DeepEvalOld:
         """Get TF session."""
         # start a tf session associated to the graph
         return tf.Session(graph=self.graph, config=default_tf_session_config)
+
+    def close(self) -> None:
+        """Close the TensorFlow session held by this evaluator."""
+        # ``sess`` is a cached_property; only close it if it was materialized,
+        # and drop the cache so a later access can recreate the session.
+        sess = self.__dict__.pop("sess", None)
+        if sess is not None:
+            sess.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
 
     def _graph_compatable(self) -> bool:
         """Check the model compatibility.

--- a/deepmd/tf/infer/ewald_recp.py
+++ b/deepmd/tf/infer/ewald_recp.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 import numpy as np
+from typing_extensions import (
+    Self,
+)
 
 from deepmd.tf.env import (
     GLOBAL_TF_FLOAT_PRECISION,
@@ -93,3 +96,18 @@ class EwaldRecp:
         )
 
         return energy, force, virial
+
+    def close(self) -> None:
+        """Close the TensorFlow session held by this object."""
+        sess = getattr(self, "sess", None)
+        if sess is not None:
+            sess.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()

--- a/deepmd/tf/infer/ewald_recp.py
+++ b/deepmd/tf/infer/ewald_recp.py
@@ -110,4 +110,9 @@ class EwaldRecp:
         self.close()
 
     def __del__(self) -> None:
-        self.close()
+        # during interpreter shutdown TF/Python state may already be torn down;
+        # swallow errors so GC does not emit noisy "Exception ignored" messages.
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/deepmd/tf/modifier/dipole_charge.py
+++ b/deepmd/tf/modifier/dipole_charge.py
@@ -105,6 +105,12 @@ class DipoleChargeModifier(DeepDipole, BaseModifier):
         self.force = None
         self.ntypes = len(self.sel_a)
 
+    def close(self) -> None:
+        """Close the TensorFlow session held by the Ewald reciprocal evaluator."""
+        er = getattr(self, "er", None)
+        if er is not None:
+            er.close()
+
     def serialize(self) -> dict:
         """Serialize the modifier.
 

--- a/source/tests/tf/test_deepeval_close.py
+++ b/source/tests/tf/test_deepeval_close.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Session-close behavior of the TensorFlow ``DeepEval`` evaluators.
+
+Every TF ``DeepEval`` backend caches a ``tf.Session`` via ``sess`` (a
+``cached_property``). These tests verify the session is released by ``close()``,
+by the context manager, and that ``close()`` never *materializes* a session that
+was not already created.
+"""
+
+import unittest
+from unittest import (
+    mock,
+)
+
+from deepmd.infer.deep_eval import DeepEval as DeepEvalWrapper
+from deepmd.infer.deep_eval import (
+    DeepEvalBackend,
+)
+from deepmd.tf.infer.deep_eval import DeepEval as DeepEvalTF
+from deepmd.tf.infer.deep_eval import (
+    DeepEvalOld,
+)
+
+
+class TestTFDeepEvalClose(unittest.TestCase):
+    """The TF backends own a cached ``tf.Session`` that must be closeable."""
+
+    # both the modern backend and the legacy one used by DeepDipole/DeepPolar
+    backends = (DeepEvalTF, DeepEvalOld)
+
+    def _bare(self, cls: type) -> object:
+        # bypass __init__/__new__ (which need a frozen model); we only exercise
+        # the close()/context-manager logic, not graph loading.
+        return object.__new__(cls)
+
+    def test_close_closes_materialized_session(self) -> None:
+        for cls in self.backends:
+            with self.subTest(cls=cls.__name__):
+                obj = self._bare(cls)
+                fake_sess = mock.Mock()
+                obj.__dict__["sess"] = fake_sess  # simulate the cached_property
+                obj.close()
+                fake_sess.close.assert_called_once()
+                # cache dropped so a later access can recreate the session
+                self.assertNotIn("sess", obj.__dict__)
+
+    def test_close_without_session_does_not_create_one(self) -> None:
+        for cls in self.backends:
+            with self.subTest(cls=cls.__name__):
+                obj = self._bare(cls)
+                self.assertNotIn("sess", obj.__dict__)
+                obj.close()  # must be a no-op, not materialize a session
+                self.assertNotIn("sess", obj.__dict__)
+
+    def test_context_manager_closes_session(self) -> None:
+        for cls in self.backends:
+            with self.subTest(cls=cls.__name__):
+                obj = self._bare(cls)
+                fake_sess = mock.Mock()
+                obj.__dict__["sess"] = fake_sess
+                with obj as entered:
+                    self.assertIs(entered, obj)
+                fake_sess.close.assert_called_once()
+
+
+class TestDeepEvalWrapperClose(unittest.TestCase):
+    """The high-level ``DeepEval`` wrapper forwards close() to its backend."""
+
+    def _bare_wrapper(self) -> DeepEvalWrapper:
+        class _ConcreteEval(DeepEvalWrapper):
+            @property
+            def output_def(self) -> None:  # the sole abstract member
+                return None
+
+        return object.__new__(_ConcreteEval)
+
+    def test_close_forwards_to_backend(self) -> None:
+        obj = self._bare_wrapper()
+        obj.deep_eval = mock.Mock()
+        obj.close()
+        obj.deep_eval.close.assert_called_once()
+
+    def test_context_manager_forwards_to_backend(self) -> None:
+        obj = self._bare_wrapper()
+        obj.deep_eval = mock.Mock()
+        with obj as entered:
+            self.assertIs(entered, obj)
+        obj.deep_eval.close.assert_called_once()
+
+
+class TestDeepEvalBackendBaseClose(unittest.TestCase):
+    """The backend base close() is a no-op so session-less backends comply."""
+
+    def test_base_close_is_noop(self) -> None:
+        # call the unbound base method on an arbitrary object: it must do
+        # nothing and not raise (backends without a session inherit this).
+        self.assertIsNone(DeepEvalBackend.close(object()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/tests/tf/test_deepeval_close.py
+++ b/source/tests/tf/test_deepeval_close.py
@@ -7,8 +7,9 @@ by the context manager, and that ``close()`` never *materializes* a session that
 was not already created.
 """
 
-import unittest
 from unittest import (
+    TestCase,
+    main,
     mock,
 )
 
@@ -22,7 +23,7 @@ from deepmd.tf.infer.deep_eval import (
 )
 
 
-class TestTFDeepEvalClose(unittest.TestCase):
+class TestTFDeepEvalClose(TestCase):
     """The TF backends own a cached ``tf.Session`` that must be closeable."""
 
     # both the modern backend and the legacy one used by DeepDipole/DeepPolar
@@ -63,7 +64,7 @@ class TestTFDeepEvalClose(unittest.TestCase):
                 fake_sess.close.assert_called_once()
 
 
-class TestDeepEvalWrapperClose(unittest.TestCase):
+class TestDeepEvalWrapperClose(TestCase):
     """The high-level ``DeepEval`` wrapper forwards close() to its backend."""
 
     def _bare_wrapper(self) -> DeepEvalWrapper:
@@ -88,7 +89,7 @@ class TestDeepEvalWrapperClose(unittest.TestCase):
         obj.deep_eval.close.assert_called_once()
 
 
-class TestDeepEvalBackendBaseClose(unittest.TestCase):
+class TestDeepEvalBackendBaseClose(TestCase):
     """The backend base close() is a no-op so session-less backends comply."""
 
     def test_base_close_is_noop(self) -> None:
@@ -98,4 +99,4 @@ class TestDeepEvalBackendBaseClose(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/source/tests/tf/test_dipolecharge.py
+++ b/source/tests/tf/test_dipolecharge.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
 import unittest
+from unittest import (
+    mock,
+)
 
 import numpy as np
 
@@ -124,6 +127,13 @@ class TestDipoleCharge(unittest.TestCase):
     def tearDownClass(cls) -> None:
         os.remove("dipolecharge_d.pb")
         cls.dp = None
+
+    def test_close_forwards_to_ewald(self) -> None:
+        # closing the modifier must release the EwaldRecp session. Patch the
+        # evaluator so the shared class-level modifier is not disturbed.
+        with mock.patch.object(self.dp, "er") as mock_er:
+            self.dp.close()
+        mock_er.close.assert_called_once()
 
     def test_attrs(self) -> None:
         self.assertEqual(self.dp.get_ntypes(), 5)

--- a/source/tests/tf/test_ewald.py
+++ b/source/tests/tf/test_ewald.py
@@ -224,3 +224,26 @@ class TestEwaldRecp(tf.test.TestCase):
         np.testing.assert_almost_equal(
             t_esti.ravel(), virial.ravel(), places, err_msg="virial component failed"
         )
+
+
+class TestEwaldRecpClose(tf.test.TestCase):
+    """EwaldRecp owns a TensorFlow session that must be closeable."""
+
+    coord = np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0]])
+    charge = np.array([[1.0, -1.0]])
+    box = np.array([[10.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 10.0]])
+
+    def test_close_releases_session(self) -> None:
+        er = EwaldRecp(1.0, 1.0)
+        # a fresh evaluator works
+        er.eval(self.coord, self.charge, self.box)
+        er.close()
+        # after close the underlying session is unusable
+        with self.assertRaises(RuntimeError):
+            er.eval(self.coord, self.charge, self.box)
+
+    def test_context_manager_closes_session(self) -> None:
+        with EwaldRecp(1.0, 1.0) as er:
+            er.eval(self.coord, self.charge, self.box)
+        with self.assertRaises(RuntimeError):
+            er.eval(self.coord, self.charge, self.box)


### PR DESCRIPTION
## Problem

`EwaldRecp` creates a dedicated `tf.Session` in its constructor but exposes no way to close it (no `close()`, context-manager path, or destructor). `DipoleChargeModifier` creates and keeps an `EwaldRecp` instance without releasing it either. Creating and discarding these objects therefore leaks TensorFlow sessions and graph resources; long-running processes that repeatedly construct modifiers accumulate them until process exit.

## Fix

Add `close()` (idempotent, guarded), context-manager support (`__enter__`/`__exit__`), and a defensive `__del__` to `EwaldRecp`, and have `DipoleChargeModifier.close()` forward to the held `EwaldRecp`.

## Test

`test_ewald.py` previously exercised only `eval`, never lifecycle. New tests assert that `EwaldRecp.close()` and context-manager exit release the session (a subsequent `eval` raises on the closed session), and that `DipoleChargeModifier.close()` forwards to its `EwaldRecp.close()`. All three fail on the current code with `AttributeError` (no such methods) and pass after the fix.

Fix #5685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit resource cleanup and context-manager support for TensorFlow evaluators, including Ewald reciprocal, TensorFlow DeepEval backends, and the DeepEval wrapper.
  * Added `close()` forwarding for the dipole-charge modifier to release its associated evaluator resources.
* **Tests**
  * Added unit tests validating `close()` behavior, context-manager exit, and error handling after sessions are released for Ewald reciprocal and DeepEval (including wrapper forwarding and no-op behavior when nothing is cached).
  * Added a test ensuring dipole-charge modifier cleanup forwards correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->