### PR TITLE
fix(c-api): return DeepSpin atomic virials

### DIFF
--- a/source/api_c/include/c_api.h
+++ b/source/api_c/include/c_api.h
@@ -1207,15 +1207,18 @@ void DP_DeepPotModelDeviCompute2(DP_DeepPotModelDevi* dp,
  *dim_fparam.
  * @param[in] aparam The atom parameters. The array can be of size nframes x
  *natoms x dim_aparam.
- * @param[out] energy Output energy.
- * @param[out] force Output force. The array should be of size natoms x 3.
- * @param[out] force_mag Output magnetic force on each atom. The array should be
- * of size natoms x 3.
- * @param[out] virial Output virial. The array should be of size 9.
- * @param[out] atomic_energy Output atomic energy. The array should be of size
- *natoms.
- * @param[out] atomic_virial Output atomic virial. The array should be of size
- *natoms x 9.
+ * @param[out] energy Output energies of all models. The array should be of size
+ *nmodels.
+ * @param[out] force Output forces of all models. The array should be of size
+ *nmodels x natoms x 3.
+ * @param[out] force_mag Output magnetic forces of all models. The array should
+ *be of size nmodels x natoms x 3.
+ * @param[out] virial Output virials of all models. The array should be of size
+ *nmodels x 9.
+ * @param[out] atomic_energy Output atomic energies of all models. The array
+ *should be of size nmodels x natoms.
+ * @param[out] atomic_virial Output atomic virials of all models. The array
+ *should be of size nmodels x natoms x 9.
  * @warning The output arrays should be allocated before calling this function.
  *Pass NULL if not required.
  * @since API version 24
@@ -1293,15 +1296,18 @@ void DP_DeepPotModelDeviComputef2(DP_DeepPotModelDevi* dp,
  *dim_fparam.
  * @param[in] aparam The atom parameters. The array can be of size nframes x
  *natoms x dim_aparam.
- * @param[out] energy Output energy.
- * @param[out] force Output force. The array should be of size natoms x 3.
- * @param[out] force_mag Output magnetic force on each atom. The array should be
- * of size natoms x 3.
- * @param[out] virial Output virial. The array should be of size 9.
- * @param[out] atomic_energy Output atomic energy. The array should be of size
- *natoms.
- * @param[out] atomic_virial Output atomic virial. The array should be of size
- *natoms x 9.
+ * @param[out] energy Output energies of all models. The array should be of size
+ *nmodels.
+ * @param[out] force Output forces of all models. The array should be of size
+ *nmodels x natoms x 3.
+ * @param[out] force_mag Output magnetic forces of all models. The array should
+ *be of size nmodels x natoms x 3.
+ * @param[out] virial Output virials of all models. The array should be of size
+ *nmodels x 9.
+ * @param[out] atomic_energy Output atomic energies of all models. The array
+ *should be of size nmodels x natoms.
+ * @param[out] atomic_virial Output atomic virials of all models. The array
+ *should be of size nmodels x natoms x 9.
  * @warning The output arrays should be allocated before calling this function.
  *Pass NULL if not required.
  * @since API version 24
@@ -1464,15 +1470,18 @@ void DP_DeepPotModelDeviComputeNList2(DP_DeepPotModelDevi* dp,
  *dim_fparam.
  * @param[in] aparam The atom parameters. The array can be of size nframes x
  *natoms x dim_aparam.
- * @param[out] energy Output energy.
- * @param[out] force Output force. The array should be of size natoms x 3.
- * @param[out] force_mag Output magnetic force on each atom. The array should be
- * of size natoms x 3.
- * @param[out] virial Output virial. The array should be of size 9.
- * @param[out] atomic_energy Output atomic energy. The array should be of size
- *natoms.
- * @param[out] atomic_virial Output atomic virial. The array should be of size
- *natoms x 9.
+ * @param[out] energy Output energies of all models. The array should be of size
+ *nmodels.
+ * @param[out] force Output forces of all models. The array should be of size
+ *nmodels x natoms x 3.
+ * @param[out] force_mag Output magnetic forces of all models. The array should
+ *be of size nmodels x natoms x 3.
+ * @param[out] virial Output virials of all models. The array should be of size
+ *nmodels x 9.
+ * @param[out] atomic_energy Output atomic energies of all models. The array
+ *should be of size nmodels x natoms.
+ * @param[out] atomic_virial Output atomic virials of all models. The array
+ *should be of size nmodels x natoms x 9.
  * @warning The output arrays should be allocated before calling this function.
  *Pass NULL if not required.
  * @since API version 24
@@ -1763,15 +1772,18 @@ void DP_DeepPotModelDeviComputeNListf3(DP_DeepPotModelDevi* dp,
  *dim_fparam.
  * @param[in] aparam The atom parameters. The array can be of size nframes x
  *natoms x dim_aparam.
- * @param[out] energy Output energy.
- * @param[out] force Output force. The array should be of size natoms x 3.
- * @param[out] force_mag Output magnetic force on each atom. The array should be
- * of size natoms x 3.
- * @param[out] virial Output virial. The array should be of size 9.
- * @param[out] atomic_energy Output atomic energy. The array should be of size
- *natoms.
- * @param[out] atomic_virial Output atomic virial. The array should be of size
- *natoms x 9.
+ * @param[out] energy Output energies of all models. The array should be of size
+ *nmodels.
+ * @param[out] force Output forces of all models. The array should be of size
+ *nmodels x natoms x 3.
+ * @param[out] force_mag Output magnetic forces of all models. The array should
+ *be of size nmodels x natoms x 3.
+ * @param[out] virial Output virials of all models. The array should be of size
+ *nmodels x 9.
+ * @param[out] atomic_energy Output atomic energies of all models. The array
+ *should be of size nmodels x natoms.
+ * @param[out] atomic_virial Output atomic virials of all models. The array
+ *should be of size nmodels x natoms x 9.
  * @warning The output arrays should be allocated before calling this function.
  *Pass NULL if not required.
  * @since API version 24

--- a/source/api_c/include/deepmd.hpp
+++ b/source/api_c/include/deepmd.hpp
@@ -2950,9 +2950,9 @@ class DeepSpinModelDevi : public DeepBaseModelDevi {
       for (int j = 0; j < natoms; j++) {
         atom_energy[i][j] = atom_energy_flat[i * natoms + j];
       }
-      // for (int j = 0; j < natoms * 9; j++) {
-      //   atom_virial[i][j] = atom_virial_flat[i * natoms * 9 + j];
-      // }
+      for (int j = 0; j < natoms * 9; j++) {
+        atom_virial[i][j] = atom_virial_flat[i * natoms * 9 + j];
+      }
     }
   };
 

--- a/source/api_c/src/c_api.cc
+++ b/source/api_c/src/c_api.cc
@@ -912,11 +912,11 @@ void DP_DeepSpinModelDeviCompute_variant(DP_DeepSpinModelDevi* dp,
     flatten_vector(ae_flat, ae);
     std::copy(ae_flat.begin(), ae_flat.end(), atomic_energy);
   }
-  // if (atomic_virial) {
-  //   std::vector<VALUETYPE> av_flat;
-  //   flatten_vector(av_flat, av);
-  //   std::copy(av_flat.begin(), av_flat.end(), atomic_virial);
-  // }
+  if (atomic_virial) {
+    std::vector<VALUETYPE> av_flat;
+    flatten_vector(av_flat, av);
+    std::copy(av_flat.begin(), av_flat.end(), atomic_virial);
+  }
 }
 
 template void DP_DeepSpinModelDeviCompute_variant<double>(

--- a/source/api_c/tests/test_deepspin_model_devi.cc
+++ b/source/api_c/tests/test_deepspin_model_devi.cc
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "c_api.h"
+#include "test_utils.h"
+
+namespace {
+
+void compute_atomic_virial(DP_DeepSpin* dp,
+                           const int natoms,
+                           const double* coord,
+                           const double* spin,
+                           const int* atype,
+                           const double* box,
+                           double* atomic_virial) {
+  DP_DeepSpinCompute2(dp, 1, natoms, coord, spin, atype, box, nullptr, nullptr,
+                      nullptr, nullptr, nullptr, nullptr, nullptr,
+                      atomic_virial);
+}
+
+void compute_atomic_virial(DP_DeepSpin* dp,
+                           const int natoms,
+                           const float* coord,
+                           const float* spin,
+                           const int* atype,
+                           const float* box,
+                           float* atomic_virial) {
+  DP_DeepSpinComputef2(dp, 1, natoms, coord, spin, atype, box, nullptr, nullptr,
+                       nullptr, nullptr, nullptr, nullptr, nullptr,
+                       atomic_virial);
+}
+
+void compute_model_devi_atomic_virial(DP_DeepSpinModelDevi* dp,
+                                      const int natoms,
+                                      const double* coord,
+                                      const double* spin,
+                                      const int* atype,
+                                      const double* box,
+                                      double* atomic_virial) {
+  DP_DeepSpinModelDeviCompute2(dp, 1, natoms, coord, spin, atype, box, nullptr,
+                               nullptr, nullptr, nullptr, nullptr, nullptr,
+                               nullptr, atomic_virial);
+}
+
+void compute_model_devi_atomic_virial(DP_DeepSpinModelDevi* dp,
+                                      const int natoms,
+                                      const float* coord,
+                                      const float* spin,
+                                      const int* atype,
+                                      const float* box,
+                                      float* atomic_virial) {
+  DP_DeepSpinModelDeviComputef2(dp, 1, natoms, coord, spin, atype, box, nullptr,
+                                nullptr, nullptr, nullptr, nullptr, nullptr,
+                                nullptr, atomic_virial);
+}
+
+template <class VALUETYPE>
+class TestInferDeepSpinModelDeviC : public ::testing::Test {
+ protected:
+  std::vector<VALUETYPE> coord = {12.83, 2.56, 2.18, 12.09, 2.87, 2.74,
+                                  00.25, 3.32, 1.68, 3.36,  3.00, 1.81,
+                                  3.51,  2.51, 2.60, 4.27,  3.22, 1.56};
+  std::vector<VALUETYPE> spin = {0.13, 0.02, 0.03, 0., 0., 0., 0., 0., 0.,
+                                 0.14, 0.10, 0.12, 0., 0., 0., 0., 0., 0.};
+  std::vector<int> atype = {0, 1, 1, 0, 1, 1};
+  std::vector<VALUETYPE> box = {13., 0., 0., 0., 13., 0., 0., 0., 13.};
+
+  DP_DeepSpin* dp = nullptr;
+  DP_DeepSpinModelDevi* dp_md = nullptr;
+
+  void SetUp() override {
+#ifndef BUILD_PYTORCH
+    GTEST_SKIP() << "Skip because PyTorch support is not enabled.";
+#endif
+    const char* model = "../../tests/infer/deeppot_dpa_spin.pth";
+    const char* models[] = {model, model};
+    dp = DP_NewDeepSpin(model);
+    dp_md = DP_NewDeepSpinModelDevi(models, 2);
+
+    const char* error = DP_DeepSpinCheckOK(dp);
+    const std::string error_message(error);
+    DP_DeleteChar(error);
+    ASSERT_TRUE(error_message.empty()) << error_message;
+
+    error = DP_DeepSpinModelDeviCheckOK(dp_md);
+    const std::string model_devi_error_message(error);
+    DP_DeleteChar(error);
+    ASSERT_TRUE(model_devi_error_message.empty()) << model_devi_error_message;
+  }
+
+  void TearDown() override {
+    DP_DeleteDeepSpin(dp);
+    DP_DeleteDeepSpinModelDevi(dp_md);
+  }
+};
+
+TYPED_TEST_SUITE(TestInferDeepSpinModelDeviC, ValueTypes);
+
+TYPED_TEST(TestInferDeepSpinModelDeviC, copies_atomic_virial_for_every_model) {
+  using VALUETYPE = TypeParam;
+  const int natoms = this->atype.size();
+  const int nmodels = 2;
+  const size_t per_model_size = static_cast<size_t>(natoms) * 9;
+  const VALUETYPE sentinel = std::numeric_limits<VALUETYPE>::quiet_NaN();
+
+  std::vector<VALUETYPE> expected(per_model_size, sentinel);
+  compute_atomic_virial(this->dp, natoms, this->coord.data(), this->spin.data(),
+                        this->atype.data(), this->box.data(), expected.data());
+
+  // A NaN sentinel makes an omitted copy-out deterministic even when a valid
+  // model happens to produce zero for some atomic-virial components.
+  std::vector<VALUETYPE> actual(nmodels * per_model_size, sentinel);
+  compute_model_devi_atomic_virial(this->dp_md, natoms, this->coord.data(),
+                                   this->spin.data(), this->atype.data(),
+                                   this->box.data(), actual.data());
+
+  for (size_t ii = 0; ii < per_model_size; ++ii) {
+    ASSERT_FALSE(std::isnan(expected[ii]))
+        << "Single-model reference did not populate element " << ii;
+  }
+  for (int model = 0; model < nmodels; ++model) {
+    for (size_t ii = 0; ii < per_model_size; ++ii) {
+      const size_t output_index = model * per_model_size + ii;
+      EXPECT_FALSE(std::isnan(actual[output_index]))
+          << "Model-deviation output did not populate model " << model
+          << ", element " << ii;
+      EXPECT_LT(std::fabs(actual[output_index] - expected[ii]), EPSILON)
+          << "Unexpected model-major atomic virial at model " << model
+          << ", element " << ii;
+    }
+  }
+}
+
+}  // namespace

--- a/source/api_c/tests/test_deepspin_model_devi_hpp.cc
+++ b/source/api_c/tests/test_deepspin_model_devi_hpp.cc
@@ -91,11 +91,11 @@ TYPED_TEST(TestInferDeepSpinModeDevi, cpu_build_nlist) {
   EXPECT_EQ(edir.size(), emd.size());
   EXPECT_EQ(fdir.size(), fmd.size());
   EXPECT_EQ(fmagdir.size(), fmmagd.size());
-  // EXPECT_EQ(vdir.size(), vmd.size());
+  EXPECT_EQ(vdir.size(), vmd.size());
   for (int kk = 0; kk < nmodel; ++kk) {
     EXPECT_EQ(fdir[kk].size(), fmd[kk].size());
     EXPECT_EQ(fmagdir[kk].size(), fmmagd[kk].size());
-    // EXPECT_EQ(vdir[kk].size(), vmd[kk].size());
+    EXPECT_EQ(vdir[kk].size(), vmd[kk].size());
   }
   for (int kk = 0; kk < nmodel; ++kk) {
     EXPECT_LT(fabs(edir[kk] - emd[kk]), EPSILON);
@@ -105,9 +105,9 @@ TYPED_TEST(TestInferDeepSpinModeDevi, cpu_build_nlist) {
     for (int ii = 0; ii < fmagdir[0].size(); ++ii) {
       EXPECT_LT(fabs(fmagdir[kk][ii] - fmmagd[kk][ii]), EPSILON);
     }
-    // for (int ii = 0; ii < vdir[0].size(); ++ii) {
-    //   EXPECT_LT(fabs(vdir[kk][ii] - vmd[kk][ii]), EPSILON);
-    // }
+    for (int ii = 0; ii < vdir[0].size(); ++ii) {
+      EXPECT_LT(fabs(vdir[kk][ii] - vmd[kk][ii]), EPSILON);
+    }
   }
 }
 
@@ -137,13 +137,13 @@ TYPED_TEST(TestInferDeepSpinModeDevi, cpu_build_nlist_atomic) {
   EXPECT_EQ(edir.size(), emd.size());
   EXPECT_EQ(fdir.size(), fmd.size());
   EXPECT_EQ(fmagdir.size(), fmmagd.size());
-  // EXPECT_EQ(vdir.size(), vmd.size());
+  EXPECT_EQ(vdir.size(), vmd.size());
   EXPECT_EQ(aedir.size(), aemd.size());
   ASSERT_EQ(avdir.size(), avmd.size());
   for (int kk = 0; kk < nmodel; ++kk) {
     EXPECT_EQ(fdir[kk].size(), fmd[kk].size());
     EXPECT_EQ(fmagdir[kk].size(), fmmagd[kk].size());
-    // EXPECT_EQ(vdir[kk].size(), vmd[kk].size());
+    EXPECT_EQ(vdir[kk].size(), vmd[kk].size());
     EXPECT_EQ(aedir[kk].size(), aemd[kk].size());
     ASSERT_EQ(avdir[kk].size(), avmd[kk].size());
   }
@@ -155,9 +155,9 @@ TYPED_TEST(TestInferDeepSpinModeDevi, cpu_build_nlist_atomic) {
     for (int ii = 0; ii < fmagdir[0].size(); ++ii) {
       EXPECT_LT(fabs(fmagdir[kk][ii] - fmmagd[kk][ii]), EPSILON);
     }
-    // for (int ii = 0; ii < vdir[0].size(); ++ii) {
-    //   EXPECT_LT(fabs(vdir[kk][ii] - vmd[kk][ii]), EPSILON);
-    // }
+    for (int ii = 0; ii < vdir[0].size(); ++ii) {
+      EXPECT_LT(fabs(vdir[kk][ii] - vmd[kk][ii]), EPSILON);
+    }
     for (int ii = 0; ii < aedir[0].size(); ++ii) {
       EXPECT_LT(fabs(aedir[kk][ii] - aemd[kk][ii]), EPSILON);
     }

--- a/source/api_c/tests/test_deepspin_model_devi_hpp.cc
+++ b/source/api_c/tests/test_deepspin_model_devi_hpp.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <limits>
 #include <vector>
 
 #include "deepmd.hpp"
@@ -38,6 +39,7 @@ class TestInferDeepSpinModeDevi : public ::testing::Test {
     dp_md.init(
         std::vector<std::string>({"../../tests/infer/deeppot_dpa_spin.pth",
                                   "../../tests/infer/deeppot_dpa_spin.pth"}));
+    natoms = atype.size();
   };
 
   void TearDown() override {};
@@ -121,10 +123,11 @@ TYPED_TEST(TestInferDeepSpinModeDevi, cpu_build_nlist_atomic) {
   deepmd::hpp::DeepSpinModelDevi& dp_md = this->dp_md;
 
   int nmodel = 2;
+  const VALUETYPE sentinel = std::numeric_limits<VALUETYPE>::quiet_NaN();
   std::vector<double> edir(nmodel), emd;
   std::vector<std::vector<VALUETYPE> > fdir(nmodel), fmagdir(nmodel),
       vdir(nmodel), fmd(nmodel), fmmagd(nmodel), vmd, aedir(nmodel), aemd,
-      avdir(nmodel), avmd(nmodel);
+      avdir(nmodel), avmd(nmodel, std::vector<VALUETYPE>(natoms * 9, sentinel));
   dp0.compute(edir[0], fdir[0], fmagdir[0], vdir[0], aedir[0], avdir[0], coord,
               spin, atype, box);
   dp1.compute(edir[1], fdir[1], fmagdir[1], vdir[1], aedir[1], avdir[1], coord,
@@ -136,13 +139,13 @@ TYPED_TEST(TestInferDeepSpinModeDevi, cpu_build_nlist_atomic) {
   EXPECT_EQ(fmagdir.size(), fmmagd.size());
   // EXPECT_EQ(vdir.size(), vmd.size());
   EXPECT_EQ(aedir.size(), aemd.size());
-  // EXPECT_EQ(avdir.size(), avmd.size());
+  ASSERT_EQ(avdir.size(), avmd.size());
   for (int kk = 0; kk < nmodel; ++kk) {
     EXPECT_EQ(fdir[kk].size(), fmd[kk].size());
     EXPECT_EQ(fmagdir[kk].size(), fmmagd[kk].size());
     // EXPECT_EQ(vdir[kk].size(), vmd[kk].size());
     EXPECT_EQ(aedir[kk].size(), aemd[kk].size());
-    // EXPECT_EQ(avdir[kk].size(), avmd[kk].size());
+    ASSERT_EQ(avdir[kk].size(), avmd[kk].size());
   }
   for (int kk = 0; kk < nmodel; ++kk) {
     EXPECT_LT(fabs(edir[kk] - emd[kk]), EPSILON);
@@ -158,8 +161,10 @@ TYPED_TEST(TestInferDeepSpinModeDevi, cpu_build_nlist_atomic) {
     for (int ii = 0; ii < aedir[0].size(); ++ii) {
       EXPECT_LT(fabs(aedir[kk][ii] - aemd[kk][ii]), EPSILON);
     }
-    // for (int ii = 0; ii < avdir[0].size(); ++ii) {
-    //   EXPECT_LT(fabs(avdir[kk][ii] - avmd[kk][ii]), EPSILON);
-    // }
+    for (int ii = 0; ii < avdir[0].size(); ++ii) {
+      EXPECT_FALSE(std::isnan(avmd[kk][ii]))
+          << "hpp wrapper did not reshape model " << kk << ", element " << ii;
+      EXPECT_LT(fabs(avdir[kk][ii] - avmd[kk][ii]), EPSILON);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- restore non-neighbor-list DeepSpin model-deviation atomic-virial copy-out in the raw C API
- restore flat-to-nested atomic-virial reshaping in the `deepmd.hpp` wrapper
- correct the model-major output-size documentation for all four DeepSpin model-deviation v2 C APIs
- add independent float/double regressions for both API layers

## Root cause and fix

The non-neighbor-list DeepSpin model-deviation helper requested atomic virials from the backend, but its flatten/copy block was commented out. The header-only wrapper had a second commented-out loop, so even a repaired raw C buffer would not be transferred into the nested `atom_virial` output.

This change restores both operations using the same model-major layout already used by the working neighbor-list path:

`model * natoms * 9 + atomic_virial_element`

The C API documentation for the double/float, neighbor-list/non-neighbor-list DeepSpin model-deviation v2 functions now consistently states that all output arrays include the `nmodels` dimension.

## Regression coverage

This escaped existing coverage for two reasons:

- the API-CC model-deviation tests call the C++ implementation directly and therefore bypass both C API layers; and
- the relevant atomic-virial size/value assertions in the hpp C API test were commented out.

The new raw C typed test evaluates one model to obtain a reference, pre-fills a two-model output buffer with NaNs, and verifies every element of both model-major blocks. The hpp test independently pre-fills its nested output buffers with NaNs and checks size, population, and values, so it also detects a missing wrapper reshape after the raw layer is fixed.

With the previous copy/reshape behavior restored, the four focused typed cases produce 0 passes and 4 failures because the NaN sentinels remain unchanged. With this fix, the expanded DeepSpin model-deviation group passes all 8 tests.

Validation performed:

- built `runUnitTests_c`, `deepmd_backend_pt`, and `deepmd_op_pt` with CPU PyTorch
- old implementation check: 0 passed, 4 failed as expected
- focused fixed raw C and hpp atomic tests: 4 passed
- expanded DeepSpin model-deviation group: 8 passed
- independent review and C++14 syntax checks found no issues
- clang-format 22.1.5 check
- `ruff format --check .`
- `ruff check .`
- `git diff --check`

Closes #5621.

Coding agent: Codex
Codex version: codex-cli 0.144.1
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model-deviation atomic virial outputs so `atomic_virial` is correctly computed and returned when requested.
  * Ensured atomic virial values are consistent across supported computation variants and for all models.
* **Documentation**
  * Updated output parameter documentation to correctly describe per-model shapes for energy, force, virial, atomic energy, and atomic virial.
* **Tests**
  * Added and strengthened tests to verify atomic virial is populated (no missing values) and matches expected results across models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->