### PR TITLE
fix(pt): honor is_sorted in SE-Attention tabulation

### DIFF
--- a/deepmd/pt/model/descriptor/se_atten.py
+++ b/deepmd/pt/model/descriptor/se_atten.py
@@ -813,7 +813,11 @@ class DescrptBlockSeAtten(DescriptorBlock):
 
     def need_sorted_nlist_for_lower(self) -> bool:
         """Returns whether the descriptor block needs sorted nlist when using `forward_lower`."""
-        return False
+        # Geometric compression uses the tabulate op's sorted-neighbor fold,
+        # which assumes padding and out-of-cutoff neighbors are trailing.
+        # `forward_lower` may receive an unsorted rcut+skin list from LAMMPS,
+        # so request the filtering/sorting pass whenever that op is active.
+        return self.geo_compress
 
 
 class NeighborGatedAttention(nn.Module):

--- a/source/op/pt/tabulate_multi_device.cc
+++ b/source/op/pt/tabulate_multi_device.cc
@@ -25,6 +25,7 @@ void TabulateFusionSeAForward(const torch::Tensor& table_tensor,
                               const torch::Tensor& em_tensor,
                               const torch::Tensor& two_embed_tensor,
                               int64_t last_layer_size,
+                              bool is_sorted,
                               torch::Tensor& descriptor_tensor) {
   // check input shape
   if (table_tensor.dim() != 2) {
@@ -60,7 +61,8 @@ void TabulateFusionSeAForward(const torch::Tensor& table_tensor,
   if (device == "GPU") {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     deepmd::tabulate_fusion_se_a_gpu(descriptor, table, table_info, em_x, em,
-                                     two_embed, nloc, nnei, last_layer_size);
+                                     two_embed, nloc, nnei, last_layer_size,
+                                     is_sorted);
 #else
     throw std::runtime_error(
         "The input tensor is on the GPU, but the GPU support for the "
@@ -68,7 +70,8 @@ void TabulateFusionSeAForward(const torch::Tensor& table_tensor,
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   } else if (device == "CPU") {
     deepmd::tabulate_fusion_se_a_cpu(descriptor, table, table_info, em_x, em,
-                                     two_embed, nloc, nnei, last_layer_size);
+                                     two_embed, nloc, nnei, last_layer_size,
+                                     is_sorted);
   }
 }
 
@@ -80,6 +83,7 @@ void TabulateFusionSeAGradForward(const torch::Tensor& table_tensor,
                                   const torch::Tensor& two_embed_tensor,
                                   const torch::Tensor& dy_tensor,
                                   const torch::Tensor& descriptor_tensor,
+                                  bool is_sorted,
                                   torch::Tensor& dy_dem_x_tensor,
                                   torch::Tensor& dy_dem_tensor,
                                   torch::Tensor& dy_dtwo_tensor) {
@@ -111,18 +115,18 @@ void TabulateFusionSeAGradForward(const torch::Tensor& table_tensor,
   // compute
   if (device == "GPU") {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-    deepmd::tabulate_fusion_se_a_grad_gpu(dy_dem_x, dy_dem, dy_dtwo, table,
-                                          table_info, em_x, em, two_embed, dy,
-                                          nloc, nnei, last_layer_size);
+    deepmd::tabulate_fusion_se_a_grad_gpu(
+        dy_dem_x, dy_dem, dy_dtwo, table, table_info, em_x, em, two_embed, dy,
+        nloc, nnei, last_layer_size, is_sorted);
 #else
     throw std::runtime_error(
         "The input tensor is on the GPU, but the GPU support for the "
         "customized OP library is not enabled.");
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   } else if (device == "CPU") {
-    deepmd::tabulate_fusion_se_a_grad_cpu(dy_dem_x, dy_dem, dy_dtwo, table,
-                                          table_info, em_x, em, two_embed, dy,
-                                          nloc, nnei, last_layer_size);
+    deepmd::tabulate_fusion_se_a_grad_cpu(
+        dy_dem_x, dy_dem, dy_dtwo, table, table_info, em_x, em, two_embed, dy,
+        nloc, nnei, last_layer_size, is_sorted);
   }
 }
 
@@ -643,7 +647,7 @@ class TabulateFusionSeAGradOp
     // compute
     TabulateFusionSeAGradForward<FPTYPE>(
         table_tensor, table_info_tensor, em_x_tensor, em_tensor, at::Tensor(),
-        dy_tensor, descriptor_tensor, dy_dem_x_tensor, dy_dem_tensor,
+        dy_tensor, descriptor_tensor, true, dy_dem_x_tensor, dy_dem_tensor,
         dy_dtwo_tensor);
     // save data
     ctx->save_for_backward({table_tensor, table_info_tensor, em_x_tensor,
@@ -785,7 +789,7 @@ class TabulateFusionSeAOp
     // compute
     TabulateFusionSeAForward<FPTYPE>(table_tensor, table_info_tensor,
                                      em_x_tensor, em_tensor, at::Tensor(),
-                                     last_layer_size, descriptor_tensor);
+                                     last_layer_size, true, descriptor_tensor);
     // save data
     ctx->save_for_backward({table_tensor, table_info_tensor, em_x_tensor,
                             em_tensor, descriptor_tensor});
@@ -870,8 +874,8 @@ class TabulateFusionSeAttenGradOp
     torch::Tensor dy_dtwo_tensor = torch::zeros_like(two_embed_tensor);
     TabulateFusionSeAGradForward<FPTYPE>(
         table_tensor, table_info_tensor, em_x_tensor, em_tensor,
-        two_embed_tensor, dy_tensor, descriptor_tensor, dy_dem_x_tensor,
-        dy_dem_tensor, dy_dtwo_tensor);
+        two_embed_tensor, dy_tensor, descriptor_tensor, is_sorted,
+        dy_dem_x_tensor, dy_dem_tensor, dy_dtwo_tensor);
 
     ctx->save_for_backward({table_tensor, table_info_tensor, em_x_tensor,
                             em_tensor, two_embed_tensor, descriptor_tensor});
@@ -969,9 +973,9 @@ class TabulateFusionSeAttenOp
     torch::Tensor descriptor_tensor =
         torch::empty({em_tensor.size(0), 4, last_layer_size}, options);
     // compute
-    TabulateFusionSeAForward<FPTYPE>(table_tensor, table_info_tensor,
-                                     em_x_tensor, em_tensor, two_embed_tensor,
-                                     last_layer_size, descriptor_tensor);
+    TabulateFusionSeAForward<FPTYPE>(
+        table_tensor, table_info_tensor, em_x_tensor, em_tensor,
+        two_embed_tensor, last_layer_size, is_sorted, descriptor_tensor);
     // save data
     ctx->save_for_backward({table_tensor, table_info_tensor, em_x_tensor,
                             em_tensor, two_embed_tensor, descriptor_tensor});

--- a/source/op/pt/tabulate_multi_device.cc
+++ b/source/op/pt/tabulate_multi_device.cc
@@ -645,6 +645,10 @@ class TabulateFusionSeAGradOp
     torch::Tensor dy_dem_tensor = torch::zeros_like(em_tensor);
     torch::Tensor dy_dtwo_tensor = at::Tensor();
     // compute
+    // The non-attention se_a path invokes this op per type-pair block, so
+    // exclusions cannot interleave zero rows. Compressed forward_lower also
+    // requests a sorted nlist through the Python-side
+    // DescrptBlockSeA.need_sorted_nlist_for_lower() contract.
     TabulateFusionSeAGradForward<FPTYPE>(
         table_tensor, table_info_tensor, em_x_tensor, em_tensor, at::Tensor(),
         dy_tensor, descriptor_tensor, true, dy_dem_x_tensor, dy_dem_tensor,
@@ -787,6 +791,8 @@ class TabulateFusionSeAOp
     torch::Tensor descriptor_tensor =
         torch::empty({em_tensor.size(0), 4, last_layer_size}, options);
     // compute
+    // Keep the sorted fold enabled: exclusions are uniform within each se_a
+    // type-pair invocation, and compressed forward_lower sorts its nlist first.
     TabulateFusionSeAForward<FPTYPE>(table_tensor, table_info_tensor,
                                      em_x_tensor, em_tensor, at::Tensor(),
                                      last_layer_size, true, descriptor_tensor);

--- a/source/tests/pt/model/test_compressed_se_atten_forward_lower.py
+++ b/source/tests/pt/model/test_compressed_se_atten_forward_lower.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Regression coverage for compressed DPA1 on an unsorted lower nlist.
+
+The geometric tabulation kernel folds trailing padding rows when its input is
+sorted. LAMMPS supplies ``forward_lower`` with an rcut+skin neighbor list that
+may put zero-switch, out-of-cutoff rows before real neighbors. A compressed
+DPA1 model must therefore request the extra filtering/sorting pass before the
+kernel applies that fold.
+"""
+
+import copy
+import unittest
+
+import torch
+
+from deepmd.pt.cxx_op import (
+    ENABLE_CUSTOMIZED_OP,
+)
+from deepmd.pt.model.model import (
+    get_model,
+)
+from deepmd.pt.utils import (
+    env,
+)
+from deepmd.pt.utils.nlist import (
+    extend_input_and_build_neighbor_list,
+)
+
+from ...seed import (
+    GLOBAL_SEED,
+)
+from .test_forward_lower import (
+    reduce_tensor,
+)
+from .test_permutation import (
+    model_dpa1,
+)
+
+dtype = torch.float64
+
+
+@unittest.skipIf(not ENABLE_CUSTOMIZED_OP, "PyTorch customized OPs are not built")
+class TestCompressedSeAttenForwardLower(unittest.TestCase):
+    def setUp(self) -> None:
+        model_params = copy.deepcopy(model_dpa1)
+        # Geometric compression is available only for the strip representation
+        # without attention layers.
+        model_params["descriptor"]["tebd_input_mode"] = "strip"
+        model_params["descriptor"]["attn_layer"] = 0
+        self.model = get_model(model_params).to(env.DEVICE)
+
+    def _make_system(self):
+        """Create a sparse periodic system with neighbors in the skin region."""
+        natoms = 6
+        cell = 6.0 * torch.eye(3, dtype=dtype, device=env.DEVICE)
+        generator = torch.Generator(device=env.DEVICE).manual_seed(GLOBAL_SEED)
+        coord = 5.5 * torch.rand(
+            [natoms, 3], dtype=dtype, device=env.DEVICE, generator=generator
+        )
+        atype = torch.tensor([0, 0, 1, 1, 2, 2], dtype=torch.int64, device=env.DEVICE)
+        return coord, atype, cell
+
+    def _min_nbor_dist(self, coord, cell) -> float:
+        """Return the periodic minimum pair distance for table construction."""
+        box = torch.diagonal(cell)
+        diff = coord[:, None, :] - coord[None, :, :]
+        diff = diff - torch.round(diff / box) * box
+        dist = torch.linalg.norm(diff, dim=-1)
+        dist = dist + torch.eye(coord.shape[0], device=coord.device) * 1e10
+        return float(dist.min())
+
+    def test_unsorted_overcut_nlist(self) -> None:
+        coord, atype, cell = self._make_system()
+        rcut = self.model.get_rcut()
+        sel = self.model.get_sel()
+
+        # Use a clean cutoff-bounded list as the uncompressed reference.
+        ec, ea, mapping, nlist = extend_input_and_build_neighbor_list(
+            coord.unsqueeze(0),
+            atype.unsqueeze(0),
+            rcut,
+            sel,
+            mixed_types=self.model.mixed_types(),
+            box=cell.unsqueeze(0),
+        )
+        ref = self.model.forward_lower(ec, ea, nlist, mapping, do_atomic_virial=False)
+
+        self.model.min_nbor_dist = torch.tensor(
+            0.9 * self._min_nbor_dist(coord, cell),
+            dtype=env.GLOBAL_PT_FLOAT_PRECISION,
+            device=env.DEVICE,
+        )
+        self.model.enable_compression()
+        self.assertTrue(self.model.need_sorted_nlist_for_lower())
+
+        # Mimic the unsorted rcut+skin list from LAMMPS and deliberately move
+        # its out-of-cutoff/padding rows ahead of the in-cutoff neighbors.
+        ec2, ea2, mapping2, nlist2 = extend_input_and_build_neighbor_list(
+            coord.unsqueeze(0),
+            atype.unsqueeze(0),
+            rcut + 2.0,
+            sum(sel),
+            mixed_types=True,
+            box=cell.unsqueeze(0),
+        )
+        safe_nlist = torch.clamp_min(nlist2, 0)
+        gather_index = safe_nlist.reshape(1, -1, 1).expand(-1, -1, 3)
+        neighbor_coord = torch.gather(ec2, 1, gather_index).view(
+            1, coord.shape[0], -1, 3
+        )
+        center_coord = ec2[:, : coord.shape[0], :].unsqueeze(2)
+        distance = torch.linalg.norm(neighbor_coord - center_coord, dim=-1)
+        real_neighbor = nlist2 >= 0
+        self.assertTrue(torch.any(real_neighbor & (distance <= rcut)).item())
+        self.assertTrue(torch.any(real_neighbor & (distance > rcut)).item())
+
+        nlist2 = torch.flip(nlist2, dims=[-1])
+        out = self.model.forward_lower(
+            ec2, ea2, nlist2, mapping2, do_atomic_virial=False
+        )
+
+        torch.testing.assert_close(out["energy"], ref["energy"], rtol=1e-10, atol=1e-10)
+        natoms = coord.shape[0]
+        ref_force = reduce_tensor(ref["extended_force"], mapping, natoms)
+        out_force = reduce_tensor(out["extended_force"], mapping2, natoms)
+        torch.testing.assert_close(out_force, ref_force, rtol=1e-10, atol=1e-10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/tests/pt/test_model_compression_se_atten.py
+++ b/source/tests/pt/test_model_compression_se_atten.py
@@ -84,10 +84,13 @@ def _init_models_exclude_types():
     INPUT = str(tests_path / "input.json")
     jdata = j_loader(str(tests_path / os.path.join("model_compression", "input.json")))
 
-    # Configure se_atten descriptor with exclude_types
+    # Plain se_atten defaults to a zero average, so excluded rows share the
+    # padding sentinel and exercise the unsorted path in the compressed op.
     jdata["model"]["descriptor"] = {
-        "type": "se_atten_v2",
+        "type": "se_atten",
         "exclude_types": [[0, 1]],
+        "set_davg_zero": True,
+        "tebd_input_mode": "strip",
         "sel": 120,
         "rcut_smth": 0.50,
         "rcut": 6.00,

--- a/source/tests/pt/test_tabulate_fusion_se_atten.py
+++ b/source/tests/pt/test_tabulate_fusion_se_atten.py
@@ -1665,7 +1665,9 @@ class TestTabulateFusionSeAttenUnsortedOp(unittest.TestCase):
             device=env.DEVICE,
         )
         table[0, :, 0] = coefficients
+        table[0, :, 1] = coefficients
         table[1, :, 0] = 2.0 * coefficients
+        table[1, :, 1] = 2.0 * coefficients
         self.table_tensor = table.reshape(self.last_layer_size, -1)
         self.table_info_tensor = torch.tensor(
             [0.0, 1.0, 2.0, 1.0, 1.0, -1.0],
@@ -1722,10 +1724,10 @@ class TestTabulateFusionSeAttenUnsortedOp(unittest.TestCase):
             dtype=self.dtype,
             device=env.DEVICE,
         )
-        expected_unsorted[0, 0] = 1.4 * coefficients
-        expected_unsorted[0, 1] = 0.3 * coefficients
+        expected_unsorted[0, 0] = 2.1 * coefficients
+        expected_unsorted[0, 1] = 0.45 * coefficients
         expected_sorted = torch.zeros_like(expected_unsorted)
-        expected_sorted[0, 0] = 0.6 * coefficients
+        expected_sorted[0, 0] = 0.9 * coefficients
 
         torch.testing.assert_close(self._forward(False), expected_unsorted)
         torch.testing.assert_close(self._forward(True), expected_sorted)
@@ -1748,17 +1750,20 @@ class TestTabulateFusionSeAttenUnsortedOp(unittest.TestCase):
             device=env.DEVICE,
         )
         expected_dem = torch.tensor(
-            [[[36.0] * 4, [108.0] * 4, [27.0] * 4]],
+            [[[54.0] * 4, [162.0] * 4, [40.5] * 4]],
             dtype=self.dtype,
             device=env.DEVICE,
         )
         expected_dtwo = torch.stack(
-            (0.2 * coefficients, 0.8 * coefficients, 0.4 * coefficients)
+            (0.3 * coefficients, 1.2 * coefficients, 0.6 * coefficients)
+        )
+        expected_dem_x = torch.tensor(
+            [[7.2, 43.2, 10.8]],
+            dtype=self.dtype,
+            device=env.DEVICE,
         )
 
-        torch.testing.assert_close(
-            unsorted_grads[0], torch.zeros_like(unsorted_grads[0])
-        )
+        torch.testing.assert_close(unsorted_grads[0], expected_dem_x)
         torch.testing.assert_close(unsorted_grads[1], expected_dem)
         torch.testing.assert_close(unsorted_grads[2], expected_dtwo)
         self.assertFalse(torch.equal(unsorted_grads[1], sorted_dem))

--- a/source/tests/pt/test_tabulate_fusion_se_atten.py
+++ b/source/tests/pt/test_tabulate_fusion_se_atten.py
@@ -1645,5 +1645,131 @@ class TestTabulateFusionSeAttenOp(unittest.TestCase):
         )
 
 
+@parameterized((torch.float64, torch.float32))
+@unittest.skipIf(not ENABLE_CUSTOMIZED_OP, "PyTorch customized OPs are not built")
+class TestTabulateFusionSeAttenUnsortedOp(unittest.TestCase):
+    """Verify that an unsorted attention neighbor row is not folded as padding."""
+
+    def setUp(self) -> None:
+        (self.dtype,) = self.param
+        self.last_layer_size = 8
+        coefficients = torch.arange(
+            1,
+            self.last_layer_size + 1,
+            dtype=self.dtype,
+            device=env.DEVICE,
+        )
+        table = torch.zeros(
+            (2, self.last_layer_size, 6),
+            dtype=self.dtype,
+            device=env.DEVICE,
+        )
+        table[0, :, 0] = coefficients
+        table[1, :, 0] = 2.0 * coefficients
+        self.table_tensor = table.reshape(self.last_layer_size, -1)
+        self.table_info_tensor = torch.tensor(
+            [0.0, 1.0, 2.0, 1.0, 1.0, -1.0],
+            dtype=self.dtype,
+            device="cpu",
+        )
+        # The first row looks like sorted padding because its scalar input
+        # matches the final row and its directional components are zero. The
+        # middle row is nevertheless a real neighbor and must still contribute
+        # when ``is_sorted`` is false.
+        self.em_x_tensor = torch.tensor(
+            [[0.5, 1.5, 0.5]],
+            dtype=self.dtype,
+            device=env.DEVICE,
+            requires_grad=True,
+        )
+        self.em_tensor = torch.tensor(
+            [[[0.2, 0.0, 0.0, 0.0], [0.3, 0.1, 0.0, 0.0], [0.4, 0.0, 0.0, 0.0]]],
+            dtype=self.dtype,
+            device=env.DEVICE,
+            requires_grad=True,
+        )
+        self.two_embed_tensor = torch.tensor(
+            [
+                [0.0] * self.last_layer_size,
+                [0.5] * self.last_layer_size,
+                [-0.25] * self.last_layer_size,
+            ],
+            dtype=self.dtype,
+            device=env.DEVICE,
+            requires_grad=True,
+        )
+
+    def _forward(self, is_sorted: bool) -> torch.Tensor:
+        return torch.ops.deepmd.tabulate_fusion_se_atten(
+            self.table_tensor,
+            self.table_info_tensor,
+            self.em_x_tensor,
+            self.em_tensor,
+            self.two_embed_tensor,
+            self.last_layer_size,
+            is_sorted,
+        )[0]
+
+    def test_forward_uses_is_sorted(self) -> None:
+        coefficients = torch.arange(
+            1,
+            self.last_layer_size + 1,
+            dtype=self.dtype,
+            device=env.DEVICE,
+        )
+        expected_unsorted = torch.zeros(
+            (1, 4, self.last_layer_size),
+            dtype=self.dtype,
+            device=env.DEVICE,
+        )
+        expected_unsorted[0, 0] = 1.4 * coefficients
+        expected_unsorted[0, 1] = 0.3 * coefficients
+        expected_sorted = torch.zeros_like(expected_unsorted)
+        expected_sorted[0, 0] = 0.6 * coefficients
+
+        torch.testing.assert_close(self._forward(False), expected_unsorted)
+        torch.testing.assert_close(self._forward(True), expected_sorted)
+
+    def test_backward_uses_is_sorted(self) -> None:
+        unsorted_grads = torch.autograd.grad(
+            self._forward(False).sum(),
+            (self.em_x_tensor, self.em_tensor, self.two_embed_tensor),
+            retain_graph=True,
+        )
+        sorted_dem = torch.autograd.grad(
+            self._forward(True).sum(),
+            self.em_tensor,
+        )[0]
+
+        coefficients = torch.arange(
+            1,
+            self.last_layer_size + 1,
+            dtype=self.dtype,
+            device=env.DEVICE,
+        )
+        expected_dem = torch.tensor(
+            [[[36.0] * 4, [108.0] * 4, [27.0] * 4]],
+            dtype=self.dtype,
+            device=env.DEVICE,
+        )
+        expected_dtwo = torch.stack(
+            (0.2 * coefficients, 0.8 * coefficients, 0.4 * coefficients)
+        )
+
+        torch.testing.assert_close(
+            unsorted_grads[0], torch.zeros_like(unsorted_grads[0])
+        )
+        torch.testing.assert_close(unsorted_grads[1], expected_dem)
+        torch.testing.assert_close(unsorted_grads[2], expected_dtwo)
+        self.assertFalse(torch.equal(unsorted_grads[1], sorted_dem))
+
+    def test_second_order_backward_uses_is_sorted(self) -> None:
+        descriptor_tensor = self._forward(False)
+        assert_second_order_backward_matches_finite_difference(
+            descriptor_tensor,
+            (self.em_x_tensor, self.em_tensor, self.two_embed_tensor),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- forward `is_sorted` through the PyTorch SE-Attention forward helper to the CPU and GPU library entry points
- forward the saved flag through the first-backward helper so all autograd stages use the same sorting contract
- require a sorted lower neighbor list while DPA1 geometric compression is active, matching the tabulation fold invariant
- add float32 and float64 regression coverage for unsorted forward, backward, and double-backward behavior, including a nonzero table derivative
- add compressed DPA1 `forward_lower` coverage for unsorted rcut+skin lists and an end-to-end plain `se_atten` case with `exclude_types` and `set_davg_zero: true`
- document why the non-attention `se_a` path intentionally keeps the sorted fold enabled

Fixes #5890

## Historical origin

- The PyTorch custom-op forwarding bug was introduced by #3877, which added `tabulate_fusion_se_atten` while omitting the backend `is_sorted` argument in forward and first backward.
- The compressed DPA1 lower-nlist exposure became reachable in #4227, which added PyTorch `se_atten` geometric compression while `need_sorted_nlist_for_lower()` still returned `False`. #3993 introduced that API/default earlier, but compression did not yet use the sorted fold.

## Performance note

With non-empty `exclude_types`, the corrected `is_sorted=False` path traverses the full neighbor list instead of applying the sorted-padding fold. This may be measurably slower, but avoids silently folding interleaved excluded rows.

## Testing

- CPU-only PyTorch `deepmd_op_pt` C++ target build
- `python -m pytest source/tests/pt/test_tabulate_fusion_se_atten.py -v` (12 passed)
- `python -m pytest source/tests/pt/model/test_compressed_se_atten_forward_lower.py -v` (1 passed)
- `python -m pytest source/tests/pt/test_model_compression_se_atten.py::TestDeepPotATPBCExcludeTypes::test_1frame -v` (1 passed)
- `ruff format .`
- `ruff check` on all modified Python files
- commit hooks, including Ruff, pylint, and clang-format
- `dp --version`
- `dp --pt -h`
- Python imports for `deepmd` and `deepmd.pt`

`ruff check .` was also run; it reports five pre-existing findings in `deepmd/jax/jax_md/__init__.py` and `deepmd/tf/entrypoints/__init__.py`, outside this PR.

Coding agent: Codex
Codex version: codex-cli 0.144.6
Model: gpt-5.6-sol
Reasoning effort: xhigh
