### PR TITLE
fix(dpa1): support nonperiodic input statistics

### DIFF
--- a/deepmd/dpmodel/utils/env_mat_stat.py
+++ b/deepmd/dpmodel/utils/env_mat_stat.py
@@ -274,11 +274,9 @@ class EnvMatStatSe(EnvMatStat):
             device=array_api_compat.device(data[0]["coord"]),
         )
         for system in data:
-            coord, atype, box = (
-                system["coord"],
-                system["atype"],
-                system["box"],
-            )
+            coord = system["coord"]
+            atype = system["atype"]
+            box = system.get("box")
             nframes, nloc = atype.shape[:2]
             pair_excl = None
             if "pair_exclude_types" in system:

--- a/deepmd/pd/utils/env_mat_stat.py
+++ b/deepmd/pd/utils/env_mat_stat.py
@@ -107,11 +107,9 @@ class EnvMatStatSe(EnvMatStat):
                 "last_dim should be 1 for raial-only or 4 for full descriptor."
             )
         for system in data:
-            coord, atype, box = (
-                system["coord"],
-                system["atype"],
-                system["box"],
-            )
+            coord = system["coord"]
+            atype = system["atype"]
+            box = system.get("box")
             (
                 extended_coord,
                 extended_atype,

--- a/source/tests/common/dpmodel/test_env_mat_stat_graph.py
+++ b/source/tests/common/dpmodel/test_env_mat_stat_graph.py
@@ -82,3 +82,22 @@ def test_dpa1_block_graph_equals_dense() -> None:
         m_graph, s_graph = _dpa1_block_stats(pair_exclude_types, use_graph=True)
         np.testing.assert_allclose(m_graph, m_dense, rtol=1e-15, atol=1e-15)
         np.testing.assert_allclose(s_graph, s_dense, rtol=1e-15, atol=1e-15)
+
+
+def test_dpa1_block_accepts_missing_box_for_nonperiodic_sample() -> None:
+    """A missing box key and an explicit None both denote a nonperiodic system."""
+    descriptor = DescrptDPA1(6.0, 0.5, 20, ntypes=2, attn_layer=0).se_atten
+    sample_without_box = _sample()
+    sample_without_box.pop("box")
+    sample_with_none = {**sample_without_box, "box": None}
+
+    missing_box_stat = EnvMatStatSe(descriptor, use_graph=False)
+    missing_box_stat.load_or_compute_stats([sample_without_box], None)
+    missing_box_mean, missing_box_stddev = missing_box_stat()
+
+    explicit_none_stat = EnvMatStatSe(descriptor, use_graph=False)
+    explicit_none_stat.load_or_compute_stats([sample_with_none], None)
+    explicit_none_mean, explicit_none_stddev = explicit_none_stat()
+
+    np.testing.assert_array_equal(missing_box_mean, explicit_none_mean)
+    np.testing.assert_array_equal(missing_box_stddev, explicit_none_stddev)

--- a/source/tests/pd/model/test_descriptor_dpa1.py
+++ b/source/tests/pd/model/test_descriptor_dpa1.py
@@ -241,6 +241,31 @@ class TestDPA1(unittest.TestCase):
         self.file_model_param = Path(CUR_DIR) / "models" / "dpa1.pd"
         self.file_type_embed = Path(CUR_DIR) / "models" / "dpa2_tebd.pd"
 
+    def test_nonperiodic_input_stats_accept_missing_box(self) -> None:
+        """A missing box key and an explicit None denote the same open boundary."""
+        descriptor = DescrptDPA1(
+            rcut=6.0,
+            rcut_smth=0.5,
+            sel=30,
+            ntypes=2,
+            attn_layer=0,
+        ).to(env.DEVICE)
+        sample = {"coord": self.coord, "atype": self.atype}
+
+        descriptor.compute_input_stats([sample])
+        missing_box_mean, missing_box_stddev = (
+            value.numpy().copy() for value in descriptor.get_stat_mean_and_stddev()
+        )
+
+        sample["box"] = None
+        descriptor.compute_input_stats([sample])
+        explicit_none_mean, explicit_none_stddev = (
+            value.numpy() for value in descriptor.get_stat_mean_and_stddev()
+        )
+
+        np.testing.assert_array_equal(missing_box_mean, explicit_none_mean)
+        np.testing.assert_array_equal(missing_box_stddev, explicit_none_stddev)
+
     def test_descriptor_block(self) -> None:
         # paddle.seed(0)
         model_dpa1 = self.model_json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for nonperiodic data by allowing input samples to omit the box information.
  * Statistical calculations now produce consistent results whether box is missing or explicitly set to `None`.
* **Tests**
  * Added regression coverage to ensure mean and standard deviation outputs remain bit-identical when `box` is absent or `box=None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->