### PR TITLE
fix(ipi): reject unknown atom names

### DIFF
--- a/source/ipi/driver.cc
+++ b/source/ipi/driver.cc
@@ -73,18 +73,25 @@ int main(int argc, char* argv[]) {
   const char* host = host_str.c_str();
   std::string graph_file = jdata["graph_file"];
   std::string coord_file = jdata["coord_file"];
-  std::map<std::string, int> name_type_map = jdata["atom_type"];
+  std::map<std::string, int> name_type_map;
+  try {
+    name_type_map = jdata.at("atom_type").get<std::map<std::string, int>>();
+  } catch (const std::exception& error) {
+    std::cerr << "dp_ipi: invalid atom_type configuration: " << error.what()
+              << std::endl;
+    return 1;
+  }
   bool b_verb = jdata["verbose"];
 
   std::vector<std::string> atom_name;
   {
-    std::vector<std::vector<double> > posi;
-    std::vector<std::vector<double> > velo;
-    std::vector<std::vector<double> > forc;
+    std::vector<std::vector<double>> posi;
+    std::vector<std::vector<double>> velo;
+    std::vector<std::vector<double>> forc;
     XyzFileManager::read(coord_file, atom_name, posi, velo, forc);
   }
 
-  std::unique_ptr<Convert<double> > cvt;
+  std::unique_ptr<Convert<double>> cvt;
   try {
     cvt.reset(new Convert<double>(atom_name, name_type_map));
   } catch (const std::exception& error) {
@@ -227,4 +234,5 @@ int main(int argc, char* argv[]) {
   if (msg_buff != NULL) {
     delete[] msg_buff;
   }
+  return 0;
 }

--- a/source/ipi/driver.cc
+++ b/source/ipi/driver.cc
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include <cstdint>
+#include <exception>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 
 #include "Convert.h"
 #ifdef DP_USE_CXX_API
@@ -82,7 +84,16 @@ int main(int argc, char* argv[]) {
     XyzFileManager::read(coord_file, atom_name, posi, velo, forc);
   }
 
-  Convert<double> cvt(atom_name, name_type_map);
+  std::unique_ptr<Convert<double> > cvt;
+  try {
+    cvt.reset(new Convert<double>(atom_name, name_type_map));
+  } catch (const std::exception& error) {
+    // Report configuration errors before model loading while keeping the
+    // command-line file access in main, where static analysis recognizes the
+    // existing CLI boundary.
+    std::cerr << "dp_ipi: " << error.what() << std::endl;
+    return 1;
+  }
   deepmd_compat::DeepPot nnp_inter(graph_file);
 
   enum { _MSGLEN = 12 };
@@ -100,7 +111,7 @@ int main(int argc, char* argv[]) {
   std::vector<double> dvirial(9, 0);
   std::vector<double> dcoord;
   std::vector<double> dcoord_tmp;
-  std::vector<int> dtype = cvt.get_type();
+  std::vector<int> dtype = cvt->get_type();
   std::vector<double> dbox(9, 0);
   double* msg_buff = NULL;
   double ener;
@@ -180,11 +191,11 @@ int main(int argc, char* argv[]) {
       for (int ii = 0; ii < natoms * 3; ++ii) {
         dcoord_tmp[ii] = msg_buff[ii] * cvt_len;
       }
-      cvt.forward(dcoord, dcoord_tmp, 3);
+      cvt->forward(dcoord, dcoord_tmp, 3);
 
       // nnp over writes ener, force and virial
       nnp_inter.compute(dener, dforce_tmp, dvirial, dcoord, dtype, dbox);
-      cvt.backward(dforce, dforce_tmp, 3);
+      cvt->backward(dforce, dforce_tmp, 3);
       hasdata = true;
     } else if (header_str == "GETFORCE") {
       ener = dener * icvt_ener;

--- a/source/ipi/src/Convert.cc
+++ b/source/ipi/src/Convert.cc
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <stdexcept>
 
 template <typename VALUETYPE>
 Convert<VALUETYPE>::Convert(const std::vector<std::string>& atomname,
@@ -10,7 +11,16 @@ Convert<VALUETYPE>::Convert(const std::vector<std::string>& atomname,
   int natoms = atomname.size();
   atype.resize(natoms);
   for (unsigned ii = 0; ii < atype.size(); ++ii) {
-    atype[ii] = name_type_map[atomname[ii]];
+    const auto type_iter = name_type_map.find(atomname[ii]);
+    if (type_iter == name_type_map.end()) {
+      // Do not use operator[] for this lookup. A missing key would mutate the
+      // map and value-initialize its integer to 0, silently evaluating an
+      // unknown atom as the valid DeePMD type 0.
+      throw std::invalid_argument("Unknown atom name '" + atomname[ii] +
+                                  "' in coordinate file: no matching entry "
+                                  "in atom_type.");
+    }
+    atype[ii] = type_iter->second;
   }
   std::vector<std::pair<int, int> > sorting(natoms);
   for (unsigned ii = 0; ii < sorting.size(); ++ii) {

--- a/source/ipi/tests/test_driver_input_validation.py
+++ b/source/ipi/tests/test_driver_input_validation.py
@@ -55,3 +55,39 @@ class TestDPIPIInputValidation(unittest.TestCase):
             "dp_ipi: Unknown atom name 'Xx' in coordinate file: "
             "no matching entry in atom_type.\n",
         )
+
+    def test_missing_atom_type_is_rejected_before_model_loading(self) -> None:
+        """Report a missing atom-type map instead of leaking a JSON exception."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            coord_file = tmp_path / "coord.xyz"
+            config_file = tmp_path / "config.json"
+            missing_model = tmp_path / "model-that-must-not-be-loaded.pb"
+
+            coord_file.write_text(
+                "1\nmissing atom map\nO 0.0 0.0 0.0\n", encoding="utf-8"
+            )
+            config_file.write_text(
+                json.dumps(
+                    {
+                        "verbose": False,
+                        "use_unix": True,
+                        "port": 31415,
+                        "host": "unused",
+                        "graph_file": str(missing_model),
+                        "coord_file": str(coord_file),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["dp_ipi", str(config_file)],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 1, msg=result.stderr)
+        self.assertIn("dp_ipi: invalid atom_type configuration:", result.stderr)

--- a/source/ipi/tests/test_driver_input_validation.py
+++ b/source/ipi/tests/test_driver_input_validation.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import (
+    Path,
+)
+
+
+class TestDPIPIInputValidation(unittest.TestCase):
+    """Test driver input validation without requiring a socket or model backend."""
+
+    def test_unknown_atom_name_is_rejected_before_model_loading(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            coord_file = tmp_path / "unknown_atom.xyz"
+            config_file = tmp_path / "config.json"
+            missing_model = tmp_path / "model-that-must-not-be-loaded.pb"
+
+            coord_file.write_text(
+                "1\nunknown atom name regression test\nXx 0.0 0.0 0.0\n",
+                encoding="utf-8",
+            )
+            config_file.write_text(
+                json.dumps(
+                    {
+                        "verbose": False,
+                        "use_unix": True,
+                        "port": 31415,
+                        "host": "unused",
+                        # The deliberately missing model proves that atom-name
+                        # validation happens before model initialization. The
+                        # old operator[] behavior reached model loading after
+                        # silently converting Xx to type 0.
+                        "graph_file": str(missing_model),
+                        "coord_file": str(coord_file),
+                        "atom_type": {"O": 0},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["dp_ipi", str(config_file)],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 1, msg=result.stderr)
+        self.assertEqual(
+            result.stderr,
+            "dp_ipi: Unknown atom name 'Xx' in coordinate file: "
+            "no matching entry in atom_type.\n",
+        )


### PR DESCRIPTION
## Summary

- look up coordinate-file atom names without `std::map::operator[]`;
- reject names missing from `atom_type` instead of inserting them as DeePMD type 0;
- catch conversion/configuration errors locally before model loading, print a stable diagnostic, and return exit code 1;
- add a backend-independent CLI regression proving validation occurs before model loading.

## Impact

Type 0 is a valid model type. The previous `operator[]` lookup silently inserted every unknown name with value 0, so a typo or incomplete `atom_type` mapping could produce plausible-looking but scientifically incorrect energies and forces.

## Why existing tests missed this

The existing i-PI tests use complete O/H mappings and exercise successful socket and inference workflows. None supplies an unknown coordinate-file name, so the default-insertion behavior was never observed.

The new test uses atom `Xx` with only `O` configured and deliberately points `graph_file` at a missing model. It requires the unknown atom diagnostic and exact exit code before any model-loading error can occur.

## Exception boundary and CodeQL

The first version wrapped the entire driver in a helper called from `main`. That preserved runtime behavior but caused CodeQL to treat the pre-existing command-line configuration-file access as a newly introduced uncontrolled path flow. The revised implementation keeps file parsing directly in `main` and limits the exception boundary to `Convert` construction, which is the operation that can reject an unknown atom name. This avoids suppressing the security scan while retaining the intended stable diagnostic.

## Validation

- full C++ build completed successfully and installed the updated `dp_ipi`;
- incremental `dp_ipi` target build succeeded after the localized exception-boundary revision;
- backend-independent unknown-name regression passed after the revision;
- complete i-PI test suite previously passed: 7 tests across TensorFlow, PyTorch, and the new validation case;
- `Convert` compiled separately under C++11 with `-Wall -Wextra -Werror`;
- both C API and C++ API driver conditional paths passed syntax checks;
- clang-format check passed;
- `ruff format .`;
- `ruff check .`;
- `git diff --check`.

Closes #5648.

Coding agent: Codex
Codex version: codex-cli 0.144.1
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or missing atom-type configuration now produces clear error messages and a clean failure.
  * Unknown atom names are rejected before model loading, preventing misleading downstream errors.
  * Model initialization failures are handled safely with user-visible diagnostics.

* **Tests**
  * Added end-to-end coverage for unknown atom names and missing atom-type configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->