### PR TITLE
feat: add named model presets for DPA4 and DPA4C

### DIFF
--- a/deepmd/dpmodel/train/entrypoint.py
+++ b/deepmd/dpmodel/train/entrypoint.py
@@ -27,6 +27,9 @@ from deepmd.utils.argcheck import (
 from deepmd.utils.compat import (
     update_deepmd_input,
 )
+from deepmd.utils.model_preset import (
+    expand_model_preset,
+)
 
 log = logging.getLogger(__name__)
 
@@ -59,6 +62,9 @@ class AbstractTrainEntrypoint(ABC):
         log.info("Configuration path: %s", options.input_file)
         options = self.prepare_options(options)
         config = self.load_config(options.input_file)
+        if "model" in config:
+            # Version-0 inputs gain their model section only in update_input.
+            config["model"] = expand_model_preset(config["model"])
         self.validate_options(config, options)
 
         config = self.preprocess_config(config, options)

--- a/deepmd/pd/entrypoints/main.py
+++ b/deepmd/pd/entrypoints/main.py
@@ -70,6 +70,9 @@ from deepmd.utils.data_system import (
     get_data,
     process_systems,
 )
+from deepmd.utils.model_preset import (
+    expand_model_preset,
+)
 from deepmd.utils.path import (
     DPPath,
 )
@@ -255,6 +258,7 @@ def train(
     if LOCAL_RANK == 0:
         SummaryPrinter()()
     config = j_loader(input_file)
+    config["model"] = expand_model_preset(config["model"])
     # ensure suffix, as in the command line help, we say "path prefix of checkpoint files"
     if init_model is not None and not init_model.endswith(".pd"):
         init_model += ".pd"

--- a/deepmd/pt/entrypoints/main.py
+++ b/deepmd/pt/entrypoints/main.py
@@ -91,6 +91,9 @@ from deepmd.utils.data_system import (
     get_data,
     process_systems,
 )
+from deepmd.utils.model_preset import (
+    expand_model_preset,
+)
 from deepmd.utils.stat_file import (
     StatFileSpec,
 )
@@ -338,6 +341,7 @@ def train(
     if LOCAL_RANK == 0:
         SummaryPrinter()()
     config = j_loader(input_file)
+    config["model"] = expand_model_preset(config["model"])
     # ensure suffix, as in the command line help, we say "path prefix of checkpoint files"
     if init_model is not None and not init_model.endswith(".pt"):
         init_model += ".pt"

--- a/deepmd/utils/argcheck.py
+++ b/deepmd/utils/argcheck.py
@@ -478,9 +478,9 @@ def descrpt_dpa4c_args() -> list[Argument]:
                 "are 8, 16, 32, 64, and 128. This is the primary scaling "
                 "knob: it widens the edge features, the per-atom angular "
                 "state, and the descriptor output together. The fitting "
-                "network is sized against it; the released grades pair "
-                "channels 8, 32, 64, and 128 with fitting hidden widths 96, "
-                "192, 256, and 384."
+                "network is sized against it; the released grades are "
+                "available as named model presets (see the DPA4C model "
+                "documentation)."
             ),
         ),
         Argument(

--- a/deepmd/utils/compat.py
+++ b/deepmd/utils/compat.py
@@ -18,6 +18,9 @@ import numpy as np
 from deepmd.common import (
     j_deprecated,
 )
+from deepmd.utils.model_preset import (
+    expand_model_preset,
+)
 
 
 def convert_input_v0_v1(
@@ -458,6 +461,7 @@ def update_deepmd_input(
 
     jdata = migrate_training_warmup(jdata, warning=warning)
     jdata = convert_optimizer_v31_to_v32(jdata, warning=warning)
+    jdata["model"] = expand_model_preset(jdata["model"])
     return jdata
 
 

--- a/deepmd/utils/model_preset.py
+++ b/deepmd/utils/model_preset.py
@@ -17,6 +17,11 @@ version lists the options it changed together with the grades it ships. A new
 version therefore adds one entry to the family's version table, and a new
 grade adds one entry to its grade table. Existing versions are never edited.
 
+In the multi-task layout a preset next to ``model_dict`` is the base of every
+branch and of the ``shared_dict`` entries the branches reference as
+``descriptor`` or ``fitting_net``, so a shared descriptor is written as just
+its run-specific keys.
+
 Presets are expanded before any other processing of the model configuration
 (multi-task sharing, fine-tuning rules, argument checking), see
 :func:`expand_model_preset`.
@@ -63,6 +68,7 @@ _PRESET_REGIONS = ("type", "type_map", "descriptor", "fitting_net")
 # === DPA4 (SeZM) ===
 # Descriptor and fitting options shared by every DPA4 grade and version.
 _DPA4_DESCRIPTOR: dict[str, Any] = {
+    "type": "dpa4",
     "rcut": 6.0,
     "n_radial": 16,
     "use_env_seed": True,
@@ -79,7 +85,11 @@ _DPA4_DESCRIPTOR: dict[str, Any] = {
     "so3_readout": "mlp",
     "precision": "float32",
 }
-_DPA4_FITTING: dict[str, Any] = {"neuron": [0], "precision": "float32"}
+_DPA4_FITTING: dict[str, Any] = {
+    "type": "dpa4_ener",
+    "neuron": [0],
+    "precision": "float32",
+}
 # Scaling knobs of each grade.
 _DPA4_GRADES: dict[str, dict[str, dict[str, Any]]] = {
     "nano": {
@@ -198,6 +208,7 @@ _DPA4C_DESCRIPTOR: dict[str, Any] = {
     "precision": "float32",
 }
 _DPA4C_FITTING: dict[str, Any] = {
+    "type": "ener",
     "resnet_dt": False,
     "activation_function": "silu",
     "precision": "float32",
@@ -311,6 +322,41 @@ def get_model_preset(name: str) -> dict[str, Any]:
     return deepcopy(MODEL_PRESETS[key])
 
 
+def _merge_region(
+    region: str, preset_value: Any, explicit: Any, overrides: list[str]
+) -> Any:
+    """Combine one preset region with its explicit counterpart.
+
+    A mapping is merged key by key: explicit keys replace preset keys, other
+    keys supplement the preset, and lists inside are replaced as a whole. Any
+    other explicit value (a scalar, a list, a multi-task shared-dict reference)
+    replaces the region entirely. Entries that change a preset value are
+    appended to ``overrides``; a shared-dict reference is wiring, not an
+    override, and is not reported.
+    """
+    if isinstance(explicit, dict):
+        overrides.extend(
+            f"{region}.{key}"
+            for key, value in explicit.items()
+            if key in preset_value and value != preset_value[key]
+        )
+        return {**preset_value, **explicit}
+    if isinstance(explicit, str) and region != "type":
+        return explicit
+    if explicit != preset_value:
+        overrides.append(region)
+    return explicit
+
+
+def _log_expansion(name: str, overrides: list[str], scope: str = "") -> None:
+    log.info(
+        "Expanded model preset %r%s%s.",
+        name,
+        scope,
+        f" with explicit overrides: {', '.join(overrides)}" if overrides else "",
+    )
+
+
 def _expand_single(model_config: dict[str, Any]) -> dict[str, Any]:
     """Expand the preset of one single-task model or one multi-task branch."""
     if "preset" not in model_config:
@@ -324,31 +370,42 @@ def _expand_single(model_config: dict[str, Any]) -> dict[str, Any]:
             continue
         if region not in model_config:
             expanded[region] = preset[region]
-            continue
-        explicit = model_config[region]
-        if isinstance(explicit, dict):
-            # Key-wise merge: explicit keys replace preset keys, other keys
-            # supplement the preset. Lists inside are replaced as a whole.
-            overrides.extend(
-                f"{region}.{key}"
-                for key, value in explicit.items()
-                if key in preset[region] and value != preset[region][key]
-            )
-            expanded[region] = {**preset[region], **explicit}
         else:
-            # A scalar, a list or a multi-task shared-dict reference replaces
-            # the preset region entirely.
-            if explicit != preset[region]:
-                overrides.append(region)
-            expanded[region] = explicit
+            expanded[region] = _merge_region(
+                region, preset[region], model_config[region], overrides
+            )
     for key, value in model_config.items():
         if key != "preset" and key not in expanded:
             expanded[key] = value
-    log.info(
-        "Expanded model preset %r%s.",
-        name,
-        f" with explicit overrides: {', '.join(overrides)}" if overrides else "",
-    )
+    _log_expansion(name, overrides)
+    return expanded
+
+
+def _expand_shared_dict(
+    name: str, shared_dict: dict[str, Any], branches: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge the shared entries referenced as ``descriptor`` or ``fitting_net``
+    over the corresponding regions of the preset ``name``.
+    """
+    roles: dict[str, str] = {}
+    for branch in branches.values():
+        if not isinstance(branch, dict):
+            continue
+        for region in ("descriptor", "fitting_net"):
+            reference = branch.get(region)
+            if isinstance(reference, str):
+                roles[reference.split(":")[0]] = region
+    preset = get_model_preset(name)
+    expanded: dict[str, Any] = {}
+    overrides: list[str] = []
+    merged: list[str] = []
+    for key, entry in shared_dict.items():
+        if key in roles and isinstance(entry, dict):
+            entry = _merge_region(key, preset[roles[key]], entry, overrides)
+            merged.append(key)
+        expanded[key] = entry
+    if merged:
+        _log_expansion(name, overrides, f" for shared entries {', '.join(merged)}")
     return expanded
 
 
@@ -359,11 +416,13 @@ def expand_model_preset(model_config: dict[str, Any]) -> dict[str, Any]:
     The single-task ``model`` section and every branch of a multi-task
     ``model_dict`` may carry a ``preset``. In the multi-task layout a
     ``preset`` next to ``model_dict`` is the default for every branch that
-    has none of its own, and ``type``, ``type_map``, ``descriptor`` and
-    ``fitting_net`` written next to ``model_dict`` are branch defaults in the
-    same way as the model-wide options of the PyTorch backend, so they take
-    part in the merge of every branch that expands a preset. The preset
-    supplies ``type``, ``type_map``, ``descriptor`` and ``fitting_net``;
+    has none of its own and the base of the ``shared_dict`` entries that the
+    branches reference as ``descriptor`` or ``fitting_net``; ``type``,
+    ``type_map``, ``descriptor`` and ``fitting_net`` written next to
+    ``model_dict`` are branch defaults in the same way as the model-wide
+    options of the PyTorch backend, so they take part in the merge of every
+    branch that expands a preset. The preset supplies ``type``, ``type_map``,
+    ``descriptor`` and ``fitting_net``;
     entries written explicitly take precedence key by key inside
     ``descriptor`` and ``fitting_net`` and as a whole for ``type`` and
     ``type_map``. The ``preset`` key itself is removed, so the result is a
@@ -407,6 +466,10 @@ def expand_model_preset(model_config: dict[str, Any]) -> dict[str, Any]:
         if key in model_config
     }
     expanded = {key: value for key, value in model_config.items() if key != "preset"}
+    if has_default and isinstance(model_config.get("shared_dict"), dict):
+        expanded["shared_dict"] = _expand_shared_dict(
+            model_config["preset"], model_config["shared_dict"], branches
+        )
     expanded["model_dict"] = {}
     for branch_name, branch in branches.items():
         if isinstance(branch, dict) and (has_default or "preset" in branch):

--- a/deepmd/utils/model_preset.py
+++ b/deepmd/utils/model_preset.py
@@ -5,8 +5,9 @@ A preset names a released model architecture. Writing ``"preset":
 "<family>-<grade>-<version>"`` in the ``model`` section of an input file
 fills in the four architecture-defining regions of the model configuration:
 ``type``, ``type_map``, ``descriptor`` and ``fitting_net``. Entries written
-explicitly next to the preset take precedence, key by key, so a cutoff radius
-or a fitting width can be overridden, and options that are not part of an
+explicitly next to the preset take precedence: ``type`` and ``type_map`` as a
+whole, ``descriptor`` and ``fitting_net`` key by key, so a cutoff radius or a
+fitting width can be overridden, and options that are not part of an
 architecture (``use_amp``, ``seed``, ``sel``, charge and spin conditioning,
 ...) are supplied alongside the preset.
 
@@ -358,12 +359,16 @@ def expand_model_preset(model_config: dict[str, Any]) -> dict[str, Any]:
     The single-task ``model`` section and every branch of a multi-task
     ``model_dict`` may carry a ``preset``. In the multi-task layout a
     ``preset`` next to ``model_dict`` is the default for every branch that
-    has none of its own. The preset supplies ``type``, ``type_map``,
-    ``descriptor`` and ``fitting_net``; entries written explicitly take
-    precedence key by key inside ``descriptor`` and ``fitting_net`` and as a
-    whole for ``type`` and ``type_map``. The ``preset`` key itself is removed,
-    so the result is a plain model configuration and the function is
-    idempotent. Branches that are not mappings are left to the argument check.
+    has none of its own, and ``type``, ``type_map``, ``descriptor`` and
+    ``fitting_net`` written next to ``model_dict`` are branch defaults in the
+    same way as the model-wide options of the PyTorch backend, so they take
+    part in the merge of every branch that expands a preset. The preset
+    supplies ``type``, ``type_map``, ``descriptor`` and ``fitting_net``;
+    entries written explicitly take precedence key by key inside
+    ``descriptor`` and ``fitting_net`` and as a whole for ``type`` and
+    ``type_map``. The ``preset`` key itself is removed, so the result is a
+    plain model configuration and the function is idempotent. A ``model_dict``
+    or a branch that is not a mapping is left to the argument check.
 
     Parameters
     ----------
@@ -386,17 +391,25 @@ def expand_model_preset(model_config: dict[str, Any]) -> dict[str, Any]:
         return _expand_single(model_config)
     branches = model_config["model_dict"]
     has_default = "preset" in model_config
-    if not has_default and not any(
-        isinstance(branch, dict) and "preset" in branch for branch in branches.values()
+    if not isinstance(branches, dict) or (
+        not has_default
+        and not any(
+            isinstance(branch, dict) and "preset" in branch
+            for branch in branches.values()
+        )
     ):
         return model_config
-    default_preset = model_config.get("preset")
+    # Branch defaults: the default preset and the region entries written next
+    # to ``model_dict``. Branch entries replace them as whole values.
+    defaults = {
+        key: model_config[key]
+        for key in ("preset", *_PRESET_REGIONS)
+        if key in model_config
+    }
     expanded = {key: value for key, value in model_config.items() if key != "preset"}
     expanded["model_dict"] = {}
     for branch_name, branch in branches.items():
-        if isinstance(branch, dict):
-            if has_default and "preset" not in branch:
-                branch = {"preset": default_preset, **branch}
-            branch = _expand_single(branch)
+        if isinstance(branch, dict) and (has_default or "preset" in branch):
+            branch = _expand_single({**defaults, **branch})
         expanded["model_dict"][branch_name] = branch
     return expanded

--- a/deepmd/utils/model_preset.py
+++ b/deepmd/utils/model_preset.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Named model presets for the DPA4 family.
+
+A preset names a released model architecture. Writing ``"preset":
+"<family>-<grade>-<version>"`` in the ``model`` section of an input file
+fills in the four architecture-defining regions of the model configuration:
+``type``, ``type_map``, ``descriptor`` and ``fitting_net``. Entries written
+explicitly next to the preset take precedence, key by key, so a cutoff radius
+or a fitting width can be overridden, and options that are not part of an
+architecture (``use_amp``, ``seed``, ``sel``, charge and spin conditioning,
+...) are supplied alongside the preset.
+
+The tables below are organised per family. Shared descriptor and fitting
+options are written once, every grade lists only its scaling knobs, and every
+version lists the options it changed together with the grades it ships. A new
+version therefore adds one entry to the family's version table, and a new
+grade adds one entry to its grade table. Existing versions are never edited.
+
+Presets are expanded before any other processing of the model configuration
+(multi-task sharing, fine-tuning rules, argument checking), see
+:func:`expand_model_preset`.
+"""
+
+import logging
+from copy import (
+    deepcopy,
+)
+from typing import (
+    Any,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "MODEL_PRESETS",
+    "PERIODIC_TABLE",
+    "expand_model_preset",
+    "get_model_preset",
+]
+
+# fmt: off
+PERIODIC_TABLE: tuple[str, ...] = (
+    "H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na", "Mg", "Al",
+    "Si", "P", "S", "Cl", "Ar", "K", "Ca", "Sc", "Ti", "V", "Cr", "Mn", "Fe",
+    "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr",
+    "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn",
+    "Sb", "Te", "I", "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd", "Pm", "Sm",
+    "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu", "Hf", "Ta", "W",
+    "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn",
+    "Fr", "Ra", "Ac", "Th", "Pa", "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf",
+    "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds",
+    "Rg", "Cn", "Nh", "Fl", "Mc", "Lv", "Ts", "Og",
+)
+"""The 118 element symbols in atomic-number order, the ``type_map`` of every preset."""
+# fmt: on
+
+# Regions a preset may define. An expanded configuration lists the regions its
+# preset defines first, in this order, followed by the remaining explicit
+# entries in their original order.
+_PRESET_REGIONS = ("type", "type_map", "descriptor", "fitting_net")
+
+# === DPA4 (SeZM) ===
+# Descriptor and fitting options shared by every DPA4 grade and version.
+_DPA4_DESCRIPTOR: dict[str, Any] = {
+    "rcut": 6.0,
+    "n_radial": 16,
+    "use_env_seed": True,
+    "mmax": 1,
+    "radial_so2_mode": "degree_channel",
+    "focus_dim": 0,
+    "n_atten_head": 1,
+    "message_node_so3": True,
+    "ffn_neurons": 0,
+    "ffn_so3_grid": True,
+    "grid_mlp": False,
+    "grid_branch": [0, 0, 1],
+    "ffn_blocks": 1,
+    "so3_readout": "mlp",
+    "precision": "float32",
+}
+_DPA4_FITTING: dict[str, Any] = {"neuron": [0], "precision": "float32"}
+# Scaling knobs of each grade.
+_DPA4_GRADES: dict[str, dict[str, dict[str, Any]]] = {
+    "nano": {
+        "descriptor": {
+            "channels": 32,
+            "lmax": 1,
+            "n_blocks": 2,
+            "mixing_layers": 3,
+            "radial_so2_mode": "none",
+            "n_focus": 1,
+        },
+    },
+    "mini": {
+        "descriptor": {
+            "channels": 32,
+            "lmax": 2,
+            "n_blocks": 2,
+            "mixing_layers": 3,
+            "radial_so2_rank": 1,
+            "n_focus": 1,
+        },
+    },
+    "neo": {
+        "descriptor": {
+            "channels": 32,
+            "lmax": 3,
+            "n_blocks": 2,
+            "mixing_layers": 3,
+            "radial_so2_rank": 1,
+            "n_focus": 2,
+        },
+    },
+    "air": {
+        "descriptor": {
+            "channels": 64,
+            "lmax": 3,
+            "n_blocks": 3,
+            "mixing_layers": 4,
+            "radial_so2_rank": 1,
+            "n_focus": 1,
+        },
+    },
+    "plus": {
+        "descriptor": {
+            "channels": 64,
+            "lmax": 4,
+            "n_blocks": 4,
+            "mixing_layers": 4,
+            "radial_so2_rank": 2,
+            "n_focus": 1,
+        },
+    },
+    "pro": {
+        "descriptor": {
+            "channels": 64,
+            "lmax": 5,
+            "n_blocks": 6,
+            "mixing_layers": 4,
+            "radial_so2_rank": 2,
+            "n_focus": 2,
+            "so3_readout": "none",
+        },
+    },
+    "max": {
+        "descriptor": {
+            "channels": 96,
+            "lmax": 6,
+            "n_blocks": 8,
+            "mixing_layers": 4,
+            "radial_so2_rank": 4,
+            "n_focus": 2,
+            "so3_readout": "none",
+        },
+    },
+    "ultra": {
+        "descriptor": {
+            "channels": 128,
+            "lmax": 6,
+            "n_blocks": 10,
+            "mixing_layers": 4,
+            "radial_so2_rank": 4,
+            "n_focus": 3,
+            "message_node_so3": False,
+            "ffn_so3_grid": False,
+            "grid_branch": 0,
+        },
+    },
+}
+# Options that changed with each version, and the grades the version ships.
+_DPA4_VERSIONS: dict[str, dict[str, Any]] = {
+    # Channel RMSNorm on every cutoff-vanishing branch; post-norm after the
+    # SO(2) branch and pre-norm before the FFN branch.
+    "v20260820": {
+        "descriptor": {
+            "edge_norm": True,
+            "sandwich_norm": [False, True, True, False],
+        },
+        "grades": ("nano", "mini", "neo", "air", "plus", "pro"),
+    },
+    # Radial-site RMSNorm removed; pre-norm before both the SO(2) and the FFN
+    # branch.
+    "v20260901": {
+        "descriptor": {
+            "edge_norm": [False, True, True],
+            "sandwich_norm": [True, False, True, False],
+        },
+        "grades": ("nano", "mini", "neo", "air", "plus", "pro", "max", "ultra"),
+    },
+}
+
+# === DPA4C ===
+# DPA4C is a descriptor of the standard model, so no model ``type`` is set.
+_DPA4C_DESCRIPTOR: dict[str, Any] = {
+    "type": "dpa4c",
+    "rcut": 6.0,
+    "precision": "float32",
+}
+_DPA4C_FITTING: dict[str, Any] = {
+    "resnet_dt": False,
+    "activation_function": "silu",
+    "precision": "float32",
+}
+_DPA4C_GRADES: dict[str, dict[str, dict[str, Any]]] = {
+    "nano": {
+        "descriptor": {"channels": 8, "lmax": 2, "radial_modes": 0},
+        "fitting_net": {"neuron": [96, 96, 96]},
+    },
+    "mini": {
+        "descriptor": {"channels": 32, "lmax": 2, "radial_modes": 0},
+        "fitting_net": {"neuron": [192, 192, 192]},
+    },
+    "neo": {
+        "descriptor": {"channels": 64, "lmax": 2, "radial_modes": 0},
+        "fitting_net": {"neuron": [256, 256, 256]},
+    },
+    "air": {
+        "descriptor": {"channels": 64, "lmax": 3, "radial_modes": 4},
+        "fitting_net": {"neuron": [256, 256, 256]},
+    },
+    "plus": {
+        "descriptor": {"channels": 128, "lmax": 3, "radial_modes": 4},
+        "fitting_net": {"neuron": [384, 384, 384]},
+    },
+}
+_DPA4C_VERSIONS: dict[str, dict[str, Any]] = {
+    "v20260901": {"grades": ("nano", "mini", "neo", "air", "plus")},
+}
+
+
+def _build_family(
+    family: str,
+    model_options: dict[str, Any],
+    descriptor: dict[str, Any],
+    fitting_net: dict[str, Any],
+    grades: dict[str, dict[str, dict[str, Any]]],
+    versions: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """
+    Compose the presets ``<family>-<grade>-<version>`` of one family.
+
+    ``model_options`` holds the model-level entries shared by every preset of
+    the family (the model ``type`` for DPA4, nothing for DPA4C). ``descriptor``
+    and ``fitting_net`` hold the options shared by every grade and version.
+    Each grade in ``grades`` adds its own ``descriptor`` and ``fitting_net``
+    options, and each version in ``versions`` adds the ``descriptor`` options
+    it changed and names the grades it ships.
+    """
+    presets: dict[str, dict[str, Any]] = {}
+    for version, spec in versions.items():
+        for grade in spec["grades"]:
+            presets[f"{family}-{grade}-{version}"] = {
+                **model_options,
+                "type_map": list(PERIODIC_TABLE),
+                "descriptor": {
+                    **descriptor,
+                    **spec.get("descriptor", {}),
+                    **grades[grade].get("descriptor", {}),
+                },
+                "fitting_net": {**fitting_net, **grades[grade].get("fitting_net", {})},
+            }
+    return presets
+
+
+MODEL_PRESETS: dict[str, dict[str, Any]] = {
+    **_build_family(
+        "dpa4",
+        {"type": "dpa4"},
+        _DPA4_DESCRIPTOR,
+        _DPA4_FITTING,
+        _DPA4_GRADES,
+        _DPA4_VERSIONS,
+    ),
+    **_build_family(
+        "dpa4c", {}, _DPA4C_DESCRIPTOR, _DPA4C_FITTING, _DPA4C_GRADES, _DPA4C_VERSIONS
+    ),
+}
+"""All presets keyed by name; each value holds the regions the preset defines."""
+
+
+def get_model_preset(name: str) -> dict[str, Any]:
+    """
+    Return a copy of the model regions defined by a named preset.
+
+    Parameters
+    ----------
+    name : str
+        The preset name, ``<family>-<grade>-<version>``, matched
+        case-insensitively.
+
+    Returns
+    -------
+    dict[str, Any]
+        A deep copy of the preset's ``type`` (when set), ``type_map``,
+        ``descriptor`` and ``fitting_net``.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is not a string or names no preset.
+    """
+    if not isinstance(name, str):
+        raise ValueError(f"model preset must be a string naming a preset, got {name!r}")
+    key = name.lower()
+    if key not in MODEL_PRESETS:
+        raise ValueError(
+            f"Unknown model preset {name!r}. Available presets: "
+            + ", ".join(MODEL_PRESETS)
+        )
+    return deepcopy(MODEL_PRESETS[key])
+
+
+def _expand_single(model_config: dict[str, Any]) -> dict[str, Any]:
+    """Expand the preset of one single-task model or one multi-task branch."""
+    if "preset" not in model_config:
+        return model_config
+    name = model_config["preset"]
+    preset = get_model_preset(name)
+    expanded: dict[str, Any] = {}
+    overrides: list[str] = []
+    for region in _PRESET_REGIONS:
+        if region not in preset:
+            continue
+        if region not in model_config:
+            expanded[region] = preset[region]
+            continue
+        explicit = model_config[region]
+        if isinstance(explicit, dict):
+            # Key-wise merge: explicit keys replace preset keys, other keys
+            # supplement the preset. Lists inside are replaced as a whole.
+            overrides.extend(
+                f"{region}.{key}"
+                for key, value in explicit.items()
+                if key in preset[region] and value != preset[region][key]
+            )
+            expanded[region] = {**preset[region], **explicit}
+        else:
+            # A scalar, a list or a multi-task shared-dict reference replaces
+            # the preset region entirely.
+            if explicit != preset[region]:
+                overrides.append(region)
+            expanded[region] = explicit
+    for key, value in model_config.items():
+        if key != "preset" and key not in expanded:
+            expanded[key] = value
+    log.info(
+        "Expanded model preset %r%s.",
+        name,
+        f" with explicit overrides: {', '.join(overrides)}" if overrides else "",
+    )
+    return expanded
+
+
+def expand_model_preset(model_config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Expand the ``preset`` entries of a model configuration.
+
+    The single-task ``model`` section and every branch of a multi-task
+    ``model_dict`` may carry a ``preset``. In the multi-task layout a
+    ``preset`` next to ``model_dict`` is the default for every branch that
+    has none of its own. The preset supplies ``type``, ``type_map``,
+    ``descriptor`` and ``fitting_net``; entries written explicitly take
+    precedence key by key inside ``descriptor`` and ``fitting_net`` and as a
+    whole for ``type`` and ``type_map``. The ``preset`` key itself is removed,
+    so the result is a plain model configuration and the function is
+    idempotent. Branches that are not mappings are left to the argument check.
+
+    Parameters
+    ----------
+    model_config : dict[str, Any]
+        The ``model`` section of an input file. It is not modified; the
+        explicit values it holds are reused in the result rather than copied.
+
+    Returns
+    -------
+    dict[str, Any]
+        The expanded model configuration, or ``model_config`` itself when it
+        carries no preset.
+
+    Raises
+    ------
+    ValueError
+        If a preset name is not a string or is unknown.
+    """
+    if "model_dict" not in model_config:
+        return _expand_single(model_config)
+    branches = model_config["model_dict"]
+    has_default = "preset" in model_config
+    if not has_default and not any(
+        isinstance(branch, dict) and "preset" in branch for branch in branches.values()
+    ):
+        return model_config
+    default_preset = model_config.get("preset")
+    expanded = {key: value for key, value in model_config.items() if key != "preset"}
+    expanded["model_dict"] = {}
+    for branch_name, branch in branches.items():
+        if isinstance(branch, dict):
+            if has_default and "preset" not in branch:
+                branch = {"preset": default_preset, **branch}
+            branch = _expand_single(branch)
+        expanded["model_dict"][branch_name] = branch
+    return expanded

--- a/deepmd/utils/model_preset.py
+++ b/deepmd/utils/model_preset.py
@@ -35,6 +35,11 @@ from typing import (
     Any,
 )
 
+from deepmd.utils.argcheck import (
+    descrpt_args_plugin,
+    fitting_args_plugin,
+)
+
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -64,6 +69,13 @@ PERIODIC_TABLE: tuple[str, ...] = (
 # preset defines first, in this order, followed by the remaining explicit
 # entries in their original order.
 _PRESET_REGIONS = ("type", "type_map", "descriptor", "fitting_net")
+
+# Argument-schema plugin that resolves the legacy key aliases of a region's
+# component, keyed by the region name.
+_REGION_ARGS_PLUGIN = {
+    "descriptor": descrpt_args_plugin,
+    "fitting_net": fitting_args_plugin,
+}
 
 # === DPA4 (SeZM) ===
 # Descriptor and fitting options shared by every DPA4 grade and version.
@@ -322,19 +334,41 @@ def get_model_preset(name: str) -> dict[str, Any]:
     return deepcopy(MODEL_PRESETS[key])
 
 
+def _canonicalize_aliases(
+    region: str, component_type: Any, explicit: dict[str, Any]
+) -> dict[str, Any]:
+    """Resolve legacy key aliases in ``explicit`` to their canonical name.
+
+    Without this, an override that names a preset-defined key by a legacy
+    alias (for example ``so2_layers`` for ``mixing_layers``) would sit next to
+    the preset's canonical key instead of replacing it, and the argument check
+    would then reject the alias as an unknown key.
+    """
+    plugin = _REGION_ARGS_PLUGIN.get(region)
+    if plugin is None or not isinstance(component_type, str):
+        return explicit
+    try:
+        schema = plugin.get_argument(component_type)
+    except KeyError:
+        return explicit
+    return schema.normalize_value(explicit, do_default=False, do_alias=True)
+
+
 def _merge_region(
     region: str, preset_value: Any, explicit: Any, overrides: list[str]
 ) -> Any:
     """Combine one preset region with its explicit counterpart.
 
-    A mapping is merged key by key: explicit keys replace preset keys, other
-    keys supplement the preset, and lists inside are replaced as a whole. Any
-    other explicit value (a scalar, a list, a multi-task shared-dict reference)
-    replaces the region entirely. Entries that change a preset value are
-    appended to ``overrides``; a shared-dict reference is wiring, not an
-    override, and is not reported.
+    ``descriptor`` and ``fitting_net`` are merged key by key: explicit keys
+    replace preset keys, other keys supplement the preset, and lists inside
+    are replaced as a whole. ``type`` and ``type_map``, and any other explicit
+    value given for ``descriptor`` or ``fitting_net`` (a multi-task shared-dict
+    reference), replace the region entirely. Entries that change a preset
+    value are appended to ``overrides``; a shared-dict reference is wiring,
+    not an override, and is not reported.
     """
-    if isinstance(explicit, dict):
+    if region in ("descriptor", "fitting_net") and isinstance(explicit, dict):
+        explicit = _canonicalize_aliases(region, preset_value.get("type"), explicit)
         overrides.extend(
             f"{region}.{key}"
             for key, value in explicit.items()
@@ -401,7 +435,8 @@ def _expand_shared_dict(
     merged: list[str] = []
     for key, entry in shared_dict.items():
         if key in roles and isinstance(entry, dict):
-            entry = _merge_region(key, preset[roles[key]], entry, overrides)
+            region = roles[key]
+            entry = _merge_region(region, preset[region], entry, overrides)
             merged.append(key)
         expanded[key] = entry
     if merged:
@@ -465,14 +500,34 @@ def expand_model_preset(model_config: dict[str, Any]) -> dict[str, Any]:
         for key in ("preset", *_PRESET_REGIONS)
         if key in model_config
     }
-    expanded = {key: value for key, value in model_config.items() if key != "preset"}
+    # Every branch that receives the top-level default, or carries its own
+    # preset, is merged with the defaults before its own preset is expanded;
+    # a branch that reaches neither path is passed through untouched. The
+    # shared-dict role scan below reads these merged branches, so an entry
+    # inherited only through a top-level default (a shared-dict reference
+    # among them) is still recognised as referenced.
+    merged_branches = {
+        branch_name: (
+            {**defaults, **branch}
+            if isinstance(branch, dict) and (has_default or "preset" in branch)
+            else branch
+        )
+        for branch_name, branch in branches.items()
+    }
+    expanded = {
+        key: value
+        for key, value in model_config.items()
+        # The regions distributed to every branch above no longer belong at
+        # the top level; a downstream backend without its own model-wide
+        # cascade would otherwise reject them as unknown top-level keys.
+        if key != "preset" and not (has_default and key in _PRESET_REGIONS)
+    }
     if has_default and isinstance(model_config.get("shared_dict"), dict):
         expanded["shared_dict"] = _expand_shared_dict(
-            model_config["preset"], model_config["shared_dict"], branches
+            model_config["preset"], model_config["shared_dict"], merged_branches
         )
-    expanded["model_dict"] = {}
-    for branch_name, branch in branches.items():
-        if isinstance(branch, dict) and (has_default or "preset" in branch):
-            branch = _expand_single({**defaults, **branch})
-        expanded["model_dict"][branch_name] = branch
+    expanded["model_dict"] = {
+        branch_name: (_expand_single(branch) if isinstance(branch, dict) else branch)
+        for branch_name, branch in merged_branches.items()
+    }
     return expanded

--- a/doc/model/dpa4.md
+++ b/doc/model/dpa4.md
@@ -83,6 +83,71 @@ unnecessary and not recommended (see [Hardware selection](#hardware-selection)).
 > `sum(sel)`. You can also set `sel` to `auto` or `auto:factor` to size it from
 > the training data.
 
+### Presets
+
+The released DPA4 grades are available as named model presets. Setting
+`model.preset` fills in the four architecture-defining regions of the model
+section, `type`, `type_map` (all 118 elements), `descriptor` and
+`fitting_net`, from the release configuration, so an input only names the grade
+and adds what is specific to the run:
+
+```json
+{
+  "model": {
+    "preset": "dpa4-nano-v20260901",
+    "type_map": [
+      "O",
+      "H"
+    ],
+    "descriptor": {
+      "rcut": 6.0,
+      "use_amp": true,
+      "seed": 42
+    },
+    "fitting_net": {
+      "seed": 42
+    }
+  }
+}
+```
+
+The preset is expanded when the input is read, before fine-tuning rules,
+multi-task sharing and argument checking, and the `preset` key is removed, so
+`out.json` records the fully expanded model. Entries written next to the preset
+take precedence over it:
+
+- `type` and `type_map` are replaced as a whole. The two-element `type_map`
+  above replaces the 118-element periodic table of the preset.
+- Inside `descriptor` and `fitting_net` the merge is key by key: a key that the
+  preset defines takes the explicit value (`rcut` above, written here with the
+  value the preset has anyway), and a key it does not define is added. Options
+  that are not part of an architecture are meant to be added this way:
+  `use_amp`, `seed`, `sel`, `trainable`, and the charge and spin conditioning
+  pair `add_chg_spin_ebd` / `default_chg_spin` for molecular datasets.
+
+Every explicit entry that changes a preset value is reported in the log. A
+`preset` inside a multi-task `model_dict` branch applies to that branch, and a
+`preset` next to `model_dict` is the default for every branch without one.
+Shared-dictionary references written in a branch keep precedence over the
+preset, and the entries of `shared_dict` itself are still written out in full,
+since a preset cannot feed them.
+
+Preset names are `<family>-<grade>-<version>`. The version tag identifies the
+release a preset reproduces: a later release with different settings gets a new
+version, and existing presets are never changed. The available DPA4 presets
+are, in ascending cost:
+
+- `v20260901`, the current release grades: `dpa4-nano-v20260901`,
+  `dpa4-mini-v20260901`, `dpa4-neo-v20260901`, `dpa4-air-v20260901`,
+  `dpa4-plus-v20260901`, `dpa4-pro-v20260901`, `dpa4-max-v20260901` and
+  `dpa4-ultra-v20260901`.
+- `v20260820`, the earlier baseline grades: `dpa4-nano-v20260820`,
+  `dpa4-mini-v20260820`, `dpa4-neo-v20260820`, `dpa4-air-v20260820`,
+  `dpa4-plus-v20260820` and `dpa4-pro-v20260820`.
+
+`examples/water/dpa4/input_preset.json` is a water example that names a preset
+instead of spelling out the architecture.
+
 ### Main options
 
 Every descriptor option, with its default and full description, is listed in

--- a/doc/model/dpa4.md
+++ b/doc/model/dpa4.md
@@ -125,12 +125,13 @@ take precedence over it:
   `use_amp`, `seed`, `sel`, `trainable`, and the charge and spin conditioning
   pair `add_chg_spin_ebd` / `default_chg_spin` for molecular datasets.
 
-Every explicit entry that changes a preset value is reported in the log. A
-`preset` inside a multi-task `model_dict` branch applies to that branch, and a
-`preset` next to `model_dict` is the default for every branch without one.
-Shared-dictionary references written in a branch keep precedence over the
-preset, and the entries of `shared_dict` itself are still written out in full,
-since a preset cannot feed them.
+Every explicit entry that changes a preset value is reported in the log. In
+multi-task training a `preset` next to `model_dict` is the base of every branch
+and of the `shared_dict` entries that the branches reference as `descriptor` or
+`fitting_net`, so a shared descriptor is written as just its run-specific keys;
+a `preset` inside a branch applies to that branch alone, and shared-dictionary
+references written in a branch keep precedence over the preset. See
+`examples/water/dpa4/input_multitask_preset.json`.
 
 Preset names are `<family>-<grade>-<version>`. The version tag identifies the
 release a preset reproduces: a later release with different settings gets a new
@@ -349,7 +350,9 @@ DPA4/SeZM supports shared-fitting multitask training. With
 of being concatenated to the descriptor, which keeps the descriptor
 case-independent while letting the energy map depend on the task branch. See
 [multi-task training](../train/multi-task-training.md) for the workflow and
-`examples/water/dpa4/input_multitask.json` for an example.
+`examples/water/dpa4/input_multitask.json` for an example;
+`examples/water/dpa4/input_multitask_preset.json` is the same setup with the
+shared descriptor and fitting network taken from a [preset](#presets).
 
 ### LoRA fine-tuning
 

--- a/doc/model/dpa4c.md
+++ b/doc/model/dpa4c.md
@@ -130,23 +130,41 @@ carry the accuracy–cost trade-off:
 > `dp --pt-expt compress` rejects it. Choose these values with deployment in
 > mind.
 
-### Recommended configurations
+### Recommended configurations and presets
 
-The released grades pair each descriptor width with a fitting width sized
-against it, in ascending cost. They are good starting points; `Neo` is the
-general-purpose default.
+The released grades, Nano, Mini, Neo, Air and Plus in ascending cost, pair each
+descriptor width with a fitting width sized against it. They are good starting
+points; `Neo` is the general-purpose default. Each grade is available as a named
+model preset, `dpa4c-nano-v20260901`, `dpa4c-mini-v20260901`,
+`dpa4c-neo-v20260901`, `dpa4c-air-v20260901` and `dpa4c-plus-v20260901`:
+setting `model.preset` fills in `type_map` (all 118 elements), `descriptor` and
+`fitting_net` from the release configuration, and entries written next to the
+preset take precedence, as a whole for `type_map` and key by key inside
+`descriptor` and `fitting_net`. Run-specific options such as `use_amp` and
+`seed` are added alongside:
 
-| Grade | `channels` | `lmax` | `radial_modes` | Fitting hidden width |
-| ----- | ---------: | -----: | -------------: | -------------------: |
-| Nano  |          8 |      2 |              0 |                   96 |
-| Mini  |         32 |      2 |              0 |                  192 |
-| Neo   |         32 |      2 |              4 |                  192 |
-| Air   |         64 |      3 |              4 |                  256 |
-| Plus  |        128 |      3 |              4 |                  384 |
+```json
+{
+  "model": {
+    "preset": "dpa4c-neo-v20260901",
+    "type_map": [
+      "O",
+      "H"
+    ],
+    "descriptor": {
+      "seed": 42
+    },
+    "fitting_net": {
+      "seed": 42
+    }
+  }
+}
+```
 
-`Mini` and `Neo` share a descriptor width and differ only in the radial modes,
-which buys accuracy at a per-edge cost while leaving the largest tractable
-system unchanged. `Air` and `Plus` additionally raise the angular degree.
+The version tag identifies the release a preset reproduces: a later release
+with different settings gets a new version, and existing presets are never
+changed. The expansion and merge rules are described on the
+[DPA4 page](dpa4.md#presets).
 
 The fitting network is sized against the descriptor because the invariant
 output grows with `channels`. Unlike `radial_modes`, fitting width is not a free
@@ -301,21 +319,6 @@ Two settings are worth knowing:
   says. The symptom is a low `CPU use` percentage in the LAMMPS timing summary
   next to a high thread count. Launch LAMMPS directly, or reset the mask in the
   child.
-
-Whole-step throughput of the released grades on a fully periodic 8000-atom
-diamond supercell, 158 neighbours per atom, on two 45-core Xeon Platinum 8457C
-sockets using 83 physical cores:
-
-| Grade | ms per step | atoms per ms |
-| ----- | ----------: | -----------: |
-| Nano  |         7.1 |         1126 |
-| Mini  |         9.7 |          828 |
-| Neo   |        10.1 |          794 |
-| Air   |        12.5 |          639 |
-| Plus  |        18.4 |          435 |
-
-Throughput peaks between roughly 16 000 and 66 000 atoms and declines beyond it
-as the step's working set leaves the last-level cache.
 
 Resident memory is roughly 16 to 31 KB per atom depending on the grade, so a 4
 GiB budget holds between 124 000 atoms (Plus) and 230 000 atoms (Nano). Most of

--- a/doc/model/overall.md
+++ b/doc/model/overall.md
@@ -47,6 +47,8 @@ The two subsections, {ref}`descriptor <model[standard]/descriptor>` and {ref}`fi
 
 The {ref}`type_map <model/type_map>` is optional, which provides the element names (but not necessarily same as the actual name of the element) of the corresponding atom types. A water model, as in this example, has two kinds of atoms. The atom types are internally recorded as integers, e.g., `0` for oxygen and `1` for hydrogen here. A mapping from the atom type to their names is provided by {ref}`type_map <model/type_map>`.
 
+Some model families ship named presets of their released architectures. Setting `preset` in the {ref}`model <model>` section fills in `type`, `type_map`, `descriptor` and `fitting_net` from the named architecture, and entries written next to it take precedence. See [DPA4](dpa4.md#presets) and [DPA4C](dpa4c.md) for the available presets and the merge rules.
+
 DeePMD-kit implements the following descriptors:
 
 1. [`se_e2_a`](train-se-e2-a.md): DeepPot-SE constructed from all information (both angular and radial) of atomic configurations. The embedding takes the distance between atoms as input.

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -14,6 +14,9 @@ Input files:
 - `input_dens.json`: direct-force denoising training.
 - `input_multitask.json`: multitask training with a shared descriptor and
   case-conditioned shared fitting network.
+- `input_multitask_preset.json`: the same multitask training with the shared
+  descriptor and fitting network taken from the named preset
+  `dpa4-nano-v20260901`.
 - `lora_ft.json`: LoRA fine-tuning.
 - `lmp/`: compact checkpoint and LAMMPS smoke-test files.
 

--- a/examples/water/dpa4/README.md
+++ b/examples/water/dpa4/README.md
@@ -8,6 +8,8 @@ Input files:
 
 - `input.json`: baseline conservative energy training, using a compact
   DPA4-Mini-style parameter set.
+- `input_preset.json`: energy training with the model architecture taken from
+  the named preset `dpa4-nano-v20260901` instead of being written out.
 - `input-zbl.json`: energy training with ZBL zone bridging.
 - `input_dens.json`: direct-force denoising training.
 - `input_multitask.json`: multitask training with a shared descriptor and

--- a/examples/water/dpa4/input_multitask_preset.json
+++ b/examples/water/dpa4/input_multitask_preset.json
@@ -1,0 +1,142 @@
+{
+  "_comment": "DPA4-Nano multitask example with a shared descriptor and case-conditioned shared fitting network, both taken from the named preset; only run-specific keys are written out.",
+  "model": {
+    "preset": "dpa4-nano-v20260901",
+    "use_compile": false,
+    "enable_tf32": true,
+    "shared_dict": {
+      "type_map": [
+        "O",
+        "H"
+      ],
+      "descriptor": {
+        "use_amp": true,
+        "seed": 42
+      },
+      "shared_fit_with_id": {
+        "dim_case_embd": 2,
+        "case_film_embd": true,
+        "seed": 42
+      }
+    },
+    "model_dict": {
+      "water_1": {
+        "type_map": "type_map",
+        "descriptor": "descriptor",
+        "fitting_net": "shared_fit_with_id",
+        "model_branch_alias": [
+          "Default",
+          "Water"
+        ],
+        "info": {
+          "description": "Water branch with the shared preset descriptor and case-embedded shared fitting net"
+        }
+      },
+      "water_2": {
+        "type_map": "type_map",
+        "descriptor": "descriptor",
+        "fitting_net": "shared_fit_with_id",
+        "model_branch_alias": [
+          "Water2"
+        ],
+        "info": {
+          "description": "Second water branch with the shared preset descriptor and case-embedded shared fitting net"
+        }
+      }
+    }
+  },
+  "learning_rate": {
+    "type": "wsd",
+    "start_lr": 4.5e-4,
+    "stop_lr": 1e-6,
+    "warmup_ratio": 0.003,
+    "warmup_start_factor": 0.2,
+    "decay_phase_ratio": 0.65,
+    "decay_type": "cosine"
+  },
+  "loss_dict": {
+    "water_1": {
+      "type": "ener",
+      "loss_func": "mae",
+      "f_use_norm": true,
+      "start_pref_e": 20,
+      "limit_pref_e": 20,
+      "start_pref_f": 20,
+      "limit_pref_f": 20,
+      "start_pref_v": 5,
+      "limit_pref_v": 5
+    },
+    "water_2": {
+      "type": "ener",
+      "loss_func": "mae",
+      "f_use_norm": true,
+      "start_pref_e": 20,
+      "limit_pref_e": 20,
+      "start_pref_f": 20,
+      "limit_pref_f": 20,
+      "start_pref_v": 5,
+      "limit_pref_v": 5
+    }
+  },
+  "optimizer": {
+    "type": "HybridMuon",
+    "weight_decay": 0.001
+  },
+  "training": {
+    "model_prob": {
+      "water_1": 0.5,
+      "water_2": 0.5
+    },
+    "data_dict": {
+      "water_1": {
+        "stat_file": "./dpa4_water_1.hdf5",
+        "training_data": {
+          "systems": [
+            "../data/data_0",
+            "../data/data_1",
+            "../data/data_2"
+          ],
+          "batch_size": 1
+        },
+        "validation_data": {
+          "systems": [
+            "../data/data_3"
+          ],
+          "batch_size": 1,
+          "numb_batch": 1
+        }
+      },
+      "water_2": {
+        "stat_file": "./dpa4_water_2.hdf5",
+        "training_data": {
+          "systems": [
+            "../data/data_0",
+            "../data/data_1",
+            "../data/data_2"
+          ],
+          "batch_size": 1
+        }
+      }
+    },
+    "numb_steps": 2000000,
+    "gradient_max_norm": 5.0,
+    "save_freq": 2000,
+    "max_ckpt_keep": 3,
+    "enable_ema": true,
+    "ema_decay": 0.999,
+    "ema_ckpt_keep": 3,
+    "disp_file": "lcurve.out",
+    "disp_freq": 1000,
+    "disp_avg": true,
+    "disp_training": true,
+    "time_training": true,
+    "tensorboard": false,
+    "enable_profiler": false,
+    "tensorboard_freq": 1000,
+    "tensorboard_log_dir": "tb_log",
+    "profiling": false,
+    "profiling_file": "timeline.json",
+    "zero_stage": 1,
+    "seed": 42
+  }
+}

--- a/examples/water/dpa4/input_preset.json
+++ b/examples/water/dpa4/input_preset.json
@@ -1,45 +1,30 @@
 {
-  "_comment": "DPA4C energy-training example for the water dataset.",
+  "_comment": "DPA4-Nano energy-training example for the water dataset. The model architecture comes from the named preset; the explicit type_map and rcut override it and use_amp and seed supplement it.",
   "model": {
+    "preset": "dpa4-nano-v20260901",
     "type_map": [
       "O",
       "H"
     ],
     "descriptor": {
-      "type": "dpa4c",
-      "_comment": "The Neo grade, the architecture of the preset dpa4c-neo-v20260901: channels and lmax fix every derived width, and radial_modes 0 leaves each ordered atom-type pair with a rescaled copy of one shared radial function.",
       "rcut": 6.0,
-      "channels": 64,
-      "lmax": 2,
-      "basis_type": "bessel",
-      "n_radial": 16,
-      "radial_modes": 0,
-      "_comment_precision": "float32 is required by the compressed CUDA path.",
-      "precision": "float32",
-      "use_amp": false,
+      "use_amp": true,
       "seed": 42
     },
     "fitting_net": {
-      "_comment": "The fitting width paired with the Neo descriptor width.",
-      "neuron": [
-        256,
-        256,
-        256
-      ],
-      "resnet_dt": false,
-      "activation_function": "silu",
-      "precision": "float32",
       "seed": 42
-    }
+    },
+    "use_compile": false,
+    "enable_tf32": true
   },
   "learning_rate": {
     "type": "wsd",
-    "start_lr": 1e-3,
+    "start_lr": 4.5e-4,
     "stop_lr": 1e-6,
     "warmup_ratio": 0.003,
     "warmup_start_factor": 0.2,
-    "decay_phase_ratio": 0.2,
-    "decay_type": "inverse_linear"
+    "decay_phase_ratio": 0.65,
+    "decay_type": "cosine"
   },
   "loss": {
     "type": "ener",
@@ -57,7 +42,7 @@
     "weight_decay": 0.001
   },
   "training": {
-    "stat_file": "./dpa4c.hdf5",
+    "stat_file": "./dpa4.hdf5",
     "stat_file_mode": "update",
     "training_data": {
       "systems": [
@@ -72,20 +57,34 @@
         "../data/data_3"
       ],
       "batch_size": 1,
-      "numb_btch": 1
+      "numb_batch": 1
     },
-    "numb_steps": 1000000,
+    "numb_steps": 2000000,
     "gradient_max_norm": 5.0,
     "save_freq": 2000,
+    "save_dir": "ckpt",
     "max_ckpt_keep": 3,
+    "enable_ema": true,
+    "ema_decay": 0.999,
+    "ema_ckpt_keep": 3,
     "disp_file": "lcurve.out",
     "disp_freq": 1000,
+    "disp_avg": true,
     "disp_training": true,
     "time_training": true,
-    "enable_compile": true,
+    "tensorboard": false,
+    "enable_profiler": false,
+    "tensorboard_freq": 1000,
+    "tensorboard_log_dir": "tb_log",
+    "profiling": false,
+    "profiling_file": "timeline.json",
+    "zero_stage": 1,
     "seed": 42
   },
   "validating": {
+    "compiled_infer": false,
+    "tf32_infer": false,
+    "amp_infer": false,
     "save_best_dir": "ckpt_best"
   }
 }

--- a/examples/water/dpa4c/README.md
+++ b/examples/water/dpa4c/README.md
@@ -8,6 +8,13 @@ backend:
 dp --pt-expt train input.json
 ```
 
+The model section spells out the `Neo` grade. The same architecture is
+available as the named preset `dpa4c-neo-v20260901`: writing
+`"preset": "dpa4c-neo-v20260901"` in the model section fills in the
+118-element `type_map`, `descriptor` and `fitting_net`, and the run-specific
+entries written next to it take precedence: the water `type_map`, `use_amp`
+and `seed`.
+
 DPA4C is built for extreme-speed molecular dynamics, so its arguments are best
 read as a budget split between two quantities: inference throughput and the
 largest system that fits in memory.
@@ -38,10 +45,8 @@ still be evaluated under mixed precision.
 ## Choosing the fitting width
 
 The fitting network is sized against the descriptor, because the invariant
-output grows with `channels`. The released grades pair `channels` 8, 32, 64 and
-128 with hidden widths 96, 192, 256 and 384, at depth three as used here. This
-file is the `Neo` grade: `channels: 32` with `radial_modes: 4` and a hidden
-width of 192.
+output grows with `channels`. Every released grade pairs its descriptor width
+with a matching hidden width at depth three, as used here.
 
 Unlike `radial_modes`, fitting width is not a free trade against memory. It
 does not enlarge the persistent node state, but it does add per-atom

--- a/source/tests/common/test_examples.py
+++ b/source/tests/common/test_examples.py
@@ -84,6 +84,7 @@ input_files_multi = (
     p_examples / "water_multi_task" / "pytorch_example" / "input_torch_with_alias.json",
     p_examples / "hessian" / "multi_task" / "input.json",
     p_examples / "water" / "dpa4" / "input_multitask.json",
+    p_examples / "water" / "dpa4" / "input_multitask_preset.json",
     p_examples
     / "water_multi_task"
     / "pytorch_example"

--- a/source/tests/common/test_examples.py
+++ b/source/tests/common/test_examples.py
@@ -14,6 +14,9 @@ from deepmd.common import (
 from deepmd.utils.argcheck import (
     normalize,
 )
+from deepmd.utils.model_preset import (
+    expand_model_preset,
+)
 
 from ..pt.test_multitask import (
     preprocess_shared_params,
@@ -64,6 +67,7 @@ input_files = (
     p_examples / "water" / "dpa3" / "input_torch.json",
     p_examples / "water" / "dpa3" / "input_torch_dynamic.json",
     p_examples / "water" / "dpa4" / "input.json",
+    p_examples / "water" / "dpa4" / "input_preset.json",
     p_examples / "water" / "dpa4" / "input-zbl.json",
     p_examples / "water" / "dpa4" / "lmp" / "input.json",
     p_examples / "water" / "dpa4c" / "input.json",
@@ -94,6 +98,7 @@ class TestExamples(unittest.TestCase):
             fn = str(fn)
             with self.subTest(fn=fn):
                 jdata = j_loader(fn)
+                jdata["model"] = expand_model_preset(jdata["model"])
                 if multi_task:
                     jdata["model"], _ = preprocess_shared_params(jdata["model"])
                 normalize(jdata, multi_task=multi_task)

--- a/source/tests/common/test_model_preset.py
+++ b/source/tests/common/test_model_preset.py
@@ -237,6 +237,48 @@ def test_multi_task_preset_passes_shared_param_preprocessing() -> None:
     assert set(normalized["model"]["model_dict"]) == {"water_1", "water_2"}
 
 
+def test_multi_task_top_level_regions_are_branch_defaults() -> None:
+    model = {
+        "preset": "dpa4-nano-v20260901",
+        "descriptor": {"rcut": 7.0},
+        "fitting_net": {"seed": 3},
+        "shared_dict": {"type_map": ["O", "H"]},
+        "model_dict": {
+            "water_1": {"type_map": "type_map"},
+            "water_2": {
+                "preset": "dpa4-mini-v20260901",
+                "type_map": "type_map",
+                "descriptor": {"rcut": 5.0},
+            },
+        },
+    }
+    expanded = expand_model_preset(model)
+    water_1 = expanded["model_dict"]["water_1"]
+    assert water_1["descriptor"]["rcut"] == 7.0
+    assert water_1["descriptor"]["lmax"] == 1
+    assert water_1["fitting_net"] == {"neuron": [0], "precision": "float32", "seed": 3}
+    # A branch entry replaces the top-level default as a whole.
+    water_2 = expanded["model_dict"]["water_2"]
+    assert water_2["descriptor"]["rcut"] == 5.0
+    assert water_2["descriptor"]["lmax"] == 2
+    assert water_2["fitting_net"]["seed"] == 3
+    # The top-level entries stay for the backend's model-wide handling.
+    assert expanded["descriptor"] == {"rcut": 7.0}
+    assert "preset" not in expanded
+
+
+def test_malformed_multi_task_layout_is_left_to_argcheck() -> None:
+    malformed = {"preset": "dpa4-nano-v20260901", "model_dict": "water"}
+    assert expand_model_preset(malformed) is malformed
+    branch_not_mapping = {
+        "preset": "dpa4-nano-v20260901",
+        "model_dict": {"water": "not a mapping"},
+    }
+    assert expand_model_preset(branch_not_mapping)["model_dict"] == {
+        "water": "not a mapping"
+    }
+
+
 def test_update_deepmd_input_expands_presets() -> None:
     jdata = {
         "model": {"preset": "dpa4c-mini-v20260901"},

--- a/source/tests/common/test_model_preset.py
+++ b/source/tests/common/test_model_preset.py
@@ -130,7 +130,10 @@ def test_multi_task_branches_expand_with_shared_references() -> None:
     }
     expanded = expand_model_preset(model)
     assert "preset" not in expanded
-    assert expanded["shared_dict"] == model["shared_dict"]
+    # The shared descriptor is the mini descriptor with the explicit keys on top.
+    mini = get_model_preset("dpa4-mini-v20260901")
+    assert expanded["shared_dict"]["descriptor"] == {**mini["descriptor"], "rcut": 6.0}
+    assert expanded["shared_dict"]["type_map"] == ["O", "H"]
 
     water_1 = expanded["model_dict"]["water_1"]
     assert "preset" not in water_1
@@ -138,7 +141,7 @@ def test_multi_task_branches_expand_with_shared_references() -> None:
     # Shared-dict references are kept for the multi-task preprocessing.
     assert water_1["type_map"] == "type_map"
     assert water_1["descriptor"] == "descriptor"
-    assert water_1["fitting_net"] == {"neuron": [0], "precision": "float32", "seed": 2}
+    assert water_1["fitting_net"] == {**mini["fitting_net"], "seed": 2}
 
     water_2 = expanded["model_dict"]["water_2"]
     assert "preset" not in water_2
@@ -216,10 +219,11 @@ def test_multi_task_preset_passes_shared_param_preprocessing() -> None:
         expand_model_preset(model), lambda item_key, params: dict
     )
     assert set(shared_links) == {"descriptor"}
+    nano = get_model_preset("dpa4-nano-v20260901")
     for branch in processed["model_dict"].values():
         assert branch["type"] == "dpa4"
         assert branch["type_map"] == ["O", "H"]
-        assert branch["descriptor"] == {"type": "dpa4", "rcut": 6.0}
+        assert branch["descriptor"] == nano["descriptor"]
         assert branch["fitting_net"]["neuron"] == [0]
     config = {
         "model": processed,
@@ -256,7 +260,8 @@ def test_multi_task_top_level_regions_are_branch_defaults() -> None:
     water_1 = expanded["model_dict"]["water_1"]
     assert water_1["descriptor"]["rcut"] == 7.0
     assert water_1["descriptor"]["lmax"] == 1
-    assert water_1["fitting_net"] == {"neuron": [0], "precision": "float32", "seed": 3}
+    nano = get_model_preset("dpa4-nano-v20260901")
+    assert water_1["fitting_net"] == {**nano["fitting_net"], "seed": 3}
     # A branch entry replaces the top-level default as a whole.
     water_2 = expanded["model_dict"]["water_2"]
     assert water_2["descriptor"]["rcut"] == 5.0
@@ -265,6 +270,60 @@ def test_multi_task_top_level_regions_are_branch_defaults() -> None:
     # The top-level entries stay for the backend's model-wide handling.
     assert expanded["descriptor"] == {"rcut": 7.0}
     assert "preset" not in expanded
+
+
+def test_shared_dict_entries_take_the_top_level_preset_as_base() -> None:
+    model = {
+        "preset": "dpa4-nano-v20260901",
+        "shared_dict": {
+            "type_map": ["O", "H"],
+            "descriptor": {"use_amp": True, "seed": 42},
+            "shared_fit": {"dim_case_embd": 2, "seed": 42},
+            "unreferenced": {"rcut": 5.0},
+        },
+        "model_dict": {
+            "water_1": {
+                "type_map": "type_map",
+                "descriptor": "descriptor:1",
+                "fitting_net": "shared_fit",
+            },
+            "water_2": {
+                "preset": "dpa4-mini-v20260901",
+                "type_map": "type_map",
+                "descriptor": "descriptor",
+            },
+        },
+    }
+    expanded = expand_model_preset(model)
+    nano = get_model_preset("dpa4-nano-v20260901")
+    shared = expanded["shared_dict"]
+    # Referenced entries: preset region plus the run-specific keys; a shared
+    # level suffix in the reference does not change the entry it names.
+    assert shared["descriptor"] == {**nano["descriptor"], "use_amp": True, "seed": 42}
+    assert shared["shared_fit"] == {
+        **nano["fitting_net"],
+        "dim_case_embd": 2,
+        "seed": 42,
+    }
+    # Entries nobody references and the type map are left as written.
+    assert shared["unreferenced"] == {"rcut": 5.0}
+    assert shared["type_map"] == ["O", "H"]
+    # A branch-level preset shapes only that branch's own regions.
+    water_2 = expanded["model_dict"]["water_2"]
+    assert water_2["descriptor"] == "descriptor"
+    assert water_2["fitting_net"]["neuron"] == [0]
+    # Without a top-level preset the shared dictionary is untouched.
+    branch_only = {
+        "shared_dict": {"type_map": ["O"], "descriptor": {"rcut": 5.0}},
+        "model_dict": {
+            "a": {
+                "preset": "dpa4-nano-v20260901",
+                "type_map": "type_map",
+                "descriptor": "descriptor",
+            }
+        },
+    }
+    assert expand_model_preset(branch_only)["shared_dict"] == branch_only["shared_dict"]
 
 
 def test_malformed_multi_task_layout_is_left_to_argcheck() -> None:

--- a/source/tests/common/test_model_preset.py
+++ b/source/tests/common/test_model_preset.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Tests for named model presets and their expansion."""
+
+import copy
+import logging
+
+import pytest
+from dargs.dargs import (
+    ArgumentKeyError,
+)
+
+from deepmd.dpmodel.utils.multi_task import (
+    preprocess_shared_params,
+)
+from deepmd.utils.argcheck import (
+    normalize,
+)
+from deepmd.utils.compat import (
+    update_deepmd_input,
+)
+from deepmd.utils.model_preset import (
+    MODEL_PRESETS,
+    PERIODIC_TABLE,
+    expand_model_preset,
+    get_model_preset,
+)
+
+TRAINING = {"training_data": {"systems": ["fake"]}, "numb_steps": 10}
+
+
+def _normalize_model(model: dict) -> dict:
+    config = {"model": copy.deepcopy(model), "training": copy.deepcopy(TRAINING)}
+    return normalize(config)["model"]
+
+
+@pytest.mark.parametrize("name", sorted(MODEL_PRESETS))
+def test_every_preset_expands_to_a_valid_model(name: str) -> None:
+    model = expand_model_preset({"preset": name})
+    assert "preset" not in model
+    assert model["type_map"] == list(PERIODIC_TABLE)
+    assert len(model["type_map"]) == 118
+    normalized = _normalize_model(model)
+    if name.startswith("dpa4c-"):
+        assert normalized["type"] == "standard"
+        assert normalized["descriptor"]["type"] == "dpa4c"
+        assert normalized["fitting_net"]["type"] == "ener"
+    else:
+        assert normalized["type"] == "dpa4"
+        assert normalized["descriptor"]["type"] == "dpa4"
+        assert normalized["fitting_net"]["type"] == "dpa4_ener"
+
+
+def test_explicit_entries_override_and_supplement(caplog) -> None:
+    model = {
+        "preset": "dpa4-nano-v20260901",
+        "type_map": ["O", "H"],
+        "descriptor": {"rcut": 5.0, "use_amp": True, "seed": 1},
+        "fitting_net": {"seed": 1},
+        "use_compile": False,
+    }
+    original = copy.deepcopy(model)
+    with caplog.at_level(logging.INFO, logger="deepmd.utils.model_preset"):
+        expanded = expand_model_preset(model)
+    assert model == original
+    preset = get_model_preset("dpa4-nano-v20260901")
+
+    assert "preset" not in expanded
+    assert expanded["type"] == "dpa4"
+    assert expanded["type_map"] == ["O", "H"]
+    assert expanded["descriptor"]["rcut"] == 5.0
+    assert expanded["descriptor"]["use_amp"] is True
+    assert expanded["descriptor"]["seed"] == 1
+    for key, value in preset["descriptor"].items():
+        if key != "rcut":
+            assert expanded["descriptor"][key] == value
+    assert expanded["fitting_net"] == {**preset["fitting_net"], "seed": 1}
+    assert expanded["use_compile"] is False
+    _normalize_model(expanded)
+
+    # Only entries that change a preset value are reported as overrides.
+    assert "type_map" in caplog.text
+    assert "descriptor.rcut" in caplog.text
+    assert "use_amp" not in caplog.text
+
+
+def test_expansion_is_idempotent_and_a_noop_without_preset() -> None:
+    plain = {
+        "type_map": ["O"],
+        "descriptor": {"type": "se_e2_a", "sel": [10]},
+        "fitting_net": {"neuron": [4]},
+    }
+    assert expand_model_preset(plain) is plain
+    multi = {"shared_dict": {}, "model_dict": {"a": copy.deepcopy(plain)}}
+    assert expand_model_preset(multi) is multi
+    expanded = expand_model_preset({"preset": "dpa4c-neo-v20260901"})
+    assert expand_model_preset(expanded) is expanded
+
+
+def test_preset_name_is_case_insensitive() -> None:
+    assert expand_model_preset({"preset": "DPA4-Neo-v20260901"}) == expand_model_preset(
+        {"preset": "dpa4-neo-v20260901"}
+    )
+
+
+def test_unknown_or_malformed_preset_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown model preset"):
+        expand_model_preset({"preset": "dpa4-huge-v20260901"})
+    with pytest.raises(ValueError, match="must be a string"):
+        expand_model_preset({"preset": 3})
+
+
+def test_multi_task_branches_expand_with_shared_references() -> None:
+    model = {
+        "preset": "dpa4-mini-v20260901",
+        "shared_dict": {
+            "type_map": ["O", "H"],
+            "descriptor": {"type": "dpa4", "rcut": 6.0},
+        },
+        "model_dict": {
+            "water_1": {
+                "type_map": "type_map",
+                "descriptor": "descriptor",
+                "fitting_net": {"seed": 2},
+            },
+            "water_2": {
+                "preset": "dpa4-neo-v20260901",
+                "type_map": "type_map",
+            },
+        },
+    }
+    expanded = expand_model_preset(model)
+    assert "preset" not in expanded
+    assert expanded["shared_dict"] == model["shared_dict"]
+
+    water_1 = expanded["model_dict"]["water_1"]
+    assert "preset" not in water_1
+    assert water_1["type"] == "dpa4"
+    # Shared-dict references are kept for the multi-task preprocessing.
+    assert water_1["type_map"] == "type_map"
+    assert water_1["descriptor"] == "descriptor"
+    assert water_1["fitting_net"] == {"neuron": [0], "precision": "float32", "seed": 2}
+
+    water_2 = expanded["model_dict"]["water_2"]
+    assert "preset" not in water_2
+    assert water_2["type_map"] == "type_map"
+    assert water_2["descriptor"]["lmax"] == 3
+    assert water_2["descriptor"]["n_focus"] == 2
+
+
+def test_dpa4_versions_differ_only_in_normalization_options() -> None:
+    for grade in ("nano", "mini", "neo", "air", "plus", "pro"):
+        old = get_model_preset(f"dpa4-{grade}-v20260820")
+        new = get_model_preset(f"dpa4-{grade}-v20260901")
+        assert old["type"] == new["type"]
+        assert old["type_map"] == new["type_map"]
+        assert old["fitting_net"] == new["fitting_net"]
+        changed = {
+            key
+            for key in set(old["descriptor"]) | set(new["descriptor"])
+            if old["descriptor"].get(key) != new["descriptor"].get(key)
+        }
+        assert changed == {"edge_norm", "sandwich_norm"}
+    for grade in ("max", "ultra"):
+        assert f"dpa4-{grade}-v20260820" not in MODEL_PRESETS
+        assert f"dpa4-{grade}-v20260901" in MODEL_PRESETS
+
+
+def test_presets_carry_no_runtime_options() -> None:
+    for name, preset in MODEL_PRESETS.items():
+        for region in ("descriptor", "fitting_net"):
+            for key in ("use_amp", "seed", "sel", "trainable"):
+                assert key not in preset[region], (name, region, key)
+        for key in ("add_chg_spin_ebd", "default_chg_spin", "so2_layers"):
+            assert key not in preset["descriptor"], (name, key)
+
+
+def test_periodic_table_matches_econf_type_map() -> None:
+    from deepmd.utils.econf_embd import (
+        type_map,
+    )
+
+    assert list(PERIODIC_TABLE) == type_map
+
+
+def test_leftover_preset_fails_argument_check() -> None:
+    config = {
+        "model": {"preset": "dpa4-nano-v20260901"},
+        "training": copy.deepcopy(TRAINING),
+    }
+    with pytest.raises(ArgumentKeyError, match="preset"):
+        normalize(config)
+
+
+def test_multi_task_preset_passes_shared_param_preprocessing() -> None:
+    """The expansion runs before multi-task preprocessing and argument check."""
+    model = {
+        "preset": "dpa4-nano-v20260901",
+        "shared_dict": {
+            "type_map": ["O", "H"],
+            "descriptor": {"type": "dpa4", "rcut": 6.0},
+        },
+        "model_dict": {
+            "water_1": {
+                "type_map": "type_map",
+                "descriptor": "descriptor",
+                "fitting_net": {"seed": 1},
+            },
+            "water_2": {
+                "type_map": "type_map",
+                "descriptor": "descriptor",
+                "fitting_net": {"seed": 2},
+            },
+        },
+    }
+    processed, shared_links = preprocess_shared_params(
+        expand_model_preset(model), lambda item_key, params: dict
+    )
+    assert set(shared_links) == {"descriptor"}
+    for branch in processed["model_dict"].values():
+        assert branch["type"] == "dpa4"
+        assert branch["type_map"] == ["O", "H"]
+        assert branch["descriptor"] == {"type": "dpa4", "rcut": 6.0}
+        assert branch["fitting_net"]["neuron"] == [0]
+    config = {
+        "model": processed,
+        "loss_dict": {"water_1": {"type": "ener"}, "water_2": {"type": "ener"}},
+        "training": {
+            "model_prob": {"water_1": 0.5, "water_2": 0.5},
+            "data_dict": {
+                "water_1": {"training_data": {"systems": ["fake"]}},
+                "water_2": {"training_data": {"systems": ["fake"]}},
+            },
+            "numb_steps": 10,
+        },
+    }
+    normalized = normalize(config, multi_task=True)
+    assert set(normalized["model"]["model_dict"]) == {"water_1", "water_2"}
+
+
+def test_update_deepmd_input_expands_presets() -> None:
+    jdata = {
+        "model": {"preset": "dpa4c-mini-v20260901"},
+        "training": copy.deepcopy(TRAINING),
+    }
+    out = update_deepmd_input(jdata, warning=False)
+    assert "preset" not in out["model"]
+    assert out["model"]["descriptor"]["channels"] == 32
+    assert out["model"]["fitting_net"]["neuron"] == [192, 192, 192]

--- a/source/tests/common/test_model_preset.py
+++ b/source/tests/common/test_model_preset.py
@@ -267,9 +267,15 @@ def test_multi_task_top_level_regions_are_branch_defaults() -> None:
     assert water_2["descriptor"]["rcut"] == 5.0
     assert water_2["descriptor"]["lmax"] == 2
     assert water_2["fitting_net"]["seed"] == 3
-    # The top-level entries stay for the backend's model-wide handling.
-    assert expanded["descriptor"] == {"rcut": 7.0}
+    # The top-level region is consumed once distributed to every branch, so a
+    # downstream backend without its own model-wide cascade (dpmodel-based
+    # entrypoints) does not see it as an unknown top-level key.
+    assert "descriptor" not in expanded
     assert "preset" not in expanded
+    processed, _ = preprocess_shared_params(
+        expanded, lambda item_key, params: dict, cascade_defaults=False
+    )
+    assert "descriptor" not in processed
 
 
 def test_shared_dict_entries_take_the_top_level_preset_as_base() -> None:
@@ -324,6 +330,50 @@ def test_shared_dict_entries_take_the_top_level_preset_as_base() -> None:
         },
     }
     assert expand_model_preset(branch_only)["shared_dict"] == branch_only["shared_dict"]
+
+
+def test_explicit_alias_replaces_the_preset_canonical_key() -> None:
+    """A legacy key alias for a preset-defined key overrides it in place,
+    instead of sitting next to it and failing the strict argument check.
+    """
+    model = expand_model_preset(
+        {
+            "preset": "dpa4-nano-v20260901",
+            "type_map": ["O", "H"],
+            "descriptor": {"so2_layers": 5},
+        }
+    )
+    assert model["descriptor"]["mixing_layers"] == 5
+    assert "so2_layers" not in model["descriptor"]
+    _normalize_model(model)
+
+
+def test_explicit_dict_for_a_whole_value_region_does_not_crash() -> None:
+    """`type_map` (and `type`) are always replaced as a whole; a malformed
+    dict there must not raise before the argument check reports it.
+    """
+    expanded = expand_model_preset(
+        {"preset": "dpa4-nano-v20260901", "type_map": {"O": 0, "H": 1}}
+    )
+    assert expanded["type_map"] == {"O": 0, "H": 1}
+    with pytest.raises(Exception):
+        _normalize_model(expanded)
+
+
+def test_shared_dict_role_is_recognised_through_a_branch_default() -> None:
+    """A `descriptor`/`fitting_net` reference inherited by a branch only
+    through the top-level default must still be recognised as referenced.
+    """
+    nano = get_model_preset("dpa4-nano-v20260901")
+    model = {
+        "preset": "dpa4-nano-v20260901",
+        "descriptor": "desc",
+        "shared_dict": {"type_map": ["O", "H"], "desc": {"seed": 42}},
+        "model_dict": {"water_1": {"type_map": "type_map"}},
+    }
+    expanded = expand_model_preset(model)
+    assert expanded["shared_dict"]["desc"] == {**nano["descriptor"], "seed": 42}
+    assert expanded["model_dict"]["water_1"]["descriptor"] == "desc"
 
 
 def test_malformed_multi_task_layout_is_left_to_argcheck() -> None:


### PR DESCRIPTION
## Summary

- add `model.preset`: `"<family>-<grade>-<version>"` (for example `dpa4-nano-v20260901` or `dpa4c-neo-v20260901`) fills in `type`, the 118-element `type_map`, `descriptor` and `fitting_net` from a released architecture; entries written next to the preset take precedence, `type` and `type_map` as a whole and `descriptor` / `fitting_net` key by key, so run-specific options (`use_amp`, `seed`, `sel`, charge and spin conditioning) are written alongside
- presets are expanded right after the input is loaded, before multi-task sharing, fine-tuning rules and argument checking, and inside `update_deepmd_input` for the other input consumers; the `preset` key is removed, so `out.json` records the expanded model and an unexpanded preset fails the strict argument check
- ship DPA4 `v20260820` (nano to pro) and `v20260901` (nano to ultra) and DPA4C `v20260901` (nano to plus); the table in `deepmd/utils/model_preset.py` lists shared options once, then per-grade knobs and per-version changes
- multi-task: a `preset` next to `model_dict` is the base of every branch and of the `shared_dict` entries the branches reference as `descriptor` or `fitting_net`; entries written next to `model_dict` are branch defaults; `examples/water/dpa4/input_multitask_preset.json` is the shared-descriptor multitask example written with a preset
- correct the DPA4C example and docs to the released Neo grade (channels 64, lmax 2, radial_modes 0, fitting width 256), drop per-grade parameter and benchmark tables from the user docs, and add `examples/water/dpa4/input_preset.json`

## Validation

- `python -m pytest source/tests/common/test_model_preset.py source/tests/common/test_examples.py source/tests/common/test_doc_train_input.py source/tests/common/test_compat_optimizer.py source/tests/common/test_dpmodel_train.py -q` — 45 passed, 218 subtests passed
- every preset normalizes to the same model as its release `input.json` (key-by-key comparison after `normalize`, runtime keys excluded)
- 20-step training runs: multi-task with the new `input_multitask_preset.json` (shared descriptor and case-embedded fitting from the preset) and with a top-level `descriptor` override next to the preset; `dp --pt train` with `dpa4-nano-v20260901` and `dpa4-neo-v20260820`, `--finetune` from the resulting checkpoint, multi-task with a top-level and a branch-level preset, `dp --pt-expt train` with `dpa4c-nano-v20260901` and with the corrected DPA4C example
- `ruff check` / `ruff format --check` clean; all pre-commit hooks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added named DPA4 and DPA4C model presets with case-insensitive selection for single-task and multitask configurations.
  - Presets now expand automatically during training and input conversion, with explicit settings taking precedence.
- **Documentation**
  - Documented preset naming, available grades, expansion behavior, and override rules.
  - Added DPA4 preset training examples and updated DPA4C examples.
- **Tests**
  - Added coverage for preset expansion, overrides, multitask models, validation, and example configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->