### PR TITLE
fix(ase): symmetrize reshaped virial stress

### DIFF
--- a/deepmd/calculator.py
+++ b/deepmd/calculator.py
@@ -152,13 +152,17 @@ class DP(Calculator):
         # see https://gitlab.com/ase/ase/-/merge_requests/2485
         self.results["free_energy"] = e[0][0]
         self.results["forces"] = f[0]
-        self.results["virial"] = v[0].reshape(3, 3)
+        virial = v[0].reshape(3, 3)
+        self.results["virial"] = virial
 
         # convert virial into stress for lattice relaxation
         if cell is not None:
             # the usual convention (tensile stress is positive)
             # stress = -virial / volume
-            stress = -0.5 * (v[0].copy() + v[0].copy().T) / atoms.get_volume()
+            # ASE represents Cauchy stress as a symmetric tensor.  Reshape the
+            # flat model output before transposing; ``.T`` on the original
+            # one-dimensional virial array would otherwise be a no-op.
+            stress = -0.5 * (virial + virial.T) / atoms.get_volume()
             # Voigt notation
             self.results["stress"] = stress.flat[[0, 4, 8, 5, 2, 1]]
         elif "stress" in properties:

--- a/source/tests/test_calculator.py
+++ b/source/tests/test_calculator.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Backend-independent regression tests for the ASE calculator adapter."""
+
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+import numpy as np
+from ase import (
+    Atoms,
+)
+
+from deepmd.calculator import (
+    DP,
+)
+
+
+def test_stress_symmetrizes_flat_virial() -> None:
+    """Convert the model virial to ASE's symmetric Voigt stress convention.
+
+    Real DeePMD models normally produce an already-symmetric total virial, so
+    the existing integration tests could not detect that transposing its flat
+    nine-component representation was a no-op.  An intentionally asymmetric
+    mock output makes each off-diagonal average independently observable.
+    """
+    model = Mock()
+    model.get_type_map.return_value = ["H"]
+    model.get_ntypes.return_value = 1
+    virial = np.arange(1.0, 10.0).reshape(1, 9)
+    model.eval.return_value = (
+        np.array([[0.0]]),
+        np.zeros((1, 1, 3)),
+        virial,
+    )
+
+    with patch("deepmd.calculator.DeepPot", return_value=model):
+        calculator = DP("unused-model")
+
+    atoms = Atoms(
+        "H",
+        positions=[[0.0, 0.0, 0.0]],
+        cell=np.eye(3) * 2.0,
+        pbc=True,
+        calculator=calculator,
+    )
+
+    np.testing.assert_allclose(
+        atoms.get_stress(voigt=True),
+        -np.array([1.0, 5.0, 9.0, 7.0, 5.0, 3.0]) / atoms.get_volume(),
+    )
+    # Symmetrizing stress must not discard diagnostic information from the
+    # model: callers requesting the virial still receive the original tensor.
+    np.testing.assert_array_equal(calculator.results["virial"], virial.reshape(3, 3))


### PR DESCRIPTION
## Summary

- reshape the nine-component model virial before transposing it
- project the virial onto ASE's symmetric Cauchy stress convention
- preserve the original, potentially asymmetric virial matrix in `results["virial"]`
- add a backend-independent mock regression with independently observable shear components

## Root cause and fix

The calculator stored `v[0].reshape(3, 3)` as the virial, but formed stress from:

```python
v[0].copy() + v[0].copy().T
```

`v[0]` is one-dimensional with shape `(9,)`, and transposing a one-dimensional NumPy array is a no-op. The calculation therefore selected only one side of each off-diagonal pair when converting to ASE Voigt order.

The code now names the reshaped `3 x 3` virial, preserves it unchanged in the results dictionary, and computes:

```python
-0.5 * (virial + virial.T) / volume
```

This matches ASE's symmetric stress convention and retains tensile-positive sign handling. It does not hide the original virial: callers can still inspect any antisymmetric component through `results["virial"]`.

## Why existing tests missed this

Standard conservative DeePMD models normally return a total virial that is already symmetric up to floating-point noise. Existing calculator integration tests use such real model output and mainly check permutation consistency, so the ineffective transpose was numerically invisible.

The new lightweight regression mocks the model with the intentionally asymmetric virial:

```text
[[1, 2, 3],
 [4, 5, 6],
 [7, 8, 9]]
```

For volume 8, the correct ASE Voigt shear entries are based on averages `yz=7`, `xz=5`, and `xy=3`. The previous implementation deterministically returned the single-sided values `6`, `3`, and `2`; the fixed implementation returns the expected symmetric values and leaves the stored virial unchanged.

## Validation

- old calculation reproduced the incorrect deterministic shear values
- new backend-independent regression: passed
- existing PyTorch calculator tests: 2 passed
- independent review found no sign, Voigt-order, PBC, or backend-coupling issues
- `ruff format --check .`
- `ruff check .`
- `git diff --check`

Closes #5689.

Coding agent: Codex
Codex version: codex-cli 0.144.1
Model: gpt-5.6-sol
Reasoning effort: xhigh
