### PR TITLE
fix(jax,tf2): deep-copy and propagate type_map in ZBL model factories

### DIFF
--- a/deepmd/jax/model/model.py
+++ b/deepmd/jax/model/model.py
@@ -65,10 +65,13 @@ def get_standard_model(data: dict) -> BaseModel:
 
 
 def get_zbl_model(data: dict) -> DPZBLModel:
+    data = deepcopy(data)
     data["descriptor"]["ntypes"] = len(data["type_map"])
+    data["descriptor"]["type_map"] = data["type_map"]
     descriptor_type = data["descriptor"].pop("type")
     descriptor = BaseDescriptor.get_class_by_type(descriptor_type)(**data["descriptor"])
     fitting_type = data["fitting_net"].pop("type")
+    data["fitting_net"]["type_map"] = data["type_map"]
     if fitting_type == "ener":
         fitting = EnergyFittingNet(
             ntypes=descriptor.get_ntypes(),

--- a/deepmd/tf2/model/model.py
+++ b/deepmd/tf2/model/model.py
@@ -66,10 +66,13 @@ def get_standard_model(data: dict) -> BaseModel:
 
 
 def get_zbl_model(data: dict) -> DPZBLModel:
+    data = deepcopy(data)
     data["descriptor"]["ntypes"] = len(data["type_map"])
+    data["descriptor"]["type_map"] = data["type_map"]
     descriptor_type = data["descriptor"].pop("type")
     descriptor = BaseDescriptor.get_class_by_type(descriptor_type)(**data["descriptor"])
     fitting_type = data["fitting_net"].pop("type")
+    data["fitting_net"]["type_map"] = data["type_map"]
     if fitting_type == "ener":
         fitting = EnergyFittingNet(
             ntypes=descriptor.get_ntypes(),

--- a/source/tests/consistent/test_tf2_zbl_model.py
+++ b/source/tests/consistent/test_tf2_zbl_model.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Test the TF2 ZBL model factory deep-copies input and injects type_map.
+
+The TF2 (and JAX) ZBL factory used to mutate the caller's config in place and
+did not propagate ``type_map`` into the descriptor and fitting sub-configs,
+unlike the standard and dpmodel factories. This checks the factory leaves the
+input dict unchanged and that the constructed descriptor and fitting carry the
+model ``type_map``. Gated on the TF2 backend (``DEEPMD_TEST_TF2=1``).
+"""
+
+import os
+import unittest
+from copy import (
+    deepcopy,
+)
+
+from .common import (
+    INSTALLED_TF2,
+)
+
+if INSTALLED_TF2:
+    from deepmd.tf2.model.model import (
+        get_zbl_model,
+    )
+
+TESTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRTAB = os.path.join(
+    TESTS_DIR, "pt", "water", "data", "zbl_tab_potential", "H2O_tab_potential.txt"
+)
+
+
+def _zbl_config() -> dict:
+    return {
+        "type_map": ["O", "H", "B"],
+        "use_srtab": SRTAB,
+        "sw_rmin": 0.2,
+        "sw_rmax": 4.0,
+        "smin_alpha": 0.1,
+        # ZBL wraps a linear atomic model, which requires a mixed-type descriptor
+        "descriptor": {
+            "type": "se_atten",
+            "sel": 40,
+            "rcut_smth": 0.5,
+            "rcut": 4.0,
+            "neuron": [3, 6],
+            "axis_neuron": 2,
+            "attn": 8,
+            "attn_layer": 2,
+            "attn_dotr": True,
+            "attn_mask": False,
+            "set_davg_zero": True,
+            "type_one_side": True,
+            "seed": 1,
+        },
+        "fitting_net": {
+            "type": "ener",
+            "neuron": [5, 5],
+            "seed": 1,
+        },
+    }
+
+
+@unittest.skipUnless(INSTALLED_TF2, "TF2 backend is not installed")
+class TestTF2ZBLModelFactory(unittest.TestCase):
+    def test_does_not_mutate_input(self) -> None:
+        data = _zbl_config()
+        orig = deepcopy(data)
+        get_zbl_model(data)
+        self.assertEqual(data, orig)
+
+    def test_injects_type_map_into_subconfigs(self) -> None:
+        data = _zbl_config()
+        model = get_zbl_model(data)
+        dp_atomic = model.atomic_model.models[0]
+        self.assertEqual(list(dp_atomic.descriptor.get_type_map()), data["type_map"])
+        self.assertEqual(list(dp_atomic.fitting_net.get_type_map()), data["type_map"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/tests/jax/test_zbl_model.py
+++ b/source/tests/jax/test_zbl_model.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Test the JAX ZBL model factory deep-copies input and injects type_map.
+
+The JAX (and TF2) ZBL factory used to mutate the caller's config in place (via
+``pop("type")``) and did not propagate ``type_map`` into the descriptor and
+fitting sub-configs, unlike the standard and dpmodel factories. This checks the
+factory leaves the input dict unchanged and that the constructed descriptor and
+fitting carry the model ``type_map``.
+"""
+
+import os
+import unittest
+from copy import (
+    deepcopy,
+)
+
+from deepmd.jax.model.model import (
+    get_zbl_model,
+)
+
+TESTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRTAB = os.path.join(
+    TESTS_DIR, "pt", "water", "data", "zbl_tab_potential", "H2O_tab_potential.txt"
+)
+
+
+def _zbl_config() -> dict:
+    return {
+        "type_map": ["O", "H", "B"],
+        "use_srtab": SRTAB,
+        "sw_rmin": 0.2,
+        "sw_rmax": 4.0,
+        "smin_alpha": 0.1,
+        # ZBL wraps a linear atomic model, which requires a mixed-type descriptor
+        "descriptor": {
+            "type": "se_atten",
+            "sel": 40,
+            "rcut_smth": 0.5,
+            "rcut": 4.0,
+            "neuron": [3, 6],
+            "axis_neuron": 2,
+            "attn": 8,
+            "attn_layer": 2,
+            "attn_dotr": True,
+            "attn_mask": False,
+            "set_davg_zero": True,
+            "type_one_side": True,
+            "seed": 1,
+        },
+        "fitting_net": {
+            "type": "ener",
+            "neuron": [5, 5],
+            "seed": 1,
+        },
+    }
+
+
+class TestJAXZBLModelFactory(unittest.TestCase):
+    def test_does_not_mutate_input(self) -> None:
+        data = _zbl_config()
+        orig = deepcopy(data)
+        get_zbl_model(data)
+        self.assertEqual(data, orig)
+
+    def test_injects_type_map_into_subconfigs(self) -> None:
+        data = _zbl_config()
+        model = get_zbl_model(data)
+        dp_atomic = model.atomic_model.models[0]
+        self.assertEqual(dp_atomic.descriptor.get_type_map(), data["type_map"])
+        self.assertEqual(dp_atomic.fitting_net.get_type_map(), data["type_map"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #5676. The JAX and TF2 ZBL model factories (`get_zbl_model`), unlike the standard-model factories and the dpmodel ZBL path, mutated the caller's config dict in place (popping the descriptor and `fitting_net` `type`) and did not inject `type_map` into the descriptor and fitting sub-configs. The in-place mutation is inconsistent with the neighboring factories, and the missing `type_map` leaves the descriptor and fitting without the model type map that standard/dpmodel construction provides.

## Fix

Deep-copy the input and inject `type_map` into the descriptor and fitting configs in both `get_zbl_model` factories, mirroring the dpmodel ZBL path.

The issue also suspected the retained JAX checkpoint metadata could be corrupted by the in-place mutation. That does not actually happen: the JAX trainer passes a `deepcopy` of the model params into the factory, so the stored `model_def_script` is never mutated. No change is made for that sub-claim.

## Test

Adds `source/tests/jax/test_zbl_model.py` and a TF2-gated `source/tests/consistent/test_tf2_zbl_model.py`, each asserting the factory leaves the input dict unchanged and that the constructed descriptor and fitting carry the model `type_map`. Both assertions fail on master (the input is mutated and the sub-config `type_map` is `None`) and pass with the fix. The TF2 test is gated on `INSTALLED_TF2` (`DEEPMD_TEST_TF2=1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZBL model setup so input configuration data is no longer modified during model creation.
  * Ensured type mappings are consistently applied to both descriptor and fitting settings when building ZBL models.

* **Tests**
  * Added coverage for JAX and TF2 ZBL model factories to verify configuration immutability and correct type mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->