### PR TITLE
fix(pt): remap spins after null atom filtering

### DIFF
--- a/source/api_cc/src/DeepSpinPT.cc
+++ b/source/api_cc/src/DeepSpinPT.cc
@@ -160,7 +160,17 @@ void DeepSpinPT::compute(ENERGYVTYPE& ener,
   at::Tensor coord_wrapped_Tensor =
       torch::from_blob(coord_wrapped.data(), {1, nall_real, 3}, options)
           .to(device);
-  std::vector<VALUETYPE> spin_wrapped = spin;
+  // ``select_real_atoms_coord`` compacts coordinates and atom types in
+  // ``bkw_map`` order.  Spin is another per-atom side channel, so it must use
+  // the same mapping; taking a prefix of the original spin buffer is only
+  // correct when every filtered NULL atom happens to be at the end.
+  std::vector<VALUETYPE> spin_wrapped(static_cast<size_t>(nall_real) * 3);
+  for (int ii = 0; ii < nall_real; ++ii) {
+    for (int dd = 0; dd < 3; ++dd) {
+      spin_wrapped[static_cast<size_t>(ii) * 3 + dd] =
+          spin[static_cast<size_t>(bkw_map[ii]) * 3 + dd];
+    }
+  }
   at::Tensor spin_wrapped_Tensor =
       torch::from_blob(spin_wrapped.data(), {1, nall_real, 3}, options)
           .to(device);

--- a/source/api_cc/tests/test_deeppot_dpa_pt_spin.cc
+++ b/source/api_cc/tests/test_deeppot_dpa_pt_spin.cc
@@ -314,6 +314,103 @@ TYPED_TEST(TestInferDeepSpinDpaPtNopbc, cpu_lmp_nlist) {
   }
 }
 
+TYPED_TEST(TestInferDeepSpinDpaPtNopbc, cpu_lmp_nlist_null_atom_in_middle) {
+  using VALUETYPE = TypeParam;
+  const std::vector<VALUETYPE>& coord = this->coord;
+  const std::vector<VALUETYPE>& spin = this->spin;
+  const std::vector<int>& atype = this->atype;
+  const std::vector<VALUETYPE>& box = this->box;
+  deepmd::DeepSpin& dp = this->dp;
+
+  // This fixture deliberately uses the TorchScript ``.pth`` artifact, which
+  // dispatches through DeepSpinPT rather than the separate PTExpt ``.pt2``
+  // implementation.
+  ASSERT_EQ(deepmd::get_backend(kModelPath), deepmd::DPBackend::PyTorch);
+
+  auto compute_with_nlist = [&dp, &box](
+                                double& energy, std::vector<VALUETYPE>& force,
+                                std::vector<VALUETYPE>& force_mag,
+                                std::vector<VALUETYPE>& virial,
+                                const std::vector<VALUETYPE>& input_coord,
+                                const std::vector<VALUETYPE>& input_spin,
+                                const std::vector<int>& input_atype,
+                                std::vector<std::vector<int> >& nlist_data) {
+    const int natoms = static_cast<int>(input_atype.size());
+    std::vector<int> ilist(natoms), numneigh(natoms);
+    std::vector<int*> firstneigh(natoms);
+    deepmd::InputNlist inlist(natoms, ilist.data(), numneigh.data(),
+                              firstneigh.data());
+    convert_nlist(inlist, nlist_data);
+    dp.compute(energy, force, force_mag, virial, input_coord, input_spin,
+               input_atype, box, 0, inlist, 0);
+  };
+
+  // First evaluate the compact six-atom representation.  The padded system
+  // below describes the same physical atoms and neighbor graph, so all real
+  // atom predictions must remain unchanged after the NULL atom is filtered.
+  std::vector<std::vector<int> > compact_nlist = {
+      {1, 2, 3, 4, 5}, {0, 2, 3, 4, 5}, {0, 1, 3, 4, 5},
+      {0, 1, 2, 4, 5}, {0, 1, 2, 3, 5}, {0, 1, 2, 3, 4}};
+  double compact_energy;
+  std::vector<VALUETYPE> compact_force, compact_force_mag, compact_virial;
+  compute_with_nlist(compact_energy, compact_force, compact_force_mag,
+                     compact_virial, coord, spin, atype, compact_nlist);
+
+  constexpr int null_index = 3;
+  std::vector<VALUETYPE> padded_coord = coord;
+  padded_coord.insert(padded_coord.begin() + null_index * 3,
+                      {static_cast<VALUETYPE>(8.1), static_cast<VALUETYPE>(7.2),
+                       static_cast<VALUETYPE>(6.3)});
+  std::vector<VALUETYPE> padded_spin = spin;
+  padded_spin.insert(
+      padded_spin.begin() + null_index * 3,
+      {static_cast<VALUETYPE>(0.91), static_cast<VALUETYPE>(-0.73),
+       static_cast<VALUETYPE>(0.57)});
+  std::vector<int> padded_atype = atype;
+  padded_atype.insert(padded_atype.begin() + null_index, -1);
+
+  // The NULL row is empty and no real row references it.  After fwd_map
+  // compaction this becomes exactly ``compact_nlist``; the distinct NULL spin
+  // makes an incorrectly prefix-truncated spin tensor observably different.
+  std::vector<std::vector<int> > padded_nlist = {
+      {1, 2, 4, 5, 6}, {0, 2, 4, 5, 6}, {0, 1, 4, 5, 6}, {},
+      {0, 1, 2, 5, 6}, {0, 1, 2, 4, 6}, {0, 1, 2, 4, 5}};
+  double padded_energy;
+  std::vector<VALUETYPE> padded_force, padded_force_mag, padded_virial;
+  compute_with_nlist(padded_energy, padded_force, padded_force_mag,
+                     padded_virial, padded_coord, padded_spin, padded_atype,
+                     padded_nlist);
+
+  // These calls describe identical real atoms and neighbor graphs, so use a
+  // strict equivalence tolerance instead of this file's loose float reference
+  // tolerance.  The old prefix-based spin mapping differs by less than 0.1 and
+  // would otherwise let the float regression pass despite the wrong inputs.
+  constexpr double equivalence_tolerance =
+      std::is_same<VALUETYPE, double>::value ? 1e-10 : 1e-5;
+  EXPECT_NEAR(padded_energy, compact_energy, equivalence_tolerance);
+  ASSERT_EQ(padded_virial.size(), compact_virial.size());
+  for (size_t ii = 0; ii < compact_virial.size(); ++ii) {
+    EXPECT_NEAR(padded_virial[ii], compact_virial[ii], equivalence_tolerance);
+  }
+
+  ASSERT_EQ(padded_force.size(), padded_atype.size() * 3);
+  ASSERT_EQ(padded_force_mag.size(), padded_atype.size() * 3);
+  const std::vector<int> compact_to_padded = {0, 1, 2, 4, 5, 6};
+  for (size_t ii = 0; ii < compact_to_padded.size(); ++ii) {
+    const int padded_index = compact_to_padded[ii];
+    for (int dd = 0; dd < 3; ++dd) {
+      EXPECT_NEAR(padded_force[padded_index * 3 + dd],
+                  compact_force[ii * 3 + dd], equivalence_tolerance);
+      EXPECT_NEAR(padded_force_mag[padded_index * 3 + dd],
+                  compact_force_mag[ii * 3 + dd], equivalence_tolerance);
+    }
+  }
+  for (int dd = 0; dd < 3; ++dd) {
+    EXPECT_EQ(padded_force[null_index * 3 + dd], static_cast<VALUETYPE>(0));
+    EXPECT_EQ(padded_force_mag[null_index * 3 + dd], static_cast<VALUETYPE>(0));
+  }
+}
+
 TYPED_TEST(TestInferDeepSpinDpaPtNopbc, cpu_lmp_nlist_atomic) {
   using VALUETYPE = TypeParam;
   const std::vector<VALUETYPE>& coord = this->coord;


### PR DESCRIPTION
## Summary

- compact DeepSpinPT spin vectors with the same `bkw_map` used for coordinates and atom types
- add a TorchScript `.pth` neighbor-list regression with a NULL atom in the middle of the input
- use a strict representation-equivalence tolerance so both float and double instances detect the old mapping error

## Root cause and fix

`select_real_atoms_coord` removes NULL-type atoms and returns compacted coordinates/types plus forward and backward maps. The DeepSpinPT neighbor-list path used the compacted coordinates and types, but reshaped a prefix of the original spin buffer to `nall_real` rows. That only preserves atom-to-spin association when all filtered NULL atoms happen to be at the end.

The fix rebuilds the spin buffer in `bkw_map` order before creating the tensor. Spin is a per-atom side channel, so it now follows exactly the same compacted ordering as coordinates and atom types, including local and ghost partitions.

## Regression coverage

The existing tests covered ordinary neighbor-list inference, but did not place `atype = -1` between real atoms. Therefore the incorrect prefix and the correct mapped spin buffers were indistinguishable in the tested layouts.

The new test evaluates the same six real atoms in two representations:

1. a compact input; and
2. a padded input with a distinctive NULL coordinate/spin inserted in the middle.

It compares energy, virial, real-atom force and magnetic force, and verifies that the NULL output slots are zero. The test explicitly checks the `.pth` backend so it exercises DeepSpinPT rather than PTExpt.

The file's historical float reference tolerance is `0.1`. The old mapping error is smaller than that (maximum observed differences: energy `0.01493`, force `0.02159`, magnetic force `0.08961`, virial `0.03228`), so this equivalence regression uses `1e-10` for double and `1e-5` for float. With the old production line restored, both typed cases fail; with the fix, both pass.

Validation performed:

- built `runUnitTests_cc`, `deepmd_backend_pt`, and `deepmd_op_pt` with CPU PyTorch
- old implementation check: 0 passed, 2 failed as expected
- focused fixed regression: 2 passed
- broader NoPBC DeepSpinPT neighbor-list group: 6 passed
- clang-format 22.1.5 check
- `ruff format --check .`
- `ruff check .`
- `git diff --check`

Closes #5619.

Coding agent: Codex
Codex version: codex-cli 0.144.1
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spin handling when NULL atoms are filtered from an input system.
  * Ensured spin data remains correctly mapped to real atoms, including when NULL atoms appear in the middle of the system.

* **Tests**
  * Added coverage verifying consistent energy, forces, and virial results for systems containing intermediate NULL atoms.
  * Confirmed NULL atoms receive zero forces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->