### PR TITLE
fix(pt): pass device and dtype in SeZMDeNSFittingNet.deserialize

### DIFF
--- a/deepmd/pt/model/descriptor/sezm_nn/dens.py
+++ b/deepmd/pt/model/descriptor/sezm_nn/dens.py
@@ -746,6 +746,12 @@ class SeZMDeNSFittingNet(torch.nn.Module):
         config = data.pop("config")
         variables = data.pop("@variables")
         obj = cls(**config)
-        state = {key: safe_numpy_to_tensor(value) for key, value in variables.items()}
+        template = obj.state_dict()
+        state = {
+            key: safe_numpy_to_tensor(
+                value, device=template[key].device, dtype=template[key].dtype
+            )
+            for key, value in variables.items()
+        }
         obj.load_state_dict(state)
         return obj


### PR DESCRIPTION
## Summary

`SeZMDeNSFittingNet.deserialize` cannot run — it raises

```
TypeError: safe_numpy_to_tensor() missing 2 required keyword-only arguments: 'device' and 'dtype'
```

`safe_numpy_to_tensor` is declared in `deepmd/pt/model/descriptor/sezm_nn/utils.py` as

```python
def safe_numpy_to_tensor(
    data: Any, *, device: torch.device, dtype: torch.dtype
) -> torch.Tensor:
```

Both are keyword-only **and** required, but `dens.py:749` called it with the array alone:

```python
state = {key: safe_numpy_to_tensor(value) for key, value in variables.items()}
```

## Why this is the right fix

This is the only one of the 17 `safe_numpy_to_tensor` call sites in the tree that omits them. The other `sezm_nn` `deserialize` implementations — `ffn.py`, `norm.py`, `embedding.py`, `block.py`, `attn_res.py`, `activation.py`, `radial.py`, `so2.py`, `so3.py` — all share one identical block, so I simply matched it:

```python
obj = cls(**config)
template = obj.state_dict()
state = {
    key: safe_numpy_to_tensor(
        value, device=template[key].device, dtype=template[key].dtype
    )
    for key, value in variables.items()
}
obj.load_state_dict(state)
return obj
```

Taking `device`/`dtype` from the freshly-built module's own `state_dict()` is what makes the round trip self-consistent: `serialize` builds `@variables` from `state = self.state_dict()`, so every key in `variables` is present in `template` and `template[key]` cannot `KeyError`.

I deliberately did **not** copy the siblings' `precision = config.pop("precision"); config["dtype"] = PRECISION_DICT[precision]` lines — `SeZMDeNSFittingNet.__init__` takes `precision` directly and derives `self.dtype` itself, so `cls(**config)` is already correct here.

## Verification

I don't have a runtime for this path, so I verified by replaying the real signature (AST-extracted from `utils.py`, not hand-copied) against the real call site:

```
DEF: def safe_numpy_to_tensor(data, *, device, dtype)
CURRENT dens.py call -> TypeError: missing a required keyword-only argument: 'device'
FIXED   call         -> BINDS OK
```

`ruff check` and `ruff format --check` (v0.16.0, the pinned pre-commit version) pass on the changed file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model deserialization to preserve each parameter’s device and data type, ensuring more reliable loading across different hardware and precision settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->