### PR TITLE
test(dpa4): enable array-api-strict consistency tests

### DIFF
--- a/deepmd/dpmodel/descriptor/dpa4_nn/norm.py
+++ b/deepmd/dpmodel/descriptor/dpa4_nn/norm.py
@@ -546,7 +546,7 @@ class ScalarRMSNorm(NativeOP):
         if x.ndim == 2:
             inv_rms = 1.0 / xp.sqrt(xp.mean(x * x, axis=-1, keepdims=True) + self.eps)
             x = x * inv_rms
-            x = x * xp_asarray_nodetach(xp, self.adam_scale[...], device=device)[0]
+            x = x * xp_asarray_nodetach(xp, self.adam_scale[...], device=device)[0, :]
             return xp.astype(x, in_dtype)
 
         inv_rms = 1.0 / xp.sqrt(xp.mean(x * x, axis=-1, keepdims=True) + self.eps)

--- a/source/tests/array_api_strict/common.py
+++ b/source/tests/array_api_strict/common.py
@@ -59,8 +59,10 @@ _REGISTRATION_MODULES = (
     f"{_PACKAGE_ROOT}.descriptor.dpa2",
     f"{_PACKAGE_ROOT}.descriptor.repflows",
     f"{_PACKAGE_ROOT}.descriptor.dpa3",
+    f"{_PACKAGE_ROOT}.descriptor.dpa4",
     f"{_PACKAGE_ROOT}.descriptor.hybrid",
     f"{_PACKAGE_ROOT}.fitting",
+    f"{_PACKAGE_ROOT}.fitting.dpa4_ener",
 )
 
 

--- a/source/tests/array_api_strict/descriptor/__init__.py
+++ b/source/tests/array_api_strict/descriptor/__init__.py
@@ -8,6 +8,9 @@ from .dpa2 import (
 from .dpa3 import (
     DescrptDPA3,
 )
+from .dpa4 import (
+    DescrptDPA4,
+)
 from .hybrid import (
     DescrptHybrid,
 )
@@ -31,6 +34,7 @@ __all__ = [
     "DescrptDPA1",
     "DescrptDPA2",
     "DescrptDPA3",
+    "DescrptDPA4",
     "DescrptHybrid",
     "DescrptSeA",
     "DescrptSeAttenV2",

--- a/source/tests/array_api_strict/descriptor/dpa4.py
+++ b/source/tests/array_api_strict/descriptor/dpa4.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from deepmd.dpmodel.descriptor.dpa4 import DescrptDPA4 as DescrptDPA4DP
+from deepmd.dpmodel.descriptor.dpa4_nn.activation import (
+    SwiGLU,
+)
+from deepmd.dpmodel.descriptor.dpa4_nn.grid_net import (
+    GridProduct,
+)
+from deepmd.dpmodel.descriptor.dpa4_nn.radial import (
+    BridgingSwitch,
+    C3CutoffEnvelope,
+    InnerClamp,
+)
+from deepmd.dpmodel.descriptor.dpa4_nn.wignerd import (
+    WignerDCalculator,
+)
+
+from ..common import (
+    array_api_strict_module,
+    register_dpmodel_mapping,
+)
+from ..utils import exclude_mask as _strict_exclude_mask  # noqa: F401
+from ..utils import network as _strict_network  # noqa: F401
+from .base_descriptor import (
+    BaseDescriptor,
+)
+
+
+@BaseDescriptor.register("SeZM")
+@BaseDescriptor.register("sezm")
+@BaseDescriptor.register("DPA4")
+@BaseDescriptor.register("dpa4")
+@array_api_strict_module
+class DescrptDPA4(DescrptDPA4DP):
+    pass
+
+
+for _stateless_cls in (
+    BridgingSwitch,
+    C3CutoffEnvelope,
+    GridProduct,
+    InnerClamp,
+    SwiGLU,
+    WignerDCalculator,
+):
+    register_dpmodel_mapping(_stateless_cls, lambda v: v)

--- a/source/tests/array_api_strict/descriptor/dpa4.py
+++ b/source/tests/array_api_strict/descriptor/dpa4.py
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from importlib import (
+    import_module,
+)
+
 from deepmd.dpmodel.descriptor.dpa4 import DescrptDPA4 as DescrptDPA4DP
 from deepmd.dpmodel.descriptor.dpa4_nn.activation import (
     SwiGLU,
@@ -19,11 +23,12 @@ from ..common import (
     array_api_strict_module,
     register_dpmodel_mapping,
 )
-from ..utils import exclude_mask as _strict_exclude_mask  # noqa: F401
-from ..utils import network as _strict_network  # noqa: F401
 from .base_descriptor import (
     BaseDescriptor,
 )
+
+import_module("..utils.exclude_mask", __package__)
+import_module("..utils.network", __package__)
 
 
 @BaseDescriptor.register("SeZM")

--- a/source/tests/array_api_strict/fitting/__init__.py
+++ b/source/tests/array_api_strict/fitting/__init__.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from .dpa4_ener import (
+    SeZMEnergyFittingNet,
+)
 from .fitting import (
     DipoleFittingNet,
     DOSFittingNet,
@@ -13,4 +16,5 @@ __all__ = [
     "EnergyFittingNet",
     "PolarFittingNet",
     "PropertyFittingNet",
+    "SeZMEnergyFittingNet",
 ]

--- a/source/tests/array_api_strict/fitting/dpa4_ener.py
+++ b/source/tests/array_api_strict/fitting/dpa4_ener.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+from typing import (
+    ClassVar,
+)
+
+from deepmd.dpmodel.fitting.dpa4_ener import GLUFittingNet as GLUFittingNetDP
+from deepmd.dpmodel.fitting.dpa4_ener import (
+    SeZMEnergyFittingNet as SeZMEnergyFittingNetDP,
+)
+from deepmd.dpmodel.fitting.dpa4_ener import (
+    SeZMNetworkCollection as SeZMNetworkCollectionDP,
+)
+
+from ..common import (
+    array_api_strict_module,
+    register_dpmodel_mapping,
+)
+from ..utils import network as _strict_network  # noqa: F401
+
+
+@array_api_strict_module
+class GLUFittingNet(GLUFittingNetDP):
+    pass
+
+
+@array_api_strict_module
+class SeZMNetworkCollection(SeZMNetworkCollectionDP):
+    NETWORK_TYPE_MAP: ClassVar[dict[str, type]] = {
+        "sezm_fitting_network": GLUFittingNet,
+    }
+
+
+@array_api_strict_module
+class SeZMEnergyFittingNet(SeZMEnergyFittingNetDP):
+    pass
+
+
+register_dpmodel_mapping(
+    GLUFittingNetDP,
+    lambda v: GLUFittingNet.deserialize(v.serialize()),
+)
+
+register_dpmodel_mapping(
+    SeZMNetworkCollectionDP,
+    lambda v: SeZMNetworkCollection.deserialize(v.serialize()),
+)

--- a/source/tests/array_api_strict/fitting/dpa4_ener.py
+++ b/source/tests/array_api_strict/fitting/dpa4_ener.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+from importlib import (
+    import_module,
+)
 from typing import (
     ClassVar,
 )
@@ -13,9 +16,9 @@ from deepmd.dpmodel.fitting.dpa4_ener import (
 
 from ..common import (
     array_api_strict_module,
-    register_dpmodel_mapping,
 )
-from ..utils import network as _strict_network  # noqa: F401
+
+import_module("..utils.network", __package__)
 
 
 @array_api_strict_module
@@ -33,14 +36,3 @@ class SeZMNetworkCollection(SeZMNetworkCollectionDP):
 @array_api_strict_module
 class SeZMEnergyFittingNet(SeZMEnergyFittingNetDP):
     pass
-
-
-register_dpmodel_mapping(
-    GLUFittingNetDP,
-    lambda v: GLUFittingNet.deserialize(v.serialize()),
-)
-
-register_dpmodel_mapping(
-    SeZMNetworkCollectionDP,
-    lambda v: SeZMNetworkCollection.deserialize(v.serialize()),
-)

--- a/source/tests/consistent/descriptor/test_dpa4.py
+++ b/source/tests/consistent/descriptor/test_dpa4.py
@@ -29,36 +29,14 @@ from .common import (
     DescriptorTest,
 )
 
-DescrptDPA4PT = None
-DescrptDPA4PTExpt = None
-
-
-def _get_descrpt_dpa4_pt() -> type | None:
-    global DescrptDPA4PT
-    if not INSTALLED_PT:
-        return None
-    if DescrptDPA4PT is None:
-        from deepmd.pt.model.descriptor.sezm import (
-            DescrptSeZM,
-        )
-
-        DescrptDPA4PT = DescrptSeZM
-    return DescrptDPA4PT
-
-
-def _get_descrpt_dpa4_pt_expt() -> type | None:
-    global DescrptDPA4PTExpt
-    if not INSTALLED_PT_EXPT:
-        return None
-    if DescrptDPA4PTExpt is None:
-        from deepmd.pt_expt.descriptor.dpa4 import (
-            DescrptDPA4,
-        )
-
-        DescrptDPA4PTExpt = DescrptDPA4
-    return DescrptDPA4PTExpt
-
-
+if INSTALLED_PT:
+    from deepmd.pt.model.descriptor.sezm import DescrptSeZM as DescrptDPA4PT
+else:
+    DescrptDPA4PT = None
+if INSTALLED_PT_EXPT:
+    from deepmd.pt_expt.descriptor.dpa4 import DescrptDPA4 as DescrptDPA4PTExpt
+else:
+    DescrptDPA4PTExpt = None
 if INSTALLED_ARRAY_API_STRICT:
     from ...array_api_strict.descriptor.dpa4 import DescrptDPA4 as DescrptDPA4Strict
 else:
@@ -173,28 +151,19 @@ class TestDPA4(CommonTest, DescriptorTest, unittest.TestCase):
 
     @property
     def skip_pt(self) -> bool:
-        return CommonTest.skip_pt or _get_descrpt_dpa4_pt() is None
-
-    @property
-    def skip_pt_expt(self) -> bool:
-        return not INSTALLED_PT_EXPT or _get_descrpt_dpa4_pt_expt() is None
-
-    @property
-    def pt_class(self) -> type | None:
-        return _get_descrpt_dpa4_pt()
-
-    @property
-    def pt_expt_class(self) -> type | None:
-        return _get_descrpt_dpa4_pt_expt()
+        return CommonTest.skip_pt
 
     skip_dp = False
     skip_tf = True
     skip_jax = True
     skip_pd = True
+    skip_pt_expt = not INSTALLED_PT_EXPT
     skip_array_api_strict = not INSTALLED_ARRAY_API_STRICT
 
     tf_class = DescrptDPA4TF
     dp_class = DescrptDPA4DP
+    pt_class = DescrptDPA4PT
+    pt_expt_class = DescrptDPA4PTExpt
     jax_class = None
     pd_class = None
     array_api_strict_class = DescrptDPA4Strict

--- a/source/tests/consistent/descriptor/test_dpa4.py
+++ b/source/tests/consistent/descriptor/test_dpa4.py
@@ -19,6 +19,7 @@ from deepmd.utils.argcheck import (
 )
 
 from ..common import (
+    INSTALLED_ARRAY_API_STRICT,
     INSTALLED_PT,
     INSTALLED_PT_EXPT,
     CommonTest,
@@ -28,14 +29,40 @@ from .common import (
     DescriptorTest,
 )
 
-if INSTALLED_PT:
-    from deepmd.pt.model.descriptor.sezm import DescrptSeZM as DescrptDPA4PT
+DescrptDPA4PT = None
+DescrptDPA4PTExpt = None
+
+
+def _get_descrpt_dpa4_pt() -> type | None:
+    global DescrptDPA4PT
+    if not INSTALLED_PT:
+        return None
+    if DescrptDPA4PT is None:
+        from deepmd.pt.model.descriptor.sezm import (
+            DescrptSeZM,
+        )
+
+        DescrptDPA4PT = DescrptSeZM
+    return DescrptDPA4PT
+
+
+def _get_descrpt_dpa4_pt_expt() -> type | None:
+    global DescrptDPA4PTExpt
+    if not INSTALLED_PT_EXPT:
+        return None
+    if DescrptDPA4PTExpt is None:
+        from deepmd.pt_expt.descriptor.dpa4 import (
+            DescrptDPA4,
+        )
+
+        DescrptDPA4PTExpt = DescrptDPA4
+    return DescrptDPA4PTExpt
+
+
+if INSTALLED_ARRAY_API_STRICT:
+    from ...array_api_strict.descriptor.dpa4 import DescrptDPA4 as DescrptDPA4Strict
 else:
-    DescrptDPA4PT = None
-if INSTALLED_PT_EXPT:
-    from deepmd.pt_expt.descriptor.dpa4 import DescrptDPA4 as DescrptDPA4PTExpt
-else:
-    DescrptDPA4PTExpt = None
+    DescrptDPA4Strict = None
 
 # not implemented
 DescrptDPA4TF = None
@@ -146,22 +173,31 @@ class TestDPA4(CommonTest, DescriptorTest, unittest.TestCase):
 
     @property
     def skip_pt(self) -> bool:
-        return CommonTest.skip_pt
+        return CommonTest.skip_pt or _get_descrpt_dpa4_pt() is None
+
+    @property
+    def skip_pt_expt(self) -> bool:
+        return not INSTALLED_PT_EXPT or _get_descrpt_dpa4_pt_expt() is None
+
+    @property
+    def pt_class(self) -> type | None:
+        return _get_descrpt_dpa4_pt()
+
+    @property
+    def pt_expt_class(self) -> type | None:
+        return _get_descrpt_dpa4_pt_expt()
 
     skip_dp = False
     skip_tf = True
     skip_jax = True
     skip_pd = True
-    skip_pt_expt = not INSTALLED_PT_EXPT
-    skip_array_api_strict = True
+    skip_array_api_strict = not INSTALLED_ARRAY_API_STRICT
 
     tf_class = DescrptDPA4TF
     dp_class = DescrptDPA4DP
-    pt_class = DescrptDPA4PT
-    pt_expt_class = DescrptDPA4PTExpt
     jax_class = None
     pd_class = None
-    array_api_strict_class = None
+    array_api_strict_class = DescrptDPA4Strict
     args: ClassVar[list] = [
         *descrpt_se_zm_args(),
         Argument("ntypes", int, optional=False),
@@ -227,6 +263,16 @@ class TestDPA4(CommonTest, DescriptorTest, unittest.TestCase):
     def eval_pt_expt(self, pt_expt_obj: Any) -> Any:
         return self.eval_pt_expt_descriptor(
             pt_expt_obj,
+            self.natoms,
+            self.coords,
+            self.atype,
+            self.box,
+            mixed_types=True,
+        )
+
+    def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
+        return self.eval_array_api_strict_descriptor(
+            array_api_strict_obj,
             self.natoms,
             self.coords,
             self.atype,

--- a/source/tests/consistent/fitting/test_dpa4_ener.py
+++ b/source/tests/consistent/fitting/test_dpa4_ener.py
@@ -28,53 +28,22 @@ from .common import (
     FittingTest,
 )
 
-torch = None
-PT_DEVICE = None
-PT_EXPT_DEVICE = None
-SeZMEnerFittingPT = None
-SeZMEnerFittingPTExpt = None
+if INSTALLED_PT:
+    import torch
 
+    from deepmd.pt.model.task.sezm_ener import SeZMEnergyFittingNet as SeZMEnerFittingPT
+    from deepmd.pt.utils.env import DEVICE as PT_DEVICE
+else:
+    SeZMEnerFittingPT = None
+if INSTALLED_PT_EXPT:
+    import torch
 
-def _get_sezm_ener_fitting_pt() -> type | None:
-    global PT_DEVICE, SeZMEnerFittingPT, torch
-    if not INSTALLED_PT:
-        return None
-    if SeZMEnerFittingPT is None:
-        import torch as torch_module
-
-        from deepmd.pt.model.task.sezm_ener import (
-            SeZMEnergyFittingNet,
-        )
-        from deepmd.pt.utils.env import (
-            DEVICE,
-        )
-
-        torch = torch_module
-        PT_DEVICE = DEVICE
-        SeZMEnerFittingPT = SeZMEnergyFittingNet
-    return SeZMEnerFittingPT
-
-
-def _get_sezm_ener_fitting_pt_expt() -> type | None:
-    global PT_EXPT_DEVICE, SeZMEnerFittingPTExpt, torch
-    if not INSTALLED_PT_EXPT:
-        return None
-    if SeZMEnerFittingPTExpt is None:
-        import torch as torch_module
-
-        from deepmd.pt_expt.fitting.dpa4_ener import (
-            SeZMEnergyFittingNet,
-        )
-        from deepmd.pt_expt.utils.env import (
-            DEVICE,
-        )
-
-        torch = torch_module
-        PT_EXPT_DEVICE = DEVICE
-        SeZMEnerFittingPTExpt = SeZMEnergyFittingNet
-    return SeZMEnerFittingPTExpt
-
-
+    from deepmd.pt_expt.fitting.dpa4_ener import (
+        SeZMEnergyFittingNet as SeZMEnerFittingPTExpt,
+    )
+    from deepmd.pt_expt.utils.env import DEVICE as PT_EXPT_DEVICE
+else:
+    SeZMEnerFittingPTExpt = None
 if INSTALLED_ARRAY_API_STRICT:
     import array_api_strict
 
@@ -113,28 +82,19 @@ class TestDPA4Ener(CommonTest, FittingTest, unittest.TestCase):
 
     @property
     def skip_pt(self) -> bool:
-        return CommonTest.skip_pt or _get_sezm_ener_fitting_pt() is None
-
-    @property
-    def skip_pt_expt(self) -> bool:
-        return not INSTALLED_PT_EXPT or _get_sezm_ener_fitting_pt_expt() is None
-
-    @property
-    def pt_class(self) -> type | None:
-        return _get_sezm_ener_fitting_pt()
-
-    @property
-    def pt_expt_class(self) -> type | None:
-        return _get_sezm_ener_fitting_pt_expt()
+        return CommonTest.skip_pt
 
     skip_dp = False
     skip_tf = True
     skip_jax = True
     skip_pd = True
+    skip_pt_expt = not INSTALLED_PT_EXPT
     skip_array_api_strict = not INSTALLED_ARRAY_API_STRICT
 
     tf_class = SeZMEnerFittingTF
     dp_class = SeZMEnerFittingDP
+    pt_class = SeZMEnerFittingPT
+    pt_expt_class = SeZMEnerFittingPTExpt
     jax_class = None
     pd_class = None
     array_api_strict_class = SeZMEnerFittingStrict

--- a/source/tests/consistent/fitting/test_dpa4_ener.py
+++ b/source/tests/consistent/fitting/test_dpa4_ener.py
@@ -6,6 +6,9 @@ from typing import (
 
 import numpy as np
 
+from deepmd.dpmodel.common import (
+    to_numpy_array,
+)
 from deepmd.dpmodel.fitting.dpa4_ener import SeZMEnergyFittingNet as SeZMEnerFittingDP
 from deepmd.env import (
     GLOBAL_NP_FLOAT_PRECISION,
@@ -15,6 +18,7 @@ from deepmd.utils.argcheck import (
 )
 
 from ..common import (
+    INSTALLED_ARRAY_API_STRICT,
     INSTALLED_PT,
     INSTALLED_PT_EXPT,
     CommonTest,
@@ -24,22 +28,61 @@ from .common import (
     FittingTest,
 )
 
-if INSTALLED_PT:
-    import torch
+torch = None
+PT_DEVICE = None
+PT_EXPT_DEVICE = None
+SeZMEnerFittingPT = None
+SeZMEnerFittingPTExpt = None
 
-    from deepmd.pt.model.task.sezm_ener import SeZMEnergyFittingNet as SeZMEnerFittingPT
-    from deepmd.pt.utils.env import DEVICE as PT_DEVICE
-else:
-    SeZMEnerFittingPT = None
-if INSTALLED_PT_EXPT:
-    import torch
 
-    from deepmd.pt_expt.fitting.dpa4_ener import (
-        SeZMEnergyFittingNet as SeZMEnerFittingPTExpt,
+def _get_sezm_ener_fitting_pt() -> type | None:
+    global PT_DEVICE, SeZMEnerFittingPT, torch
+    if not INSTALLED_PT:
+        return None
+    if SeZMEnerFittingPT is None:
+        import torch as torch_module
+
+        from deepmd.pt.model.task.sezm_ener import (
+            SeZMEnergyFittingNet,
+        )
+        from deepmd.pt.utils.env import (
+            DEVICE,
+        )
+
+        torch = torch_module
+        PT_DEVICE = DEVICE
+        SeZMEnerFittingPT = SeZMEnergyFittingNet
+    return SeZMEnerFittingPT
+
+
+def _get_sezm_ener_fitting_pt_expt() -> type | None:
+    global PT_EXPT_DEVICE, SeZMEnerFittingPTExpt, torch
+    if not INSTALLED_PT_EXPT:
+        return None
+    if SeZMEnerFittingPTExpt is None:
+        import torch as torch_module
+
+        from deepmd.pt_expt.fitting.dpa4_ener import (
+            SeZMEnergyFittingNet,
+        )
+        from deepmd.pt_expt.utils.env import (
+            DEVICE,
+        )
+
+        torch = torch_module
+        PT_EXPT_DEVICE = DEVICE
+        SeZMEnerFittingPTExpt = SeZMEnergyFittingNet
+    return SeZMEnerFittingPTExpt
+
+
+if INSTALLED_ARRAY_API_STRICT:
+    import array_api_strict
+
+    from ...array_api_strict.fitting.dpa4_ener import (
+        SeZMEnergyFittingNet as SeZMEnerFittingStrict,
     )
-    from deepmd.pt_expt.utils.env import DEVICE as PT_EXPT_DEVICE
 else:
-    SeZMEnerFittingPTExpt = None
+    SeZMEnerFittingStrict = None
 
 # not implemented
 SeZMEnerFittingTF = None
@@ -70,22 +113,31 @@ class TestDPA4Ener(CommonTest, FittingTest, unittest.TestCase):
 
     @property
     def skip_pt(self) -> bool:
-        return CommonTest.skip_pt
+        return CommonTest.skip_pt or _get_sezm_ener_fitting_pt() is None
+
+    @property
+    def skip_pt_expt(self) -> bool:
+        return not INSTALLED_PT_EXPT or _get_sezm_ener_fitting_pt_expt() is None
+
+    @property
+    def pt_class(self) -> type | None:
+        return _get_sezm_ener_fitting_pt()
+
+    @property
+    def pt_expt_class(self) -> type | None:
+        return _get_sezm_ener_fitting_pt_expt()
 
     skip_dp = False
     skip_tf = True
     skip_jax = True
     skip_pd = True
-    skip_pt_expt = not INSTALLED_PT_EXPT
-    skip_array_api_strict = True
+    skip_array_api_strict = not INSTALLED_ARRAY_API_STRICT
 
     tf_class = SeZMEnerFittingTF
     dp_class = SeZMEnerFittingDP
-    pt_class = SeZMEnerFittingPT
-    pt_expt_class = SeZMEnerFittingPTExpt
     jax_class = None
     pd_class = None
-    array_api_strict_class = None
+    array_api_strict_class = SeZMEnerFittingStrict
     args = fitting_sezm_ener()
 
     def setUp(self) -> None:
@@ -136,6 +188,14 @@ class TestDPA4Ener(CommonTest, FittingTest, unittest.TestCase):
             .detach()
             .cpu()
             .numpy()
+        )
+
+    def eval_array_api_strict(self, array_api_strict_obj: Any) -> Any:
+        return to_numpy_array(
+            array_api_strict_obj(
+                array_api_strict.asarray(self.inputs),
+                array_api_strict.asarray(self.atype.reshape(1, -1)),
+            )["energy"]
         )
 
     def extract_ret(self, ret: Any, backend) -> tuple[np.ndarray, ...]:


### PR DESCRIPTION
## Summary
- add array-api-strict wrappers for the DPA4 descriptor and SeZM energy fitting net
- enable array-api-strict coverage in the existing DPA4 descriptor/fitting consistent tests
- make DPA4 scalar RMSNorm indexing array-api-strict compliant and lazy-load DPA4 PT test classes during PT-only execution

## Validation
- `ruff format .`
- `ruff check .`
- `pytest source/tests/consistent/descriptor/test_dpa4.py source/tests/consistent/fitting/test_dpa4_ener.py -q -k array_api_strict` -> 32 passed, 224 deselected
- `pytest source/tests/consistent/descriptor/test_dpa4.py source/tests/consistent/fitting/test_dpa4_ener.py -q -k dp_self_consistent` -> 16 passed, 240 deselected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded strict array-API coverage for the DPA4 descriptor and DPA4 energy fitting workflow, including new DPA4 strict descriptor exports and energy fitting wrappers.
* **Bug Fixes**
  * Corrected 2D input normalization scaling so the applied scale matches the expected channel layout.
* **Tests**
  * Updated consistency tests to conditionally enable the strict backend and added strict-backend evaluation helpers for descriptor and energy outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->