### PR TITLE
fix(tf): close C++ API sessions

### DIFF
--- a/source/api_cc/include/DeepPotJAX.h
+++ b/source/api_cc/include/DeepPotJAX.h
@@ -242,6 +242,13 @@ class DeepPotJAX : public DeepPotBackend {
                            const bool atomic);
 
  private:
+  /** Release every TensorFlow C API handle owned by this backend.
+   *
+   * This helper is intentionally safe for partially initialized objects so an
+   * exception from init() cannot leak handles or make a later retry unsafe.
+   */
+  void clear_tf_resources() noexcept;
+
   bool inited;
   // device
   std::string device;
@@ -284,12 +291,12 @@ class DeepPotJAX : public DeepPotBackend {
   /**  TF C API objects.
    * @{
    */
-  TF_Graph* graph;
-  TF_Status* status;
-  TF_Session* session;
-  TF_SessionOptions* sessionopts;
-  TFE_ContextOptions* ctx_opts;
-  TFE_Context* ctx;
+  TF_Graph* graph = nullptr;
+  TF_Status* status = nullptr;
+  TF_Session* session = nullptr;
+  TF_SessionOptions* sessionopts = nullptr;
+  TFE_ContextOptions* ctx_opts = nullptr;
+  TFE_Context* ctx = nullptr;
   std::vector<TF_Function*> func_vector;
   /**
    * @}

--- a/source/api_cc/include/tf_private.h
+++ b/source/api_cc/include/tf_private.h
@@ -18,4 +18,49 @@ typedef tensorflow::tstring STRINGTYPE;
 #else
 typedef std::string STRINGTYPE;
 #endif
+
+/**
+ * @brief Close and release an exclusively owned TensorFlow session.
+ *
+ * TensorFlow permits concurrent Run calls, but requires them all to finish
+ * before the sole Close call.  Owners must therefore stop concurrent use
+ * before destruction; this helper only centralizes the non-throwing cleanup
+ * needed by destructors and partially constructed API objects.
+ *
+ * @param[in,out] session Exclusively owned session, reset to nullptr.
+ */
+inline void close_and_delete_session(tensorflow::Session*& session) noexcept {
+  if (session == nullptr) {
+    return;
+  }
+  session->Close().IgnoreError();
+  delete session;
+  session = nullptr;
+}
+
+/**
+ * @brief Roll back a session assigned during a potentially throwing init call.
+ *
+ * Call release() only after initialization has completed successfully.
+ */
+class SessionCleanupGuard {
+ public:
+  explicit SessionCleanupGuard(tensorflow::Session*& session) noexcept
+      : session_(session), active_(true) {}
+
+  ~SessionCleanupGuard() {
+    if (active_) {
+      close_and_delete_session(session_);
+    }
+  }
+
+  SessionCleanupGuard(const SessionCleanupGuard&) = delete;
+  SessionCleanupGuard& operator=(const SessionCleanupGuard&) = delete;
+
+  void release() noexcept { active_ = false; }
+
+ private:
+  tensorflow::Session*& session_;
+  bool active_;
+};
 }  // namespace deepmd

--- a/source/api_cc/src/DataModifierTF.cc
+++ b/source/api_cc/src/DataModifierTF.cc
@@ -8,22 +8,29 @@ using namespace deepmd;
 using namespace tensorflow;
 
 DipoleChargeModifierTF::DipoleChargeModifierTF()
-    : inited(false), graph_def(new GraphDef()) {}
+    : session(nullptr), graph_def(new GraphDef()), inited(false) {}
 
 DipoleChargeModifierTF::DipoleChargeModifierTF(const std::string& model,
                                                const int& gpu_rank,
                                                const std::string& name_scope_)
-    : inited(false), name_scope(name_scope_), graph_def(new GraphDef()) {
+    : session(nullptr),
+      name_scope(name_scope_),
+      graph_def(new GraphDef()),
+      inited(false) {
   try {
     init(model, gpu_rank, name_scope_);
   } catch (...) {
     // Clean up and rethrow, as the destructor will not be called
+    deepmd::close_and_delete_session(session);
     delete graph_def;
     throw;
   }
 }
 
-DipoleChargeModifierTF::~DipoleChargeModifierTF() { delete graph_def; };
+DipoleChargeModifierTF::~DipoleChargeModifierTF() {
+  deepmd::close_and_delete_session(session);
+  delete graph_def;
+};
 
 void DipoleChargeModifierTF::init(const std::string& model,
                                   const int& gpu_rank,
@@ -34,6 +41,7 @@ void DipoleChargeModifierTF::init(const std::string& model,
               << std::endl;
     return;
   }
+  deepmd::SessionCleanupGuard session_guard(session);
   name_scope = name_scope_;
   SessionOptions options;
   get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
@@ -72,6 +80,7 @@ void DipoleChargeModifierTF::init(const std::string& model,
   get_vector<int>(sel_type, "model_attr/sel_type");
   sort(sel_type.begin(), sel_type.end());
   inited = true;
+  session_guard.release();
 }
 
 template <class VT>

--- a/source/api_cc/src/DeepPotJAX.cc
+++ b/source/api_cc/src/DeepPotJAX.cc
@@ -542,169 +542,199 @@ void deepmd::DeepPotJAX::init(const std::string& model,
     return;
   }
 
-  const char* saved_model_dir = model.c_str();
-  graph = TF_NewGraph();
-  status = TF_NewStatus();
+  try {
+    const char* saved_model_dir = model.c_str();
+    graph = TF_NewGraph();
+    status = TF_NewStatus();
 
-  sessionopts = TF_NewSessionOptions();
-  int num_intra_nthreads, num_inter_nthreads;
-  get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
-  // https://github.com/Neargye/hello_tf_c_api/blob/51516101cf59408a6bb456f7e5f3c6628e327b3a/src/tf_utils.cpp#L400-L401
-  // https://github.com/Neargye/hello_tf_c_api/blob/51516101cf59408a6bb456f7e5f3c6628e327b3a/src/tf_utils.cpp#L364-L379
-  // The following is an equivalent of setting this in Python:
-  // config = tf.ConfigProto( allow_soft_placement = True )
-  // config.gpu_options.allow_growth = True
-  // config.gpu_options.per_process_gpu_memory_fraction = percentage
-  // Create a byte-array for the serialized ProtoConfig, set the mandatory bytes
-  // (first three and last four)
-  std::array<std::uint8_t, 19> config = {
-      {0x10, static_cast<std::uint8_t>(num_intra_nthreads), 0x28,
-       static_cast<std::uint8_t>(num_inter_nthreads), 0x32, 0xb, 0x9, 0xFF,
-       0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x20, 0x1, 0x38, 0x1}};
+    sessionopts = TF_NewSessionOptions();
+    int num_intra_nthreads, num_inter_nthreads;
+    get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
+    // https://github.com/Neargye/hello_tf_c_api/blob/51516101cf59408a6bb456f7e5f3c6628e327b3a/src/tf_utils.cpp#L400-L401
+    // https://github.com/Neargye/hello_tf_c_api/blob/51516101cf59408a6bb456f7e5f3c6628e327b3a/src/tf_utils.cpp#L364-L379
+    // The following is an equivalent of setting this in Python:
+    // config = tf.ConfigProto( allow_soft_placement = True )
+    // config.gpu_options.allow_growth = True
+    // config.gpu_options.per_process_gpu_memory_fraction = percentage
+    // Create a byte-array for the serialized ProtoConfig, set the mandatory
+    // bytes (first three and last four)
+    std::array<std::uint8_t, 19> config = {
+        {0x10, static_cast<std::uint8_t>(num_intra_nthreads), 0x28,
+         static_cast<std::uint8_t>(num_inter_nthreads), 0x32, 0xb, 0x9, 0xFF,
+         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x20, 0x1, 0x38, 0x1}};
 
-  // Convert the desired percentage into a byte-array.
-  double gpu_memory_fraction = 0.9;
-  auto bytes = reinterpret_cast<std::uint8_t*>(&gpu_memory_fraction);
+    // Convert the desired percentage into a byte-array.
+    double gpu_memory_fraction = 0.9;
+    auto bytes = reinterpret_cast<std::uint8_t*>(&gpu_memory_fraction);
 
-  // Put it to the config byte-array, from 7 to 14:
-  for (std::size_t i = 0; i < sizeof(gpu_memory_fraction); ++i) {
-    config[i + 7] = bytes[i];
-  }
+    // Put it to the config byte-array, from 7 to 14:
+    for (std::size_t i = 0; i < sizeof(gpu_memory_fraction); ++i) {
+      config[i + 7] = bytes[i];
+    }
 
-  TF_SetConfig(sessionopts, config.data(), config.size(), status);
-  check_status(status);
+    TF_SetConfig(sessionopts, config.data(), config.size(), status);
+    check_status(status);
 
-  TF_Buffer* runopts = NULL;
+    TF_Buffer* runopts = NULL;
 
-  const char* tags = "serve";
-  int ntags = 1;
+    const char* tags = "serve";
+    int ntags = 1;
 
-  session = TF_LoadSessionFromSavedModel(sessionopts, runopts, saved_model_dir,
-                                         &tags, ntags, graph, NULL, status);
-  check_status(status);
+    session =
+        TF_LoadSessionFromSavedModel(sessionopts, runopts, saved_model_dir,
+                                     &tags, ntags, graph, NULL, status);
+    check_status(status);
 
-  int nfuncs = TF_GraphNumFunctions(graph);
-  // allocate memory for the TF_Function* array
-  func_vector.resize(nfuncs);
-  TF_Function** funcs = func_vector.data();
-  TF_GraphGetFunctions(graph, funcs, nfuncs, status);
-  check_status(status);
-  uses_xla_compilation_ = uses_xla_compilation(graph, func_vector, status);
+    int nfuncs = TF_GraphNumFunctions(graph);
+    // allocate memory for the TF_Function* array
+    func_vector.resize(nfuncs);
+    TF_Function** funcs = func_vector.data();
+    TF_GraphGetFunctions(graph, funcs, nfuncs, status);
+    check_status(status);
+    uses_xla_compilation_ = uses_xla_compilation(graph, func_vector, status);
 
-  ctx_opts = TFE_NewContextOptions();
-  TFE_ContextOptionsSetConfig(ctx_opts, config.data(), config.size(), status);
-  check_status(status);
-  ctx = TFE_NewContext(ctx_opts, status);
-  check_status(status);
+    ctx_opts = TFE_NewContextOptions();
+    TFE_ContextOptionsSetConfig(ctx_opts, config.data(), config.size(), status);
+    check_status(status);
+    ctx = TFE_NewContext(ctx_opts, status);
+    check_status(status);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-  int gpu_num;
-  DPGetDeviceCount(gpu_num);  // check current device environment
-  if (gpu_num > 0 && gpu_rank >= 0) {
-    DPErrcheck(DPSetDevice(gpu_rank % gpu_num));
-    device = "/gpu:" + std::to_string(gpu_rank % gpu_num);
-  } else {
-    device = "/cpu:0";
-  }
+    int gpu_num;
+    DPGetDeviceCount(gpu_num);  // check current device environment
+    if (gpu_num > 0 && gpu_rank >= 0) {
+      DPErrcheck(DPSetDevice(gpu_rank % gpu_num));
+      device = "/gpu:" + std::to_string(gpu_rank % gpu_num);
+    } else {
+      device = "/cpu:0";
+    }
 #else
-  device = "/cpu:0";
+    device = "/cpu:0";
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-  // add all functions, otherwise the function will not be found
-  // even for tf.cond
-  for (size_t i = 0; i < func_vector.size(); i++) {
-    TF_Function* func = func_vector[i];
-    TFE_ContextAddFunction(ctx, func, status);
-    check_status(status);
-  }
+    // add all functions, otherwise the function will not be found
+    // even for tf.cond
+    for (size_t i = 0; i < func_vector.size(); i++) {
+      TF_Function* func = func_vector[i];
+      TFE_ContextAddFunction(ctx, func, status);
+      check_status(status);
+    }
 
-  rcut = get_scalar<double>(ctx, "get_rcut", func_vector, device, status);
-  dfparam =
-      get_scalar<int64_t>(ctx, "get_dim_fparam", func_vector, device, status);
-  daparam =
-      get_scalar<int64_t>(ctx, "get_dim_aparam", func_vector, device, status);
-  try {
-    dchgspin = get_scalar<int64_t>(ctx, "get_dim_chg_spin", func_vector, device,
-                                   status);
-  } catch (tf_function_not_found& e) {
-    dchgspin = 0;
-  }
-  try {
-    has_default_chg_spin_ = get_scalar<bool>(ctx, "has_default_chg_spin",
-                                             func_vector, device, status);
-  } catch (tf_function_not_found& e) {
-    has_default_chg_spin_ = false;
-  }
-  if (dchgspin > 0 && has_default_chg_spin_) {
+    rcut = get_scalar<double>(ctx, "get_rcut", func_vector, device, status);
+    dfparam =
+        get_scalar<int64_t>(ctx, "get_dim_fparam", func_vector, device, status);
+    daparam =
+        get_scalar<int64_t>(ctx, "get_dim_aparam", func_vector, device, status);
     try {
-      default_chg_spin_ = get_vector<double>(ctx, "get_default_chg_spin",
-                                             func_vector, device, status);
+      dchgspin = get_scalar<int64_t>(ctx, "get_dim_chg_spin", func_vector,
+                                     device, status);
     } catch (tf_function_not_found& e) {
+      dchgspin = 0;
+    }
+    try {
+      has_default_chg_spin_ = get_scalar<bool>(ctx, "has_default_chg_spin",
+                                               func_vector, device, status);
+    } catch (tf_function_not_found& e) {
+      has_default_chg_spin_ = false;
+    }
+    if (dchgspin > 0 && has_default_chg_spin_) {
+      try {
+        default_chg_spin_ = get_vector<double>(ctx, "get_default_chg_spin",
+                                               func_vector, device, status);
+      } catch (tf_function_not_found& e) {
+        default_chg_spin_.clear();
+      }
+    } else {
       default_chg_spin_.clear();
     }
-  } else {
-    default_chg_spin_.clear();
-  }
-  std::vector<std::string> type_map_ =
-      get_vector_string(ctx, "get_type_map", func_vector, device, status);
-  // deepmd-kit stores type_map as a concatenated string, split by ' '
-  type_map = type_map_[0];
-  for (size_t i = 1; i < type_map_.size(); i++) {
-    type_map += " " + type_map_[i];
-  }
-  ntypes = type_map_.size();
-  sel = get_vector<int64_t>(ctx, "get_sel", func_vector, device, status);
-  nnei = std::accumulate(sel.begin(), sel.end(), decltype(sel)::value_type(0));
-  try {
-    do_message_passing = get_scalar<bool>(ctx, "has_message_passing",
-                                          func_vector, device, status);
-  } catch (tf_function_not_found& e) {
+    std::vector<std::string> type_map_ =
+        get_vector_string(ctx, "get_type_map", func_vector, device, status);
+    // deepmd-kit stores type_map as a concatenated string, split by ' '
+    type_map = type_map_[0];
+    for (size_t i = 1; i < type_map_.size(); i++) {
+      type_map += " " + type_map_[i];
+    }
+    ntypes = type_map_.size();
+    sel = get_vector<int64_t>(ctx, "get_sel", func_vector, device, status);
+    nnei =
+        std::accumulate(sel.begin(), sel.end(), decltype(sel)::value_type(0));
     try {
-      do_message_passing = get_scalar<bool>(ctx, "do_message_passing",
+      do_message_passing = get_scalar<bool>(ctx, "has_message_passing",
                                             func_vector, device, status);
     } catch (tf_function_not_found& e) {
-      // compatible with models generated by v3.0.0rc0
-      do_message_passing = false;
+      try {
+        do_message_passing = get_scalar<bool>(ctx, "do_message_passing",
+                                              func_vector, device, status);
+      } catch (tf_function_not_found& e) {
+        // compatible with models generated by v3.0.0rc0
+        do_message_passing = false;
+      }
     }
-  }
-  try {
-    has_default_fparam_ = get_scalar<bool>(ctx, "has_default_fparam",
-                                           func_vector, device, status);
-  } catch (tf_function_not_found& e) {
-    has_default_fparam_ = false;
-  }
-  try {
-    // Model-level pair_exclude_types, exported flat [ti0, tj0, ti1, tj1, ...].
-    // Fold exclusion into the LAMMPS nlist at ingestion (decision #18/A4); the
-    // exported call_lower_* consumes a pre-excluded nlist. Models exported
-    // before this getter existed baked exclusion into the graph, so a missing
-    // getter (=> empty table => identity here) is correct for them.
-    std::vector<int64_t> pet_flat = get_vector<int64_t>(
-        ctx, "get_pair_exclude_types", func_vector, device, status);
-    std::vector<std::pair<int, int>> pair_exclude_types;
-    for (size_t ii = 0; ii + 1 < pet_flat.size(); ii += 2) {
-      pair_exclude_types.emplace_back(static_cast<int>(pet_flat[ii]),
-                                      static_cast<int>(pet_flat[ii + 1]));
+    try {
+      has_default_fparam_ = get_scalar<bool>(ctx, "has_default_fparam",
+                                             func_vector, device, status);
+    } catch (tf_function_not_found& e) {
+      has_default_fparam_ = false;
     }
-    pair_exclude_table_ = buildPairExcludeTable(ntypes, pair_exclude_types);
-  } catch (tf_function_not_found& e) {
-    pair_exclude_table_.clear();
+    try {
+      // Model-level pair_exclude_types, exported flat [ti0, tj0, ti1, tj1,
+      // ...]. Fold exclusion into the LAMMPS nlist at ingestion (decision
+      // #18/A4); the exported call_lower_* consumes a pre-excluded nlist.
+      // Models exported before this getter existed baked exclusion into the
+      // graph, so a missing getter (=> empty table => identity here) is correct
+      // for them.
+      std::vector<int64_t> pet_flat = get_vector<int64_t>(
+          ctx, "get_pair_exclude_types", func_vector, device, status);
+      std::vector<std::pair<int, int>> pair_exclude_types;
+      for (size_t ii = 0; ii + 1 < pet_flat.size(); ii += 2) {
+        pair_exclude_types.emplace_back(static_cast<int>(pet_flat[ii]),
+                                        static_cast<int>(pet_flat[ii + 1]));
+      }
+      pair_exclude_table_ = buildPairExcludeTable(ntypes, pair_exclude_types);
+    } catch (tf_function_not_found& e) {
+      pair_exclude_table_.clear();
+    }
+    inited = true;
+  } catch (...) {
+    clear_tf_resources();
+    throw;
   }
-  inited = true;
 }
 
-deepmd::DeepPotJAX::~DeepPotJAX() {
-  if (inited) {
-    TF_DeleteSession(session, status);
-    TF_DeleteGraph(graph);
-    TF_DeleteSessionOptions(sessionopts);
-    TF_DeleteStatus(status);
+void deepmd::DeepPotJAX::clear_tf_resources() noexcept {
+  if (ctx != nullptr) {
     TFE_DeleteContext(ctx);
+    ctx = nullptr;
+  }
+  if (ctx_opts != nullptr) {
     TFE_DeleteContextOptions(ctx_opts);
-    for (size_t i = 0; i < func_vector.size(); i++) {
-      TF_DeleteFunction(func_vector[i]);
+    ctx_opts = nullptr;
+  }
+  for (TF_Function* function : func_vector) {
+    if (function != nullptr) {
+      TF_DeleteFunction(function);
     }
   }
+  func_vector.clear();
+  if (session != nullptr) {
+    TF_DeleteSession(session, status);
+    session = nullptr;
+  }
+  if (graph != nullptr) {
+    TF_DeleteGraph(graph);
+    graph = nullptr;
+  }
+  if (sessionopts != nullptr) {
+    TF_DeleteSessionOptions(sessionopts);
+    sessionopts = nullptr;
+  }
+  if (status != nullptr) {
+    TF_DeleteStatus(status);
+    status = nullptr;
+  }
+  inited = false;
 }
+
+deepmd::DeepPotJAX::~DeepPotJAX() { clear_tf_resources(); }
 
 template <typename VALUETYPE>
 void deepmd::DeepPotJAX::compute(std::vector<ENERGYTYPE>& ener,

--- a/source/api_cc/src/DeepPotTF.cc
+++ b/source/api_cc/src/DeepPotTF.cc
@@ -401,22 +401,32 @@ template void run_model<float, float>(
 // end single frame
 
 DeepPotTF::DeepPotTF()
-    : inited(false), init_nbor(false), graph_def(new GraphDef()) {}
+    : session(nullptr),
+      graph_def(new GraphDef()),
+      inited(false),
+      init_nbor(false) {}
 
 DeepPotTF::DeepPotTF(const std::string& model,
                      const int& gpu_rank,
                      const std::string& file_content)
-    : inited(false), init_nbor(false), graph_def(new GraphDef()) {
+    : session(nullptr),
+      graph_def(new GraphDef()),
+      inited(false),
+      init_nbor(false) {
   try {
     init(model, gpu_rank, file_content);
   } catch (...) {
     // Clean up and rethrow, as the destructor will not be called
+    deepmd::close_and_delete_session(session);
     delete graph_def;
     throw;
   }
 }
 
-DeepPotTF::~DeepPotTF() { delete graph_def; }
+DeepPotTF::~DeepPotTF() {
+  deepmd::close_and_delete_session(session);
+  delete graph_def;
+}
 
 void DeepPotTF::init(const std::string& model,
                      const int& gpu_rank,
@@ -427,6 +437,7 @@ void DeepPotTF::init(const std::string& model,
               << std::endl;
     return;
   }
+  deepmd::SessionCleanupGuard session_guard(session);
   SessionOptions options;
   get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
   options.config.set_inter_op_parallelism_threads(num_inter_nthreads);
@@ -498,6 +509,7 @@ void DeepPotTF::init(const std::string& model,
   }
   model_type = get_scalar<STRINGTYPE>("model_attr/model_type");
   inited = true;
+  session_guard.release();
 
   init_nbor = false;
 }

--- a/source/api_cc/src/DeepSpinTF.cc
+++ b/source/api_cc/src/DeepSpinTF.cc
@@ -401,22 +401,32 @@ template void run_model<float, float>(
 // end single frame
 
 DeepSpinTF::DeepSpinTF()
-    : inited(false), init_nbor(false), graph_def(new GraphDef()) {}
+    : session(nullptr),
+      graph_def(new GraphDef()),
+      inited(false),
+      init_nbor(false) {}
 
 DeepSpinTF::DeepSpinTF(const std::string& model,
                        const int& gpu_rank,
                        const std::string& file_content)
-    : inited(false), init_nbor(false), graph_def(new GraphDef()) {
+    : session(nullptr),
+      graph_def(new GraphDef()),
+      inited(false),
+      init_nbor(false) {
   try {
     init(model, gpu_rank, file_content);
   } catch (...) {
     // Clean up and rethrow, as the destructor will not be called
+    deepmd::close_and_delete_session(session);
     delete graph_def;
     throw;
   }
 }
 
-DeepSpinTF::~DeepSpinTF() { delete graph_def; }
+DeepSpinTF::~DeepSpinTF() {
+  deepmd::close_and_delete_session(session);
+  delete graph_def;
+}
 
 void DeepSpinTF::init(const std::string& model,
                       const int& gpu_rank,
@@ -427,6 +437,7 @@ void DeepSpinTF::init(const std::string& model,
               << std::endl;
     return;
   }
+  deepmd::SessionCleanupGuard session_guard(session);
   SessionOptions options;
   get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
   options.config.set_inter_op_parallelism_threads(num_inter_nthreads);
@@ -498,6 +509,7 @@ void DeepSpinTF::init(const std::string& model,
   }
   model_type = get_scalar<STRINGTYPE>("model_attr/model_type");
   inited = true;
+  session_guard.release();
 
   init_nbor = false;
 }

--- a/source/api_cc/src/DeepTensorTF.cc
+++ b/source/api_cc/src/DeepTensorTF.cc
@@ -5,22 +5,30 @@
 using namespace deepmd;
 using namespace tensorflow;
 
-DeepTensorTF::DeepTensorTF() : inited(false), graph_def(new GraphDef()) {}
+DeepTensorTF::DeepTensorTF()
+    : session(nullptr), graph_def(new GraphDef()), inited(false) {}
 
 DeepTensorTF::DeepTensorTF(const std::string& model,
                            const int& gpu_rank,
                            const std::string& name_scope_)
-    : inited(false), name_scope(name_scope_), graph_def(new GraphDef()) {
+    : session(nullptr),
+      name_scope(name_scope_),
+      graph_def(new GraphDef()),
+      inited(false) {
   try {
     init(model, gpu_rank, name_scope_);
   } catch (...) {
     // Clean up and rethrow, as the destructor will not be called
+    deepmd::close_and_delete_session(session);
     delete graph_def;
     throw;
   }
 }
 
-DeepTensorTF::~DeepTensorTF() { delete graph_def; }
+DeepTensorTF::~DeepTensorTF() {
+  deepmd::close_and_delete_session(session);
+  delete graph_def;
+}
 
 void DeepTensorTF::init(const std::string& model,
                         const int& gpu_rank,
@@ -31,6 +39,7 @@ void DeepTensorTF::init(const std::string& model,
               << std::endl;
     return;
   }
+  deepmd::SessionCleanupGuard session_guard(session);
   name_scope = name_scope_;
   SessionOptions options;
   get_env_nthreads(num_intra_nthreads, num_inter_nthreads);
@@ -82,6 +91,7 @@ void DeepTensorTF::init(const std::string& model,
   get_vector<int>(sel_type, "model_attr/sel_type");
   model_type = get_scalar<STRINGTYPE>("model_attr/model_type");
   inited = true;
+  session_guard.release();
 }
 
 template <class VT>

--- a/source/api_cc/tests/CMakeLists.txt
+++ b/source/api_cc/tests/CMakeLists.txt
@@ -8,11 +8,11 @@ target_link_libraries(runUnitTests_cc GTest::gtest_main ${LIB_DEEPMD_CC}
                       coverage_config)
 if(ENABLE_TENSORFLOW)
   target_compile_definitions(runUnitTests_cc PRIVATE BUILD_TENSORFLOW)
-  # Lifecycle tests instantiate the backend classes directly, so they need
-  # both the backend symbols and TensorFlow's public header search path.
-  target_link_libraries(runUnitTests_cc deepmd_backend_tf
-                        TensorFlow::tensorflow_cc
-                        TensorFlow::tensorflow_framework)
+  # Lifecycle tests instantiate the backend classes directly, so they need both
+  # the backend symbols and TensorFlow's public header search path.
+  target_link_libraries(
+    runUnitTests_cc deepmd_backend_tf TensorFlow::tensorflow_cc
+    TensorFlow::tensorflow_framework)
 endif()
 if(ENABLE_PYTORCH)
   target_compile_definitions(runUnitTests_cc PRIVATE BUILD_PYTORCH)

--- a/source/api_cc/tests/CMakeLists.txt
+++ b/source/api_cc/tests/CMakeLists.txt
@@ -23,6 +23,9 @@ if(ENABLE_PYTORCH)
 endif()
 if(ENABLE_JAX)
   target_compile_definitions(runUnitTests_cc PRIVATE BUILD_JAX)
+  # DeepPotJAX lifecycle tests instantiate the backend directly to exercise
+  # cleanup without relying on the dlopen plugin facade.
+  target_link_libraries(runUnitTests_cc deepmd_backend_jax)
 endif()
 if(ENABLE_PADDLE)
   target_compile_definitions(runUnitTests_cc PRIVATE BUILD_PADDLE)

--- a/source/api_cc/tests/CMakeLists.txt
+++ b/source/api_cc/tests/CMakeLists.txt
@@ -8,6 +8,11 @@ target_link_libraries(runUnitTests_cc GTest::gtest_main ${LIB_DEEPMD_CC}
                       coverage_config)
 if(ENABLE_TENSORFLOW)
   target_compile_definitions(runUnitTests_cc PRIVATE BUILD_TENSORFLOW)
+  # Lifecycle tests instantiate the backend classes directly, so they need
+  # both the backend symbols and TensorFlow's public header search path.
+  target_link_libraries(runUnitTests_cc deepmd_backend_tf
+                        TensorFlow::tensorflow_cc
+                        TensorFlow::tensorflow_framework)
 endif()
 if(ENABLE_PYTORCH)
   target_compile_definitions(runUnitTests_cc PRIVATE BUILD_PYTORCH)

--- a/source/api_cc/tests/test_tf_session_lifecycle.cc
+++ b/source/api_cc/tests/test_tf_session_lifecycle.cc
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include <gtest/gtest.h>
+#include <sys/stat.h>
 
 #ifdef BUILD_TENSORFLOW
 #define TF_PRIVATE
 
+#include <cstdio>
 #include <string>
 
 #include "DataModifierTF.h"
+#ifdef BUILD_JAX
+#include "DeepPotJAX.h"
+#endif
 #include "DeepPotTF.h"
 #include "DeepSpinTF.h"
 #include "DeepTensorTF.h"
+#include "common.h"
 #include "errors.h"
 
 namespace {
@@ -18,6 +24,11 @@ std::string empty_model_content() {
   tensorflow::GraphDef graph;
   graph.mutable_versions()->set_producer(1);
   return graph.SerializeAsString();
+}
+
+bool path_exists(const std::string& path) {
+  struct stat stat_buffer;
+  return stat(path.c_str(), &stat_buffer) == 0;
 }
 
 TEST(TestTensorFlowSessionLifecycle, failed_init_can_be_retried) {
@@ -53,6 +64,61 @@ TEST(TestTensorFlowSessionLifecycle, failed_init_can_be_retried) {
     EXPECT_THROW(model.init("_no_such_file.pb"), deepmd::deepmd_exception);
   }
 }
+
+TEST(TestTensorFlowSessionLifecycle, successful_init_is_destroyed_normally) {
+  // Directly instantiate each backend owner so LSan observes its normal
+  // destructor path instead of cleanup through the public dlopen facade.
+  deepmd::convert_pbtxt_to_pb("../../tests/infer/deeppot-r.pbtxt",
+                              "lifecycle_deeppot.pb");
+  {
+    deepmd::DeepPotTF model("lifecycle_deeppot.pb");
+    EXPECT_GT(model.cutoff(), 0.0);
+  }
+  std::remove("lifecycle_deeppot.pb");
+
+  deepmd::convert_pbtxt_to_pb("../../tests/infer/deepspin_nlist.pbtxt",
+                              "lifecycle_deepspin.pb");
+  {
+    deepmd::DeepSpinTF model("lifecycle_deepspin.pb");
+    EXPECT_GT(model.cutoff(), 0.0);
+  }
+  std::remove("lifecycle_deepspin.pb");
+
+  deepmd::convert_pbtxt_to_pb("../../tests/infer/deeppolar.pbtxt",
+                              "lifecycle_deeptensor.pb");
+  {
+    deepmd::DeepTensorTF model("lifecycle_deeptensor.pb");
+    EXPECT_GT(model.cutoff(), 0.0);
+  }
+  std::remove("lifecycle_deeptensor.pb");
+
+  deepmd::convert_pbtxt_to_pb("../../tests/infer/dipolecharge_e.pbtxt",
+                              "lifecycle_modifier.pb");
+  {
+    deepmd::DipoleChargeModifierTF model("lifecycle_modifier.pb", 0,
+                                         "dipole_charge");
+    EXPECT_GT(model.cutoff(), 0.0);
+  }
+  std::remove("lifecycle_modifier.pb");
+}
+
+#ifdef BUILD_JAX
+TEST(TestTensorFlowSessionLifecycle, jax_failed_init_can_be_retried) {
+  deepmd::DeepPotJAX model;
+  EXPECT_THROW(model.init("_no_such_savedmodel"), deepmd::deepmd_exception);
+  EXPECT_THROW(model.init("_no_such_savedmodel"), deepmd::deepmd_exception);
+}
+
+TEST(TestTensorFlowSessionLifecycle,
+     jax_successful_init_is_destroyed_normally) {
+  const std::string model_path = "../../tests/infer/deeppot_dpa.savedmodel";
+  if (!path_exists(model_path)) {
+    GTEST_SKIP() << "JAX SavedModel artifact is not available.";
+  }
+  deepmd::DeepPotJAX model(model_path);
+  EXPECT_GT(model.cutoff(), 0.0);
+}
+#endif  // BUILD_JAX
 
 }  // namespace
 #endif  // BUILD_TENSORFLOW

--- a/source/api_cc/tests/test_tf_session_lifecycle.cc
+++ b/source/api_cc/tests/test_tf_session_lifecycle.cc
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#ifdef BUILD_TENSORFLOW
+#define TF_PRIVATE
+
+#include <string>
+
+#include "DataModifierTF.h"
+#include "DeepPotTF.h"
+#include "DeepSpinTF.h"
+#include "DeepTensorTF.h"
+#include "errors.h"
+
+namespace {
+
+std::string empty_model_content() {
+  tensorflow::GraphDef graph;
+  graph.mutable_versions()->set_producer(1);
+  return graph.SerializeAsString();
+}
+
+TEST(TestTensorFlowSessionLifecycle, failed_init_can_be_retried) {
+  const std::string model_content = empty_model_content();
+
+  // Each failure happens after NewSession succeeds. Retrying the same public
+  // init method checks that failure leaves the object reusable and destruction
+  // checks that the final failed attempt is also safe. Leak detection itself
+  // requires an LSan build; ordinary tests cannot observe released resources
+  // without relying on unstable thread-count or RSS assertions.
+  {
+    deepmd::DeepPotTF model;
+    EXPECT_THROW(model.init("unused", 0, model_content),
+                 deepmd::deepmd_exception);
+    EXPECT_THROW(model.init("unused", 0, model_content),
+                 deepmd::deepmd_exception);
+  }
+  {
+    deepmd::DeepSpinTF model;
+    EXPECT_THROW(model.init("unused", 0, model_content),
+                 deepmd::deepmd_exception);
+    EXPECT_THROW(model.init("unused", 0, model_content),
+                 deepmd::deepmd_exception);
+  }
+  {
+    deepmd::DeepTensorTF model;
+    EXPECT_THROW(model.init("_no_such_file.pb"), deepmd::deepmd_exception);
+    EXPECT_THROW(model.init("_no_such_file.pb"), deepmd::deepmd_exception);
+  }
+  {
+    deepmd::DipoleChargeModifierTF model;
+    EXPECT_THROW(model.init("_no_such_file.pb"), deepmd::deepmd_exception);
+    EXPECT_THROW(model.init("_no_such_file.pb"), deepmd::deepmd_exception);
+  }
+}
+
+}  // namespace
+#endif  // BUILD_TENSORFLOW


### PR DESCRIPTION
Closes #5657.

## Summary

- initialize the TensorFlow `Session*` member to `nullptr` in `DeepPotTF`, `DeepSpinTF`, `DeepTensorTF`, and `DipoleChargeModifierTF`;
- centralize exclusive session teardown as `Close()` followed by `delete` and pointer reset;
- use an initialization rollback guard so public `init()` calls are failure-atomic and can be retried without overwriting a session left by an earlier failed attempt;
- clean sessions from both initializing-constructor exception paths and normal destructors;
- make `DeepPotJAX` initialization failure-atomic by unconditionally releasing all partially created TensorFlow C API handles (`TF_Session`, `TF_Graph`, `TF_SessionOptions`, `TF_Status`, `TFE_Context`, `TFE_ContextOptions`, and `TF_Function` references);
- add direct lifecycle regressions for failed initialization/retry and successful initialization/normal destruction.

## Root cause

The TensorFlow wrappers owned raw sessions created by `NewSession`, but their destructors and initializing-constructor catch blocks only deleted the `GraphDef`. Default construction followed by a failing public `init()` could also retain a partially initialized session, allowing a retry to overwrite the pointer.

`DeepPotJAX` had the same failure mode with TensorFlow C API handles: its destructor only released resources when `inited == true`, so an exception before the final initialization commit leaked every handle created up to that point.

The TensorFlow rollback guard now owns cleanup until initialization has completely committed. `DeepPotJAX::clear_tf_resources()` is null-safe for partial initialization and is called both from the exception path and the destructor. Successful initialization commits only after all metadata has been loaded.

## Test coverage

The lifecycle test intentionally white-box-links `deepmd_backend_tf` and `deepmd_backend_jax` into `runUnitTests_cc`, rather than going through the `dlopen` plugin facade. This makes the concrete backend destructors directly visible to the LSan test process.

The tests cover:

- repeated failed initialization followed by safe destruction for all four TensorFlow C++ wrappers;
- successful initialization followed by normal destruction for all four TensorFlow C++ wrappers;
- repeated failed `DeepPotJAX` initialization;
- successful `DeepPotJAX` initialization followed by normal destruction when the generated SavedModel test artifact is available.

Ordinary builds verify retry safety and destructor behavior; the CI leak-sanitizer leg provides the direct leak regression signal.

## Validation

- built `deepmd_backend_tf`, `deepmd_backend_jax`, `runUnitTests_cc`, and `deepmd_op` in a TensorFlow/JAX C++ test configuration with LAMMPS plugin mode disabled;
- `TestTensorFlowSessionLifecycle.*`: 3 passed, 1 skipped locally because the generated JAX SavedModel artifact was unavailable;
- `ruff check .`;
- `ruff format .`;
- clang-format check;
- CMake formatting hook;
- `git diff --check`.

Coding agent: Codex
Codex version: codex-cli 0.144.4
Model: gpt-5.6-sol
Reasoning effort: xhigh
