### PR TITLE
fix(lmp): avoid double qe2f in DPLR efield

### DIFF
--- a/source/lmp/fix_dplr.cpp
+++ b/source/lmp/fix_dplr.cpp
@@ -652,7 +652,7 @@ void FixDPLR::post_force(int vflag) {
     for (int ii = 0; ii < nlocal; ++ii) {
       double tmpf[3];
       for (int dd = 0; dd < 3; ++dd) {
-        tmpf[dd] = q[ii] * efield[dd] * force->qe2f;
+        tmpf[dd] = q[ii] * efield[dd];
       }
       for (int dd = 0; dd < 3; ++dd) {
         dfele[ii * 3 + dd] += tmpf[dd];

--- a/source/lmp/tests/test_dplr.py
+++ b/source/lmp/tests/test_dplr.py
@@ -355,6 +355,13 @@ def lammps_si():
     lmp.close()
 
 
+@pytest.fixture
+def lammps_real():
+    lmp = _lammps(data_file=data_file, units="real")
+    yield lmp
+    lmp.close()
+
+
 def test_pair_deepmd_sr(lammps) -> None:
     lammps.pair_style(f"deepmd {pb_file.resolve()}")
     lammps.pair_coeff("* *")
@@ -506,6 +513,39 @@ def test_pair_deepmd_lr_efield_variable(lammps) -> None:
         assert lammps.atoms[np.where(id_list == (ii + 1))[0][0]].force == pytest.approx(
             expected_f_lr_efield_variable_step1[ii]
         )
+
+
+def test_pair_deepmd_lr_efield_constant_real(lammps_real) -> None:
+    lammps_real.pair_style(f"deepmd {pb_file.resolve()}")
+    lammps_real.pair_coeff("* *")
+    lammps_real.bond_style("zero")
+    lammps_real.bond_coeff("*")
+    lammps_real.special_bonds("lj/coul 1 1 1 angle no")
+    lammps_real.fix(
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 1"
+    )
+    lammps_real.fix_modify("0 energy yes virial yes")
+    lammps_real.run(0)
+    assert lammps_real.eval("f_0") == pytest.approx(
+        expected_e_efield_constant * constants.ener_metal2real
+    )
+
+
+def test_pair_deepmd_lr_efield_variable_real(lammps_real) -> None:
+    lammps_real.variable("EFIELD_Z equal 1.0")
+    lammps_real.pair_style(f"deepmd {pb_file.resolve()}")
+    lammps_real.pair_coeff("* *")
+    lammps_real.bond_style("zero")
+    lammps_real.bond_coeff("*")
+    lammps_real.special_bonds("lj/coul 1 1 1 angle no")
+    lammps_real.fix(
+        f"0 all dplr model {pb_file.resolve()} type_associate 1 3 bond_type 1 efield 0 0 v_EFIELD_Z"
+    )
+    lammps_real.fix_modify("0 energy yes virial yes")
+    lammps_real.run(0)
+    assert lammps_real.eval("f_0") == pytest.approx(
+        expected_e_efield_constant * constants.ener_metal2real
+    )
 
 
 def test_min_dplr(lammps) -> None:


### PR DESCRIPTION
## Summary
- remove the second qe2f multiplication when forming fix dplr efield forces
- keep the existing conversion when storing constant and equal-style efield values
- add real-unit regressions for constant and equal-style efield paths so qe2f != 1 is covered

Closes #5646.

## Tests
- git diff --check
- /tmp/deepmd-check-venv/bin/ruff check .
- /tmp/deepmd-check-venv/bin/ruff format --check .

## Not run
- Targeted LAMMPS DPLR pytest tests could not run in the local ad hoc venv: the lammps Python module is not installed there, and pytest startup segfaulted in the temporary environment before collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected electric-field force calculations so results are accumulated consistently in real-unit simulations.
  * Fixed related force and virial contributions to match expected values.

* **Tests**
  * Added coverage for electric-field behavior in real units.
  * Included checks for both constant and variable field settings to confirm force results remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->