### PR TITLE
fix(test): read the hessian from the correct dp test result slot

### DIFF
--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -734,7 +734,6 @@ def test_ener(
         numb_test=numb_test,
     )
     ae = optional_outputs.atom_energy
-    av = optional_outputs.atom_virial
     force_m = optional_outputs.force_mag
     mask_mag = optional_outputs.mask_mag
     hessian = optional_outputs.hessian

--- a/deepmd/entrypoints/test.py
+++ b/deepmd/entrypoints/test.py
@@ -8,6 +8,7 @@ from pathlib import (
 from typing import (
     TYPE_CHECKING,
     Any,
+    NamedTuple,
 )
 
 import numpy as np
@@ -559,6 +560,47 @@ def _write_energy_test_details(
         )
 
 
+class _OptionalEnerOutputs(NamedTuple):
+    """The optional trailing outputs of ``DeepPot.eval`` (``None`` when absent)."""
+
+    atom_energy: "np.ndarray | None"
+    atom_virial: "np.ndarray | None"
+    force_mag: "np.ndarray | None"
+    mask_mag: "np.ndarray | None"
+    hessian: "np.ndarray | None"
+
+
+def _split_optional_ener_outputs(
+    ret: tuple,
+    *,
+    has_atom_ener: bool,
+    has_spin: bool,
+    has_hessian: bool,
+    numb_test: int,
+) -> _OptionalEnerOutputs:
+    """Split the optional trailing outputs of ``DeepPot.eval``.
+
+    ``DeepPot.eval`` appends its optional outputs after ``(energy, force,
+    virial)`` in a fixed order: atomic ``(atom_energy, atom_virial)``, then spin
+    ``(force_mag, mask_mag)``, then ``hessian``. Read them by advancing an index
+    through the tuple in that same order, so the hessian slot is not confused
+    with atomic energy/virial or spin outputs when those are also present.
+    """
+    atom_energy = atom_virial = force_mag = mask_mag = hessian = None
+    idx = 3
+    if has_atom_ener:
+        atom_energy = ret[idx].reshape([numb_test, -1])
+        atom_virial = ret[idx + 1].reshape([numb_test, -1])
+        idx += 2
+    if has_spin:
+        force_mag = ret[idx].reshape([numb_test, -1])
+        mask_mag = ret[idx + 1].reshape([numb_test, -1])
+        idx += 2
+    if has_hessian:
+        hessian = ret[idx].reshape([numb_test, -1])
+    return _OptionalEnerOutputs(atom_energy, atom_virial, force_mag, mask_mag, hessian)
+
+
 def test_ener(
     dp: "DeepPot",
     data: DeepmdData,
@@ -684,28 +726,18 @@ def test_ener(
     energy = energy.reshape([numb_test, 1])
     force = force.reshape([numb_test, -1])
     virial = virial.reshape([numb_test, 9])
-    hessian = None
-    force_m = None
-    mask_mag = None
-    if dp.has_hessian:
-        hessian = ret[3]
-        hessian = hessian.reshape([numb_test, -1])
-    if has_atom_ener:
-        ae = ret[3]
-        av = ret[4]
-        ae = ae.reshape([numb_test, -1])
-        av = av.reshape([numb_test, -1])
-        if dp.has_spin:
-            force_m = ret[5]
-            force_m = force_m.reshape([numb_test, -1])
-            mask_mag = ret[6]
-            mask_mag = mask_mag.reshape([numb_test, -1])
-    else:
-        if dp.has_spin:
-            force_m = ret[3]
-            force_m = force_m.reshape([numb_test, -1])
-            mask_mag = ret[4]
-            mask_mag = mask_mag.reshape([numb_test, -1])
+    optional_outputs = _split_optional_ener_outputs(
+        ret,
+        has_atom_ener=has_atom_ener,
+        has_spin=dp.has_spin,
+        has_hessian=dp.has_hessian,
+        numb_test=numb_test,
+    )
+    ae = optional_outputs.atom_energy
+    av = optional_outputs.atom_virial
+    force_m = optional_outputs.force_mag
+    mask_mag = optional_outputs.mask_mag
+    hessian = optional_outputs.hessian
     out_put_spin = dp.get_ntypes_spin() != 0 or dp.has_spin
     spin_metrics = None
     force_r = None

--- a/source/tests/common/test_dp_test_ener_split.py
+++ b/source/tests/common/test_dp_test_ener_split.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Regression test for splitting DeepPot.eval optional outputs in `dp test`.
+
+`DeepPot.eval` appends optional outputs after (energy, force, virial) in a fixed
+order: atomic (atom_energy, atom_virial), then spin (force_mag, mask_mag), then
+hessian. `dp test` used to read the hessian unconditionally from ret[3], so when
+atomic or spin outputs were also present the hessian slot was mistaken for an
+atomic energy / magnetic force. This checks the hessian (and the other optional
+outputs) are read from the correct advancing index.
+"""
+
+import unittest
+
+import numpy as np
+
+from deepmd.entrypoints.test import (
+    _split_optional_ener_outputs,
+)
+
+
+def _sentinel(value: int, width: int) -> np.ndarray:
+    # one frame, filled with `value` so the source slot is identifiable
+    return np.full((1, width), value, dtype=np.float64)
+
+
+# distinct sentinel value per optional output slot
+AE, AV, FM, MM, HE = 3, 4, 5, 6, 7
+
+
+def _ret(*, atomic: bool, spin: bool, hessian: bool) -> tuple:
+    ret = [_sentinel(0, 1), _sentinel(1, 6), _sentinel(2, 9)]  # energy, force, virial
+    if atomic:
+        ret += [_sentinel(AE, 2), _sentinel(AV, 18)]
+    if spin:
+        ret += [_sentinel(FM, 6), _sentinel(MM, 2)]
+    if hessian:
+        ret += [_sentinel(HE, 36)]
+    return tuple(ret)
+
+
+class TestSplitOptionalEnerOutputs(unittest.TestCase):
+    def _run(self, atomic: bool, spin: bool, hessian: bool):
+        return _split_optional_ener_outputs(
+            _ret(atomic=atomic, spin=spin, hessian=hessian),
+            has_atom_ener=atomic,
+            has_spin=spin,
+            has_hessian=hessian,
+            numb_test=1,
+        )
+
+    def test_hessian_only(self) -> None:
+        out = self._run(atomic=False, spin=False, hessian=True)
+        self.assertEqual(out.hessian[0, 0], HE)
+        self.assertIsNone(out.atom_energy)
+
+    def test_atomic_and_hessian(self) -> None:
+        # hessian must come from ret[5], not ret[3] (which is atom_energy)
+        out = self._run(atomic=True, spin=False, hessian=True)
+        self.assertEqual(out.atom_energy[0, 0], AE)
+        self.assertEqual(out.atom_virial[0, 0], AV)
+        self.assertEqual(out.hessian[0, 0], HE)
+
+    def test_spin_and_hessian(self) -> None:
+        out = self._run(atomic=False, spin=True, hessian=True)
+        self.assertEqual(out.force_mag[0, 0], FM)
+        self.assertEqual(out.mask_mag[0, 0], MM)
+        self.assertEqual(out.hessian[0, 0], HE)
+
+    def test_atomic_spin_and_hessian(self) -> None:
+        # hessian at ret[7] with all optional outputs present
+        out = self._run(atomic=True, spin=True, hessian=True)
+        self.assertEqual(out.atom_energy[0, 0], AE)
+        self.assertEqual(out.force_mag[0, 0], FM)
+        self.assertEqual(out.hessian[0, 0], HE)
+
+    def test_atomic_and_spin_no_hessian(self) -> None:
+        out = self._run(atomic=True, spin=True, hessian=False)
+        self.assertEqual(out.atom_energy[0, 0], AE)
+        self.assertEqual(out.force_mag[0, 0], FM)
+        self.assertIsNone(out.hessian)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #5672. `DeepPot.eval` appends its optional outputs after `(energy, force, virial)` in a fixed order: atomic `(atom_energy, atom_virial)`, then spin `(force_mag, mask_mag)`, then `hessian`, so the hessian index is `3 + 2*atomic + 2*spin`. But `dp test` read `hessian = ret[3]` unconditionally, before advancing past the atomic and spin outputs. For a hessian model evaluated with atomic output (`dp test -a`) or with spin output, `ret[3]` is the atomic energy or the magnetic force, so the hessian metric compared the wrong array against the hessian label, raising a shape error or reporting invalid hessian MAE/RMSE. The atomic and spin reads already advanced correctly; only the hessian read was hard-wired.

The plain non-atomic non-spin path was correct (hessian is genuinely at `ret[3]` there), which is why this went unnoticed: `dp test` has no test that exercises hessian together with atomic or spin outputs.

## Fix

Parse the optional outputs by advancing an index through the tuple in the same order `eval` constructs them, via a `_split_optional_ener_outputs` helper. Following the issue's suggestion to return a named structure internally, the helper returns an `_OptionalEnerOutputs` NamedTuple so the hessian, atomic, and spin slots are read by name rather than by a hard-coded index. `DeepPot.eval`'s public tuple return is unchanged (a dict return there would be a breaking change to a core public API and belongs in a separate PR).

## Test

Adds `source/tests/common/test_dp_test_ener_split.py`, which feeds sentinel-valued `ret` tuples for every combination of atomic/spin/hessian and asserts each optional output is read from the correct advancing slot. The atomic+hessian and spin+hessian cases fail against the old `ret[3]` read (the hessian slot is `ret[5]`/`ret[7]` when those outputs are present).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `dp test` handling of optional energy-related outputs to ensure values are extracted in the correct sequence when atomic, spin, and Hessian data are present together.
  * Prevented cases where optional fields could be read from the wrong position, improving accuracy and stability.

* **Tests**
  * Added regression tests covering atomic-only, spin-only, Hessian-only, and combined scenarios to verify correct output splitting for each supported combination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->