### PR TITLE
fix(tf): count spin ghost atom types with dense bins

### DIFF
--- a/deepmd/tf/descriptor/se_a.py
+++ b/deepmd/tf/descriptor/se_a.py
@@ -1443,7 +1443,11 @@ class DescrptSeA(DescrptSe):
         with tf.control_dependencies([atype_equal]):
             aatype = atype[0, :]
         ghost_atype = aatype[natoms[0] :]
-        _, _, ghost_natoms = tf.unique_with_counts(ghost_atype)
+        # Dense per-type ghost counts: the ghost region is sorted ascending by
+        # type (see DeepSpinTF::extend), but a type may be absent. bincount with
+        # minlength keeps the count vector indexable by type id, whereas
+        # tf.unique_with_counts drops absent types and shifts every offset.
+        ghost_natoms = tf.math.bincount(ghost_atype, minlength=self.ntypes)
         ghost_natoms_index = tf.concat([[0], tf.cumsum(ghost_natoms)], axis=0)
         ghost_natoms_index += natoms[0]
         for i in range(self.ntypes):

--- a/deepmd/tf/model/ener.py
+++ b/deepmd/tf/model/ener.py
@@ -549,7 +549,11 @@ class EnerModel(StandardModel):
         loc_force = self.natoms_match(force, natoms)
         aatype = atype[0, :]
         ghost_atype = aatype[natoms[0] :]
-        _, _, ghost_natoms = tf.unique_with_counts(ghost_atype)
+        # Dense per-type ghost counts: the ghost region is sorted ascending by
+        # type (see DeepSpinTF::extend), but a type may be absent. bincount with
+        # minlength keeps the count vector indexable by type id, whereas
+        # tf.unique_with_counts drops absent types and shifts every offset.
+        ghost_natoms = tf.math.bincount(ghost_atype, minlength=self.ntypes)
         ghost_natoms_index = tf.concat([[0], tf.cumsum(ghost_natoms)], axis=0)
         ghost_natoms_index += natoms[0]
 

--- a/source/tests/tf/test_spin_ghost_natoms.py
+++ b/source/tests/tf/test_spin_ghost_natoms.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Regression test for the TensorFlow spin ghost-atom type counting.
+
+The spin ``natoms_not_match`` path (triggered only when ``natoms[0] != natoms[1]``,
+i.e. ghost atoms are present) needs a *dense*, type-indexed count vector of the
+ghost atoms so that the per-type coordinate slices land on the right offsets.
+
+The ghost region fed to the graph is guaranteed to be sorted in ascending type
+order by the C++ side (``DeepSpinTF::extend`` reorders ghost atoms into
+contiguous per-type blocks), but a type may be entirely absent from a rank's
+ghost region.  Counting the ghost types with ``tf.unique_with_counts`` returns
+only the *present* types in encounter order, so a missing type shifts every
+subsequent count and the last index runs past the end of the vector, corrupting
+the ghost spin coordinates or failing at runtime.  ``tf.math.bincount`` with
+``minlength=ntypes`` produces the dense vector the slicing assumes.
+"""
+
+import unittest
+
+import numpy as np
+
+from deepmd.tf.descriptor.se_a import (
+    DescrptSeA,
+)
+from deepmd.tf.env import (
+    tf,
+)
+from deepmd.tf.utils.spin import (
+    Spin,
+)
+
+
+def _make_spin_descriptor() -> DescrptSeA:
+    """Build a minimal ``DescrptSeA`` exposing only what the ghost-count path uses.
+
+    ``natoms_not_match`` / ``natoms_match`` read only ``self.ntypes``,
+    ``self.ntypes_spin`` and ``self.spin.use_spin``, so we bypass the full
+    constructor and set those attributes directly to keep the test focused on
+    the counting logic.  ``use_spin=[True, False]`` gives two real types (type 0
+    has spin, type 1 has none) plus one virtual type (type 2 = spin of type 0),
+    i.e. ``ntypes == 3``, ``ntypes_spin == 1``.
+    """
+    dd = DescrptSeA.__new__(DescrptSeA)
+    dd.spin = Spin(use_spin=[True, False], spin_norm=[1.0], virtual_len=[0.4])
+    dd.ntypes = 3
+    dd.ntypes_spin = 1
+    return dd
+
+
+class TestSpinGhostNatoms(unittest.TestCase):
+    def _run_natoms_not_match(
+        self, coord: np.ndarray, natoms: np.ndarray, atype: np.ndarray
+    ) -> np.ndarray:
+        dd = _make_spin_descriptor()
+        with tf.Graph().as_default():
+            t_coord = tf.placeholder(tf.float64, [None, None], name="t_coord")
+            t_natoms = tf.placeholder(tf.int32, [2 + dd.ntypes], name="t_natoms")
+            t_atype = tf.placeholder(tf.int32, [None, None], name="t_atype")
+            diff = dd.natoms_not_match(t_coord, t_natoms, t_atype)
+            with tf.Session() as sess:
+                return sess.run(
+                    diff,
+                    feed_dict={
+                        t_coord: coord,
+                        t_natoms: natoms,
+                        t_atype: atype,
+                    },
+                )
+
+    def test_missing_ghost_type(self) -> None:
+        """A non-spin real type absent from the ghost region must not corrupt slices.
+
+        Layout (each atom is one 3-vector):
+        - local:  type0, type1, type2      (nloc = 3, dense counts [1, 1, 1])
+        - ghost:  type0, type2             (type 1 absent; ascending, dense [1, 0, 1])
+
+        ``diff_coord`` is the real->virtual spin displacement per atom, laid out in
+        the same order as ``coord``.  Only the spin/virtual type (2) is nonzero;
+        it pairs with its real type (0).
+        """
+        # fmt: off
+        coord = np.array(
+            [[
+                1.0, 1.0, 1.0,   # local type 0 (real, spin)
+                2.0, 2.0, 2.0,   # local type 1 (real, no spin)
+                3.0, 3.0, 3.0,   # local type 2 (virtual of 0)
+                5.0, 5.0, 5.0,   # ghost type 0 (real, spin)
+                6.0, 6.0, 6.0,   # ghost type 2 (virtual of 0)
+            ]],
+            dtype=np.float64,
+        )
+        # fmt: on
+        natoms = np.array([3, 5, 1, 1, 1], dtype=np.int32)
+        atype = np.array([[0, 1, 2, 0, 2]], dtype=np.int32)
+
+        out = self._run_natoms_not_match(coord, natoms, atype)
+
+        # fmt: off
+        expected = np.array(
+            [[
+                0.0, 0.0, 0.0,   # local type 0 -> zero
+                0.0, 0.0, 0.0,   # local type 1 -> zero
+                2.0, 2.0, 2.0,   # local type 2 -> t2_loc - t0_loc
+                0.0, 0.0, 0.0,   # ghost type 0 -> zero
+                1.0, 1.0, 1.0,   # ghost type 2 -> t2_ghost - t0_ghost
+            ]],
+            dtype=np.float64,
+        )
+        # fmt: on
+        np.testing.assert_allclose(out, expected)
+
+    def test_all_ghost_types_present(self) -> None:
+        """Control: every type present in the ghost region (behaviour-preserving)."""
+        # fmt: off
+        coord = np.array(
+            [[
+                1.0, 1.0, 1.0,   # local type 0
+                2.0, 2.0, 2.0,   # local type 1
+                3.0, 3.0, 3.0,   # local type 2
+                5.0, 5.0, 5.0,   # ghost type 0
+                6.5, 6.5, 6.5,   # ghost type 1
+                8.0, 8.0, 8.0,   # ghost type 2
+            ]],
+            dtype=np.float64,
+        )
+        # fmt: on
+        natoms = np.array([3, 6, 1, 1, 1], dtype=np.int32)
+        atype = np.array([[0, 1, 2, 0, 1, 2]], dtype=np.int32)
+
+        out = self._run_natoms_not_match(coord, natoms, atype)
+
+        # fmt: off
+        expected = np.array(
+            [[
+                0.0, 0.0, 0.0,   # local type 0
+                0.0, 0.0, 0.0,   # local type 1
+                2.0, 2.0, 2.0,   # local type 2 -> t2_loc - t0_loc
+                0.0, 0.0, 0.0,   # ghost type 0
+                0.0, 0.0, 0.0,   # ghost type 1 (no spin)
+                3.0, 3.0, 3.0,   # ghost type 2 -> t2_ghost - t0_ghost
+            ]],
+            dtype=np.float64,
+        )
+        # fmt: on
+        np.testing.assert_allclose(out, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #5681. The TensorFlow spin `natoms_not_match` path — in the se_e2_a descriptor (`deepmd/tf/descriptor/se_a.py`) and the energy model (`deepmd/tf/model/ener.py`), reached only when ghost atoms are present (`natoms[0] != natoms[1]`) — counted ghost atom types with `tf.unique_with_counts` and then indexed the returned counts and their prefix sums as if they were a dense vector indexed by type id. `tf.unique_with_counts` returns only the types that are actually present, in encounter order, so when a type is entirely absent from a rank's ghost region every subsequent count and offset is shifted and the final index runs past the end of the vector. The result is corrupted ghost spin coordinate/force slices, or a runtime out-of-bounds failure, for otherwise valid ghost atom layouts.

## Root cause and scope

The ghost region that reaches the graph is already sorted in ascending type order: `DeepSpinTF::extend` (`source/api_cc/src/DeepSpinTF.cc`) places each ghost atom at `cum_ghost_type_count[type] + reset`, i.e. contiguous per-type blocks, and `session_input_tensors` appends that region verbatim. So the slicing's ascending-order assumption always holds and the only broken assumption is density — the count vector must have one slot per type id, including zero-count slots for absent types. This is exactly what the issue's first failure mode ("ghost atoms absent for some types") describes; the second ("order differs from ascending type order") does not occur for this code path because the C++ side enforces the ordering.

## Fix

Replace `tf.unique_with_counts(ghost_atype)` with `tf.math.bincount(ghost_atype, minlength=self.ntypes)` in both call sites. This produces the dense, type-indexed count vector the slicing already assumes, with absent types kept as zero-count slots so all prefix-sum offsets stay aligned. When every type is present the two are equivalent, so the change is behavior-preserving for the common case.

## Test

Adds `source/tests/tf/test_spin_ghost_natoms.py`, which drives `natoms_not_match` through a TF session. `test_missing_ghost_type` uses a ghost layout that omits a (non-spin) type — it fails on master with `slice index 2 of dimension 0 out of bounds` and passes with the fix; `test_all_ghost_types_present` is an all-types-present control that passes either way. This branch previously had no coverage at all because every existing spin test exercises the box path or calls the neighbor-list path with `nghost == 0`, so `natoms_not_match` was never reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atom-type counting so missing types no longer shift downstream indexing.
  * Fixed ghost-atom handling to produce stable per-type offsets even when some types are absent.

* **Tests**
  * Added regression coverage for ghost-atom counting with missing and fully present atom types.
  * Verified the affected TensorFlow path behaves consistently across both scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->