### PR TITLE
fix(pd): preserve dtype in Paddle RepFlow dynamic aggregation

### DIFF
--- a/deepmd/pd/model/network/utils.py
+++ b/deepmd/pd/model/network/utils.py
@@ -39,8 +39,9 @@ def aggregate(
     else:
         bin_count = None
 
-    # make sure this operation is done on the same device of data and owners
-    output = paddle.zeros([num_owner, data.shape[1]])
+    # make sure this operation is done on the same device of data and owners,
+    # and preserve the input dtype instead of falling back to the default float
+    output = paddle.zeros([num_owner, data.shape[1]], dtype=data.dtype)
     output = output.index_add_(owners, 0, data.astype(output.dtype))
     if average:
         assert bin_count is not None

--- a/deepmd/pd/model/network/utils.py
+++ b/deepmd/pd/model/network/utils.py
@@ -39,8 +39,9 @@ def aggregate(
     else:
         bin_count = None
 
-    # make sure this operation is done on the same device of data and owners,
-    # and preserve the input dtype instead of falling back to the default float
+    # preserve the input dtype instead of falling back to the default float;
+    # paddle.zeros creates the tensor on the current global device (it has no
+    # place argument), which matches data/owners under deepmd's global device.
     output = paddle.zeros([num_owner, data.shape[1]], dtype=data.dtype)
     output = output.index_add_(owners, 0, data.astype(output.dtype))
     if average:

--- a/source/tests/pd/model/test_aggregate.py
+++ b/source/tests/pd/model/test_aggregate.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Test that ``aggregate`` preserves the input dtype (float64 must not downcast)."""
+
+import unittest
+
+import numpy as np
+import paddle
+
+from deepmd.pd.model.network.utils import (
+    aggregate,
+)
+
+
+class TestAggregateDtype(unittest.TestCase):
+    def _data(self) -> tuple[paddle.Tensor, paddle.Tensor]:
+        # rows 0,1 -> owner 0 ; row 2 -> owner 1
+        data = paddle.to_tensor([[1.0], [2.0], [3.0]], dtype="float64")
+        owners = paddle.to_tensor([0, 0, 1], dtype="int64")
+        return data, owners
+
+    def test_sum_preserves_float64(self) -> None:
+        # exercises the shared ``output = paddle.zeros(..., dtype=data.dtype)``
+        # allocation via the summation path
+        data, owners = self._data()
+        out = aggregate(data, owners, average=False, num_owner=2)
+        self.assertEqual(out.dtype, paddle.float64)
+        np.testing.assert_allclose(out.numpy().ravel(), [3.0, 3.0])


### PR DESCRIPTION
## Problem

The Paddle `aggregate()` helper in `deepmd/pd/model/network/utils.py` allocated its output with `paddle.zeros([num_owner, data.shape[1]])` without specifying a dtype, so it fell back to Paddle's default floating dtype (float32). It then cast the input `data` to `output.dtype` before `index_add_`. For float64 Paddle RepFlow/DPA3 models, the dynamic-selection aggregation therefore accumulated descriptor updates in float32, silently downcasting intermediate values before returning them to the descriptor path.

## Fix

Allocate the output with `dtype=data.dtype` so the input precision is preserved (and the subsequent `data.astype(output.dtype)` becomes a no-op for matching dtypes).

## Test

A new test aggregates float64 input and asserts the result stays float64 (and has the expected values). On the current code the output is float32; after the fix it is float64. This exercises the shared `output = paddle.zeros(..., dtype=data.dtype)` allocation via the summation path.

## Note on verification

Verified locally with `paddlepaddle==3.3.1`. The CI target is a newer nightly (`paddlepaddle==3.4.0.dev20260310`), but the behavior fixed here is version-agnostic: `paddle.zeros` without `dtype` defaults to float32 in all versions, and `dtype=data.dtype` corrects it regardless. The test is scoped to the summation path to keep it independent of an unrelated `Tensor.where` API difference in the older local Paddle.

Fix #5688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the input tensor’s numeric dtype when aggregating values, preventing unintended dtype fallback during summation.
* **Tests**
  * Added unit coverage to confirm aggregation keeps `float64` output dtype and returns the expected summed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->