### PR TITLE
fix(jax): default fitting_net.type to ener in standard model factory

### DIFF
--- a/deepmd/jax/model/model.py
+++ b/deepmd/jax/model/model.py
@@ -42,7 +42,10 @@ def get_standard_model(data: dict) -> BaseModel:
     descriptor_type = data["descriptor"].pop("type")
     data["descriptor"]["type_map"] = data["type_map"]
     data["descriptor"]["ntypes"] = len(data["type_map"])
-    fitting_type = data["fitting_net"].pop("type")
+    # Default the fitting type to energy and tolerate a missing fitting_net
+    # block, matching the dpmodel and TF2 standard-model factories.
+    data["fitting_net"] = data.get("fitting_net", {})
+    fitting_type = data["fitting_net"].pop("type", "ener")
     data["fitting_net"]["type_map"] = data["type_map"]
     descriptor = BaseDescriptor.get_class_by_type(descriptor_type)(
         **data["descriptor"],

--- a/source/tests/jax/test_model_factory.py
+++ b/source/tests/jax/test_model_factory.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Test the JAX standard-model factory defaults the fitting type to energy.
+
+dpmodel and TF2 both default ``fitting_net.type`` to ``"ener"`` (and tolerate a
+missing ``fitting_net`` block) when constructing a standard model.  The JAX
+factory used a bare ``data["fitting_net"].pop("type")``, so a config that omits
+``fitting_net`` or leaves ``type`` unset raised ``KeyError`` on JAX only.  In
+normal training this is masked because argcheck normalization fills the default
+before the factory runs; the factory is exposed when called with a raw dict.
+"""
+
+import unittest
+
+from deepmd.jax.model.ener_model import (
+    EnergyModel,
+)
+from deepmd.jax.model.model import (
+    get_model,
+)
+
+
+def _base_config() -> dict:
+    return {
+        "type_map": ["O", "H"],
+        "descriptor": {
+            "type": "se_e2_a",
+            "sel": [20, 20],
+            "rcut_smth": 0.5,
+            "rcut": 6.0,
+            "neuron": [3, 6],
+            "axis_neuron": 2,
+            "precision": "float64",
+            "seed": 1,
+        },
+        "fitting_net": {
+            "neuron": [5, 5],
+            "precision": "float64",
+            "seed": 1,
+        },
+    }
+
+
+class TestJAXModelFactoryFittingDefault(unittest.TestCase):
+    def test_fitting_net_without_type_defaults_to_ener(self) -> None:
+        # fitting_net present but no "type": must default to energy.
+        data = _base_config()
+        model = get_model(data)
+        self.assertIsInstance(model, EnergyModel)
+
+    def test_fitting_net_omitted_defaults_to_ener(self) -> None:
+        # fitting_net block omitted entirely: must default to energy.
+        data = _base_config()
+        del data["fitting_net"]
+        model = get_model(data)
+        self.assertIsInstance(model, EnergyModel)
+
+    def test_explicit_fitting_type_preserved(self) -> None:
+        # Control: an explicit type is still honored.
+        data = _base_config()
+        data["fitting_net"]["type"] = "ener"
+        model = get_model(data)
+        self.assertIsInstance(model, EnergyModel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #5675. The JAX standard-model factory `get_standard_model` did a bare `data["fitting_net"].pop("type")` and assumed the `fitting_net` block exists, so a configuration that omits `fitting_net` or leaves `type` unset raised `KeyError` on the JAX backend only. The dpmodel and TF2 standard factories both create an empty `fitting_net` when absent and default `type` to `"ener"`, so JAX rejected otherwise valid default-energy configurations that the neighboring backends accept, and backend switching could fail for configs relying on the default energy fitting type.

This is normally masked because argcheck normalization fills the default before the factory runs, but the factory is reachable with a raw, un-normalized dict (direct API use, deserialized configs, backend switching), where the missing key surfaces.

## Fix

Mirror the TF2 factory: default the block and the type in place — `data["fitting_net"] = data.get("fitting_net", {})` then `fitting_type = data["fitting_net"].pop("type", "ener")`.

## Test

Adds `source/tests/jax/test_model_factory.py`, which calls `get_model` with a `fitting_net` that lacks `type` and with `fitting_net` omitted entirely — both raise `KeyError` on master and build an `EnergyModel` after the fix — plus an explicit-type control. This factory path had no coverage for the missing-type case (every existing test supplies a normalized config).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading so configurations without a fitting section no longer fail.
  * When a fitting type is not specified, it now defaults to an energy model.
  * Explicitly provided fitting types continue to be respected.

* **Tests**
  * Added coverage for missing fitting settings and missing fitting type defaults.
  * Added a check to confirm explicitly configured fitting types are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->