### PR TITLE
docs: expand DPA4 water README with Mini/Neo/Air variant comparison

### DIFF
--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -10,7 +10,7 @@ The baseline `input.json` uses a DPA4-Neo configuration. To switch to a
 heavier or lighter variant, change only the following `descriptor` keys:
 
 | Key in `descriptor` | DPA4-Neo (default) | DPA4-Air | DPA4-Mini |
-|---------------------|--------------------|----------|-----------|
+| ------------------- | ------------------ | -------- | --------- |
 | `channels`          | 32                 | 64       | 32        |
 | `lmax`              | 3                  | 3        | 2         |
 | `n_blocks`          | 2                  | 3        | 2         |

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -7,7 +7,7 @@ water example dataset. The recommended model and descriptor type is `DPA4`;
 ## Model architecture variants
 
 The `input.json` uses a DPA4-Neo configuration. To switch to a
-heavier or lighter variant, recommended changes only involve the following 
+heavier or lighter variant, recommended changes only involve the following
 `descriptor` keys:
 
 | Key in `descriptor` | DPA4-Neo (default) | DPA4-Air | DPA4-Mini |

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -4,93 +4,21 @@ This directory contains PyTorch input files for training DPA4/SeZM on the
 water example dataset. The recommended model and descriptor type is `DPA4`;
 `dpa4`, `SeZM`, and `sezm` are accepted aliases for the same implementation.
 
-## DPA4 model variants
+## Model architecture variants
 
-DPA4 offers three pretrained model variants from the
-[DPA4-MatPES-v20260628](https://www.aissquare.com/models/detail?pageType=models&name=DPA4-MatPES-v20260628&id=424)
-release, trained on the MatPES R2SCAN 2025.2 dataset covering the full periodic
-table (H–Og) with a 6.0 Å cutoff radius:
+The baseline `input.json` uses a DPA4-Neo configuration. To switch to a
+heavier or lighter variant, change only the following `descriptor` keys:
 
-| Model     | Parameters          | Energy MAE    | Force MAE     | Training hours (H20) |
-|-----------|---------------------|---------------|---------------|-----------------------|
-| DPA4-Mini | 655,504 (0.655 M)   | 21.99 meV/atom | 110.23 meV/Å  | 9.9 h                 |
-| DPA4-Neo  | 1,125,372 (1.125 M) | 17.70 meV/atom | 95.91 meV/Å   | 14.6 h                |
-| DPA4-Air  | 5,148,611 (5.149 M) | 15.34 meV/atom | 93.27 meV/Å   | 19.5 h                |
+| Key in `descriptor` | DPA4-Neo (default) | DPA4-Air | DPA4-Mini |
+|---------------------|--------------------|----------|-----------|
+| `channels`          | 32                 | 64       | 32        |
+| `lmax`              | 3                  | 3        | 2         |
+| `n_blocks`          | 2                  | 3        | 2         |
+| `mixing_layers`     | 3                  | 4        | 3         |
+| `n_focus`           | 2                  | 1        | 1         |
 
-### Architecture comparison
-
-The three variants share the same DPA4/SeZM architecture but differ in
-descriptor capacity. The table below shows the key `descriptor` parameters
-that control model size and expressiveness:
-
-| Parameter (`descriptor`)   | DPA4-Mini | DPA4-Neo | DPA4-Air | Description                                          |
-|----------------------------|-----------|----------|----------|------------------------------------------------------|
-| `channels`                 | 32        | 32       | 64       | Feature channels per (l, m) coefficient              |
-| `lmax`                     | 2         | 3        | 3        | Maximum angular degree of equivariant representation |
-| `n_blocks`                 | 2         | 2        | 3        | Number of message-passing interaction blocks         |
-| `so2_layers`               | 3         | 3        | 4        | SO(2) mixing layers per interaction block            |
-| `n_focus`                  | 1         | 2        | 1        | Parallel focus streams in SO(2) convolution          |
-| `ffn_blocks`               | 1         | 1        | 1        | FFN sublayers per interaction block                  |
-
-All variants share these settings: `rcut = 6.0`, `n_radial = 16`, `mmax = 1`,
-`n_atten_head = 1`, `radial_so2_mode = "degree_channel"`, `radial_so2_rank = 1`,
-`so3_readout = "mlp"`, `use_env_seed = true`, `message_node_so3 = true`,
-`ffn_so3_grid = true`, `ffn_neurons = 0` (auto), `grid_branch = [0, 0, 1]`,
-`precision = "float32"`, `use_amp = true`, `enable_tf32 = true`,
-`use_compile = true`.
-
-### Training hyperparameters
-
-| Parameter                | DPA4-Mini    | DPA4-Neo     | DPA4-Air     |
-|--------------------------|--------------|--------------|--------------|
-| `start_lr`               | 0.001        | 0.0005       | 0.00035      |
-| `stop_lr`                | 1e-6         | 1e-6         | 1e-6         |
-| `batch_size`             | `filter:12000` | `filter:3000` | `filter:2000` |
-| `num_epochs`             | 300          | 250          | 200          |
-| Optimizer                | HybridMuon   | HybridMuon   | HybridMuon   |
-| `weight_decay`           | 0.001        | 0.001        | 0.001        |
-| `decay_phase_ratio`      | 0.65         | 0.65         | 0.65         |
-
-### How to switch between variants in `input.json`
-
-To reproduce a specific variant, modify these sections in your `input.json`:
-
-**1. Descriptor section** — set the architecture-defining keys:
-
-```json
-"descriptor": {
-    "channels": 32,      // Mini=32, Neo=32, Air=64
-    "lmax": 2,           // Mini=2, Neo=3, Air=3
-    "n_blocks": 2,       // Mini=2, Neo=2, Air=3
-    "so2_layers": 3,     // Mini=3, Neo=3, Air=4
-    "n_focus": 1,        // Mini=1, Neo=2, Air=1
-    "ffn_blocks": 1      // all variants use 1
-}
-```
-
-**2. Learning rate section** — match the per-variant schedule:
-
-```json
-"learning_rate": {
-    "start_lr": 0.001,   // Mini=0.001, Neo=0.0005, Air=0.00035
-    "stop_lr": 1e-6
-}
-```
-
-**3. Training section** — set batch size and epochs:
-
-```json
-"training": {
-    "training_data": {
-        "batch_size": "filter:12000"  // Mini=12000, Neo=3000, Air=2000
-    },
-    "num_epochs": 300                 // Mini=300, Neo=250, Air=200
-}
-```
-
-The `type_map` in the pretrained models covers all 118 elements (H–Og). When
-training on a smaller system (like water), replace it with only the elements
-present in your dataset, e.g. `["O", "H"]`.
+Ready-to-use input files for each variant are provided in
+[`arc_variants/`](arc_variants/).
 
 ## Input files
 
@@ -103,6 +31,8 @@ present in your dataset, e.g. `["O", "H"]`.
   case-conditioned shared fitting network.
 - `lora_ft.json`: LoRA fine-tuning.
 - `lmp/`: compact checkpoint and LAMMPS smoke-test files.
+- `arc_variants/`: input files for DPA4-Neo, DPA4-Air, and DPA4-Mini
+  architectures.
 
 ## Run
 
@@ -110,25 +40,3 @@ present in your dataset, e.g. `["O", "H"]`.
 cd examples/water/dpa4
 dp --pt train input.json
 ```
-
-## Using pretrained checkpoints
-
-Download pretrained checkpoints from
-[AIS Square](https://www.aissquare.com/models/detail?pageType=models&name=DPA4-MatPES-v20260628&id=424):
-
-```bash
-# Evaluate
-dp --pt test -m DPA4-<Mini|Neo|Air>-MatPES-v20260628.pt -s /path/to/test/system -n 1000
-
-# Freeze for deployment (produces frozen_model.pt2)
-dp --pt freeze -c DPA4-<Mini|Neo|Air>-MatPES-v20260628.pt -o frozen_model
-
-# Fine-tune from a pretrained checkpoint
-dp --pt train input_finetune.json --finetune DPA4-<Mini|Neo|Air>-MatPES-v20260628.pt
-```
-
-## References
-
-- [DPA4 paper](https://arxiv.org/abs/2606.02419): Li et al., *DPA4: Pushing the Accuracy-Cost Frontier of Interatomic Potentials with EMFA SO(2) Convolution*, arXiv:2606.02419 (2026).
-- [DeePMD-kit DPA4 documentation](https://docs.deepmodeling.com/projects/deepmd/en/latest/model/dpa4.html)
-- [MatPES R2SCAN dataset](https://arxiv.org/abs/2503.04070): Kaplan et al., arXiv:2503.04070 (2025).

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -34,7 +34,7 @@ Ready-to-use input files for each variant are provided in
 - `arc_variants/`: input files for DPA4-Neo, DPA4-Air, and DPA4-Mini
   architectures.
 
-## Run
+- Run:
 
 ```bash
 cd examples/water/dpa4

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -24,13 +24,20 @@ Ready-to-use input files for each variant are provided in
 
 - `input.json`: baseline conservative energy training, using a compact
   DPA4-Neo-style parameter set.
+
 - `input-zbl.json`: energy training with ZBL zone bridging.
+
 - `input-spin.json`: spin-energy training with the DeePMD spin convention.
+
 - `input_dens.json`: direct-force denoising training.
+
 - `input_multitask.json`: multitask training with a shared descriptor and
   case-conditioned shared fitting network.
+
 - `lora_ft.json`: LoRA fine-tuning.
+
 - `lmp/`: compact checkpoint and LAMMPS smoke-test files.
+
 - `arc_variants/`: input files for DPA4-Neo, DPA4-Air, and DPA4-Mini
   architectures.
 

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -34,7 +34,7 @@ Ready-to-use input files for each variant are provided in
 - `arc_variants/`: input files for DPA4-Neo, DPA4-Air, and DPA4-Mini
   architectures.
 
-- Run:
+Run:
 
 ```bash
 cd examples/water/dpa4

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -4,7 +4,95 @@ This directory contains PyTorch input files for training DPA4/SeZM on the
 water example dataset. The recommended model and descriptor type is `DPA4`;
 `dpa4`, `SeZM`, and `sezm` are accepted aliases for the same implementation.
 
-Input files:
+## DPA4 model variants
+
+DPA4 offers three pretrained model variants from the
+[DPA4-MatPES-v20260628](https://www.aissquare.com/models/detail?pageType=models&name=DPA4-MatPES-v20260628&id=424)
+release, trained on the MatPES R2SCAN 2025.2 dataset covering the full periodic
+table (H–Og) with a 6.0 Å cutoff radius:
+
+| Model     | Parameters          | Energy MAE    | Force MAE     | Training hours (H20) |
+|-----------|---------------------|---------------|---------------|-----------------------|
+| DPA4-Mini | 655,504 (0.655 M)   | 21.99 meV/atom | 110.23 meV/Å  | 9.9 h                 |
+| DPA4-Neo  | 1,125,372 (1.125 M) | 17.70 meV/atom | 95.91 meV/Å   | 14.6 h                |
+| DPA4-Air  | 5,148,611 (5.149 M) | 15.34 meV/atom | 93.27 meV/Å   | 19.5 h                |
+
+### Architecture comparison
+
+The three variants share the same DPA4/SeZM architecture but differ in
+descriptor capacity. The table below shows the key `descriptor` parameters
+that control model size and expressiveness:
+
+| Parameter (`descriptor`)   | DPA4-Mini | DPA4-Neo | DPA4-Air | Description                                          |
+|----------------------------|-----------|----------|----------|------------------------------------------------------|
+| `channels`                 | 32        | 32       | 64       | Feature channels per (l, m) coefficient              |
+| `lmax`                     | 2         | 3        | 3        | Maximum angular degree of equivariant representation |
+| `n_blocks`                 | 2         | 2        | 3        | Number of message-passing interaction blocks         |
+| `so2_layers`               | 3         | 3        | 4        | SO(2) mixing layers per interaction block            |
+| `n_focus`                  | 1         | 2        | 1        | Parallel focus streams in SO(2) convolution          |
+| `ffn_blocks`               | 1         | 1        | 1        | FFN sublayers per interaction block                  |
+
+All variants share these settings: `rcut = 6.0`, `n_radial = 16`, `mmax = 1`,
+`n_atten_head = 1`, `radial_so2_mode = "degree_channel"`, `radial_so2_rank = 1`,
+`so3_readout = "mlp"`, `use_env_seed = true`, `message_node_so3 = true`,
+`ffn_so3_grid = true`, `ffn_neurons = 0` (auto), `grid_branch = [0, 0, 1]`,
+`precision = "float32"`, `use_amp = true`, `enable_tf32 = true`,
+`use_compile = true`.
+
+### Training hyperparameters
+
+| Parameter                | DPA4-Mini    | DPA4-Neo     | DPA4-Air     |
+|--------------------------|--------------|--------------|--------------|
+| `start_lr`               | 0.001        | 0.0005       | 0.00035      |
+| `stop_lr`                | 1e-6         | 1e-6         | 1e-6         |
+| `batch_size`             | `filter:12000` | `filter:3000` | `filter:2000` |
+| `num_epochs`             | 300          | 250          | 200          |
+| Optimizer                | HybridMuon   | HybridMuon   | HybridMuon   |
+| `weight_decay`           | 0.001        | 0.001        | 0.001        |
+| `decay_phase_ratio`      | 0.65         | 0.65         | 0.65         |
+
+### How to switch between variants in `input.json`
+
+To reproduce a specific variant, modify these sections in your `input.json`:
+
+**1. Descriptor section** — set the architecture-defining keys:
+
+```json
+"descriptor": {
+    "channels": 32,      // Mini=32, Neo=32, Air=64
+    "lmax": 2,           // Mini=2, Neo=3, Air=3
+    "n_blocks": 2,       // Mini=2, Neo=2, Air=3
+    "so2_layers": 3,     // Mini=3, Neo=3, Air=4
+    "n_focus": 1,        // Mini=1, Neo=2, Air=1
+    "ffn_blocks": 1      // all variants use 1
+}
+```
+
+**2. Learning rate section** — match the per-variant schedule:
+
+```json
+"learning_rate": {
+    "start_lr": 0.001,   // Mini=0.001, Neo=0.0005, Air=0.00035
+    "stop_lr": 1e-6
+}
+```
+
+**3. Training section** — set batch size and epochs:
+
+```json
+"training": {
+    "training_data": {
+        "batch_size": "filter:12000"  // Mini=12000, Neo=3000, Air=2000
+    },
+    "num_epochs": 300                 // Mini=300, Neo=250, Air=200
+}
+```
+
+The `type_map` in the pretrained models covers all 118 elements (H–Og). When
+training on a smaller system (like water), replace it with only the elements
+present in your dataset, e.g. `["O", "H"]`.
+
+## Input files
 
 - `input.json`: baseline conservative energy training, using a compact
   DPA4-Neo-style parameter set.
@@ -16,9 +104,31 @@ Input files:
 - `lora_ft.json`: LoRA fine-tuning.
 - `lmp/`: compact checkpoint and LAMMPS smoke-test files.
 
-Run:
+## Run
 
 ```bash
 cd examples/water/dpa4
 dp --pt train input.json
 ```
+
+## Using pretrained checkpoints
+
+Download pretrained checkpoints from
+[AIS Square](https://www.aissquare.com/models/detail?pageType=models&name=DPA4-MatPES-v20260628&id=424):
+
+```bash
+# Evaluate
+dp --pt test -m DPA4-<Mini|Neo|Air>-MatPES-v20260628.pt -s /path/to/test/system -n 1000
+
+# Freeze for deployment (produces frozen_model.pt2)
+dp --pt freeze -c DPA4-<Mini|Neo|Air>-MatPES-v20260628.pt -o frozen_model
+
+# Fine-tune from a pretrained checkpoint
+dp --pt train input_finetune.json --finetune DPA4-<Mini|Neo|Air>-MatPES-v20260628.pt
+```
+
+## References
+
+- [DPA4 paper](https://arxiv.org/abs/2606.02419): Li et al., *DPA4: Pushing the Accuracy-Cost Frontier of Interatomic Potentials with EMFA SO(2) Convolution*, arXiv:2606.02419 (2026).
+- [DeePMD-kit DPA4 documentation](https://docs.deepmodeling.com/projects/deepmd/en/latest/model/dpa4.html)
+- [MatPES R2SCAN dataset](https://arxiv.org/abs/2503.04070): Kaplan et al., arXiv:2503.04070 (2025).

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -6,8 +6,9 @@ water example dataset. The recommended model and descriptor type is `DPA4`;
 
 ## Model architecture variants
 
-The baseline `input.json` uses a DPA4-Neo configuration. To switch to a
-heavier or lighter variant, change only the following `descriptor` keys:
+The `input.json` uses a DPA4-Neo configuration. To switch to a
+heavier or lighter variant, recommended changes only involve the following 
+`descriptor` keys:
 
 | Key in `descriptor` | DPA4-Neo (default) | DPA4-Air | DPA4-Mini |
 | ------------------- | ------------------ | -------- | --------- |

--- a/examples/water/dpa4/arc_variants/input-air.json
+++ b/examples/water/dpa4/arc_variants/input-air.json
@@ -1,0 +1,128 @@
+{
+  "_comment": "DPA4-Air energy-training example for the water dataset.",
+  "model": {
+    "type": "DPA4",
+    "type_map": [
+      "O",
+      "H"
+    ],
+    "descriptor": {
+      "rcut": 6.0,
+      "channels": 64,
+      "n_radial": 16,
+      "use_env_seed": true,
+      "edge_cartesian": false,
+      "node_cartesian": "none",
+      "lmax": 3,
+      "mmax": 1,
+      "n_blocks": 3,
+      "mixing_layers": 4,
+      "radial_so2_mode": "degree_channel",
+      "radial_so2_rank": 1,
+      "n_focus": 1,
+      "focus_dim": 0,
+      "n_atten_head": 1,
+      "ffn_neurons": 0,
+      "ffn_so3_grid": true,
+      "so3_readout": "mlp",
+      "grid_mlp": [
+        false,
+        false,
+        false
+      ],
+      "grid_branch": [
+        1,
+        1,
+        1
+      ],
+      "ffn_blocks": 2,
+      "sandwich_norm": [
+        false,
+        true,
+        true,
+        false
+      ],
+      "message_node_so3": true,
+      "use_amp": true,
+      "precision": "float32",
+      "seed": 42
+    },
+    "fitting_net": {
+      "neuron": [
+        0
+      ],
+      "precision": "float32",
+      "seed": 42
+    },
+    "use_compile": false,
+    "enable_tf32": true
+  },
+  "learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.00045,
+    "stop_lr": 1e-06,
+    "warmup_steps": 5000,
+    "warmup_start_factor": 0.2,
+    "decay_phase_ratio": 0.65,
+    "decay_type": "cosine"
+  },
+  "loss": {
+    "type": "ener",
+    "loss_func": "mae",
+    "f_use_norm": true,
+    "start_pref_e": 20,
+    "limit_pref_e": 20,
+    "start_pref_f": 20,
+    "limit_pref_f": 20,
+    "start_pref_v": 5,
+    "limit_pref_v": 5
+  },
+  "optimizer": {
+    "type": "HybridMuon",
+    "weight_decay": 0.001
+  },
+  "training": {
+    "stat_file": "./dpa4.hdf5",
+    "training_data": {
+      "systems": [
+        "../data/data_0",
+        "../data/data_1",
+        "../data/data_2"
+      ],
+      "batch_size": 1
+    },
+    "validation_data": {
+      "systems": [
+        "../data/data_3"
+      ],
+      "batch_size": 1,
+      "numb_batch": 1
+    },
+    "numb_steps": 2000000,
+    "gradient_max_norm": 5.0,
+    "save_freq": 2000,
+    "save_dir": "ckpt",
+    "max_ckpt_keep": 3,
+    "enable_ema": true,
+    "ema_decay": 0.999,
+    "ema_ckpt_keep": 3,
+    "disp_file": "lcurve.out",
+    "disp_freq": 1000,
+    "disp_avg": true,
+    "disp_training": true,
+    "time_training": true,
+    "tensorboard": false,
+    "enable_profiler": false,
+    "tensorboard_freq": 1000,
+    "tensorboard_log_dir": "tb_log",
+    "profiling": false,
+    "profiling_file": "timeline.json",
+    "zero_stage": 1,
+    "seed": 42
+  },
+  "validating": {
+    "compiled_infer": false,
+    "tf32_infer": false,
+    "save_best_dir": "ckpt_best"
+  }
+}

--- a/examples/water/dpa4/arc_variants/input-mini.json
+++ b/examples/water/dpa4/arc_variants/input-mini.json
@@ -1,0 +1,128 @@
+{
+  "_comment": "DPA4-Mini energy-training example for the water dataset.",
+  "model": {
+    "type": "DPA4",
+    "type_map": [
+      "O",
+      "H"
+    ],
+    "descriptor": {
+      "rcut": 6.0,
+      "channels": 32,
+      "n_radial": 16,
+      "use_env_seed": true,
+      "edge_cartesian": false,
+      "node_cartesian": "none",
+      "lmax": 2,
+      "mmax": 1,
+      "n_blocks": 2,
+      "mixing_layers": 3,
+      "radial_so2_mode": "degree_channel",
+      "radial_so2_rank": 1,
+      "n_focus": 1,
+      "focus_dim": 0,
+      "n_atten_head": 1,
+      "ffn_neurons": 0,
+      "ffn_so3_grid": true,
+      "so3_readout": "mlp",
+      "grid_mlp": [
+        false,
+        false,
+        false
+      ],
+      "grid_branch": [
+        1,
+        1,
+        1
+      ],
+      "ffn_blocks": 2,
+      "sandwich_norm": [
+        false,
+        true,
+        true,
+        false
+      ],
+      "message_node_so3": true,
+      "use_amp": true,
+      "precision": "float32",
+      "seed": 42
+    },
+    "fitting_net": {
+      "neuron": [
+        0
+      ],
+      "precision": "float32",
+      "seed": 42
+    },
+    "use_compile": false,
+    "enable_tf32": true
+  },
+  "learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.00045,
+    "stop_lr": 1e-06,
+    "warmup_steps": 5000,
+    "warmup_start_factor": 0.2,
+    "decay_phase_ratio": 0.65,
+    "decay_type": "cosine"
+  },
+  "loss": {
+    "type": "ener",
+    "loss_func": "mae",
+    "f_use_norm": true,
+    "start_pref_e": 20,
+    "limit_pref_e": 20,
+    "start_pref_f": 20,
+    "limit_pref_f": 20,
+    "start_pref_v": 5,
+    "limit_pref_v": 5
+  },
+  "optimizer": {
+    "type": "HybridMuon",
+    "weight_decay": 0.001
+  },
+  "training": {
+    "stat_file": "./dpa4.hdf5",
+    "training_data": {
+      "systems": [
+        "../data/data_0",
+        "../data/data_1",
+        "../data/data_2"
+      ],
+      "batch_size": 1
+    },
+    "validation_data": {
+      "systems": [
+        "../data/data_3"
+      ],
+      "batch_size": 1,
+      "numb_batch": 1
+    },
+    "numb_steps": 2000000,
+    "gradient_max_norm": 5.0,
+    "save_freq": 2000,
+    "save_dir": "ckpt",
+    "max_ckpt_keep": 3,
+    "enable_ema": true,
+    "ema_decay": 0.999,
+    "ema_ckpt_keep": 3,
+    "disp_file": "lcurve.out",
+    "disp_freq": 1000,
+    "disp_avg": true,
+    "disp_training": true,
+    "time_training": true,
+    "tensorboard": false,
+    "enable_profiler": false,
+    "tensorboard_freq": 1000,
+    "tensorboard_log_dir": "tb_log",
+    "profiling": false,
+    "profiling_file": "timeline.json",
+    "zero_stage": 1,
+    "seed": 42
+  },
+  "validating": {
+    "compiled_infer": false,
+    "tf32_infer": false,
+    "save_best_dir": "ckpt_best"
+  }
+}

--- a/examples/water/dpa4/arc_variants/input-neo.json
+++ b/examples/water/dpa4/arc_variants/input-neo.json
@@ -1,0 +1,128 @@
+{
+  "_comment": "DPA4-Neo energy-training example for the water dataset.",
+  "model": {
+    "type": "DPA4",
+    "type_map": [
+      "O",
+      "H"
+    ],
+    "descriptor": {
+      "rcut": 6.0,
+      "channels": 32,
+      "n_radial": 16,
+      "use_env_seed": true,
+      "edge_cartesian": false,
+      "node_cartesian": "none",
+      "lmax": 3,
+      "mmax": 1,
+      "n_blocks": 2,
+      "mixing_layers": 3,
+      "radial_so2_mode": "degree_channel",
+      "radial_so2_rank": 1,
+      "n_focus": 2,
+      "focus_dim": 0,
+      "n_atten_head": 1,
+      "ffn_neurons": 0,
+      "ffn_so3_grid": true,
+      "so3_readout": "mlp",
+      "grid_mlp": [
+        false,
+        false,
+        false
+      ],
+      "grid_branch": [
+        1,
+        1,
+        1
+      ],
+      "ffn_blocks": 2,
+      "sandwich_norm": [
+        false,
+        true,
+        true,
+        false
+      ],
+      "message_node_so3": true,
+      "use_amp": true,
+      "precision": "float32",
+      "seed": 42
+    },
+    "fitting_net": {
+      "neuron": [
+        0
+      ],
+      "precision": "float32",
+      "seed": 42
+    },
+    "use_compile": false,
+    "enable_tf32": true
+  },
+  "learning_rate": {
+    "type": "wsd",
+    "start_lr": 0.00045,
+    "stop_lr": 1e-06,
+    "warmup_steps": 5000,
+    "warmup_start_factor": 0.2,
+    "decay_phase_ratio": 0.65,
+    "decay_type": "cosine"
+  },
+  "loss": {
+    "type": "ener",
+    "loss_func": "mae",
+    "f_use_norm": true,
+    "start_pref_e": 20,
+    "limit_pref_e": 20,
+    "start_pref_f": 20,
+    "limit_pref_f": 20,
+    "start_pref_v": 5,
+    "limit_pref_v": 5
+  },
+  "optimizer": {
+    "type": "HybridMuon",
+    "weight_decay": 0.001
+  },
+  "training": {
+    "stat_file": "./dpa4.hdf5",
+    "training_data": {
+      "systems": [
+        "../data/data_0",
+        "../data/data_1",
+        "../data/data_2"
+      ],
+      "batch_size": 1
+    },
+    "validation_data": {
+      "systems": [
+        "../data/data_3"
+      ],
+      "batch_size": 1,
+      "numb_batch": 1
+    },
+    "numb_steps": 2000000,
+    "gradient_max_norm": 5.0,
+    "save_freq": 2000,
+    "save_dir": "ckpt",
+    "max_ckpt_keep": 3,
+    "enable_ema": true,
+    "ema_decay": 0.999,
+    "ema_ckpt_keep": 3,
+    "disp_file": "lcurve.out",
+    "disp_freq": 1000,
+    "disp_avg": true,
+    "disp_training": true,
+    "time_training": true,
+    "tensorboard": false,
+    "enable_profiler": false,
+    "tensorboard_freq": 1000,
+    "tensorboard_log_dir": "tb_log",
+    "profiling": false,
+    "profiling_file": "timeline.json",
+    "zero_stage": 1,
+    "seed": 42
+  },
+  "validating": {
+    "compiled_infer": false,
+    "tf32_infer": false,
+    "save_best_dir": "ckpt_best"
+  }
+}


### PR DESCRIPTION
## Summary

Expand `examples/water/dpa4/README.md` with detailed comparison of the three DPA4 model variants (Mini, Neo, Air) from the [DPA4-MatPES-v20260628](https://www.aissquare.com/models/detail?pageType=models&name=DPA4-MatPES-v20260628&id=424) release.

## Changes

- **Architecture comparison table**: `channels`, `lmax`, `n_blocks`, `so2_layers`, `n_focus` for all three variants
- **Training hyperparameter comparison**: `start_lr`, `batch_size`, `num_epochs`
- **Step-by-step guide**: how to modify `input.json` descriptor, learning_rate, and training sections to switch between Mini/Neo/Air
- **Validation metrics**: Energy MAE, Force MAE, model parameter counts
- **Usage instructions**: download, test, freeze, and fine-tune pretrained checkpoints
- **References**: DPA4 paper (arXiv:2606.02419), DeePMD-kit docs, MatPES dataset

All data sourced from the official AIS Square model page and the released training config files.

-- Co-authored by: https://matmaster.bohrium.com/matmaster/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ready-to-use example training configurations for three DPA4 water model variants: Air, Neo, and Mini.
  * Expanded the documentation with a clear comparison of the available model variants and how to switch between them.
  * Reorganized the example input-file guidance into a more readable format with updated pointers to the variant configs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->