### PR TITLE
fix(test): exclude virtual atoms from force and Hessian metrics

### DIFF
--- a/deepmd/infer/model_test/ener.py
+++ b/deepmd/infer/model_test/ener.py
@@ -30,7 +30,6 @@ from deepmd.utils.eval_metrics import (
     DP_TEST_WEIGHTED_METRIC_KEYS,
     compute_energy_type_metrics,
     compute_error_stat,
-    compute_spin_force_metrics,
     compute_weighted_error_stat,
 )
 
@@ -71,8 +70,13 @@ def _align_spin_force_arrays(
     prediction_force_mag: np.ndarray | None,
     reference_force_mag: np.ndarray | None,
     mask_mag: np.ndarray | None,
+    exclude_padding: bool = False,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None, np.ndarray | None]:
-    """Align spin force arrays into real-atom and magnetic subsets."""
+    """Align spin forces, optionally omitting type -1 rows for metrics.
+
+    The default preserves the detail-file layout. Legacy spin partner types
+    are magnetic degrees of freedom, not padding, and remain selected.
+    """
     prediction_force_by_atom = _reshape_force_by_atom(prediction_force, natoms)
     reference_force_by_atom = _reshape_force_by_atom(reference_force, natoms)
     if dp.get_ntypes_spin() != 0:  # old tf support for spin
@@ -98,7 +102,9 @@ def _align_spin_force_arrays(
             strict=False,
         ):
             real_mask = frame_atype < ntypes_real
-            magnetic_mask = ~real_mask
+            magnetic_mask = frame_atype >= ntypes_real
+            if exclude_padding:
+                real_mask &= frame_atype >= 0
             force_real_prediction_chunks.append(frame_prediction[real_mask])
             force_real_reference_chunks.append(frame_reference[real_mask])
             force_magnetic_prediction_chunks.append(frame_prediction[magnetic_mask])
@@ -124,9 +130,17 @@ def _align_spin_force_arrays(
 
     force_real_prediction = prediction_force_by_atom.reshape(-1, 3)
     force_real_reference = reference_force_by_atom.reshape(-1, 3)
+    if exclude_padding:
+        real_mask = _real_atom_mask(
+            atype, prediction_force_by_atom.shape[0], natoms
+        ).reshape(-1)
+        force_real_prediction = force_real_prediction[real_mask]
+        force_real_reference = force_real_reference[real_mask]
     if prediction_force_mag is None or reference_force_mag is None or mask_mag is None:
         return force_real_prediction, force_real_reference, None, None
     magnetic_mask = mask_mag.reshape(-1).astype(bool)
+    if exclude_padding:
+        magnetic_mask &= real_mask
     return (
         force_real_prediction,
         force_real_reference,
@@ -695,36 +709,42 @@ class SpinEnerTester(EnerTester):
             reference_force_mag=test_data.get("force_mag"),
             mask_mag=optional_outputs.mask_mag,
         )
-        if find_force_mag == 1 and (force_mag is None or reference_mag is None):
-            raise RuntimeError(
-                "Spin magnetic force metrics require magnetic force arrays and mask."
+        # Filter metric inputs before subtraction, independently of the raw
+        # arrays above that retain padding positions for detail output.
+        metric_real, metric_reference_real, metric_mag, metric_reference_mag = (
+            _align_spin_force_arrays(
+                dp=self.dp,
+                atype=atype,
+                natoms=natoms,
+                prediction_force=prediction_force,
+                reference_force=test_data["force"],
+                prediction_force_mag=optional_outputs.force_mag,
+                reference_force_mag=test_data.get("force_mag"),
+                mask_mag=optional_outputs.mask_mag,
+                exclude_padding=True,
             )
-        spin_metrics = compute_spin_force_metrics(
-            force_real_prediction=force_real,
-            force_real_reference=reference_real,
-            force_magnetic_prediction=force_mag if find_force_mag == 1 else None,
-            force_magnetic_reference=reference_mag if find_force_mag == 1 else None,
         )
-        if spin_metrics.force_real is None:
-            raise RuntimeError("Spin force metrics are unavailable for dp test.")
-        if find_force == 1:
+        if find_force == 1 and metric_real.size:
             errors.update(
-                spin_metrics.as_weighted_average_errors(
-                    {"force_real": DP_TEST_SPIN_WEIGHTED_METRIC_KEYS["force_real"]}
+                compute_error_stat(
+                    metric_real, metric_reference_real
+                ).as_weighted_average_errors(
+                    *DP_TEST_SPIN_WEIGHTED_METRIC_KEYS["force_real"]
                 )
             )
         if find_force_mag == 1:
-            if spin_metrics.force_magnetic is None:
-                raise RuntimeError("Spin magnetic force metrics are unavailable.")
-            errors.update(
-                spin_metrics.as_weighted_average_errors(
-                    {
-                        "force_magnetic": DP_TEST_SPIN_WEIGHTED_METRIC_KEYS[
-                            "force_magnetic"
-                        ]
-                    }
+            if metric_mag is None or metric_reference_mag is None:
+                raise RuntimeError(
+                    "Spin magnetic force metrics require magnetic force arrays and mask."
                 )
-            )
+            if metric_mag.size:
+                errors.update(
+                    compute_error_stat(
+                        metric_mag, metric_reference_mag
+                    ).as_weighted_average_errors(
+                        *DP_TEST_SPIN_WEIGHTED_METRIC_KEYS["force_magnetic"]
+                    )
+                )
         return _ForceDetails(
             reference_real=reference_real,
             prediction_real=force_real,

--- a/deepmd/infer/model_test/ener.py
+++ b/deepmd/infer/model_test/ener.py
@@ -47,6 +47,11 @@ def _reshape_force_by_atom(force_array: np.ndarray, natoms: int) -> np.ndarray:
     return np.reshape(force_array, [-1, natoms, 3])
 
 
+def _real_atom_mask(atype: np.ndarray, nframes: int, natoms: int) -> np.ndarray:
+    """Select non-padding atoms, broadcasting fixed types across frames."""
+    return np.broadcast_to(np.reshape(atype, [-1, natoms]) >= 0, (nframes, natoms))
+
+
 def _concat_force_rows(
     force_blocks: list[np.ndarray], dtype: np.dtype | type[np.generic]
 ) -> np.ndarray:
@@ -482,19 +487,33 @@ class EnerTester(ModelTester):
             find_atom_pref=find_atom_pref,
         )
 
+        real_atoms = _real_atom_mask(atype, nframes, natoms)
+        has_real_atoms = bool(np.any(real_atoms))
+        metric_force = force
+        metric_reference_force = test_data["force"]
+        if self.reports_plain_force:
+            # Select before subtracting so even NaN padding cannot enter the
+            # numerator. The selected scalar count also supplies chunk weights.
+            metric_force = _reshape_force_by_atom(force, natoms)[real_atoms]
+            metric_reference_force = _reshape_force_by_atom(test_data["force"], natoms)[
+                real_atoms
+            ]
+
         reports_virial = find_virial == 1 and data.pbc
         shared_metrics = compute_energy_type_metrics(
             prediction={
                 "energy": energy,
-                "force": force,
+                "force": metric_force,
                 **({"virial": virial} if reports_virial else {}),
             },
             test_data={
                 "find_energy": find_energy,
-                "find_force": find_force if self.reports_plain_force else 0.0,
+                "find_force": (
+                    find_force if self.reports_plain_force and has_real_atoms else 0.0
+                ),
                 "find_virial": find_virial,
                 "energy": test_data["energy"],
-                "force": test_data["force"],
+                "force": metric_reference_force,
                 **(
                     {"virial": test_data["virial"], "box": box}
                     if reports_virial
@@ -531,10 +550,17 @@ class EnerTester(ModelTester):
             prediction_stress = -virial / volume
             reference_stress = -test_data["virial"] / volume
 
-        if dp.has_hessian:
+        if dp.has_hessian and has_real_atoms:
+            # A Hessian entry is valid only when both Cartesian indices
+            # belong to real atoms in the same frame.
+            real_dof = np.repeat(real_atoms, 3, axis=1)
+            real_pairs = (real_dof[:, :, None] & real_dof[:, None, :]).reshape(
+                nframes, -1
+            )
             errors.update(
                 compute_error_stat(
-                    optional_outputs.hessian, test_data["hessian"]
+                    optional_outputs.hessian[real_pairs],
+                    test_data["hessian"].reshape(nframes, -1)[real_pairs],
                 ).as_weighted_average_errors(*DP_TEST_HESSIAN_METRIC_KEYS)
             )
         if self.atomic:
@@ -616,13 +642,20 @@ class EnerTester(ModelTester):
             forces the shared detail writer already covers.
         """
         if find_force == 1 and find_atom_pref == 1:
-            errors.update(
-                compute_weighted_error_stat(
-                    prediction_force,
-                    test_data["force"],
-                    test_data["atom_pref"],
-                ).as_weighted_average_errors(*DP_TEST_WEIGHTED_FORCE_METRIC_KEYS)
+            real_atoms = _real_atom_mask(atype, prediction_force.shape[0], natoms)
+            if not np.any(real_atoms):
+                return _ForceDetails()
+            weighted_force = compute_weighted_error_stat(
+                _reshape_force_by_atom(prediction_force, natoms)[real_atoms],
+                _reshape_force_by_atom(test_data["force"], natoms)[real_atoms],
+                _reshape_force_by_atom(test_data["atom_pref"], natoms)[real_atoms],
             )
+            if weighted_force.weight > 0.0:
+                errors.update(
+                    weighted_force.as_weighted_average_errors(
+                        *DP_TEST_WEIGHTED_FORCE_METRIC_KEYS
+                    )
+                )
         return _ForceDetails()
 
 

--- a/source/tests/common/test_dp_test_spin_virtual_atoms.py
+++ b/source/tests/common/test_dp_test_spin_virtual_atoms.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Padding must not enter real or magnetic dp test spin-force metrics."""
+
+from types import (
+    SimpleNamespace,
+)
+
+import numpy as np
+import pytest
+
+from deepmd.infer.model_test.ener import (
+    SpinEnerTester,
+    _OptionalEnerOutputs,
+)
+from deepmd.utils.weight_avg import (
+    merge_weighted_errors,
+    weighted_average,
+)
+
+pytestmark = pytest.mark.filterwarnings("error::RuntimeWarning")
+
+
+def _evaluate_spin(
+    types,
+    legacy,
+    padding,
+    padding_side="prediction",
+    *,
+    fixed_types=False,
+    find_force=1.0,
+    find_magnetic=1.0,
+):
+    """Evaluate controlled arrays with the real spin tester, including chunks."""
+    types = np.asarray(types)
+    nframes, natoms = types.shape
+    valid = types >= 0
+    force = np.arange(nframes * natoms * 3, dtype=float).reshape(nframes, natoms, 3)
+    force = force / 10 + 1
+    magnetic = force * 2
+    reference = np.zeros_like(force)
+    magnetic_reference = np.zeros_like(magnetic)
+    force[~valid] = padding if padding_side in ("prediction", "both") else 0.0
+    magnetic[~valid] = padding if padding_side in ("prediction", "both") else 0.0
+    reference[~valid] = padding if padding_side in ("reference", "both") else 0.0
+    magnetic_reference[~valid] = (
+        padding if padding_side in ("reference", "both") else 0.0
+    )
+    # Deliberately include padding in the supplied mask: the tester must
+    # intersect it with valid atom types, and preserve the raw detail rows.
+    mask = types != 1
+    dp = SimpleNamespace(get_ntypes_spin=lambda: int(legacy), get_ntypes=lambda: 3)
+    tester = SpinEnerTester(dp, atomic=False)
+
+    def evaluate(frame_slice):
+        """Exercise the production force-metric entry point without inference."""
+        errors = {}
+        atype = types[0] if fixed_types else types[frame_slice]
+        details = tester.force_errors(
+            errors,
+            data=None,
+            test_data={
+                "force": reference[frame_slice].reshape(-1, natoms * 3),
+                "force_mag": magnetic_reference[frame_slice].reshape(-1, natoms * 3),
+                "find_force_mag": find_magnetic,
+            },
+            atype=atype,
+            natoms=natoms,
+            prediction_force=force[frame_slice].reshape(-1, natoms * 3),
+            optional_outputs=_OptionalEnerOutputs(
+                None,
+                None,
+                None if legacy else magnetic[frame_slice].reshape(-1, natoms * 3),
+                None if legacy else mask[frame_slice],
+                None,
+            ),
+            find_force=find_force,
+            find_atom_pref=0.0,
+        )
+        return errors, details
+
+    before = [a.copy() for a in (force, reference, magnetic, magnetic_reference, mask)]
+    errors, details = evaluate(slice(None))
+    chunks = [evaluate(slice(i, i + 1))[0] for i in range(nframes)]
+    expected = {}
+    real_mask = valid & (types < 2) if legacy else valid
+    mag_mask = types == 2 if legacy else valid & mask
+    magnetic_prediction = force if legacy else magnetic
+    magnetic_labels = reference if legacy else magnetic_reference
+    for suffix, selection, prediction, labels, found in (
+        ("fr", real_mask, force, reference, find_force),
+        ("fm", mag_mask, magnetic_prediction, magnetic_labels, find_magnetic),
+    ):
+        if found and np.any(selection):
+            delta = prediction[selection] - labels[selection]
+            expected["mae_" + suffix] = (np.mean(abs(delta)), delta.size)
+            expected["rmse_" + suffix] = (np.sqrt(np.mean(delta**2)), delta.size)
+
+    # Detail output intentionally retains the existing padding layout.
+    raw_real_mask = types < 2 if legacy else np.ones_like(valid)
+    raw_mag_mask = types == 2 if legacy else mask
+    np.testing.assert_equal(details.prediction_real, force[raw_real_mask])
+    np.testing.assert_equal(details.reference_real, reference[raw_real_mask])
+    if find_magnetic:
+        np.testing.assert_equal(
+            details.prediction_magnetic, magnetic_prediction[raw_mag_mask]
+        )
+        np.testing.assert_equal(
+            details.reference_magnetic, magnetic_labels[raw_mag_mask]
+        )
+    else:
+        assert details.prediction_magnetic is None
+        assert details.reference_magnetic is None
+    for original, actual in zip(
+        before, (force, reference, magnetic, magnetic_reference, mask), strict=True
+    ):
+        np.testing.assert_equal(actual, original)
+    return errors, chunks, expected
+
+
+def _assert_metrics(errors, chunks, expected):
+    """Check both in-chunk values and chunk/system aggregation weights."""
+    for actual in (errors, merge_weighted_errors(chunks)):
+        assert actual.keys() == expected.keys()
+        for key, value in expected.items():
+            np.testing.assert_allclose(actual[key], value)
+    actual = weighted_average(chunks)
+    assert actual.keys() == expected.keys()
+    for key, value in actual.items():
+        np.testing.assert_allclose(value, expected[key][0])
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+@pytest.mark.parametrize(
+    "types",
+    [
+        [[0, 1, 2], [2, 0, 1]],
+        [[0, -1, 2], [-1, 0, 2]],
+        [[0, 1, 2], [0, -1, 2]],
+        [[-1, -1, -1], [0, 1, 2]],
+        [[-1, -1, -1], [-1, -1, -1]],
+    ],
+)
+@pytest.mark.parametrize("padding", [0.0, 10.0, np.nan])
+@pytest.mark.parametrize("padding_side", ["prediction", "reference", "both"])
+def test_spin_virtual_atom_metrics(types, legacy, padding, padding_side):
+    """Zero, nonzero and NaN padding cannot change either metric or weight."""
+    _assert_metrics(*_evaluate_spin(types, legacy, padding, padding_side))
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_spin_fixed_types_broadcast_across_frames(legacy):
+    """A single type row selects valid force rows in every frame."""
+    types = [[0, -1, 2], [0, -1, 2]]
+    result = _evaluate_spin(types, legacy, np.nan, fixed_types=True)
+    _assert_metrics(*result)
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+@pytest.mark.parametrize("find_force,find_magnetic", [(0, 0), (0, 1), (1, 0), (1, 1)])
+def test_spin_missing_force_labels(legacy, find_force, find_magnetic):
+    """Each available label controls only its corresponding force metric."""
+    _assert_metrics(
+        *_evaluate_spin(
+            [[0, -1, 2]],
+            legacy,
+            np.nan,
+            find_force=find_force,
+            find_magnetic=find_magnetic,
+        )
+    )
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_spin_without_magnetic_atoms_omits_magnetic_metrics(legacy):
+    """Empty magnetic selections do not produce NaNs or zero-weight metrics."""
+    result = _evaluate_spin([[1, -1, -1], [1, 1, -1]], legacy, np.nan)
+    _assert_metrics(*result)
+    assert result[0].keys() == {"mae_fr", "rmse_fr"}
+
+
+def test_legacy_spin_without_real_rows_can_report_magnetic_metrics():
+    """A magnetic-only legacy chunk does not reduce an empty real-force array."""
+    result = _evaluate_spin([[2, -1]], True, np.nan)
+    _assert_metrics(*result)
+    assert result[0].keys() == {"mae_fm", "rmse_fm"}
+
+
+def test_spin_missing_magnetic_arrays_still_raises():
+    """A requested magnetic metric needs both arrays and the model mask."""
+    tester = SpinEnerTester(
+        SimpleNamespace(get_ntypes_spin=lambda: 0, get_ntypes=lambda: 1),
+        atomic=False,
+    )
+    with pytest.raises(RuntimeError, match="magnetic force arrays and mask"):
+        tester.force_errors(
+            {},
+            data=None,
+            test_data={"force": np.zeros((1, 6)), "find_force_mag": 1.0},
+            atype=np.array([[0, -1]]),
+            natoms=2,
+            prediction_force=np.zeros((1, 6)),
+            optional_outputs=_OptionalEnerOutputs(None, None, None, None, None),
+            find_force=1.0,
+            find_atom_pref=0.0,
+        )

--- a/source/tests/common/test_dp_test_virtual_atoms.py
+++ b/source/tests/common/test_dp_test_virtual_atoms.py
@@ -28,19 +28,24 @@ class _Evaluator:
     has_hessian = True
 
     def __init__(self, force, hessian):
+        """Store the controlled force and Hessian predictions."""
         self.force = force
         self.hessian = hessian
 
     def get_dim_fparam(self):
+        """Report that this evaluator needs no frame parameters."""
         return 0
 
     def get_dim_aparam(self):
+        """Report that this evaluator needs no atom parameters."""
         return 0
 
     def has_chg_spin_ebd(self):
+        """Keep charge/spin conditioning outside this metric-only evaluator."""
         return False
 
     def eval(self, coord, box, atype, **kwargs):
+        """Return controlled predictions in the energy-model output order."""
         nframes = len(coord)
         return (
             np.zeros((nframes, 1)),
@@ -59,6 +64,7 @@ def _evaluate(
     mixed_type=True,
     zero_real_pref=False,
 ):
+    """Evaluate padding cases together and per frame for reduction checks."""
     types = np.asarray(types)
     nframes, natoms = types.shape
     valid = np.repeat(types >= 0, 3, axis=1)
@@ -125,6 +131,7 @@ def _evaluate(
 )
 @pytest.mark.parametrize("padding_error", [0.0, 10.0, np.nan])
 def test_virtual_atom_metrics(types, padding_error):
+    """Padding cannot alter errors or their chunk/system aggregation weights."""
     errors, chunks, force, hessian, pref = _evaluate(types, padding_error)
     expected = {
         "mae_f": (np.mean(abs(force)), force.size),
@@ -144,18 +151,21 @@ def test_virtual_atom_metrics(types, padding_error):
 
 
 def test_all_virtual_chunk_has_no_atom_metrics():
+    """An all-padding chunk contributes no atom metrics or zero-weight values."""
     errors, chunks, *_ = _evaluate([[-1, -1]], np.nan)
     assert errors == {}
     assert merge_weighted_errors(chunks) == {}
 
 
 def test_fixed_atom_types_broadcast_across_frames():
+    """Fixed-type and mixed-type inputs select the same valid components."""
     mixed, *_ = _evaluate([[0, -1], [0, -1]], np.nan)
     fixed, *_ = _evaluate([[0, -1], [0, -1]], np.nan, mixed_type=False)
     assert mixed == fixed
 
 
 def test_only_virtual_atoms_have_force_weights():
+    """Preferences assigned only to padding do not create weighted metrics."""
     errors, chunks, *_ = _evaluate([[0, -1], [-1, 0]], np.nan, zero_real_pref=True)
     assert errors.keys() == {"mae_f", "rmse_f", "mae_h", "rmse_h"}
     for key, value in merge_weighted_errors(chunks).items():
@@ -163,11 +173,13 @@ def test_only_virtual_atoms_have_force_weights():
 
 
 def test_missing_force_labels_do_not_report_force():
+    """Absent force labels leave only the available Hessian metrics."""
     errors, *_ = _evaluate([[0, -1]], np.nan, find_force=0.0)
     assert errors.keys() == {"mae_h", "rmse_h"}
 
 
 def test_padding_keeps_detail_file_layout(tmp_path):
+    """Detail files retain the padded force and Hessian row counts."""
     detail = str(tmp_path / "details")
     _evaluate([[0, -1], [-1, 0]], 10.0, detail_file=detail)
     assert np.loadtxt(detail + ".f.out").shape == (4, 6)

--- a/source/tests/common/test_dp_test_virtual_atoms.py
+++ b/source/tests/common/test_dp_test_virtual_atoms.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Virtual padding must not contribute to dp test force/Hessian metrics."""
+
+from types import (
+    SimpleNamespace,
+)
+
+import numpy as np
+import pytest
+
+from deepmd.infer.model_test.base import (
+    ChunkContext,
+)
+from deepmd.infer.model_test.ener import (
+    EnerTester,
+)
+from deepmd.utils.weight_avg import (
+    merge_weighted_errors,
+    weighted_average,
+)
+
+
+class _Evaluator:
+    """Controlled predictions for testing metric reduction, not inference."""
+
+    has_efield = False
+    has_spin = False
+    has_hessian = True
+
+    def __init__(self, force, hessian):
+        self.force = force
+        self.hessian = hessian
+
+    def get_dim_fparam(self):
+        return 0
+
+    def get_dim_aparam(self):
+        return 0
+
+    def has_chg_spin_ebd(self):
+        return False
+
+    def eval(self, coord, box, atype, **kwargs):
+        nframes = len(coord)
+        return (
+            np.zeros((nframes, 1)),
+            self.force,
+            np.zeros((nframes, 9)),
+            self.hessian,
+        )
+
+
+def _evaluate(
+    types,
+    padding_error,
+    *,
+    detail_file=None,
+    find_force=1.0,
+    mixed_type=True,
+    zero_real_pref=False,
+):
+    types = np.asarray(types)
+    nframes, natoms = types.shape
+    valid = np.repeat(types >= 0, 3, axis=1)
+    valid_hessian = valid[:, :, None] & valid[:, None, :]
+    # Different errors in every row/column catch masking just one Hessian axis.
+    force_error = np.arange(valid.size).reshape(valid.shape) / 10 + 1
+    hessian_error = np.arange(valid_hessian.size).reshape(valid_hessian.shape) / 10 + 1
+    force = np.where(valid, force_error, padding_error)
+    hessian = np.where(valid_hessian, hessian_error, padding_error)
+    atom_pref = np.arange(valid.size).reshape(valid.shape) + 1.0
+    if zero_real_pref:
+        atom_pref[valid] = 0.0
+    labels = {
+        "type": types,
+        "box": np.zeros((nframes, 9)),
+        "coord": np.zeros((nframes, natoms * 3)),
+        "energy": np.zeros((nframes, 1)),
+        "virial": np.zeros((nframes, 9)),
+        "force": np.zeros_like(force),
+        "hessian": np.zeros((nframes, (natoms * 3) ** 2)),
+        "atom_pref": atom_pref,
+        "find_energy": 0.0,
+        "find_force": find_force,
+        "find_virial": 0.0,
+        "find_atom_pref": 1.0,
+    }
+    context = ChunkContext("padding", detail_file, False, 0)
+    tester = EnerTester(_Evaluator(force, hessian), atomic=False)
+    data = SimpleNamespace(mixed_type=mixed_type, pbc=False)
+    errors = tester.evaluate_chunk(data, labels, context)
+
+    chunks = []
+    for frame in range(nframes):
+        frame_labels = {
+            key: value[frame : frame + 1] if isinstance(value, np.ndarray) else value
+            for key, value in labels.items()
+        }
+        frame_tester = EnerTester(
+            _Evaluator(force[frame : frame + 1], hessian[frame : frame + 1]),
+            atomic=False,
+        )
+        chunks.append(
+            frame_tester.evaluate_chunk(
+                data, frame_labels, ChunkContext("padding", None, False, frame)
+            )
+        )
+    return (
+        errors,
+        chunks,
+        force_error[valid],
+        hessian_error[valid_hessian],
+        atom_pref[valid],
+    )
+
+
+@pytest.mark.parametrize(
+    "types",
+    [
+        [[0, 0], [0, 0]],
+        [[0, -1], [-1, 0]],
+        [[0, 0], [-1, 0]],
+        [[-1, -1], [0, -1]],
+    ],
+)
+@pytest.mark.parametrize("padding_error", [0.0, 10.0, np.nan])
+def test_virtual_atom_metrics(types, padding_error):
+    errors, chunks, force, hessian, pref = _evaluate(types, padding_error)
+    expected = {
+        "mae_f": (np.mean(abs(force)), force.size),
+        "rmse_f": (np.sqrt(np.mean(force**2)), force.size),
+        "mae_h": (np.mean(abs(hessian)), hessian.size),
+        "rmse_h": (np.sqrt(np.mean(hessian**2)), hessian.size),
+        "mae_fw": (np.average(abs(force), weights=pref), pref.sum()),
+        "rmse_fw": (np.sqrt(np.average(force**2, weights=pref)), pref.sum()),
+    }
+    for actual in (errors, merge_weighted_errors(chunks)):
+        assert actual.keys() == expected.keys()
+        for key, value in expected.items():
+            np.testing.assert_allclose(actual[key], value)
+    # The same weights are also consumed by run-level, cross-system reduction.
+    for key, value in weighted_average(chunks).items():
+        np.testing.assert_allclose(value, expected[key][0])
+
+
+def test_all_virtual_chunk_has_no_atom_metrics():
+    errors, chunks, *_ = _evaluate([[-1, -1]], np.nan)
+    assert errors == {}
+    assert merge_weighted_errors(chunks) == {}
+
+
+def test_fixed_atom_types_broadcast_across_frames():
+    mixed, *_ = _evaluate([[0, -1], [0, -1]], np.nan)
+    fixed, *_ = _evaluate([[0, -1], [0, -1]], np.nan, mixed_type=False)
+    assert mixed == fixed
+
+
+def test_only_virtual_atoms_have_force_weights():
+    errors, chunks, *_ = _evaluate([[0, -1], [-1, 0]], np.nan, zero_real_pref=True)
+    assert errors.keys() == {"mae_f", "rmse_f", "mae_h", "rmse_h"}
+    for key, value in merge_weighted_errors(chunks).items():
+        np.testing.assert_allclose(value, errors[key])
+
+
+def test_missing_force_labels_do_not_report_force():
+    errors, *_ = _evaluate([[0, -1]], np.nan, find_force=0.0)
+    assert errors.keys() == {"mae_h", "rmse_h"}
+
+
+def test_padding_keeps_detail_file_layout(tmp_path):
+    detail = str(tmp_path / "details")
+    _evaluate([[0, -1], [-1, 0]], 10.0, detail_file=detail)
+    assert np.loadtxt(detail + ".f.out").shape == (4, 6)
+    assert np.loadtxt(detail + ".h.out").shape == (72, 2)

--- a/source/tests/pt/test_dp_test_spin_virtual_atoms.py
+++ b/source/tests/pt/test_dp_test_spin_virtual_atoms.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Validate padded spin metrics through a real checkpoint, dataset and CLI."""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+from deepmd.infer.deep_eval import (
+    DeepEval,
+)
+from deepmd.infer.model_test import (
+    build_tester,
+)
+from deepmd.pt.model.model import (
+    get_model,
+)
+from deepmd.pt.train.wrapper import (
+    ModelWrapper,
+)
+from deepmd.utils.data import (
+    DeepmdData,
+)
+
+
+@pytest.mark.parametrize("padding_label", [0.0, np.nan])
+def test_dp_test_spin_virtual_atom_metrics(tmp_path, monkeypatch, padding_label):
+    """Real and magnetic errors use valid scalar counts after chunk merging."""
+    params = {
+        "type_map": ["A", "B"],
+        "descriptor": {
+            "type": "se_e2_a",
+            "sel": [4, 4],
+            "rcut": 3.0,
+            "rcut_smth": 2.0,
+            "neuron": [2, 4],
+            "axis_neuron": 2,
+            "precision": "float64",
+            "seed": 1,
+        },
+        "fitting_net": {"neuron": [4], "precision": "float64", "seed": 1},
+        "spin": {"use_spin": [True, False], "virtual_scale": [0.5]},
+    }
+    checkpoint = tmp_path / "spin_model.pt"
+    model = get_model(params)
+    torch.save(ModelWrapper(model, model_params=params).state_dict(), checkpoint)
+    dp = DeepEval(str(checkpoint), auto_batch_size=False)
+    assert dp.has_spin
+
+    types = np.array([[0, 1, -1], [1, 0, 0], [-1, 1, 0]])
+    coord = np.tile([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], (3, 1, 1))
+    spin = np.tile([0.0, 0.0, 1.0], (3, 3, 1)) * (types == 0)[..., None]
+    _, force, _, force_mag, mask_mag = dp.eval(
+        coord.reshape(3, -1),
+        None,
+        types,
+        mixed_type=True,
+        spin=spin.reshape(3, -1),
+    )
+    valid = types >= 0
+    magnetic = types == 0
+    np.testing.assert_array_equal(mask_mag.reshape(3, 3), magnetic)
+    frame_error = np.arange(1, 4, dtype=float)
+    force_ref = np.where(
+        valid[..., None],
+        force.reshape(3, 3, 3) + frame_error[:, None, None],
+        padding_label,
+    )
+    force_mag_ref = np.where(
+        magnetic[..., None],
+        force_mag.reshape(3, 3, 3) + 2 * frame_error[:, None, None],
+        padding_label,
+    )
+
+    system = tmp_path / "spin_system"
+    set_dir = system / "set.000"
+    set_dir.mkdir(parents=True)
+    (system / "type.raw").write_text("0\n0\n0\n")
+    (system / "type_map.raw").write_text("A\nB\n")
+    (system / "nopbc").touch()
+    for name, value in (
+        ("coord", coord.reshape(3, -1)),
+        ("real_atom_types", types),
+        ("spin", spin.reshape(3, -1)),
+        ("force", force_ref.reshape(3, -1)),
+        ("force_mag", force_mag_ref.reshape(3, -1)),
+    ):
+        np.save(set_dir / (name + ".npy"), value)
+
+    expected = {}
+    for suffix, selection, values in (
+        ("fr", valid, frame_error),
+        ("fm", magnetic, 2 * frame_error),
+    ):
+        counts = 3 * selection.sum(axis=1)
+        expected["mae_" + suffix] = (np.average(values, weights=counts), counts.sum())
+        expected["rmse_" + suffix] = (
+            np.sqrt(np.average(values**2, weights=counts)),
+            counts.sum(),
+        )
+
+    for chunk_atoms in (3, 100):
+        monkeypatch.setenv("DP_TEST_CHUNK_ATOMS", str(chunk_atoms))
+        data = DeepmdData(
+            str(system),
+            "set",
+            shuffle_test=False,
+            type_map=dp.get_type_map(),
+            sort_atoms=False,
+        )
+        assert data.mixed_type
+        details = str(tmp_path / f"spin_details_{chunk_atoms}")
+        errors = build_tester(dp, atomic=False).run(
+            data, str(system), numb_test=3, detail_file=details
+        )
+        assert errors.keys() == expected.keys()
+        for key, value in expected.items():
+            np.testing.assert_allclose(errors[key], value, rtol=1e-6)
+        real_detail = np.loadtxt(details + ".fr.out", ndmin=2)
+        mag_detail = np.loadtxt(details + ".fm.out", ndmin=2)
+        np.testing.assert_allclose(real_detail[:, :3], force_ref.reshape(-1, 3))
+        np.testing.assert_allclose(real_detail[:, 3:], force.reshape(-1, 3))
+        np.testing.assert_allclose(mag_detail[:, :3], force_mag_ref[magnetic])
+        np.testing.assert_allclose(
+            mag_detail[:, 3:], force_mag.reshape(3, 3, 3)[magnetic]
+        )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "deepmd",
+            "--pt",
+            "test",
+            "-m",
+            str(checkpoint),
+            "-s",
+            str(system),
+            "-n",
+            "0",
+        ],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    output = result.stdout + result.stderr
+    for label, key in (("Force atom RMSE", "rmse_fr"), ("Force spin RMSE", "rmse_fm")):
+        assert label in output
+        assert f"{expected[key][0]:e}" in output

--- a/source/tests/pt/test_dp_test_virtual_atoms.py
+++ b/source/tests/pt/test_dp_test_virtual_atoms.py
@@ -28,6 +28,7 @@ from deepmd.utils.data import (
 
 @pytest.mark.parametrize("padding_label", [0.0, np.nan])
 def test_dp_test_virtual_atom_metrics(tmp_path, monkeypatch, padding_label):
+    """Check checkpoint, disk-data and CLI metrics without counting padding."""
     params = {
         "type_map": ["H"],
         "descriptor": {

--- a/source/tests/pt/test_dp_test_virtual_atoms.py
+++ b/source/tests/pt/test_dp_test_virtual_atoms.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Exercise virtual-atom metrics with a real checkpoint and mixed-type data."""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+from deepmd.infer.deep_eval import (
+    DeepEval,
+)
+from deepmd.infer.model_test import (
+    build_tester,
+)
+from deepmd.pt.model.model import (
+    get_model,
+)
+from deepmd.pt.train.wrapper import (
+    ModelWrapper,
+)
+from deepmd.utils.data import (
+    DeepmdData,
+)
+
+
+@pytest.mark.parametrize("padding_label", [0.0, np.nan])
+def test_dp_test_virtual_atom_metrics(tmp_path, monkeypatch, padding_label):
+    params = {
+        "type_map": ["H"],
+        "descriptor": {
+            "type": "se_e2_a",
+            "sel": [4],
+            "rcut": 3.0,
+            "rcut_smth": 2.0,
+            "neuron": [2, 4],
+            "axis_neuron": 2,
+            "precision": "float64",
+            "seed": 1,
+        },
+        "fitting_net": {"neuron": [4], "precision": "float64", "seed": 1},
+        "hessian_mode": True,
+    }
+    checkpoint = tmp_path / "model.pt"
+    model = get_model(params)
+    torch.save(ModelWrapper(model, model_params=params).state_dict(), checkpoint)
+    dp = DeepEval(str(checkpoint), auto_batch_size=False)
+    assert dp.has_hessian
+
+    types = np.array([[0, 0, -1], [0, 0, 0], [-1, 0, 0]])
+    coord = np.tile([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], (3, 1, 1))
+    _, force, _, hessian = dp.eval(coord.reshape(3, -1), None, types, mixed_type=True)
+    valid = np.repeat(types >= 0, 3, axis=1)
+    pairs = valid[:, :, None] & valid[:, None, :]
+    frame_error = np.arange(1, 4, dtype=float)
+    force_ref = np.where(
+        valid, force.reshape(3, -1) + frame_error[:, None], padding_label
+    )
+    hessian_ref = np.where(
+        pairs, hessian.reshape(3, 9, 9) + frame_error[:, None, None], padding_label
+    )
+
+    system = tmp_path / "system"
+    set_dir = system / "set.000"
+    set_dir.mkdir(parents=True)
+    (system / "type.raw").write_text("0\n0\n0\n")
+    (system / "type_map.raw").write_text("H\n")
+    (system / "nopbc").touch()
+    np.save(set_dir / "coord.npy", coord.reshape(3, -1))
+    np.save(set_dir / "real_atom_types.npy", types)
+    np.save(set_dir / "force.npy", force_ref)
+    np.save(set_dir / "hessian.npy", hessian_ref.reshape(3, -1))
+    np.save(set_dir / "atom_pref.npy", np.tile(frame_error[:, None], (1, 3)))
+
+    expected = {}
+    for suffix, counts in (
+        ("f", valid.sum(axis=1)),
+        ("h", pairs.sum(axis=(1, 2))),
+        ("fw", valid.sum(axis=1) * frame_error),
+    ):
+        expected["mae_" + suffix] = (
+            np.average(frame_error, weights=counts),
+            counts.sum(),
+        )
+        expected["rmse_" + suffix] = (
+            np.sqrt(np.average(frame_error**2, weights=counts)),
+            counts.sum(),
+        )
+
+    for chunk_atoms in (3, 100):
+        monkeypatch.setenv("DP_TEST_CHUNK_ATOMS", str(chunk_atoms))
+        data = DeepmdData(
+            str(system),
+            "set",
+            shuffle_test=False,
+            type_map=dp.get_type_map(),
+            sort_atoms=False,
+        )
+        assert data.mixed_type
+        details = str(tmp_path / f"details_{chunk_atoms}")
+        errors = build_tester(dp, atomic=False).run(
+            data, str(system), numb_test=3, detail_file=details
+        )
+        for key, value in expected.items():
+            np.testing.assert_allclose(errors[key], value, rtol=1e-6)
+        force_detail = np.loadtxt(details + ".f.out")
+        hessian_detail = np.loadtxt(details + ".h.out")
+        np.testing.assert_allclose(force_detail[:, :3], force_ref.reshape(-1, 3))
+        np.testing.assert_allclose(hessian_detail[:, 0], hessian_ref.reshape(-1))
+
+    # Run the actual command in a separate process, including disk loading,
+    # checkpoint loading, chunk reduction and the final run-level report.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "deepmd",
+            "--pt",
+            "test",
+            "-m",
+            str(checkpoint),
+            "-s",
+            str(system),
+            "-n",
+            "0",
+        ],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    output = result.stdout + result.stderr
+    for label, key in (("Force  RMSE", "rmse_f"), ("Hessian RMSE", "rmse_h")):
+        assert label in output
+        assert f"{expected[key][0]:e}" in output


### PR DESCRIPTION
## Summary

Fixes #5928.

`dp test` currently reduces force and Hessian errors over padded arrays. Type `-1` slots lower MAE/RMSE even when both values are zero, and nonzero/NaN padding can contaminate the numerator. The padded array size is also reused as the chunk/system aggregation weight.

- Select real-atom force components before computing errors, including optional `atom_pref` weighting.
- Select Hessian entries only when both Cartesian indices belong to real atoms in the same frame.
- Let the selected scalar count (or selected preference sum) drive existing chunk and cross-system aggregation. Omit atom metrics for all-padding chunks and weighted-force metrics when no positive real-atom preference remains.
- Preserve raw detail-file shapes/order. Spin force metrics now exclude padding as described in the follow-up below; the legacy spin-partner mapping, atomic-energy errors, and energy/virial per-atom normalization are unchanged.

The change is confined to the energy tester; shared training/full-validation metrics are not modified.

## Regression coverage

Controlled evaluator tests cover no padding, changing virtual-atom positions, unequal per-frame real-atom counts, zero/nonzero/NaN padding, all-padding chunks, fixed-type broadcasting, missing force labels, virtual-only preferences, chunk/system weighting, and detail-file layout.

The integration test writes and reloads a small **real PyTorch Hessian-enabled checkpoint**, creates an on-disk mixed-type dataset, and evaluates it with one-frame and multi-frame chunks. It independently checks MAE, RMSE, weights, and detail data for forces, weighted forces, and Hessians. It also runs `python -m deepmd --pt test` in a separate process. This is an initialized test model with real inference, not a mock evaluator or a trained scientific-potential benchmark.

For example, the integration dataset contains 7 real atoms in 9 padded slots: the force weight must be 21, not 27, and the Hessian weight 153, not 243.

## Validation

Built an independent checkout of upstream `58a12b1e0a72cfcc322c64d70c21469220bef74f` from source in WSL Ubuntu with Python 3.12.3, PyTorch 2.11.0+cpu, TensorFlow CPU 2.21.0 and real compiled operators; e3nn 0.6.0 is installed for the PyTorch model import path.

- Final new tests against unmodified production code: **14 failed, 5 passed**.
- With the fix, all **19 new tests passed**, and the complete focused/related run produced **56 passed**:

```sh
python -m pytest -q \
  source/tests/common/test_dp_test_virtual_atoms.py \
  source/tests/pt/test_dp_test_virtual_atoms.py \
  source/tests/common/test_dp_test_ener_split.py \
  source/tests/common/test_data_system_hessian.py \
  source/tests/pt/test_dp_test.py \
  source/tests/pt/test_weighted_avg.py \
  source/tests/tf/test_dp_test.py \
  source/tests/tf/test_virtual_type.py
```

Full-repository Ruff 0.16.0 lint and formatting, changed-file isort 9.0.0b1 and `git diff --check` passed. The three tested source blobs match the submitted files.

CPU-only validation; no GPU, JAX, full-project suite or complete pre-commit-hook run is claimed. The related suite emits TorchScript deprecation, CPU pin-memory, and multiprocessing-fork warnings. Upstream CI remains authoritative.

## Review follow-up: spin padding

Addressed the spin-force finding in `3f54a70`.

- The spin alignment helper can now exclude padding for metric inputs while its default still preserves the existing detail-file rows. Legacy TF spin-partner types remain magnetic degrees of freedom; they are not confused with type `-1` padding.
- The separate-magnetic-force layout intersects `mask_mag` with valid atom types. Both predictions and references are selected before subtraction, so padded NaNs cannot enter the statistics.
- Only nonempty, labeled real/magnetic selections produce metrics. The valid scalar counts feed the existing chunk/system weighted reduction; no training/full-validation metric code is changed.

New controlled tests exercise both spin layouts, no/changing/unequal/all-padding frames, fixed-type broadcasting, zero/nonzero/NaN padding on either or both inputs, missing labels, empty magnetic selections, detail-array preservation and nonmutation.

A second integration test saves/reloads a real initialized PyTorch spin checkpoint, evaluates on-disk mixed-type data with two chunk sizes, checks both real and magnetic force statistics and detail files, and runs `python -m deepmd --pt test` in a separate process. The dataset has **21 valid real-force scalars, not 27 padded scalars**, and 12 magnetic-force scalars.

Validation in the same independent native CPU build:

- Against the previous PR head's production blob `3e83d3f`: new controlled spin tests **82 failed / 22 passed**; new checkpoint tests **2 failed** (incorrect real-force count/MAE, or NaN contamination).
- With this follow-up: all **106 new tests passed**.
- Previous related suite plus the two new files: **162 passed**.
- Additional existing `source/tests/tf/test_deeppot_spin.py`: **4 passed**. Legacy padded metric selection is covered by controlled tests; this extra inference suite is not presented as a new padded-TF-checkpoint integration test.
- Full-repository Ruff lint/format, changed-file isort, velin at the repository's Git tag `0.0.12`, and `git diff --check` passed. The repository's E8001/E8002 checker also passed when explicitly registered with Pylint 4.0.6. The normal Pylint command emitted existing checker-registration warnings, so this is **not** a claim that every pre-commit hook ran successfully.
- Tested Linux and submitted Windows file blobs match. No GPU, JAX, full-project suite or trained-potential accuracy claim. Upstream CI/review remains pending.

Reproduce the added tests in a source-built CPU test environment:

```sh
python -m pytest -q \
  source/tests/common/test_dp_test_spin_virtual_atoms.py \
  source/tests/pt/test_dp_test_spin_virtual_atoms.py
```

## AI assistance

Implementation and local verification were prepared with OpenAI Codex. Local success is not maintainer approval or an upstream merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Force, Hessian, and weighted force metrics now exclude virtual or padding atoms.
  - Spin and magnetic-force metrics correctly exclude virtual atoms while preserving detail output.
  - Metrics remain consistent across mixed-type and fixed-type data, chunk sizes, and per-frame evaluation.
  - Datasets containing only virtual atoms no longer produce misleading metrics.
  - Force metrics are omitted when force labels are unavailable.
  - Padding represented by zeros or NaN values is handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
