### PR TITLE
fix(dpmodel): map DPA4 charge-spin conditions to ragged frames

### DIFF
--- a/deepmd/dpmodel/descriptor/dpa4.py
+++ b/deepmd/dpmodel/descriptor/dpa4.py
@@ -65,6 +65,7 @@ from deepmd.dpmodel.utils.exclude_mask import (
 )
 from deepmd.dpmodel.utils.neighbor_graph import (
     apply_pair_exclusion,
+    frame_id_from_n_node,
     graph_from_dense_quartet,
 )
 from deepmd.dpmodel.utils.seed import (
@@ -1373,7 +1374,6 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
         x_scalar, _ = self._run_graph(
             graph,
             atype_flat,
-            nf=nf,
             n_out_nodes=nf * nloc,
             force_embedding=force_embedding,
             charge_spin=charge_spin,
@@ -1430,10 +1430,9 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
             ``default_chg_spin`` when configured, shape validation,
             broadcast to ``nf``); ``call_graph`` is the one owner of that
             step on the graph route. ``nf`` is recovered from
-            ``graph.n_node.shape[0]`` (a static shape, safe under
-            ``torch.export``); each frame's node block must therefore hold
-            exactly ``N // nf`` nodes, which single-rank carry-all graphs
-            built from a rectangular ``(nf, nloc)`` input always satisfy.
+            ``graph.n_node.shape[0]``; each node receives the condition of
+            its frame according to the actual counts in ``graph.n_node``,
+            including when those counts differ between frames.
 
         Returns
         -------
@@ -1455,7 +1454,7 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
             ref=graph.edge_vec,
         )
         x_scalar, _ = self._run_graph(
-            graph, atype, nf=nf, charge_spin=charge_spin, spin=spin, comm_dict=comm_dict
+            graph, atype, charge_spin=charge_spin, spin=spin, comm_dict=comm_dict
         )
         # ``_run_graph`` returns the read-out with its SO(3) singleton
         # axes still attached, shape (n_nodes, 1, 1, channels); flatten to the
@@ -1469,7 +1468,6 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
         graph: NeighborGraph,
         atype_flat: Array,
         *,
-        nf: int = 1,
         n_out_nodes: int | None = None,
         force_embedding: Array | None = None,
         charge_spin: Array | None = None,
@@ -1505,8 +1503,6 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
             geometry/autograd leaf, ``edge_mask`` flags valid edges.
         atype_flat
             Flat node types with shape (N,).
-        nf
-            Frame count (only consumed by the charge/spin FiLM conditioning).
         n_out_nodes
             Leading node count kept for the read-out (owned atoms). ``None``
             keeps all nodes (``atype_flat.shape[0]``).
@@ -1557,8 +1553,7 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
             type_ebed = self._apply_charge_spin_embedding(
                 type_ebed,
                 charge_spin,
-                nf=nf,
-                nloc=n_out_nodes // nf,
+                graph.n_node,
             )
         n_nodes = type_ebed.shape[0]
 
@@ -2012,9 +2007,7 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
         self,
         type_ebed: Array,
         charge_spin: Array,
-        *,
-        nf: int,
-        nloc: int,
+        n_node: Array,
     ) -> Array:
         """
         Add frame-level charge and spin conditions to scalar type features.
@@ -2022,23 +2015,21 @@ class DescrptDPA4(NativeOP, BaseDescriptor):
         Parameters
         ----------
         type_ebed
-            Flattened type embeddings with shape (nf * nloc, channels).
+            Flattened type embeddings with shape (N, channels).
         charge_spin
             Frame-level charge and spin conditions with shape (nf, 2).
-        nf
-            Number of frames.
-        nloc
-            Number of local atoms.
+        n_node
+            Number of nodes in each frame, with shape (nf,).
 
         Returns
         -------
         Array
-            Conditioned type embeddings with shape (nf * nloc, channels).
+            Conditioned type embeddings with shape (N, channels).
         """
         xp = array_api_compat.array_namespace(type_ebed, charge_spin)
         condition = self.charge_spin_embedding(xp.astype(charge_spin, type_ebed.dtype))
-        condition = xp.broadcast_to(condition[:, None, :], (nf, nloc, self.channels))
-        return type_ebed + xp.reshape(condition, type_ebed.shape)
+        frame_index = frame_id_from_n_node(n_node, n_total=type_ebed.shape[0])
+        return type_ebed + xp.take(condition, frame_index, axis=0)
 
     def _apply_spin_embedding(
         self,

--- a/source/tests/common/dpmodel/test_dpa4_call_graph.py
+++ b/source/tests/common/dpmodel/test_dpa4_call_graph.py
@@ -1000,3 +1000,49 @@ def test_call_graph_comm_dict_reaches_leaf_stub() -> None:
     )
     with pytest.raises(NotImplementedError, match="dpmodel backend"):
         dd.call_graph(graph, atype.reshape(-1), comm_dict=fake_comm)
+
+
+@pytest.mark.parametrize("counts", [(1, 2), (1, 3), (2, 2)])
+@pytest.mark.parametrize("precision", ["float32", "float64"])
+@pytest.mark.parametrize("use_default", [False, True])
+def test_call_graph_ragged_charge_spin(counts, precision, use_default) -> None:
+    """Each node must receive its own frame's condition, not N // nf rows."""
+    descriptor = DescrptDPA4(
+        ntypes=1,
+        sel=2,
+        rcut=3.0,
+        channels=4,
+        n_radial=2,
+        lmax=0,
+        kmax=0,
+        n_blocks=0,
+        use_env_seed=False,
+        random_gamma=False,
+        add_chg_spin_ebd=True,
+        default_chg_spin=[-1.0, 3.0],
+        precision=precision,
+        seed=1,
+    )
+    descriptor = DescrptDPA4.deserialize(descriptor.serialize())
+    conditions = np.asarray([[0.0, 1.0], [1.0, 2.0]], dtype=precision)
+
+    def evaluate(frame_counts, charge_spin):
+        # Masked guard edges isolate the frame-to-node conditioning map.
+        graph = NeighborGraph(
+            n_node=np.asarray(frame_counts, dtype=np.int64),
+            edge_index=np.zeros((2, 2), dtype=np.int64),
+            edge_vec=np.zeros((2, 3), dtype=precision),
+            edge_mask=np.zeros(2, dtype=bool),
+        )
+        return descriptor.call_graph(
+            graph,
+            np.zeros(sum(frame_counts), dtype=np.int64),
+            charge_spin=None if use_default else charge_spin,
+        )[0]
+
+    expected = np.concatenate(
+        [evaluate([n], conditions[i : i + 1]) for i, n in enumerate(counts)]
+    )
+    actual = evaluate(counts, conditions)
+    tol = 1e-6 if precision == "float32" else 1e-12
+    np.testing.assert_allclose(actual, expected, rtol=tol, atol=tol)

--- a/source/tests/pt_expt/descriptor/test_dpa4.py
+++ b/source/tests/pt_expt/descriptor/test_dpa4.py
@@ -51,6 +51,66 @@ def make_descriptor(nt, sel, rcut, **overrides) -> DescrptDPA4:
     return DescrptDPA4(**kwargs)
 
 
+@pytest.mark.parametrize("counts", [(1, 2), (1, 3), (2, 2)])
+@pytest.mark.parametrize("precision", ["float32", "float64"])
+@pytest.mark.parametrize("use_default", [False, True])
+def test_call_graph_ragged_charge_spin(counts, precision, use_default) -> None:
+    """Ragged outputs and embedding parameter gradients match single frames."""
+    from deepmd.dpmodel.utils.neighbor_graph import (
+        NeighborGraph,
+    )
+
+    dtype = PRECISION_DICT[precision]
+    descriptor = DescrptDPA4(
+        ntypes=1,
+        sel=2,
+        rcut=3.0,
+        channels=4,
+        n_radial=2,
+        lmax=0,
+        kmax=0,
+        n_blocks=0,
+        use_env_seed=False,
+        random_gamma=False,
+        add_chg_spin_ebd=True,
+        default_chg_spin=[-1.0, 3.0],
+        precision=precision,
+        seed=1,
+    )
+    descriptor = DescrptDPA4.deserialize(descriptor.serialize()).to(env.DEVICE)
+    conditions = torch.tensor(
+        [[0.0, 1.0], [1.0, 2.0]],
+        dtype=dtype,
+        device=env.DEVICE,
+    )
+
+    def evaluate(frame_counts, charge_spin):
+        graph = NeighborGraph(
+            n_node=torch.tensor(frame_counts, dtype=torch.int64, device=env.DEVICE),
+            edge_index=torch.zeros((2, 2), dtype=torch.int64, device=env.DEVICE),
+            edge_vec=torch.zeros((2, 3), dtype=dtype, device=env.DEVICE),
+            edge_mask=torch.zeros(2, dtype=torch.bool, device=env.DEVICE),
+        )
+        return descriptor.call_graph(
+            graph,
+            torch.zeros(sum(frame_counts), dtype=torch.int64, device=env.DEVICE),
+            charge_spin=None if use_default else charge_spin,
+        )[0]
+
+    expected = torch.cat(
+        [evaluate([n], conditions[i : i + 1]) for i, n in enumerate(counts)]
+    )
+    actual = evaluate(counts, conditions)
+    tol = 1e-6 if precision == "float32" else 1e-12
+    torch.testing.assert_close(actual, expected, rtol=tol, atol=tol)
+    parameters = tuple(descriptor.charge_spin_embedding.parameters())
+    expected_grads = torch.autograd.grad(expected.sum(), parameters)
+    actual_grads = torch.autograd.grad(actual.sum(), parameters)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        assert expected_grad.abs().max() > 1e-8
+        torch.testing.assert_close(actual_grad, expected_grad, rtol=tol, atol=tol)
+
+
 class TestDescrptDPA4(TestCaseSingleFrameWithNlist):
     def setup_method(self) -> None:
         TestCaseSingleFrameWithNlist.setUp(self)

--- a/source/tests/pt_expt/model/test_dpa4_graph_lower.py
+++ b/source/tests/pt_expt/model/test_dpa4_graph_lower.py
@@ -128,13 +128,24 @@ _DPA4_CONFIG = {
 }
 
 
-def _make_model(device) -> EnergyModel:
+def _make_model(device, *, add_chg_spin_ebd: bool = False) -> EnergyModel:
     """Build a graph-eligible pt_expt DPA4/SeZM model from the exported config."""
-    model = get_model(_DPA4_CONFIG)
+    model = get_model(
+        {
+            **_DPA4_CONFIG,
+            "descriptor": {
+                **_DPA4_CONFIG["descriptor"],
+                "add_chg_spin_ebd": add_chg_spin_ebd,
+                "default_chg_spin": [-1.0, 3.0] if add_chg_spin_ebd else None,
+            },
+        }
+    )
     return model.to(device)
 
 
-def _make_message_sensitive_model(device, seed: int = 99) -> EnergyModel:
+def _make_message_sensitive_model(
+    device, seed: int = 99, *, add_chg_spin_ebd: bool = False
+) -> EnergyModel:
     """A ``_make_model()`` variant with the zero-init residuals jittered.
 
     DPA4 deliberately zero-initializes several residual output projections
@@ -150,7 +161,7 @@ def _make_message_sensitive_model(device, seed: int = 99) -> EnergyModel:
     the neighbor edges (pinned by an in-test coordinate-perturbation guard
     in ``test_forward_common_graph_matches_dense``).
     """
-    model = _make_model(device)
+    model = _make_model(device, add_chg_spin_ebd=add_chg_spin_ebd)
     ds = model.atomic_model.descriptor
     data = ds.serialize()
     data = jitter_zero_arrays(data, np.random.default_rng(seed))
@@ -160,6 +171,46 @@ def _make_message_sensitive_model(device, seed: int = 99) -> EnergyModel:
     # ``_modules`` entry in place.
     model.atomic_model.descriptor = jittered
     return model
+
+
+@pytest.mark.parametrize("counts", [(1, 2), (1, 3), (2, 2)])
+@pytest.mark.parametrize("use_default", [False, True])
+def test_forward_ragged_charge_spin(counts, use_default) -> None:
+    """Real message-dependent energies, forces and virials respect frame sizes."""
+    model = _make_message_sensitive_model(env.DEVICE, add_chg_spin_ebd=True).eval()
+    model.neighbor_graph_method = "ase"
+    conditions = torch.tensor(
+        [[0.0, 1.0], [1.0, 2.0]], dtype=torch.float64, device=env.DEVICE
+    )
+    frames = [
+        torch.tensor(
+            [[0.6 * j, 0.1 * j, 0.0] for j in range(n)],
+            dtype=torch.float64,
+            device=env.DEVICE,
+        )
+        for n in counts
+    ]
+
+    def evaluate(coords, frame_counts, charge_spin):
+        return model.forward_ragged(
+            coords,
+            torch.zeros(sum(frame_counts), dtype=torch.int64, device=env.DEVICE),
+            torch.tensor(frame_counts, dtype=torch.int64, device=env.DEVICE),
+            charge_spin=None if use_default else charge_spin,
+            do_atomic_virial=True,
+        )
+
+    singles = [
+        evaluate(c, [n], conditions[i : i + 1])
+        for i, (n, c) in enumerate(zip(counts, frames, strict=True))
+    ]
+    # Zero-initialized residuals would make force parity vacuous.
+    assert torch.cat([r["force"] for r in singles]).abs().max() > 1e-8
+    batched = evaluate(torch.cat(frames), counts, conditions)
+    for key in ("energy", "atom_energy", "force", "virial", "atom_virial"):
+        expected = torch.cat([r[key] for r in singles])
+        assert torch.isfinite(batched[key]).all()
+        torch.testing.assert_close(batched[key], expected, rtol=1e-10, atol=1e-12)
 
 
 def _small_graph_inputs(
@@ -511,7 +562,8 @@ class TestDpa4GraphLower:
             out["virial"], ref["energy_derv_c_redu"].reshape(out["virial"].shape), **tol
         )
 
-    def test_graph_lower_torch_export(self) -> None:
+    @pytest.mark.parametrize("add_chg_spin_ebd", [False, True])
+    def test_graph_lower_torch_export(self, add_chg_spin_ebd) -> None:
         """``torch.export.export`` the traced graph lower with the
         production dynamic shapes (``_build_graph_dynamic_shapes``): the
         edge axis ``E``, the flat node axis ``N``, and the frame axis ``nf``
@@ -526,12 +578,16 @@ class TestDpa4GraphLower:
             build_synthetic_graph_inputs,
         )
 
-        model = _make_message_sensitive_model(self.device).to("cpu")
+        model = _make_message_sensitive_model(
+            self.device, add_chg_spin_ebd=add_chg_spin_ebd
+        ).to("cpu")
         model.eval()
         sample = build_synthetic_graph_inputs(
             model,
             e_max=175,
-            nframes=2,
+            # Keep nf distinct from the fixed charge/spin (2) and xyz (3)
+            # axes, which symbolic tracing can otherwise duck-shape together.
+            nframes=5,
             nloc=7,
             dtype=torch.float64,
             device=torch.device("cpu"),
@@ -623,6 +679,7 @@ class TestDpa4GraphLower:
             destination_sorted=True,
             fparam=s_fp,
             aparam=s_ap,
+            charge_spin=s_cs,
             do_atomic_virial=True,
         )
         for key in ("energy", "force", "virial"):


### PR DESCRIPTION
## Summary

Fixes #5992.

DPA4 currently broadcasts each frame's charge/spin embedding to `N // nf` nodes. This raises for `n_node=[1, 2]` and silently assigns the first frame's condition to a node from the second frame for `[1, 3]`.

- Gather the frame embeddings with the existing `frame_id_from_n_node(graph.n_node, n_total=N)` helper.
- Remove the now-unused private `_run_graph(nf=...)` argument and the documented uniform-count restriction. Public arguments, condition canonicalization, and serialization remain unchanged.
- Add NumPy and PyTorch fp32/fp64 graph regressions against independent frame calls for `[1, 2]`, `[1, 3]`, and the equal-size `[2, 2]` control, with explicit and default conditions and a serialization round trip. PyTorch also checks the embedding parameter gradients.
- Exercise the public `EnergyModel.forward_ragged()` path with the existing message-sensitive weight fixture: batch and independent calls agree on energy, atom energy, nonzero forces, virial, and atom virial.
- Extend the dynamic graph-export test to charge-conditioned models. The trace sample uses five frames to avoid duck-shape aliasing with the fixed charge/spin and xyz axes, and the exported model is checked on a smaller one-frame system.

## Validation

Built an independent checkout of upstream `58a12b1e0a72cfcc322c64d70c21469220bef74f` from source in WSL Ubuntu, with Python 3.12.3, PyTorch 2.11.0+cpu, TensorFlow CPU 2.21.0, and the real C++/PyTorch/TensorFlow operators.

Before the production fix, the 30 new ragged regressions produced **15 failed, 15 passed**. With the fix, **30 passed**.

The final related suite produced **130 passed**:

```sh
python -m pytest -q \
  source/tests/common/dpmodel/test_dpa4_call_graph.py \
  source/tests/common/dpmodel/test_descrpt_dpa4.py \
  source/tests/pt_expt/descriptor/test_dpa4.py \
  source/tests/pt_expt/model/test_dpa4_graph_lower.py \
  source/tests/pt_expt/descriptor/test_dpa4c_cpu.py \
  source/tests/tf/test_dp_test.py::TestDPTestEner::test_1frame
```

This includes dense/graph goldens, serialization, dynamic export both with and without conditioning, 31 native CPU-operator tests, and a TensorFlow inference smoke test. Full-repository Ruff lint/format checks (0.16.0), changed-file isort checks (9.0.0b1), and `git diff --check` passed. All four tested source blobs match the submitted files.

CPU validation only; no GPU, JAX, multi-rank execution, or full-project test-suite result is claimed. The run emitted the existing operator-registration warning. Legacy `pt`/cross-backend parity collection requires the optional `e3nn` dependency, absent in this environment; those suites are not included in the 130. Not every pre-commit hook was run locally.

## AI assistance

Implementation and local verification were prepared with OpenAI Codex. Maintainer review and upstream CI remain pending; local test results are not an upstream approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DPA4 descriptor handling for batches containing frames with different numbers of nodes.
  * Corrected charge and spin conditioning so each node uses the values associated with its frame.
  * Ensured consistent outputs, energies, forces, virials, and gradients for ragged frame batches across supported precisions and configurations.

* **Tests**
  * Added coverage for ragged batches, charge/spin embeddings, gradient computation, and graph-based model export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->