### PR TITLE
fix(dpmodel): handle zero-node DPA4C spin graphs

### DIFF
--- a/deepmd/dpmodel/descriptor/dpa4c_nn/spin.py
+++ b/deepmd/dpmodel/descriptor/dpa4c_nn/spin.py
@@ -327,7 +327,10 @@ class SpinChannels(NativeOP):
                 # anisotropy sum over neighbours.
                 xp.reshape(
                     xp.matmul(xp.permute_dims(quadrupole, (0, 2, 1)), degree_two),
-                    (spin_moments.shape[0], -1),
+                    (
+                        spin_moments.shape[0],
+                        self.quadrupole_width * self.degree_channels[2],
+                    ),
                 ),
                 magnitude,
                 coordination,

--- a/source/tests/common/dpmodel/test_descriptor_dpa4c.py
+++ b/source/tests/common/dpmodel/test_descriptor_dpa4c.py
@@ -804,6 +804,32 @@ def make_spin_descriptor(**overrides: Any) -> DescrptDPA4C:
     return descriptor
 
 
+@pytest.mark.parametrize("precision", ["float32", "float64"])
+@pytest.mark.parametrize("channels", [8, 32])
+@pytest.mark.parametrize("node_count", [0, 2])
+def test_native_spin_graph_without_edges(
+    precision: str, channels: int, node_count: int
+) -> None:
+    """Both zero-node graphs and isolated atoms retain the feature width."""
+    descriptor = make_spin_descriptor(precision=precision, channels=channels)
+    graph = neighbor_graph.NeighborGraph(
+        n_node=np.array([node_count], dtype=np.int64),
+        n_local=np.array([node_count], dtype=np.int64),
+        edge_index=np.empty((2, 0), dtype=np.int64),
+        edge_vec=np.empty((0, 3), dtype=precision),
+        edge_mask=np.empty((0,), dtype=bool),
+    )
+    output, rot_mat = descriptor.call_graph(
+        graph,
+        np.arange(node_count, dtype=np.int64) % 2,
+        spin=np.ones((node_count, 3), dtype=precision),
+    )
+    assert output.shape == (node_count, descriptor.get_dim_out())
+    assert output.dtype == graph.edge_vec.dtype
+    assert np.isfinite(output).all()
+    assert rot_mat is None
+
+
 def spin_reference_terms(
     descriptor: DescrptDPA4C,
     graph: Any,

--- a/source/tests/pt_expt/descriptor/test_dpa4c.py
+++ b/source/tests/pt_expt/descriptor/test_dpa4c.py
@@ -458,6 +458,45 @@ class TestDPA4C:
             )
 
 
+@pytest.mark.parametrize("precision", ["float32", "float64"])
+@pytest.mark.parametrize("channels", [8, 32])
+@pytest.mark.parametrize("node_count", [0, 2])
+def test_native_spin_graph_without_edges(
+    precision: str, channels: int, node_count: int
+) -> None:
+    """The reference spin path supports zero nodes as well as isolated atoms."""
+    descriptor = TestDPA4C.build(
+        precision=precision, channels=channels, use_spin=[True, False]
+    ).eval()
+    with torch.no_grad():
+        descriptor.spin.spin_gate.fill_(1.0)
+    dtype = getattr(torch, precision)
+    graph = NeighborGraph(
+        n_node=torch.tensor([node_count], dtype=torch.int64, device=env.DEVICE),
+        n_local=torch.tensor([node_count], dtype=torch.int64, device=env.DEVICE),
+        edge_index=torch.empty((2, 0), dtype=torch.int64, device=env.DEVICE),
+        edge_vec=torch.empty((0, 3), dtype=dtype, device=env.DEVICE),
+        edge_mask=torch.empty((0,), dtype=torch.bool, device=env.DEVICE),
+    )
+    spin = torch.ones(
+        (node_count, 3), dtype=dtype, device=env.DEVICE, requires_grad=True
+    )
+    output, rot_mat = descriptor.call_graph(
+        graph,
+        torch.arange(node_count, dtype=torch.int64, device=env.DEVICE) % 2,
+        spin=spin,
+    )
+    assert output.shape == (node_count, descriptor.get_dim_out())
+    assert output.dtype == dtype
+    assert output.device == spin.device
+    assert torch.isfinite(output).all()
+    assert rot_mat is None
+    output.sum().backward()
+    assert spin.grad is not None
+    assert spin.grad.shape == spin.shape
+    assert torch.isfinite(spin.grad).all()
+
+
 class TestDPA4CSpinGate:
     """Torch-side contracts of the spin branch gate."""
 


### PR DESCRIPTION
## Summary

Fixes #5991.

The native-spin cross Gram has shape `(N, quadrupole_width, C_2)`. Reshaping it to `(N, -1)` raises for `N == 0`, since the feature width cannot be inferred from an empty array. Use the existing `quadrupole_width * degree_channels[2]` instead. This preserves the feature layout for nonempty inputs and requires no empty-graph special case.

Add regression tests through the actual `DescrptDPA4C.call_graph()` API in both NumPy and PyTorch. They cover float32/float64, channels 8/32, zero nodes and two isolated nodes, with the spin gate open. Check output shape/dtype, and PyTorch device and spin gradients.

## Validation

Built from upstream `58a12b1e0a72cfcc322c64d70c21469220bef74f` on Linux x86-64 / Python 3.12.3, with PyTorch 2.11.0+cpu and TensorFlow CPU 2.21.0. Compiled the native C++ libraries and TensorFlow/PyTorch operators from this source.

Before the production change, the new tests produced **8 failed, 8 passed**: all eight zero-node cases failed at the reported reshape, while the isolated-node controls passed. After the change, **16 passed**.

```sh
python -m pytest -q \
  source/tests/common/dpmodel/test_descriptor_dpa4c.py \
  source/tests/pt_expt/descriptor/test_dpa4c.py \
  source/tests/pt_expt/descriptor/test_dpa4c_cpu.py \
  source/tests/pt_expt/model/test_dpa4c_graph_lower.py \
  source/tests/tf/test_dp_test.py::TestDPTestEner::test_1frame
```

Result: **173 passed, 17 skipped**. This includes all 31 CPU-operator tests, existing nonempty-input parity/gradient contracts, graph lowering, and a TensorFlow inference smoke test. The skipped cases are one JAX test (JAX is not installed) and 16 CUDA-only tests; GPU execution is not claimed. The run emitted operator-registration and TorchScript deprecation warnings.

`ruff check .`, `ruff format --check .`, and `git diff --check` passed.

## AI assistance

This implementation and its local verification were prepared with assistance from OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spin descriptor output handling so generated feature dimensions remain consistent across supported configurations.
  - Ensured edge-free and isolated-node graphs produce valid, finite outputs without requiring rotation matrices.

- **Tests**
  - Added coverage for native spin graphs across float32 and float64 precision, multiple channel widths, zero or isolated nodes, and gradient calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->