### PR TITLE
ci: use ubuntu-slim for lightweight workflows

### DIFF
--- a/.github/workflows/build_cc.yml
+++ b/.github/workflows/build_cc.yml
@@ -77,7 +77,7 @@ jobs:
   pass:
     name: Pass building C++
     needs: [buildcc]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -192,7 +192,7 @@ jobs:
   pass:
     name: Pass testing build wheels
     needs: [build_wheels, build_sdist, build_docker, build_pypi_index]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/mirror_gitee.yml
+++ b/.github/workflows/mirror_gitee.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   git-mirror:
     if: github.repository_owner == 'deepmodeling'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: wearerequired/git-mirror-action@v1
         env:

--- a/.github/workflows/package_c.yml
+++ b/.github/workflows/package_c.yml
@@ -101,7 +101,7 @@ jobs:
   pass:
     name: Pass building c library
     needs: [build_c, test_c]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/remove_test_cuda_label.yml
+++ b/.github/workflows/remove_test_cuda_label.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     # so one can re-trigger the workflow without manually removing the label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository_owner == 'deepmodeling' && github.event.label.name == 'Test CUDA'
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1

--- a/.github/workflows/test_cc.yml
+++ b/.github/workflows/test_cc.yml
@@ -111,7 +111,7 @@ jobs:
   pass:
     name: Pass testing C++
     needs: [testcc]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -97,7 +97,7 @@ jobs:
   pass:
     name: Pass testing on CUDA
     needs: [test_cuda]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -112,7 +112,7 @@ jobs:
       id-token: write
   update_durations:
     name: Combine and update integration test durations
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:
@@ -140,7 +140,7 @@ jobs:
   pass:
     name: Pass testing Python
     needs: [testpython, update_durations]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     if: github.repository_owner == 'deepmodeling'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
       - name: Run tdg-github-action


### PR DESCRIPTION
## Summary
- switch lightweight label, mirror, TODO, and pass aggregation jobs to ubuntu-slim
- switch the Python test duration aggregation job to ubuntu-slim
- keep build and test execution jobs on their existing runners

## Validation
- python YAML parse for all workflow files
- git diff --check
- ruff check .

Note: ruff format --check . still reports pre-existing formatting in dpa_adapt/cli.py, which is unrelated to this workflow-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several GitHub Actions jobs to run on a slimmer Ubuntu runner.
  * Applied this environment change across build, test, packaging, labeling, mirroring, and maintenance workflows.
  * No workflow steps, dependencies, or job logic were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->