### PR TITLE
fix(jax): return stored HLO neighbor count

### DIFF
--- a/deepmd/jax/model/hlo.py
+++ b/deepmd/jax/model/hlo.py
@@ -369,7 +369,7 @@ class HLO(BaseModel):
 
     def get_nnei(self) -> int:
         """Returns the total number of selected neighboring atoms in the cut-off radius."""
-        return self.nsel
+        return self.get_nsel()
 
     def get_sel(self) -> list[int]:
         return self.sel

--- a/source/tests/jax/test_deep_dos.py
+++ b/source/tests/jax/test_deep_dos.py
@@ -72,6 +72,10 @@ class TestDeepDOSJAX(unittest.TestCase):
     def test_numb_dos_survives_export(self) -> None:
         self.assertEqual(self.dp.get_numb_dos(), 2)
 
+    def test_neighbor_count_survives_export(self) -> None:
+        """Load the exported HLO and expose its serialized selection width."""
+        self.assertEqual(self.dp.deep_eval.dp.get_nnei(), 40)
+
     def test_global_dos_only(self) -> None:
         (dos,) = self.dp.eval(self.coords, self.cells, self.atypes, atomic=False)
         self.assertEqual(dos.shape, (1, 2))

--- a/source/tests/jax/test_hlo.py
+++ b/source/tests/jax/test_hlo.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Regression tests for metadata exposed by serialized JAX HLO models."""
+
+from deepmd.jax.model.hlo import HLO
+
+
+def test_hlo_get_nnei_uses_stored_selection() -> None:
+    """Return the neighbor width encoded in an HLO model's selection metadata.
+
+    Constructing a complete ``HLO`` instance requires valid serialized
+    StableHLO artifacts.  This API only depends on the stored ``sel`` metadata,
+    so bypass initialization to test that metadata contract directly.
+    """
+    model = HLO.__new__(HLO)
+    model.sel = [6, 12, 1]
+
+    assert model.get_nnei() == sum(model.sel)

--- a/source/tests/jax/test_hlo.py
+++ b/source/tests/jax/test_hlo.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 """Regression tests for metadata exposed by serialized JAX HLO models."""
 
-from deepmd.jax.model.hlo import HLO
+from deepmd.jax.model.hlo import (
+    HLO,
+)
 
 
 def test_hlo_get_nnei_uses_stored_selection() -> None:


### PR DESCRIPTION
## Summary

- make HLO.get_nnei() derive the total neighbor width from the stored sel metadata;
- delegate to get_nsel() so the metadata contract has one source of truth;
- add a focused regression for a serialized HLO model's selection metadata.

## Why existing tests missed this

The constructor stores self.sel but never creates self.nsel. Existing consistency and model tests exercise neighbor counts on dpmodel, TensorFlow, and PyTorch wrappers, but no JAX test directly queried the HLO wrapper. Serialization and export helpers can therefore reach an AttributeError even though the broader model tests pass.

The new unit test isolates the metadata API without constructing real StableHLO byte artifacts, which are unrelated to this accessor.

## Validation

- targeted HLO metadata test: 1 passed;
- pre-fix implementation fails the same test with AttributeError;
- ruff format .;
- ruff check .;
- git diff --check.

Closes #5669.

Coding agent: Codex
Codex version: codex-cli 0.144.1
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected neighbor-count reporting for serialized JAX HLO model metadata.
  * Neighbor counts now accurately reflect the stored selection values.
* **Tests**
  * Added regression coverage to verify neighbor-count calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->