### PR TITLE
fix(cli): recognize pretrained model aliases in format_model_suffix

### DIFF
--- a/deepmd/backend/suffix.py
+++ b/deepmd/backend/suffix.py
@@ -63,8 +63,13 @@ def format_model_suffix(
         )
     )
     pp = Path(filename)
-    current_suffix = pp.suffix
-    if current_suffix not in all_suffixes:
+    # Match on a case-insensitive endswith, consistent with
+    # Backend.match_filename / detect_backend_by_model. This recognizes both
+    # ordinary dotted suffixes (e.g. ".pth") and whole-name aliases registered
+    # as suffixes by PretrainedBackend (e.g. "dpa-3.2-5m"), which Path().suffix
+    # would miss (Path("DPA-3.2-5M").suffix == ".2-5M").
+    fname = str(pp).lower()
+    if not any(fname.endswith(suffix) for suffix in all_suffixes):
         if preferred_backend is not None:
             return str(pp) + preferred_backend.suffixes[0]
         raise ValueError(f"Unsupported model file format: {filename}")

--- a/source/tests/common/test_pretrained_backend.py
+++ b/source/tests/common/test_pretrained_backend.py
@@ -10,6 +10,9 @@ from deepmd.backend.backend import (
 from deepmd.backend.pretrained import (
     PretrainedBackend,
 )
+from deepmd.backend.suffix import (
+    format_model_suffix,
+)
 from deepmd.pretrained.deep_eval import (
     parse_pretrained_alias,
 )
@@ -65,3 +68,45 @@ class TestPretrainedBackend(unittest.TestCase):
         )
 
         self.assertIs(PretrainedBackend().deep_eval, PretrainedDeepEvalBackend)
+
+    def test_format_model_suffix_keeps_pretrained_alias(self) -> None:
+        # CLI deep-eval commands normalize `-m` through format_model_suffix
+        # (strict_prefer=False). A pretrained alias must be recognized and
+        # returned unchanged so PretrainedBackend can resolve it, matching the
+        # endswith-based detection in Backend.detect_backend_by_model. Before
+        # the fix these were mangled (e.g. "DPA-3.2-5M" -> "DPA-3.2-5M.pth")
+        # because only Path(...).suffix was compared against the alias list.
+        for alias in ("DPA-3.2-5M", "DPA3-Omol-Large", "dpa-3.2-5m"):
+            self.assertEqual(
+                format_model_suffix(
+                    alias,
+                    feature=Backend.Feature.DEEP_EVAL,
+                    preferred_backend="pytorch",
+                    strict_prefer=False,
+                ),
+                alias,
+            )
+
+    def test_format_model_suffix_keeps_regular_suffix(self) -> None:
+        # Control: an ordinary backend suffix is still returned unchanged.
+        self.assertEqual(
+            format_model_suffix(
+                "model.pth",
+                feature=Backend.Feature.DEEP_EVAL,
+                preferred_backend="pytorch",
+                strict_prefer=False,
+            ),
+            "model.pth",
+        )
+
+    def test_format_model_suffix_appends_for_unknown(self) -> None:
+        # Control: a genuinely unknown name still gets the preferred suffix.
+        self.assertEqual(
+            format_model_suffix(
+                "model",
+                feature=Backend.Feature.DEEP_EVAL,
+                preferred_backend="pytorch",
+                strict_prefer=False,
+            ),
+            "model" + PretrainedBackend.get_backend("pytorch").suffixes[0],
+        )


### PR DESCRIPTION
## Problem

Fixes #5673. CLI deep-eval commands (`dp test`, `dp eval-desc`, `dp embed`, `dp model-devi`) normalize their `-m` argument through `format_model_suffix()`, which decided whether a name is supported by comparing `Path(filename).suffix` against the registered backend suffixes. `PretrainedBackend` registers built-in model names as whole-name (lowercased) suffix aliases such as `dpa-3.2-5m`, but `Path("DPA-3.2-5M").suffix` is `.2-5M` (and `DPA3-Omol-Large` has an empty suffix), so the alias never matched. Because the CLI always passes a `preferred_backend`, the unmatched alias did not raise; it silently got the default backend suffix appended (`DPA-3.2-5M` becomes `DPA-3.2-5M.pth`) and the subsequent load failed.

Note this refines the issue's description: the observed failure is a silent suffix-mangle, not the `ValueError("Unsupported model file format")` the issue predicts — that raise branch is unreachable from these CLI commands because a preferred backend is always supplied. The Python API (`DeepPot("DPA-3.2-5M")`) already worked, because `Backend.detect_backend_by_model` matches with a case-insensitive `endswith`; the two matchers were simply inconsistent.

## Fix

Align `format_model_suffix` with `Backend.match_filename`: match on a case-insensitive `endswith` over the suffix set. This recognizes both ordinary dotted suffixes (`.pth`, `.pb`, ...) and whole-name pretrained aliases (`dpa-3.2-5m`, `dpa3-omol-large`) and returns the recognized name unchanged, so `PretrainedBackend` can resolve it downstream.

## Test

Adds tests to `source/tests/common/test_pretrained_backend.py` asserting that `DPA-3.2-5M`, `DPA3-Omol-Large`, and a lowercase alias pass through `format_model_suffix` unchanged, with controls that an ordinary `model.pth` is preserved and an unknown bare name still receives the preferred suffix. The alias case fails on master (mangled to `DPA-3.2-5M.pth`) and passes with the fix. This path had no prior coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model file suffix detection so supported formats are recognized more reliably, including case-insensitive matches and non-standard suffix aliases.
  * Preserved existing behavior for unknown model names, while ensuring the preferred backend suffix is still applied when needed.

* **Tests**
  * Expanded coverage for model suffix handling to verify aliases, standard suffixes, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->