### PR TITLE
fix(tabulate): correct sorted padding two-embed gradients

### DIFF
--- a/source/lib/src/gpu/tabulate.cu
+++ b/source/lib/src/gpu/tabulate.cu
@@ -453,10 +453,26 @@ __global__ void tabulate_fusion_se_a_grad_fifth_order_polynomial(
       Csub += (nnei - breakpoint) * res_grad *
               (enable_se_atten ? res * t + res : res);
       if (enable_se_atten) {
-        // from ii to ii + (nnei - breakpoint)
-        for (int ii2 = ii; ii2 < ii + nnei - breakpoint; ii2++) {
-          dy_dtwo[block_idx * nnei * last_layer_size + ii2 * last_layer_size +
+        if (!unloop) {
+          dy_dtwo[block_idx * nnei * last_layer_size + ii * last_layer_size +
                   jj] = oldres * res;
+        } else {
+          // Several warps can encounter different entries in the same sorted
+          // padding tail. Only its first sentinel is used by forward, so only
+          // that entry receives the repeat-scaled two-embedding gradient.
+          bool first_padding_sentinel = ii == 0;
+          if (ii > 0) {
+            const int_64 previous_em_index =
+                block_idx * nnei * MTILE + (ii - 1) * MTILE;
+            first_padding_sentinel = em_x[block_idx * nnei + ii - 1] != ago ||
+                                     em[previous_em_index + 1] != 0. ||
+                                     em[previous_em_index + 2] != 0. ||
+                                     em[previous_em_index + 3] != 0.;
+          }
+          if (first_padding_sentinel) {
+            dy_dtwo[block_idx * nnei * last_layer_size + ii * last_layer_size +
+                    jj] = (nnei - ii) * oldres * res;
+          }
         }
       }
     }
@@ -534,8 +550,9 @@ __global__ void tabulate_fusion_se_a_grad_grad_fifth_order_polynomial(
     if (enable_se_atten) {
       FPTYPE t = two_embed[block_idx * nnei * last_layer_size +
                            ii * last_layer_size + thread_idx];
-      // dz_dy_dtwo * res * em
-      // res above should be used instead of res + res * t below
+      // For sorted padding, only the first sentinel has a nonzero
+      // two-embedding gradient. The repeat factor below applies its full tail
+      // multiplicity to this cotangent.
       two_grad = dz_dy_dtwo[block_idx * nnei * last_layer_size +
                             ii * last_layer_size + thread_idx] *
                  res;
@@ -1071,6 +1088,12 @@ void tabulate_fusion_se_a_grad_gpu(FPTYPE* dy_dem_x,
   DPErrcheck(gpuDeviceSynchronize());
   DPErrcheck(gpuMemset(dy_dem_x, 0, sizeof(FPTYPE) * nloc * nnei));
   DPErrcheck(gpuMemset(dy_dem, 0, sizeof(FPTYPE) * nloc * nnei * 4));
+  if (two_embed != nullptr) {
+    // The sorted-padding fast path writes only the first sentinel. Explicitly
+    // clear the unused tail because framework output buffers are uninitialized.
+    DPErrcheck(
+        gpuMemset(dy_dtwo, 0, sizeof(FPTYPE) * nloc * nnei * last_layer_size));
+  }
 
   tabulate_fusion_se_a_grad_fifth_order_polynomial<FPTYPE, MM, KK>
       <<<nloc, KK * WARP_SIZE, sizeof(FPTYPE) * MM * last_layer_size>>>(

--- a/source/lib/src/gpu/tabulate.cu
+++ b/source/lib/src/gpu/tabulate.cu
@@ -1093,7 +1093,7 @@ void tabulate_fusion_se_a_grad_gpu(FPTYPE* dy_dem_x,
   DPErrcheck(gpuDeviceSynchronize());
   DPErrcheck(gpuMemset(dy_dem_x, 0, sizeof(FPTYPE) * nloc * nnei));
   DPErrcheck(gpuMemset(dy_dem, 0, sizeof(FPTYPE) * nloc * nnei * 4));
-  if (two_embed != nullptr) {
+  if (two_embed != nullptr && is_sorted) {
     // The sorted-padding fast path writes only the first sentinel. Explicitly
     // clear the unused tail because framework output buffers are uninitialized.
     DPErrcheck(

--- a/source/lib/src/tabulate.cc
+++ b/source/lib/src/tabulate.cc
@@ -310,11 +310,12 @@ void deepmd::tabulate_fusion_se_a_grad_cpu(FPTYPE* dy_dem_x,
           dy_dem[ii * nnei * 4 + jj * 4 + 2] += res * rr[2] * (nnei - jj);
           dy_dem[ii * nnei * 4 + jj * 4 + 3] += res * rr[3] * (nnei - jj);
           if (enable_se_atten) {
-            // fill from jj to nnei
-            for (int jj2 = jj; jj2 < nnei; jj2++) {
-              dy_dtwo[ii * nnei * last_layer_size + jj2 * last_layer_size +
-                      kk] += resold * dotllrr;
-            }
+            // Forward folds the complete padding tail using only this first
+            // sentinel's two-embedding value. Its gradient therefore owns the
+            // full repeat count; later padding entries remain independent of
+            // the folded output and retain the zero initialized above.
+            dy_dtwo[ii * nnei * last_layer_size + jj * last_layer_size + kk] +=
+                (nnei - jj) * resold * dotllrr;
           }
         } else {
           grad += g * dotllrr;
@@ -397,8 +398,9 @@ void deepmd::tabulate_fusion_se_a_grad_grad_cpu(FPTYPE* dz_dy,
         if (enable_se_atten) {
           FPTYPE t = two_embed[ii * nnei * last_layer_size +
                                jj * last_layer_size + kk];
-          // dz_dy_dtwo * var * ll
-          // var above should be used instead of var + var * t below
+          // For sorted padding, only the first sentinel has a nonzero
+          // two-embedding gradient. The repeat factor below applies its full
+          // tail multiplicity to this cotangent.
           two_grad = dz_dy_dtwo[ii * nnei * last_layer_size +
                                 jj * last_layer_size + kk] *
                      var;

--- a/source/lib/tests/test_tabulate_se_a.cc
+++ b/source/lib/tests/test_tabulate_se_a.cc
@@ -857,3 +857,226 @@ TEST_F(TestTabulateSeA, tabulate_fusion_se_a_grad_gpu) {
   deepmd::delete_device_memory(two_embed_dev);
 }
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+class TestTabulateSeASortedPaddingTwoEmbed : public ::testing::Test {
+ protected:
+  static constexpr int nloc = 1;
+  static constexpr int nnei = 6;
+  static constexpr int last_layer_size = 1;
+
+  // The last five neighbors form a sorted padding tail. Its length exceeds the
+  // GPU kernel's four-warp tile so the test also covers tail entries that no
+  // warp writes after encountering an earlier sentinel. The constant table
+  // polynomial keeps the expected Jacobian focused on the folding contract.
+  const std::vector<double> info = {0.0, 1.0, 2.0, 1.0, 1.0, -1.0};
+  const std::vector<double> table = {2.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  const std::vector<double> em_x = {0.25, 0.5, 0.5, 0.5, 0.5, 0.5};
+  const std::vector<double> em = {
+      1.0, 0.3, 0.2, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0,
+      0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0,
+  };
+  const std::vector<double> two_embed = {0.1, 0.2, 0.3, 0.4, 0.5, 0.9};
+  const std::vector<double> dy = {1.0, -0.5, 0.25, 2.0};
+
+  static double dot(const std::vector<double>& lhs,
+                    const std::vector<double>& rhs) {
+    double result = 0.0;
+    for (int ii = 0; ii < lhs.size(); ++ii) {
+      result += lhs[ii] * rhs[ii];
+    }
+    return result;
+  }
+
+  double forward_projection_cpu(
+      const std::vector<double>& test_two_embed) const {
+    std::vector<double> descriptor(nloc * 4 * last_layer_size);
+    deepmd::tabulate_fusion_se_a_cpu<double>(
+        descriptor.data(), table.data(), info.data(), em_x.data(), em.data(),
+        test_two_embed.data(), nloc, nnei, last_layer_size, true);
+    return dot(descriptor, dy);
+  }
+
+  std::vector<double> grad_two_cpu(const std::vector<double>& test_dy) const {
+    std::vector<double> dy_dem_x(nloc * nnei);
+    std::vector<double> dy_dem(nloc * nnei * 4);
+    std::vector<double> dy_dtwo(nloc * nnei * last_layer_size);
+    deepmd::tabulate_fusion_se_a_grad_cpu<double>(
+        dy_dem_x.data(), dy_dem.data(), dy_dtwo.data(), table.data(),
+        info.data(), em_x.data(), em.data(), two_embed.data(), test_dy.data(),
+        nloc, nnei, last_layer_size, true);
+    return dy_dtwo;
+  }
+
+  double backward_projection_cpu(const std::vector<double>& test_dy,
+                                 const std::vector<double>& dz_dy_dtwo) const {
+    return dot(grad_two_cpu(test_dy), dz_dy_dtwo);
+  }
+
+  std::vector<double> grad_grad_cpu(
+      const std::vector<double>& dz_dy_dtwo) const {
+    std::vector<double> dz_dy(nloc * 4 * last_layer_size);
+    const std::vector<double> dz_dy_dem_x(nloc * nnei, 0.0);
+    const std::vector<double> dz_dy_dem(nloc * nnei * 4, 0.0);
+    deepmd::tabulate_fusion_se_a_grad_grad_cpu<double>(
+        dz_dy.data(), table.data(), info.data(), em_x.data(), em.data(),
+        two_embed.data(), dz_dy_dem_x.data(), dz_dy_dem.data(),
+        dz_dy_dtwo.data(), nloc, nnei, last_layer_size, true);
+    return dz_dy;
+  }
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  std::vector<double> grad_two_gpu(const std::vector<double>& test_dy) const {
+    std::vector<double> dy_dem_x(nloc * nnei);
+    std::vector<double> dy_dem(nloc * nnei * 4);
+    // Start from nonzero memory to verify that unused padding gradients are
+    // explicitly cleared by the GPU wrapper.
+    std::vector<double> dy_dtwo(nloc * nnei * last_layer_size, 7.0);
+    double *dy_dem_x_dev = nullptr, *dy_dem_dev = nullptr,
+           *dy_dtwo_dev = nullptr, *table_dev = nullptr, *em_x_dev = nullptr,
+           *em_dev = nullptr, *two_embed_dev = nullptr, *dy_dev = nullptr;
+    deepmd::malloc_device_memory_sync(dy_dem_x_dev, dy_dem_x);
+    deepmd::malloc_device_memory_sync(dy_dem_dev, dy_dem);
+    deepmd::malloc_device_memory_sync(dy_dtwo_dev, dy_dtwo);
+    deepmd::malloc_device_memory_sync(table_dev, table);
+    deepmd::malloc_device_memory_sync(em_x_dev, em_x);
+    deepmd::malloc_device_memory_sync(em_dev, em);
+    deepmd::malloc_device_memory_sync(two_embed_dev, two_embed);
+    deepmd::malloc_device_memory_sync(dy_dev, test_dy);
+
+    deepmd::tabulate_fusion_se_a_grad_gpu<double>(
+        dy_dem_x_dev, dy_dem_dev, dy_dtwo_dev, table_dev, info.data(), em_x_dev,
+        em_dev, two_embed_dev, dy_dev, nloc, nnei, last_layer_size, true);
+    deepmd::memcpy_device_to_host(dy_dtwo_dev, dy_dtwo);
+
+    deepmd::delete_device_memory(dy_dem_x_dev);
+    deepmd::delete_device_memory(dy_dem_dev);
+    deepmd::delete_device_memory(dy_dtwo_dev);
+    deepmd::delete_device_memory(table_dev);
+    deepmd::delete_device_memory(em_x_dev);
+    deepmd::delete_device_memory(em_dev);
+    deepmd::delete_device_memory(two_embed_dev);
+    deepmd::delete_device_memory(dy_dev);
+    return dy_dtwo;
+  }
+
+  double backward_projection_gpu(const std::vector<double>& test_dy,
+                                 const std::vector<double>& dz_dy_dtwo) const {
+    return dot(grad_two_gpu(test_dy), dz_dy_dtwo);
+  }
+
+  std::vector<double> grad_grad_gpu(
+      const std::vector<double>& dz_dy_dtwo) const {
+    std::vector<double> dz_dy(nloc * 4 * last_layer_size);
+    const std::vector<double> dz_dy_dem_x(nloc * nnei, 0.0);
+    const std::vector<double> dz_dy_dem(nloc * nnei * 4, 0.0);
+    double *dz_dy_dev = nullptr, *table_dev = nullptr, *em_x_dev = nullptr,
+           *em_dev = nullptr, *two_embed_dev = nullptr,
+           *dz_dy_dem_x_dev = nullptr, *dz_dy_dem_dev = nullptr,
+           *dz_dy_dtwo_dev = nullptr;
+    deepmd::malloc_device_memory_sync(dz_dy_dev, dz_dy);
+    deepmd::malloc_device_memory_sync(table_dev, table);
+    deepmd::malloc_device_memory_sync(em_x_dev, em_x);
+    deepmd::malloc_device_memory_sync(em_dev, em);
+    deepmd::malloc_device_memory_sync(two_embed_dev, two_embed);
+    deepmd::malloc_device_memory_sync(dz_dy_dem_x_dev, dz_dy_dem_x);
+    deepmd::malloc_device_memory_sync(dz_dy_dem_dev, dz_dy_dem);
+    deepmd::malloc_device_memory_sync(dz_dy_dtwo_dev, dz_dy_dtwo);
+
+    deepmd::tabulate_fusion_se_a_grad_grad_gpu<double>(
+        dz_dy_dev, table_dev, info.data(), em_x_dev, em_dev, two_embed_dev,
+        dz_dy_dem_x_dev, dz_dy_dem_dev, dz_dy_dtwo_dev, nloc, nnei,
+        last_layer_size, true);
+    deepmd::memcpy_device_to_host(dz_dy_dev, dz_dy);
+
+    deepmd::delete_device_memory(dz_dy_dev);
+    deepmd::delete_device_memory(table_dev);
+    deepmd::delete_device_memory(em_x_dev);
+    deepmd::delete_device_memory(em_dev);
+    deepmd::delete_device_memory(two_embed_dev);
+    deepmd::delete_device_memory(dz_dy_dem_x_dev);
+    deepmd::delete_device_memory(dz_dy_dem_dev);
+    deepmd::delete_device_memory(dz_dy_dtwo_dev);
+    return dz_dy;
+  }
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+};
+
+TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
+       two_embed_gradient_matches_forward_cpu) {
+  constexpr double step = 1e-6;
+  const std::vector<double> actual = grad_two_cpu(dy);
+  for (int ii = 0; ii < two_embed.size(); ++ii) {
+    std::vector<double> plus = two_embed;
+    std::vector<double> minus = two_embed;
+    plus[ii] += step;
+    minus[ii] -= step;
+    const double expected =
+        (forward_projection_cpu(plus) - forward_projection_cpu(minus)) /
+        (2.0 * step);
+    EXPECT_NEAR(actual[ii], expected, 1e-9);
+  }
+  EXPECT_NEAR(actual[1], 1.0, 1e-12);
+  for (int ii = 2; ii < two_embed.size(); ++ii) {
+    EXPECT_DOUBLE_EQ(actual[ii], 0.0);
+  }
+}
+
+TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
+       two_embed_grad_grad_matches_backward_cpu) {
+  constexpr double step = 1e-6;
+  // The last weight is deliberately different and must not affect grad-grad,
+  // because the trailing padding entry is independent of forward.
+  const std::vector<double> dz_dy_dtwo = {0.0, 1.0, 2.0, 4.0, 8.0, 16.0};
+  const std::vector<double> actual = grad_grad_cpu(dz_dy_dtwo);
+  for (int ii = 0; ii < dy.size(); ++ii) {
+    std::vector<double> plus = dy;
+    std::vector<double> minus = dy;
+    plus[ii] += step;
+    minus[ii] -= step;
+    const double expected = (backward_projection_cpu(plus, dz_dy_dtwo) -
+                             backward_projection_cpu(minus, dz_dy_dtwo)) /
+                            (2.0 * step);
+    EXPECT_NEAR(actual[ii], expected, 1e-9);
+  }
+  EXPECT_NEAR(actual[0], 1.0, 1e-12);
+}
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
+       two_embed_gradient_matches_forward_gpu) {
+  constexpr double step = 1e-6;
+  const std::vector<double> actual = grad_two_gpu(dy);
+  for (int ii = 0; ii < two_embed.size(); ++ii) {
+    std::vector<double> plus = two_embed;
+    std::vector<double> minus = two_embed;
+    plus[ii] += step;
+    minus[ii] -= step;
+    const double expected =
+        (forward_projection_cpu(plus) - forward_projection_cpu(minus)) /
+        (2.0 * step);
+    EXPECT_NEAR(actual[ii], expected, 1e-9);
+  }
+  EXPECT_NEAR(actual[1], 1.0, 1e-12);
+  for (int ii = 2; ii < two_embed.size(); ++ii) {
+    EXPECT_DOUBLE_EQ(actual[ii], 0.0);
+  }
+}
+
+TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
+       two_embed_grad_grad_matches_backward_gpu) {
+  constexpr double step = 1e-6;
+  const std::vector<double> dz_dy_dtwo = {0.0, 1.0, 2.0, 4.0, 8.0, 16.0};
+  const std::vector<double> actual = grad_grad_gpu(dz_dy_dtwo);
+  for (int ii = 0; ii < dy.size(); ++ii) {
+    std::vector<double> plus = dy;
+    std::vector<double> minus = dy;
+    plus[ii] += step;
+    minus[ii] -= step;
+    const double expected = (backward_projection_gpu(plus, dz_dy_dtwo) -
+                             backward_projection_gpu(minus, dz_dy_dtwo)) /
+                            (2.0 * step);
+    EXPECT_NEAR(actual[ii], expected, 1e-9);
+  }
+  EXPECT_NEAR(actual[0], 1.0, 1e-12);
+}
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/source/lib/tests/test_tabulate_se_a.cc
+++ b/source/lib/tests/test_tabulate_se_a.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <iostream>
 #include <vector>
 
@@ -984,28 +985,37 @@ class TestTabulateSeASortedPaddingTwoEmbed : public ::testing::Test {
   const std::vector<double> table = {2.0, 0.0, 0.0, 0.0, 0.0, 0.0};
   const std::vector<double> em_x = {0.25, 0.5, 0.5, 0.5, 0.5, 0.5};
   const std::vector<double> em = {
-      1.0, 0.3, 0.2, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0,
-      0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0,
+      1.0, 0.3, 0.2, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0,
+      0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0,
   };
   const std::vector<double> two_embed = {0.1, 0.2, 0.3, 0.4, 0.5, 0.9};
   const std::vector<double> dy = {1.0, -0.5, 0.25, 2.0};
 
   static double dot(const std::vector<double>& lhs,
                     const std::vector<double>& rhs) {
+    EXPECT_EQ(lhs.size(), rhs.size());
+    if (lhs.size() != rhs.size()) {
+      return 0.0;
+    }
     double result = 0.0;
-    for (int ii = 0; ii < lhs.size(); ++ii) {
+    for (std::size_t ii = 0; ii < lhs.size(); ++ii) {
       result += lhs[ii] * rhs[ii];
     }
     return result;
   }
 
-  double forward_projection_cpu(
+  std::vector<double> forward_cpu(
       const std::vector<double>& test_two_embed) const {
     std::vector<double> descriptor(nloc * 4 * last_layer_size);
     deepmd::tabulate_fusion_se_a_cpu<double>(
         descriptor.data(), table.data(), info.data(), em_x.data(), em.data(),
         test_two_embed.data(), nloc, nnei, last_layer_size, true);
-    return dot(descriptor, dy);
+    return descriptor;
+  }
+
+  double forward_projection_cpu(
+      const std::vector<double>& test_two_embed) const {
+    return dot(forward_cpu(test_two_embed), dy);
   }
 
   std::vector<double> grad_two_cpu(const std::vector<double>& test_dy) const {
@@ -1037,6 +1047,30 @@ class TestTabulateSeASortedPaddingTwoEmbed : public ::testing::Test {
   }
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  std::vector<double> forward_gpu(
+      const std::vector<double>& test_two_embed) const {
+    std::vector<double> descriptor(nloc * 4 * last_layer_size);
+    double *descriptor_dev = nullptr, *table_dev = nullptr, *em_x_dev = nullptr,
+           *em_dev = nullptr, *two_embed_dev = nullptr;
+    deepmd::malloc_device_memory_sync(descriptor_dev, descriptor);
+    deepmd::malloc_device_memory_sync(table_dev, table);
+    deepmd::malloc_device_memory_sync(em_x_dev, em_x);
+    deepmd::malloc_device_memory_sync(em_dev, em);
+    deepmd::malloc_device_memory_sync(two_embed_dev, test_two_embed);
+
+    deepmd::tabulate_fusion_se_a_gpu<double>(
+        descriptor_dev, table_dev, info.data(), em_x_dev, em_dev, two_embed_dev,
+        nloc, nnei, last_layer_size, true);
+    deepmd::memcpy_device_to_host(descriptor_dev, descriptor);
+
+    deepmd::delete_device_memory(descriptor_dev);
+    deepmd::delete_device_memory(table_dev);
+    deepmd::delete_device_memory(em_x_dev);
+    deepmd::delete_device_memory(em_dev);
+    deepmd::delete_device_memory(two_embed_dev);
+    return descriptor;
+  }
+
   std::vector<double> grad_two_gpu(const std::vector<double>& test_dy) const {
     std::vector<double> dy_dem_x(nloc * nnei);
     std::vector<double> dy_dem(nloc * nnei * 4);
@@ -1117,7 +1151,7 @@ TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
        two_embed_gradient_matches_forward_cpu) {
   constexpr double step = 1e-6;
   const std::vector<double> actual = grad_two_cpu(dy);
-  for (int ii = 0; ii < two_embed.size(); ++ii) {
+  for (std::size_t ii = 0; ii < two_embed.size(); ++ii) {
     std::vector<double> plus = two_embed;
     std::vector<double> minus = two_embed;
     plus[ii] += step;
@@ -1128,7 +1162,7 @@ TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
     EXPECT_NEAR(actual[ii], expected, 1e-9);
   }
   EXPECT_NEAR(actual[1], 1.0, 1e-12);
-  for (int ii = 2; ii < two_embed.size(); ++ii) {
+  for (std::size_t ii = 2; ii < two_embed.size(); ++ii) {
     EXPECT_DOUBLE_EQ(actual[ii], 0.0);
   }
 }
@@ -1140,7 +1174,7 @@ TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
   // because the trailing padding entry is independent of forward.
   const std::vector<double> dz_dy_dtwo = {0.0, 1.0, 2.0, 4.0, 8.0, 16.0};
   const std::vector<double> actual = grad_grad_cpu(dz_dy_dtwo);
-  for (int ii = 0; ii < dy.size(); ++ii) {
+  for (std::size_t ii = 0; ii < dy.size(); ++ii) {
     std::vector<double> plus = dy;
     std::vector<double> minus = dy;
     plus[ii] += step;
@@ -1157,8 +1191,15 @@ TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
 TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
        two_embed_gradient_matches_forward_gpu) {
   constexpr double step = 1e-6;
+  const std::vector<double> expected_forward = forward_cpu(two_embed);
+  const std::vector<double> actual_forward = forward_gpu(two_embed);
+  ASSERT_EQ(actual_forward.size(), expected_forward.size());
+  for (std::size_t ii = 0; ii < actual_forward.size(); ++ii) {
+    EXPECT_NEAR(actual_forward[ii], expected_forward[ii], 1e-10);
+  }
+
   const std::vector<double> actual = grad_two_gpu(dy);
-  for (int ii = 0; ii < two_embed.size(); ++ii) {
+  for (std::size_t ii = 0; ii < two_embed.size(); ++ii) {
     std::vector<double> plus = two_embed;
     std::vector<double> minus = two_embed;
     plus[ii] += step;
@@ -1169,7 +1210,7 @@ TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
     EXPECT_NEAR(actual[ii], expected, 1e-9);
   }
   EXPECT_NEAR(actual[1], 1.0, 1e-12);
-  for (int ii = 2; ii < two_embed.size(); ++ii) {
+  for (std::size_t ii = 2; ii < two_embed.size(); ++ii) {
     EXPECT_DOUBLE_EQ(actual[ii], 0.0);
   }
 }
@@ -1179,7 +1220,7 @@ TEST_F(TestTabulateSeASortedPaddingTwoEmbed,
   constexpr double step = 1e-6;
   const std::vector<double> dz_dy_dtwo = {0.0, 1.0, 2.0, 4.0, 8.0, 16.0};
   const std::vector<double> actual = grad_grad_gpu(dz_dy_dtwo);
-  for (int ii = 0; ii < dy.size(); ++ii) {
+  for (std::size_t ii = 0; ii < dy.size(); ++ii) {
     std::vector<double> plus = dy;
     std::vector<double> minus = dy;
     plus[ii] += step;


### PR DESCRIPTION
## Summary

- preserve the folded sorted-padding forward contract and make only the first sentinel depend on `two_embed`
- scale that sentinel gradient by the padding-tail length while leaving later padding gradients zero on CPU and GPU
- add finite-difference and nonuniform-cotangent grad-grad regression tests, including a GPU tail longer than the four-warp tile

## Validation

- `source/build/lib/tests/runUnitTests_lib --gtest_filter='TestTabulateSeA.*:TestTabulateSeASortedPaddingTwoEmbed.*'`
- CUDA 12.4 build of `deepmd_op_cuda` and `runUnitTests_lib`
- RTX 5090 Slurm run of all 8 existing/new SE-A CPU and GPU tests
- `ruff format .`
- `ruff check .`
- `clang-format --dry-run --Werror` on changed C++/CUDA files

Closes #5891

Note: #5844 modifies the same GPU kernel for the shared-breakpoint fix, so the later-merging branch may need a small conflict resolution; the gradient contract fixed here is independent.

Coding agent: Codex
Codex version: codex-cli 0.144.6
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sorted-padding two-embedding gradient behavior so only the first sentinel receives the full tail multiplicity; later padding sentinel gradients remain zero.
  * Updated CPU and GPU gradient/grad-grad accumulation to apply the padding-tail repeat factor consistently.
  * Ensured the GPU two-embedding gradient buffer is cleared only when applicable to avoid stale values.
* **Tests**
  * Strengthened sorted-padding assertions and expanded GPU coverage to confirm forward output consistency with CPU before numerical gradient checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->