### PR TITLE
fix: propagate frame-level data modifier failures

### DIFF
--- a/deepmd/utils/data.py
+++ b/deepmd/utils/data.py
@@ -530,6 +530,9 @@ class DeepmdData:
                     frame_data,
                     self,
                 )
+                # propagate any exception raised inside the modifier instead of
+                # silently returning (and caching) an unmodified frame
+                future.result()
             if self.use_modifier_cache:
                 # Cache the modified frame to avoid recomputation
                 self._modified_frame_cache[index] = copy.deepcopy(frame_data)

--- a/source/tests/common/test_deepmd_data.py
+++ b/source/tests/common/test_deepmd_data.py
@@ -46,3 +46,41 @@ class TestDeepmdDataTypeMap(unittest.TestCase):
         loaded = data._load_set(self.set_dir)
         expected_sorted = expected_atom_types[data.idx_map]
         np.testing.assert_array_equal(loaded["type"], np.tile(expected_sorted, (1, 1)))
+
+
+class _RaisingModifier:
+    """A modifier whose ``modify_data`` always fails."""
+
+    use_cache = True
+
+    def modify_data(self, data: dict, data_sys: DeepmdData) -> None:
+        raise ValueError("modifier failure")
+
+
+class TestDeepmdDataModifierError(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmpdir.name)
+        set_dir = self.root / "set.000"
+        set_dir.mkdir()
+        atom_types = np.array([0, 1], dtype=np.int32)
+        np.savetxt(self.root / "type.raw", atom_types, fmt="%d")
+        np.save(
+            set_dir / "coord.npy",
+            np.zeros((3, atom_types.size * 3), dtype=np.float32),
+        )
+        np.save(
+            set_dir / "box.npy",
+            np.tile(np.eye(3, dtype=np.float32).reshape(9), (3, 1)),
+        )
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_get_single_frame_propagates_modifier_error(self) -> None:
+        data = DeepmdData(str(self.root), modifier=_RaisingModifier())
+        # a failing modifier must surface its error, not be swallowed
+        with self.assertRaises(ValueError):
+            data.get_single_frame(0, num_worker=1)
+        # and the unmodified frame must not be cached
+        self.assertNotIn(0, data._modified_frame_cache)


### PR DESCRIPTION
## Problem

`DeepmdData.get_single_frame()` runs the data modifier through a one-off `ThreadPoolExecutor` but never calls `future.result()`. The context manager waits for the submitted task to finish, but any exception raised inside `modifier.modify_data(...)` stays stored on the `Future` and is never surfaced. As a result, frame-level data loading silently ignores modifier failures: callers receive the unmodified frame, and when caching is enabled that bad frame can be cached for future use. Other code paths call the modifier directly and do propagate errors, so the behavior was inconsistent.

## Fix

Call `future.result()` before leaving the modifier block so an exception raised inside the modifier propagates instead of being swallowed (and the unmodified frame cached).

## Test

A new test constructs a `DeepmdData` with a modifier whose `modify_data` always raises, and asserts that `get_single_frame` re-raises the error and does not cache the failed frame. On the current code the error is swallowed (no exception, frame cached); after the fix the error propagates.

Fix #5690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when preparing a single frame so failures from data modifiers are no longer hidden.
  * Prevented invalid frames from being saved and reused after a modifier error.
* **Tests**
  * Added coverage to verify modifier failures are reported correctly and do not populate the frame cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->