### PR TITLE
fix(lammps): validate compute parameter sources

### DIFF
--- a/source/lmp/pair_base.cpp
+++ b/source/lmp/pair_base.cpp
@@ -139,25 +139,48 @@ void PairDeepBaseModel::make_fparam_from_compute(vector<double>& fparam) {
   assert(do_compute_fparam);
 
   int icompute = modify->find_compute(compute_fparam_id);
-  Compute* compute = modify->compute[icompute];
+  if (icompute < 0) {
+    error->all(FLERR,
+               "compute " + compute_fparam_id + " for fparam is not found");
+  }
 
+  Compute* compute = modify->compute[icompute];
   if (!compute) {
-    error->all(FLERR, "compute id is not found: " + compute_fparam_id);
+    error->all(FLERR,
+               "compute " + compute_fparam_id + " for fparam is not found");
   }
   fparam.resize(dim_fparam);
 
   if (dim_fparam == 1) {
+    if (!compute->scalar_flag) {
+      error->all(FLERR, "compute " + compute_fparam_id +
+                            " does not provide a scalar for fparam");
+    }
     if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
       compute->compute_scalar();
       compute->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     fparam[0] = compute->scalar;
   } else if (dim_fparam > 1) {
+    if (!compute->vector_flag) {
+      error->all(FLERR, "compute " + compute_fparam_id +
+                            " does not provide a vector for fparam");
+    }
     if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
       compute->compute_vector();
       compute->invoked_flag |= Compute::INVOKED_VECTOR;
     }
+    // Variable-length computes update size_vector when they are invoked, so
+    // validate the realized length rather than their initial zero capacity.
+    if (compute->size_vector < dim_fparam) {
+      error->all(FLERR, "compute " + compute_fparam_id +
+                            " vector is shorter than fparam dimension");
+    }
     double* cvector = compute->vector;
+    if (!cvector) {
+      error->all(FLERR, "compute " + compute_fparam_id +
+                            " returned a null vector for fparam");
+    }
     for (int jj = 0; jj < dim_fparam; ++jj) {
       fparam[jj] = cvector[jj];
     }
@@ -214,10 +237,30 @@ void PairDeepBaseModel::make_aparam_from_compute(vector<double>& aparam) {
   assert(do_compute_aparam);
 
   int icompute = modify->find_compute(compute_aparam_id);
-  Compute* compute = modify->compute[icompute];
+  if (icompute < 0) {
+    error->all(FLERR,
+               "compute " + compute_aparam_id + " for aparam is not found");
+  }
 
+  Compute* compute = modify->compute[icompute];
   if (!compute) {
-    error->all(FLERR, "compute id is not found: " + compute_aparam_id);
+    error->all(FLERR,
+               "compute " + compute_aparam_id + " for aparam is not found");
+  }
+  if (!compute->peratom_flag) {
+    error->all(FLERR, "compute " + compute_aparam_id +
+                          " does not provide per-atom data for aparam");
+  }
+  // LAMMPS represents per-atom vectors with zero columns and per-atom
+  // arrays with a positive column count. Validate that layout before
+  // invoking the compute so the corresponding result pointer is safe to use.
+  if (dim_aparam == 1 && compute->size_peratom_cols != 0) {
+    error->all(FLERR, "compute " + compute_aparam_id +
+                          " does not provide a per-atom vector for aparam");
+  }
+  if (dim_aparam > 1 && compute->size_peratom_cols < dim_aparam) {
+    error->all(FLERR, "compute " + compute_aparam_id +
+                          " array has fewer columns than aparam dimension");
   }
   int nlocal = atom->nlocal;
   aparam.resize(static_cast<size_t>(dim_aparam) * nlocal);
@@ -226,12 +269,29 @@ void PairDeepBaseModel::make_aparam_from_compute(vector<double>& aparam) {
     compute->compute_peratom();
     compute->invoked_flag |= Compute::INVOKED_PERATOM;
   }
+  // Empty MPI subdomains legitimately have no per-atom storage. The result is
+  // already an empty vector, so do not require output pointers in that case.
+  if (nlocal == 0) {
+    return;
+  }
   if (dim_aparam == 1) {
     double* cvector = compute->vector_atom;
+    if (!cvector) {
+      error->all(FLERR, "compute " + compute_aparam_id +
+                            " returned a null per-atom vector for aparam");
+    }
     aparam.assign(cvector, cvector + nlocal);
   } else if (dim_aparam > 1) {
     double** carray = compute->array_atom;
+    if (!carray) {
+      error->all(FLERR, "compute " + compute_aparam_id +
+                            " returned a null per-atom array for aparam");
+    }
     for (int ii = 0; ii < nlocal; ++ii) {
+      if (!carray[ii]) {
+        error->all(FLERR, "compute " + compute_aparam_id +
+                              " returned a null per-atom array row for aparam");
+      }
       for (int jj = 0; jj < dim_aparam; ++jj) {
         aparam[ii * dim_aparam + jj] = carray[ii][jj];
       }

--- a/source/lmp/pair_base.cpp
+++ b/source/lmp/pair_base.cpp
@@ -147,7 +147,7 @@ void PairDeepBaseModel::make_fparam_from_compute(vector<double>& fparam) {
   Compute* compute = modify->compute[icompute];
   if (!compute) {
     error->all(FLERR,
-               "compute " + compute_fparam_id + " for fparam is not found");
+               "compute " + compute_fparam_id + " for fparam is invalid");
   }
   fparam.resize(dim_fparam);
 
@@ -245,7 +245,7 @@ void PairDeepBaseModel::make_aparam_from_compute(vector<double>& aparam) {
   Compute* compute = modify->compute[icompute];
   if (!compute) {
     error->all(FLERR,
-               "compute " + compute_aparam_id + " for aparam is not found");
+               "compute " + compute_aparam_id + " for aparam is invalid");
   }
   if (!compute->peratom_flag) {
     error->all(FLERR, "compute " + compute_aparam_id +
@@ -277,19 +277,19 @@ void PairDeepBaseModel::make_aparam_from_compute(vector<double>& aparam) {
   if (dim_aparam == 1) {
     double* cvector = compute->vector_atom;
     if (!cvector) {
-      error->all(FLERR, "compute " + compute_aparam_id +
+      error->one(FLERR, "compute " + compute_aparam_id +
                             " returned a null per-atom vector for aparam");
     }
     aparam.assign(cvector, cvector + nlocal);
   } else if (dim_aparam > 1) {
     double** carray = compute->array_atom;
     if (!carray) {
-      error->all(FLERR, "compute " + compute_aparam_id +
+      error->one(FLERR, "compute " + compute_aparam_id +
                             " returned a null per-atom array for aparam");
     }
     for (int ii = 0; ii < nlocal; ++ii) {
       if (!carray[ii]) {
-        error->all(FLERR, "compute " + compute_aparam_id +
+        error->one(FLERR, "compute " + compute_aparam_id +
                               " returned a null per-atom array row for aparam");
       }
       for (int jj = 0; jj < dim_aparam; ++jj) {

--- a/source/lmp/tests/test_lammps_faparam.py
+++ b/source/lmp/tests/test_lammps_faparam.py
@@ -2,6 +2,8 @@
 """Test LAMMPS fparam and aparam input."""
 
 import os
+import subprocess as sp
+import sys
 from pathlib import (
     Path,
 )
@@ -196,3 +198,147 @@ def test_pair_deepmd_virial(lammps) -> None:
         assert np.array(
             lammps.variables[f"virial{ii}"].value
         ) / constants.nktv2p == pytest.approx(expected_v[idx_map, ii])
+
+
+def _run_compute_source_scenario(scenario: str) -> None:
+    """Run one compute-source scenario in an isolated LAMMPS process.
+
+    Invalid sources used to dereference missing or mismatched compute outputs,
+    which can terminate the interpreter instead of raising a LAMMPS error.
+    Keeping those scenarios in a subprocess prevents a regression from taking
+    down the pytest worker that checks the diagnostic.
+    """
+    lmp = _lammps(data_file=data_file)
+    if scenario == "missing_fparam":
+        lmp.pair_style(
+            f"deepmd {pb_file.resolve()} "
+            "fparam_from_compute missing_frame_value aparam 0.25852028"
+        )
+    elif scenario == "missing_aparam":
+        lmp.pair_style(
+            f"deepmd {pb_file.resolve()} "
+            "fparam 0.25852028 aparam_from_compute missing_atom_value"
+        )
+    elif scenario == "fparam_peratom":
+        lmp.compute("atom_value all property/atom x")
+        lmp.pair_style(
+            f"deepmd {pb_file.resolve()} "
+            "fparam_from_compute atom_value aparam 0.25852028"
+        )
+    elif scenario == "fparam_vector":
+        lmp.compute("frame_vector all reduce sum x y")
+        lmp.pair_style(
+            f"deepmd {pb_file.resolve()} "
+            "fparam_from_compute frame_vector aparam 0.25852028"
+        )
+    elif scenario == "aparam_global":
+        lmp.compute("frame_value all temp")
+        lmp.pair_style(
+            f"deepmd {pb_file.resolve()} "
+            "fparam 0.25852028 aparam_from_compute frame_value"
+        )
+    elif scenario == "aparam_array":
+        lmp.compute("atom_array all property/atom x y")
+        lmp.pair_style(
+            f"deepmd {pb_file.resolve()} "
+            "fparam 0.25852028 aparam_from_compute atom_array"
+        )
+    else:
+        raise ValueError(f"unknown compute-source scenario: {scenario}")
+
+    lmp.pair_coeff("* *")
+    lmp.run(0)
+    lmp.close()
+
+
+def _run_compute_source_subprocess(scenario: str) -> sp.CompletedProcess[str]:
+    """Execute a scenario through this module's isolated script entry point."""
+    return sp.run(
+        [sys.executable, str(Path(__file__).resolve()), scenario],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_compute_sources_match_explicit_parameters(lammps) -> None:
+    """Valid compute sources reproduce equivalent explicit parameters.
+
+    With no assigned velocities, ``compute temp`` supplies a zero frame
+    parameter. ``property/atom type`` supplies one for every atom in this
+    single-type system. Compare against an independent LAMMPS instance using
+    those values explicitly, so success cannot hide incorrect source data.
+    """
+    lammps.compute("frame_value all temp")
+    lammps.compute("atom_value all property/atom type")
+    lammps.pair_style(
+        f"deepmd {pb_file.resolve()} "
+        "fparam_from_compute frame_value "
+        "aparam_from_compute atom_value"
+    )
+    lammps.pair_coeff("* *")
+    lammps.run(0)
+    compute_energy = lammps.eval("pe")
+    compute_ids = lammps.lmp.numpy.extract_atom("id")[: coord.shape[0]]
+    compute_force_array = lammps.lmp.numpy.extract_atom("f")[: coord.shape[0]]
+    compute_forces = {
+        int(atom_id): np.asarray(force, dtype=np.float64).copy()
+        for atom_id, force in zip(compute_ids, compute_force_array, strict=True)
+    }
+
+    explicit = _lammps(data_file=data_file)
+    try:
+        explicit.pair_style(f"deepmd {pb_file.resolve()} fparam 0.0 aparam 1.0")
+        explicit.pair_coeff("* *")
+        explicit.run(0)
+        assert compute_energy == pytest.approx(explicit.eval("pe"))
+        explicit_ids = explicit.lmp.numpy.extract_atom("id")[: coord.shape[0]]
+        explicit_forces = explicit.lmp.numpy.extract_atom("f")[: coord.shape[0]]
+        for atom_id, force in zip(explicit_ids, explicit_forces, strict=True):
+            assert compute_forces[int(atom_id)] == pytest.approx(force)
+    finally:
+        explicit.close()
+
+
+@pytest.mark.parametrize(
+    ("scenario", "message"),
+    [
+        (
+            "missing_fparam",
+            "compute missing_frame_value for fparam is not found",
+        ),
+        (
+            "missing_aparam",
+            "compute missing_atom_value for aparam is not found",
+        ),
+        (
+            "fparam_peratom",
+            "compute atom_value does not provide a scalar for fparam",
+        ),
+        (
+            "fparam_vector",
+            "compute frame_vector does not provide a scalar for fparam",
+        ),
+        (
+            "aparam_global",
+            "compute frame_value does not provide per-atom data for aparam",
+        ),
+        (
+            "aparam_array",
+            "compute atom_array does not provide a per-atom vector for aparam",
+        ),
+    ],
+)
+def test_invalid_compute_sources_report_controlled_error(
+    scenario: str, message: str
+) -> None:
+    """Invalid compute contracts fail with the intended DeePMD diagnostic."""
+    proc = _run_compute_source_subprocess(scenario)
+    output = proc.stdout + proc.stderr
+    assert proc.returncode != 0
+    # Match the actual LAMMPS diagnostic, not merely a nonzero status (which a
+    # segmentation fault would also satisfy) or incidental traceback text.
+    assert f"ERROR: {message} (" in output
+
+
+if __name__ == "__main__":
+    _run_compute_source_scenario(sys.argv[1])


### PR DESCRIPTION
Closes #5643.

## Summary

- reject missing `fparam_from_compute` and `aparam_from_compute` IDs before indexing LAMMPS's compute table;
- validate scalar, vector, and per-atom output contracts before selecting the corresponding result field;
- check realized global-vector length after invocation, which preserves support for LAMMPS computes whose `size_vector` is dynamic;
- validate per-atom vector/array dimensions and result pointers before copying, including individual array rows;
- return an empty aparam result safely on MPI ranks with zero local atoms, without forming a range from a null pointer;
- add subprocess regressions for missing IDs and incompatible output styles, plus a valid-path numerical comparison against equivalent explicit fparam/aparam values.

## Root cause

`PairDeepBaseModel` trusted `find_compute()` and the selected compute's output layout. A missing ID could index `modify->compute[-1]`; an incompatible compute could select an unsupported scalar/vector/per-atom method; and insufficient dimensions or null output storage could be read directly.

The checks now follow LAMMPS's compute contract:

- scalar fparam requires `scalar_flag`;
- multi-component fparam requires `vector_flag`, invocation, then a sufficient realized `size_vector`;
- aparam requires `peratom_flag`;
- one-component aparam requires the per-atom-vector layout (`size_peratom_cols == 0`);
- multi-component aparam requires enough array columns;
- non-empty copies require non-null output pointers.

## Why existing tests missed this

The existing test module exercised explicit `fparam` and `aparam` values, not the `*_from_compute` branches. It therefore never supplied a missing compute ID, selected the wrong output style, or reached the unsafe result-pointer reads.

Each invalid scenario now runs in a subprocess because the old code can terminate the Python interpreter. The parent test requires the exact new `ERROR: ... (` diagnostic as well as a nonzero status, so a SIGSEGV or unrelated LAMMPS error cannot be mistaken for success.

I did not count an executable old-fail run: an attempt to reuse a pre-existing old plugin was invalid because the available LAMMPS runtime/plugin versions did not match and LAMMPS loaded zero plugins. The regression is therefore not presented as a verified old-binary run. Its assertions are specifically constructed so the old missing-ID/wrong-layout behavior cannot pass merely by crashing.

## Validation

- built `deepmd_lmp`, `deepmd_backend_tf`, and `deepmd_op` against the repository's fixed `stable_22Jul2025_update2` LAMMPS source;
- built the matching LAMMPS shared library;
- `pytest source/lmp/tests/test_lammps_faparam.py -v`: 9 passed;
- valid compute-sourced parameters reproduce the total energy and atom-ID-aligned forces from explicit `fparam 0.0 aparam 1.0`;
- clang-format 22.1.5 check;
- `ruff format .`;
- `ruff check .`;
- `git diff --check`;
- two independent code reviews, with findings for null result pointers and dynamic `size_vector` ordering addressed before the final no-findings review.

The repository currently has no directly usable LAMMPS model fixture with multi-component fparam/aparam. The `dim > 1` flag, length, column, and copy paths compile, but their runtime size-error branches are not covered by this PR's one-component model. Adding a new cross-backend model artifact would materially expand this focused fix, so this limitation is stated explicitly.

Coding agent: Codex
Codex version: codex-cli 0.144.1
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for compute-sourced parameters, with more targeted and controlled error reporting when compute outputs are missing, incompatible, or not available for the requested shape/mode.
  * Improved safety checks for empty systems and per-atom parameter extraction, including better handling of null/invalid returned data.

* **Tests**
  * Added subprocess-based scenarios to validate that compute-derived parameters match explicitly specified parameters.
  * Extended test coverage for multiple invalid compute configurations, asserting expected error-message substrings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->