### PR TITLE
fix(lmp): clear DPLR PPPM force cache

### DIFF
--- a/source/lmp/pppm_dplr.cpp
+++ b/source/lmp/pppm_dplr.cpp
@@ -48,6 +48,14 @@ PPPMDPLR::PPPMDPLR(LAMMPS* lmp)
 
 /* ---------------------------------------------------------------------- */
 
+void PPPMDPLR::clear_fele() {
+  int nlocal = atom->nlocal;
+  fele.resize(static_cast<size_t>(nlocal) * 3);
+  fill(fele.begin(), fele.end(), 0.0);
+}
+
+/* ---------------------------------------------------------------------- */
+
 void PPPMDPLR::init() {
   // DPLR PPPM requires newton on, b/c it computes forces on ghost atoms
 
@@ -57,10 +65,8 @@ void PPPMDPLR::init() {
 
   PPPM::init();
 
-  int nlocal = atom->nlocal;
   // cout << " ninit pppm/dplr ---------------------- " << nlocal << endl;
-  fele.resize(static_cast<size_t>(nlocal) * 3);
-  fill(fele.begin(), fele.end(), 0.0);
+  clear_fele();
 }
 
 /* ----------------------------------------------------------------------
@@ -89,6 +95,7 @@ void PPPMDPLR::compute(int eflag, int vflag) {
   // return if there are no charges
 
   if (qsqsum == 0.0) {
+    clear_fele();
     return;
   }
 
@@ -296,8 +303,7 @@ void PPPMDPLR::fieldforce_ik() {
   int nghost = atom->nghost;
   int nall = nlocal + nghost;
 
-  fele.resize(static_cast<size_t>(nlocal) * 3);
-  fill(fele.begin(), fele.end(), 0.0);
+  clear_fele();
 
   for (i = 0; i < nlocal; i++) {
     nx = part2grid[i][0];
@@ -372,8 +378,7 @@ void PPPMDPLR::fieldforce_ad() {
   int nghost = atom->nghost;
   int nall = nlocal + nghost;
 
-  fele.resize(static_cast<size_t>(nlocal) * 3);
-  fill(fele.begin(), fele.end(), 0.0);
+  clear_fele();
 
   for (i = 0; i < nlocal; i++) {
     nx = part2grid[i][0];

--- a/source/lmp/pppm_dplr.h
+++ b/source/lmp/pppm_dplr.h
@@ -36,6 +36,7 @@ class PPPMDPLR : public PPPM {
   void fieldforce_ad() override;
 
  private:
+  void clear_fele();
   std::vector<double> fele;
 };
 


### PR DESCRIPTION
## Summary
- add a small helper to resize and zero the DPLR PPPM fele cache
- clear fele before returning from PPPMDPLR::compute when qsqsum == 0
- reuse the same helper in init and fieldforce paths

This addresses #5647 as a defensive consistency fix. In normal DeePMD DPLR usage, atom charges are fixed and are not changed from nonzero to all-zero during a run, so this stale-cache path should not be triggered by standard DeePMD workflows. It would only matter for unusual external charge mutation or reinitialization paths where qsqsum is refreshed to zero after a previous nonzero-charge PPPM/DPLR step.

## Tests
- git diff --check
- /tmp/deepmd-check-venv/bin/ruff check .
- /tmp/deepmd-check-venv/bin/ruff format --check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in per-atom field/force handling by clearing the accumulator before early exits and during setup.
  * Reduced the chance of stale values carrying over between calculations.

* **Refactor**
  * Consolidated repeated zeroing and resizing steps into a shared internal routine, simplifying the calculation flow and making the code easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->