### PR TITLE
fix(lammps): register native-spin host pair style in plugin

### DIFF
--- a/source/lmp/plugin/deepmdplugin.cpp
+++ b/source/lmp/plugin/deepmdplugin.cpp
@@ -13,6 +13,7 @@
 #endif
 #include "pair_deepmd.h"
 #include "pair_deepspin.h"
+#include "pair_dpa4spin.h"
 #include "version.h"
 #if LAMMPS_VERSION_NUMBER >= 20220328
 #include "pppm_dplr.h"
@@ -22,6 +23,7 @@ using namespace LAMMPS_NS;
 
 static Pair* pairdeepmd(LAMMPS* lmp) { return new PairDeepMD(lmp); }
 static Pair* pairdeepspin(LAMMPS* lmp) { return new PairDeepSpin(lmp); }
+static Pair* pairdpa4spin(LAMMPS* lmp) { return new PairDPA4Spin(lmp); }
 
 #ifdef LMP_KOKKOS
 // Runtime plugins do not consume the PairStyle declarations used by LAMMPS'
@@ -107,6 +109,13 @@ extern "C" void lammpsplugin_init(void* lmp, void* handle, void* regfunc) {
   plugin.author = "Duo Zhang";
   plugin.creator.v1 = (lammpsplugin_factory1*)&pairdeepspin;
   plugin.handle = handle;
+  (*register_plugin)(&plugin, lmp);
+
+  plugin.style = "pair";
+  plugin.name = "dpa4spin";
+  plugin.info = "dpa4spin pair style " STR_GIT_SUMM;
+  plugin.author = "Tiancheng Li";
+  plugin.creator.v1 = (lammpsplugin_factory1*)&pairdpa4spin;
   (*register_plugin)(&plugin, lmp);
 
   plugin.style = "compute";

--- a/source/lmp/tests/test_lammps_dpa4spin_registration.py
+++ b/source/lmp/tests/test_lammps_dpa4spin_registration.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Native-spin host registration does not require a model artifact."""
+
+import os
+
+from lammps import (
+    lammps,
+)
+
+
+def test_native_spin_host_style_is_registered() -> None:
+    """The plugin must expose the host style, not only Kokkos aliases."""
+    lmp = lammps(cmdargs=["-log", "none", "-screen", "none"])
+    try:
+        if plugin := os.environ.get("DEEPMD_TEST_PLUGIN"):
+            lmp.command(f"plugin load {plugin}")
+        assert lmp.has_style("pair", "dpa4spin")
+    finally:
+        lmp.close()


### PR DESCRIPTION
## Summary

Register the existing `PairDPA4Spin` host implementation as `dpa4spin` in the runtime plugin. Currently, a non-Kokkos plugin loads successfully but `pair_style dpa4spin ...` is unrecognized. The header's `PairStyle` declaration serves built-in packages; runtime plugins register their factories explicitly. The plugin already registers the Kokkos variants, but omits this host factory.

This adds the host factory and registration alongside the existing pair styles, plus an artifact-independent LAMMPS Python test asserting that the host style is available after loading the plugin. No model, force conversion, Kokkos alias or unit-policy changes are included.

## Validation

Built against DeePMD master `28b7d068801716765ab8119257f814596e49a10c` and LAMMPS `stable_22Jul2025_update6` (`9c5ab448c78a14fd534619622162ba418d6a1fb1`), using a CPU serial shared LAMMPS build with PLUGIN and SPIN. The separate DeePMD build uses `ALLOW_NO_BACKEND=ON`, `BUILD_CPP_IF=ON`, `BUILD_PY_IF=OFF`, `DP_USING_C_API=OFF`, and `LAMMPS_SOURCE_ROOT` pointing to that checkout.

With the matching LAMMPS Python package on `PYTHONPATH`, its shared library on `LD_LIBRARY_PATH`, and `DEEPMD_TEST_PLUGIN` pointing to the compiled plugin:

```sh
python -m pytest source/lmp/tests/test_lammps_dpa4spin_registration.py -q
```

The exact new test fails on pristine upstream production sources because `has_style("pair", "dpa4spin")` is false. It passes with the candidate, including after restoring and rebuilding the candidate following the baseline comparison. Ruff 0.16.0, isort 9.0.0b1 checks and clang-format 22.1.8 dry-run pass for the changed files.

No model inference, GPU, MPI, Kokkos execution or full backend-suite coverage is claimed. This is intentionally separate from the native-spin unit-policy issue #5993 and does not close it.

AI assistance was used for diagnosis, implementation and validation. Opening as a draft for scope feedback; broader backend validation remains outstanding.
