### PR TITLE
fix(api_cc): size remapped atomic parameters by stride

### DIFF
--- a/source/api_cc/src/common.cc
+++ b/source/api_cc/src/common.cc
@@ -189,8 +189,11 @@ void deepmd::select_real_atoms_coord(std::vector<VALUETYPE>& dcoord,
   select_map<int>(datype, datype_, fwd_map, 1);
   // aparam
   if (daparam > 0) {
+    // Atomic parameters store ``daparam`` consecutive components per atom.
+    // Keep the allocation consistent with the stride passed to ``select_map``
+    // below so every remapped component has a valid destination element.
     aparam.resize(static_cast<size_t>(nframes) *
-                  (aparam_nall ? nall_real : nloc_real));
+                  (aparam_nall ? nall_real : nloc_real) * daparam);
     select_map<VALUETYPE>(aparam, aparam_, fwd_map, daparam, nframes,
                           (aparam_nall ? nall_real : nloc_real),
                           (aparam_nall ? nall : (nall - nghost)));

--- a/source/api_cc/tests/test_select_map.cc
+++ b/source/api_cc/tests/test_select_map.cc
@@ -94,3 +94,85 @@ TYPED_TEST(TestSelectMap, selectmap_type1) {
     EXPECT_EQ(this->expected_atype_out_1[ii], this->atype_out_1[ii]);
   }
 }
+
+TYPED_TEST(TestSelectMap, select_real_atoms_coord_aparam_local) {
+  constexpr int nframes = 2;
+  constexpr int daparam = 2;
+  constexpr int nall = 5;
+  constexpr int nghost = 2;
+  constexpr int ntypes = 2;
+
+  // Type 2 represents a virtual atom.  The input contains virtual atoms in
+  // both the local [0, 3) and ghost [3, 5) portions of the neighbor list.
+  const std::vector<int> atype = {0, 2, 1, 0, 2};
+  std::vector<TypeParam> coord(nframes * nall * 3);
+  const std::vector<TypeParam> aparam_in = {
+      10, 11, 20, 21, 30, 31,  // frame 0: three local atoms
+      40, 41, 50, 51, 60, 61,  // frame 1: three local atoms
+  };
+  const std::vector<TypeParam> expected_aparam = {
+      10, 11, 30, 31,  // frame 0: local virtual atom removed
+      40, 41, 60, 61,  // frame 1: local virtual atom removed
+  };
+
+  std::vector<TypeParam> coord_out;
+  std::vector<int> atype_out;
+  // Seed the output with the expected logical size.  The helper must preserve
+  // this size contract while remapping every daparam component below.
+  std::vector<TypeParam> aparam_out(expected_aparam.size());
+  int nghost_real = 0;
+  std::vector<int> fwd_map;
+  std::vector<int> bkw_map;
+  int nall_real = 0;
+  int nloc_real = 0;
+
+  deepmd::select_real_atoms_coord(coord_out, atype_out, aparam_out, nghost_real,
+                                  fwd_map, bkw_map, nall_real, nloc_real, coord,
+                                  atype, aparam_in, nghost, ntypes, nframes,
+                                  daparam, nall, false);
+
+  ASSERT_EQ(aparam_out.size(), expected_aparam.size());
+  EXPECT_EQ(aparam_out, expected_aparam);
+  EXPECT_EQ(nloc_real, 2);
+  EXPECT_EQ(nghost_real, 1);
+}
+
+TYPED_TEST(TestSelectMap, select_real_atoms_coord_aparam_all) {
+  constexpr int nframes = 2;
+  constexpr int daparam = 2;
+  constexpr int nall = 5;
+  constexpr int nghost = 2;
+  constexpr int ntypes = 2;
+
+  const std::vector<int> atype = {0, 2, 1, 0, 2};
+  std::vector<TypeParam> coord(nframes * nall * 3);
+  const std::vector<TypeParam> aparam_in = {
+      10, 11, 20, 21, 30, 31, 40, 41, 50,  51,   // frame 0: all atoms
+      60, 61, 70, 71, 80, 81, 90, 91, 100, 101,  // frame 1: all atoms
+  };
+  const std::vector<TypeParam> expected_aparam = {
+      10, 11, 30, 31, 40, 41,  // frame 0: both virtual atoms removed
+      60, 61, 80, 81, 90, 91,  // frame 1: both virtual atoms removed
+  };
+
+  std::vector<TypeParam> coord_out;
+  std::vector<int> atype_out;
+  // As above, assert the full scalar-count contract rather than only checking
+  // the remapped prefix of the output buffer.
+  std::vector<TypeParam> aparam_out(expected_aparam.size());
+  int nghost_real = 0;
+  std::vector<int> fwd_map;
+  std::vector<int> bkw_map;
+  int nall_real = 0;
+  int nloc_real = 0;
+
+  deepmd::select_real_atoms_coord(coord_out, atype_out, aparam_out, nghost_real,
+                                  fwd_map, bkw_map, nall_real, nloc_real, coord,
+                                  atype, aparam_in, nghost, ntypes, nframes,
+                                  daparam, nall, true);
+
+  ASSERT_EQ(aparam_out.size(), expected_aparam.size());
+  EXPECT_EQ(aparam_out, expected_aparam);
+  EXPECT_EQ(nloc_real, 2);
+  EXPECT_EQ(nghost_real, 1);
+}


### PR DESCRIPTION
## Summary

- allocate remapped atomic-parameter buffers for every frame, retained atom, and daparam component;
- keep the allocation count aligned with the stride passed to select_map;
- add typed C++ regressions for float and double, two frames, local and ghost virtual atoms, and both local-only and all-atom aparam layouts.

## Impact

The previous allocation omitted the daparam factor. For models with dim_aparam greater than one, select_map wrote more scalar components than the vector contained, causing undefined behavior and potential heap memory corruption in shared neighbor-list API paths.

## Why existing tests missed this

Existing multiframe and neighbor-list API tests use models whose daparam is one. The aparam_nall=true fixtures also use one component per atom, so the missing multiplier was numerically hidden.

The new direct helper tests exercise the exact missing combination: daparam=2 with virtual-atom remapping, multiple frames, local parameters, and local-plus-ghost parameters.

## Validation

- backend-neutral C++ unit-test target compiled and linked successfully;
- TestSelectMap typed suite: 12 passed;
- the four new cases fail with the pre-fix allocation and pass with the corrected size;
- clang-format applied to changed C++ files;
- ruff format .;
- ruff check .;
- git diff --check.

Closes #5618.

Coding agent: Codex
Codex version: codex-cli 0.144.1
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of multi-component atom parameters when filtering virtual atoms.
  * Ensured remapped parameter data maintains the correct size and values for local and ghost atoms.

* **Tests**
  * Added coverage for multi-frame data and virtual-atom filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->